### PR TITLE
feat: M5 i18n + fonts (gettext-style + Settings + LLM translate menu)

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -37,11 +37,11 @@ Pre-registered on `UI.Registry`. Use as XML tags by name:
 |---|---|---|
 | `<Frame>` | Empty container (RectTransform only). | — |
 | `<Image>` | uGUI Image; loads sprites from `Resources`. | `sprite` (resource path), `color` (`#RRGGBB[AA]`), `type` (`simple` / `sliced` / `tiled` / `filled`) |
-| `<Text>` | TMP_Text. Has text-content shorthand: `<Text>Hello</Text>` ≡ `<Text text="Hello"/>`. | `text`, `fontSize` (int), `color`, `align` (`left` / `center` / `right`), `wrap` (bool), `raycastTarget` (bool) |
+| `<Text>` | TMP_Text. Has text-content shorthand: `<Text>Hello</Text>` ≡ `<Text text="Hello"/>`. | `text`, `fontSize` (int), `color`, `align` (`left` / `center` / `right`), `wrap` (bool), `raycastTarget` (bool), `font` (string, font type from Settings; default `default`), `tr` (bool, default `true`; set `false` to skip i18n extraction), `ctx` (string, msgctxt to disambiguate same-msgid in the .po table) |
 | `<VStack>` | Vertical layout group. | `spacing` (float), `padding` (`T,R,B,L` 1/2/4 components) |
 | `<HStack>` | Horizontal layout group. | Same as VStack. |
 | `<Grid>` | Grid layout group, fixed columns. | `columns` (int), `cellSize` (`WxH`), `spacing` (single or `H,V`), `padding` |
-| `<Btn>` | Image + Button + R3 `OnClick`. Use as **template root** or registered prefab tag for any clickable. | `color`, `sprite` |
+| `<Btn>` | Image + Button + R3 `OnClick`. `<Btn>开始</Btn>` shorthand creates an internal TMP label child. Use as **template root** or registered prefab tag for any clickable. | `color`, `sprite`, `font` (string, font type from Settings; default `default`), `tr` (bool, default `true`; set `false` to skip i18n extraction), `ctx` (string, msgctxt to disambiguate same-msgid in the .po table) |
 | `<Icon>` | Sprite from a project-level IconSet; by-name lookup, package-time pruning. | `name` (required, `ns:icon-name`), `color` (`#RRGGBB[AA]`), `size` (numeric / `WxH` / `stretch` / `native`) |
 
 **No built-in `<Button>` / `<Toggle>` / `<Slider>` / `<Dropdown>` / `<ScrollList>`.** Build those as `<Template>` (composing `<Btn>` + `<Image>` + `<Text>`) or register your own C# `Control` + Prefab.
@@ -213,6 +213,54 @@ For inserting elements per variant (no `Remove`, no `Replace` — use `hidden.va
 - `<Param default>` values
 
 Trying to write `id.mobile="..."` or `default.mobile="..."` is a parse error.
+
+## i18n & 字体（M5 起）
+
+源文本直接写在 `<Text>` / `<Btn>` 中。`UI.Locale.Set("en")` 切语言；切语言走 Variant 通路，已 open 的 Screen 自动 ReSolve。
+
+```xml
+<!-- 源文本 = msgid；零 key -->
+<Text>开始游戏</Text>
+<Btn>设置</Btn>
+
+<!-- 不要翻译 -->
+<Text tr="false">{{playerName}}</Text>
+
+<!-- 同 msgid 多义；ctx 进 msgctxt -->
+<Btn ctx="door">Open</Btn>
+<Btn ctx="file-menu">Open</Btn>
+
+<!-- 字体 type 走 Settings；缺省 "default" -->
+<Text font="title">设置</Text>
+<Text font="damage" fontSize="96">9999!</Text>
+
+<!-- 配合既有 Variant 系统 -->
+<Text font="title" font.zh-Hans="title-cn">设置</Text>
+```
+
+C#:
+
+```csharp
+// 切 locale；同时切 .po 表与字体表
+UI.Locale.Set("en");
+UI.Locale.SetToSystemDefault();
+
+// 代码里抽取的字符串
+var text = string.Format(c, UI.Tr("总价: {0:C}"), price);
+```
+
+**保留命名空间**：`UI.Locale.Set("zh-Hans")` 内部把 `zh-Hans` 注册为活跃 Variant。author 不应使用同名 Variant 表达 locale 之外的状态。
+
+### 图文混排 / TMP 富文本
+
+`<Text>` 默认不允许 mix text + child elements。要 inline 写 `<sprite>` / `<color>` 等 TMP 标签，包 CDATA：
+
+```xml
+<Text><![CDATA[金币: <sprite name="coin"/>{{count}}]]></Text>
+<Text><![CDATA[<color=#ff0>警告</color>: 库存不足]]></Text>
+```
+
+抽取器把 CDATA 内容作为完整 msgid 抽出；运行时翻译保留标签。
 
 ## Import & namespaces
 
@@ -399,6 +447,14 @@ C# EVENT      .OnClick.Subscribe(...).AddTo(screen)
 C# VARIANT    UI.Variants.Set("name", true)
 XML CANVAS    <Screen name="X" canvas="overlay|camera|world">   default overlay; renderMode only
 C# CANVAS     UI.CanvasConfigurator = (canvas, name) => { ... }  worldCamera / sortingOrder / overrides; runs after XML
+
+## i18n
+<Text>...</Text>                 抽取 + 翻译
+<Text tr="false">...</Text>      跳过
+<Text font="title">...</Text>    字体 type
+<Text ctx="door">Open</Text>     msgctxt 消歧
+UI.Tr("...")                     C# 抽取入口
+UI.Locale.Set("zh-Hans")         切 locale (= 切 .po + 切字体)
 ```
 
 ## Worked end-to-end example

--- a/Editor/AssemblyInfo.cs
+++ b/Editor/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("PromptUGUI.Tests.EditorOnly")]

--- a/Editor/AssemblyInfo.cs.meta
+++ b/Editor/AssemblyInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f542d50f4ba77b0448e3b4392679bbb3

--- a/Editor/I18n.meta
+++ b/Editor/I18n.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4324440bf5224e141ac26f21d0fbae3f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/I18n/CSharpStringScanner.cs
+++ b/Editor/I18n/CSharpStringScanner.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace PromptUGUI.Editor.I18n {
+    internal static class CSharpStringScanner {
+        public static IEnumerable<ExtractedString> Scan(string source, string filePath) {
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var root = tree.GetRoot();
+            var calls = root.DescendantNodes().OfType<InvocationExpressionSyntax>();
+
+            foreach (var call in calls) {
+                if (!IsUiTr(call)) continue;
+                var args = call.ArgumentList.Arguments;
+                if (args.Count == 0) continue;
+
+                var msgid = AsLiteral(args[0].Expression);
+                if (msgid == null) continue;       // dynamic — skip
+
+                string ctx = null;
+                bool ctxArgInvalid = false;
+                for (int i = 1; i < args.Count; i++) {
+                    var a = args[i];
+                    if (a.NameColon?.Name.Identifier.ValueText == "ctx") {
+                        ctx = AsLiteral(a.Expression);
+                        if (ctx == null) { ctxArgInvalid = true; break; }
+                    }
+                }
+                if (ctxArgInvalid) continue;
+
+                var es = new ExtractedString {
+                    Msgid = msgid,
+                    Msgctxt = ctx,
+                    LocalePartition = "_code",
+                };
+                var line = call.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                es.References.Add($"{filePath}:{line}");
+
+                var enclosing = call.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
+                if (enclosing != null)
+                    es.ExtractedComments.Add($"in {enclosing.Identifier.ValueText}()");
+
+                foreach (var c in CollectLeadingComments(call))
+                    es.ExtractedComments.Add(c);
+
+                if (TmpRichTextDetector.HasTmpTags(msgid))
+                    es.ExtractedComments.Add(
+                        "Contains TMP rich text tags. Preserve tags and attribute values verbatim.");
+
+                yield return es;
+            }
+        }
+
+        static bool IsUiTr(InvocationExpressionSyntax call) {
+            // Match `UI.Tr(...)` and `PromptUGUI.Application.UI.Tr(...)` and `Tr(...)` (looser).
+            return call.Expression switch {
+                MemberAccessExpressionSyntax m =>
+                    m.Name.Identifier.ValueText == "Tr",
+                IdentifierNameSyntax id =>
+                    id.Identifier.ValueText == "Tr",
+                _ => false,
+            };
+        }
+
+        static string AsLiteral(ExpressionSyntax e) {
+            if (e is LiteralExpressionSyntax lit && lit.IsKind(SyntaxKind.StringLiteralExpression))
+                return lit.Token.ValueText;
+            return null;
+        }
+
+        static IEnumerable<string> CollectLeadingComments(InvocationExpressionSyntax call) {
+            var stmt = call.AncestorsAndSelf().OfType<StatementSyntax>().FirstOrDefault();
+            if (stmt == null) yield break;
+            foreach (var trivia in stmt.GetLeadingTrivia()) {
+                if (trivia.IsKind(SyntaxKind.SingleLineCommentTrivia)) {
+                    var text = trivia.ToString().TrimStart('/').Trim();
+                    if (!string.IsNullOrEmpty(text)) yield return text;
+                }
+            }
+        }
+    }
+}

--- a/Editor/I18n/CSharpStringScanner.cs.meta
+++ b/Editor/I18n/CSharpStringScanner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b6a25f838d391914193ee786993ad054

--- a/Editor/I18n/ExtractedString.cs
+++ b/Editor/I18n/ExtractedString.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace PromptUGUI.Editor.I18n {
+    /// <summary>
+    /// One translatable string discovered by a scanner. Multiple ExtractedStrings with the same
+    /// (msgid, msgctxt) get merged at write-time — comments/refs concatenated.
+    /// </summary>
+    internal sealed class ExtractedString {
+        public string Msgid;
+        public string Msgctxt;       // null = no explicit ctx
+        public List<string> Comments = new();   // # ...
+        public List<string> ExtractedComments = new();   // #. ...
+        public List<string> References = new();          // #: file:line
+        public string LocalePartition;       // e.g. "screens/MainMenu" or "_code"
+    }
+}

--- a/Editor/I18n/ExtractedString.cs.meta
+++ b/Editor/I18n/ExtractedString.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 80cb501fc1a2c904aaba55650a515d7b

--- a/Editor/I18n/PoFileWriter.cs
+++ b/Editor/I18n/PoFileWriter.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Linq;
+using PromptUGUI.I18n;
+
+namespace PromptUGUI.Editor.I18n {
+    internal static class PoFileWriter {
+        /// <summary>
+        /// Take an existing .po file's text and a fresh extraction; produce a new .po text where
+        /// existing non-empty msgstr values are preserved (keyed by (msgctxt, msgid)), comments are
+        /// replaced by the current extraction, and entries no longer in extraction are dropped.
+        /// </summary>
+        public static string Merge(string existingPoText, IEnumerable<ExtractedString> extracted) {
+            var existingByKey = string.IsNullOrEmpty(existingPoText)
+                ? new Dictionary<(string, string), PoEntry>()
+                : PoParser.Parse(existingPoText)
+                    .ToDictionary(e => (e.Msgctxt, e.Msgid));
+
+            // Group extracted by key so multi-occurrence msgid merge their comments.
+            var grouped = new Dictionary<(string ctx, string id), ExtractedString>();
+            foreach (var e in extracted) {
+                var k = (e.Msgctxt, e.Msgid);
+                if (!grouped.TryGetValue(k, out var existing)) {
+                    grouped[k] = new ExtractedString {
+                        Msgid = e.Msgid,
+                        Msgctxt = e.Msgctxt,
+                        Comments = new List<string>(e.Comments),
+                        ExtractedComments = new List<string>(e.ExtractedComments),
+                        References = new List<string>(e.References),
+                    };
+                } else {
+                    existing.ExtractedComments.AddRange(e.ExtractedComments);
+                    existing.References.AddRange(e.References);
+                    existing.Comments.AddRange(e.Comments);
+                }
+            }
+
+            var output = new List<PoEntry>();
+            foreach (var kv in grouped) {
+                var es = kv.Value;
+                var entry = new PoEntry {
+                    Msgctxt = es.Msgctxt,
+                    Msgid = es.Msgid,
+                    Msgstr = existingByKey.TryGetValue(kv.Key, out var prev) ? prev.Msgstr : "",
+                    TranslatorComments = new List<string>(),
+                };
+                // Merge comment streams: # translator (free) + #. extracted + #: refs.
+                foreach (var c in es.Comments) entry.TranslatorComments.Add(c);
+                foreach (var c in es.ExtractedComments) entry.TranslatorComments.Add($". {c}");
+                foreach (var r in es.References) entry.TranslatorComments.Add($": {r}");
+                output.Add(entry);
+            }
+            // Stable order: by ctx, then by msgid.
+            output.Sort((a, b) => {
+                int c = string.Compare(a.Msgctxt ?? "", b.Msgctxt ?? "", System.StringComparison.Ordinal);
+                return c != 0 ? c : string.Compare(a.Msgid ?? "", b.Msgid ?? "", System.StringComparison.Ordinal);
+            });
+            return PoParser.Serialize(output);
+        }
+    }
+}

--- a/Editor/I18n/PoFileWriter.cs.meta
+++ b/Editor/I18n/PoFileWriter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3ed2c173791d47e4abff4bab84b4063d

--- a/Editor/I18n/StringExtractor.cs
+++ b/Editor/I18n/StringExtractor.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using PromptUGUI.Application;
+using UnityEditor;
+using UnityEngine;
+
+namespace PromptUGUI.Editor.I18n {
+    internal static class StringExtractor {
+        const string OutputRoot = "Assets/Resources/PromptUGUI/i18n";
+
+        [MenuItem("Tools/PromptUGUI/Extract Strings")]
+        public static void ExtractAll() {
+            var settings = PromptUGUISettings.Instance;
+            if (settings == null || settings.locales.Count == 0) {
+                EditorUtility.DisplayDialog(
+                    "PromptUGUI",
+                    "No PromptUGUISettings found, or it has no locales configured. " +
+                    "Add one and configure locales first.",
+                    "OK");
+                return;
+            }
+
+            var allExtracted = new List<ExtractedString>();
+            allExtracted.AddRange(ScanAllXml());
+            allExtracted.AddRange(ScanAllCSharp());
+
+            // Group by partition.
+            var byPartition = allExtracted
+                .GroupBy(e => e.LocalePartition ?? "_code")
+                .ToDictionary(g => g.Key, g => g.ToList());
+
+            int filesWritten = 0;
+            foreach (var lc in settings.locales) {
+                if (string.IsNullOrEmpty(lc.locale)) continue;
+                foreach (var kv in byPartition) {
+                    var path = Path.Combine(OutputRoot, lc.locale, kv.Key + ".po")
+                        .Replace('\\', '/');
+                    Directory.CreateDirectory(Path.GetDirectoryName(path));
+                    var existing = File.Exists(path) ? File.ReadAllText(path) : "";
+                    var merged = PoFileWriter.Merge(existing, kv.Value);
+                    File.WriteAllText(path, merged);
+                    filesWritten++;
+                }
+            }
+            AssetDatabase.Refresh();
+            Debug.Log($"[PromptUGUI] Extract Strings: {allExtracted.Count} msgids → {filesWritten} .po files across {settings.locales.Count} locales.");
+        }
+
+        static IEnumerable<ExtractedString> ScanAllXml() {
+            var guids = AssetDatabase.FindAssets("t:TextAsset");
+            foreach (var guid in guids) {
+                var path = AssetDatabase.GUIDToAssetPath(guid);
+                if (!path.EndsWith(".ui.xml")) continue;
+                if (path.StartsWith("Packages/")) continue;
+                var text = File.ReadAllText(path);
+                var partition = PathToPartition(path);
+                foreach (var es in XmlStringScanner.Scan(text, partition)) {
+                    if (es.References.Count == 0) es.References.Add(path);
+                    yield return es;
+                }
+            }
+        }
+
+        static IEnumerable<ExtractedString> ScanAllCSharp() {
+            var guids = AssetDatabase.FindAssets("t:Script");
+            foreach (var guid in guids) {
+                var path = AssetDatabase.GUIDToAssetPath(guid);
+                if (!path.EndsWith(".cs")) continue;
+                if (path.StartsWith("Packages/")) continue;
+                if (path.Contains("/Tests/")) continue;
+                var text = File.ReadAllText(path);
+                foreach (var es in CSharpStringScanner.Scan(text, path))
+                    yield return es;
+            }
+        }
+
+        static string PathToPartition(string assetPath) {
+            // "Assets/UI/screens/MainMenu.ui.xml" → "screens/MainMenu"
+            // "Assets/UI/common/Buttons.ui.xml"   → "common/Buttons"
+            const string prefix = "Assets/";
+            var p = assetPath.StartsWith(prefix) ? assetPath.Substring(prefix.Length) : assetPath;
+            // Drop top-level folder (UI/) for shorter partitions; but only if path is multi-segment.
+            int firstSlash = p.IndexOf('/');
+            if (firstSlash > 0) p = p.Substring(firstSlash + 1);
+            if (p.EndsWith(".ui.xml")) p = p.Substring(0, p.Length - ".ui.xml".Length);
+            return p;
+        }
+    }
+}

--- a/Editor/I18n/StringExtractor.cs.meta
+++ b/Editor/I18n/StringExtractor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f14f4afa934117840a807acc7ee5e1c8

--- a/Editor/I18n/TmpRichTextDetector.cs
+++ b/Editor/I18n/TmpRichTextDetector.cs
@@ -1,0 +1,15 @@
+using System.Text.RegularExpressions;
+
+namespace PromptUGUI.Editor.I18n {
+    internal static class TmpRichTextDetector {
+        // Recognized TMP rich-text tags. Conservative — only tags whose attributes carry resource
+        // references that translators MUST NOT touch. False positives here only add a "preserve" hint
+        // comment; false negatives skip the hint.
+        static readonly Regex Tag = new(
+            @"</?(?:sprite|color|b|i|u|s|size|font|font-weight|align|alpha|space|indent|line-height|line-indent|link|lowercase|uppercase|smallcaps|mark|noparse|page|pos|rotate|style|sub|sup|voffset|width)(\s|=|/|>)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        public static bool HasTmpTags(string s) =>
+            !string.IsNullOrEmpty(s) && Tag.IsMatch(s);
+    }
+}

--- a/Editor/I18n/TmpRichTextDetector.cs.meta
+++ b/Editor/I18n/TmpRichTextDetector.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a489ca1b76905dc4c9fe670e55dc68df

--- a/Editor/I18n/TranslationAuth.cs
+++ b/Editor/I18n/TranslationAuth.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+namespace PromptUGUI.Editor.I18n {
+    /// <summary>
+    /// Per-user secret. Lives at `UserSettings/PromptUGUI/Auth.asset` (Unity 2020+
+    /// default .gitignore excludes UserSettings/).
+    /// </summary>
+    internal sealed class TranslationAuth : ScriptableObject {
+        public string apiKey = "";
+    }
+}

--- a/Editor/I18n/TranslationAuth.cs.meta
+++ b/Editor/I18n/TranslationAuth.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f046982fef2ed1943bcb3ad0a09e7df6

--- a/Editor/I18n/TranslationClient.cs
+++ b/Editor/I18n/TranslationClient.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PromptUGUI.Editor.I18n {
+    internal sealed class TranslationItem {
+        public string Msgid { get; set; }
+        public string Msgctxt { get; set; }
+        public List<string> Comments { get; set; } = new();
+    }
+
+    internal sealed class TranslationClient {
+        readonly HttpClient _http;
+
+        public TranslationClient(HttpClient http = null) {
+            _http = http ?? new HttpClient();
+        }
+
+        public async Task<Dictionary<string, string>> TranslateBatch(
+            IList<TranslationItem> items,
+            string targetLocale,
+            string endpoint, string model, string apiKey, string systemPrompt,
+            CancellationToken ct) {
+
+            var req = new HttpRequestMessage(HttpMethod.Post, endpoint);
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+            var prompt = systemPrompt.Replace("{{targetLocale}}", targetLocale);
+            var userMessage = JsonSerializer.Serialize(new {
+                target_locale = targetLocale,
+                items = items.Select(i => new {
+                    msgid = i.Msgid,
+                    msgctxt = i.Msgctxt,
+                    comments = i.Comments,
+                }),
+            });
+            var body = new {
+                model,
+                messages = new object[] {
+                    new { role = "system", content = prompt },
+                    new { role = "user", content = userMessage },
+                },
+                response_format = new {
+                    type = "json_schema",
+                    json_schema = new {
+                        name = "Translations",
+                        strict = true,
+                        schema = new {
+                            type = "object",
+                            additionalProperties = false,
+                            required = new[] { "translations" },
+                            properties = new {
+                                translations = new {
+                                    type = "array",
+                                    items = new {
+                                        type = "object",
+                                        additionalProperties = false,
+                                        required = new[] { "msgid", "msgctxt", "msgstr" },
+                                        properties = new {
+                                            msgid = new { type = "string" },
+                                            msgctxt = new { type = new[] { "string", "null" } },
+                                            msgstr = new { type = "string" },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+            req.Content = new StringContent(
+                JsonSerializer.Serialize(body),
+                Encoding.UTF8,
+                "application/json");
+
+            var resp = await _http.SendAsync(req, ct);
+            resp.EnsureSuccessStatusCode();
+            var text = await resp.Content.ReadAsStringAsync();
+
+            using var doc = JsonDocument.Parse(text);
+            var content = doc.RootElement
+                .GetProperty("choices")[0]
+                .GetProperty("message")
+                .GetProperty("content").GetString();
+            using var inner = JsonDocument.Parse(content);
+            var result = new Dictionary<string, string>(System.StringComparer.Ordinal);
+            foreach (var t in inner.RootElement.GetProperty("translations").EnumerateArray()) {
+                var msgid = t.GetProperty("msgid").GetString();
+                var msgstr = t.GetProperty("msgstr").GetString();
+                result[msgid] = msgstr;
+            }
+            return result;
+        }
+    }
+}

--- a/Editor/I18n/TranslationClient.cs
+++ b/Editor/I18n/TranslationClient.cs
@@ -21,7 +21,7 @@ namespace PromptUGUI.Editor.I18n {
             _http = http ?? new HttpClient();
         }
 
-        public async Task<Dictionary<string, string>> TranslateBatch(
+        public async Task<Dictionary<(string, string), string>> TranslateBatch(
             IList<TranslationItem> items,
             string targetLocale,
             string endpoint, string model, string apiKey, string systemPrompt,
@@ -88,11 +88,15 @@ namespace PromptUGUI.Editor.I18n {
                 .GetProperty("message")
                 .GetProperty("content").GetString();
             using var inner = JsonDocument.Parse(content);
-            var result = new Dictionary<string, string>(System.StringComparer.Ordinal);
+            var result = new Dictionary<(string, string), string>();
             foreach (var t in inner.RootElement.GetProperty("translations").EnumerateArray()) {
                 var msgid = t.GetProperty("msgid").GetString();
+                var msgctxt = t.TryGetProperty("msgctxt", out var ctxProp)
+                              && ctxProp.ValueKind != System.Text.Json.JsonValueKind.Null
+                    ? ctxProp.GetString()
+                    : null;
                 var msgstr = t.GetProperty("msgstr").GetString();
-                result[msgid] = msgstr;
+                result[(msgid, msgctxt)] = msgstr;
             }
             return result;
         }

--- a/Editor/I18n/TranslationClient.cs.meta
+++ b/Editor/I18n/TranslationClient.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 05f8215f5da7741428cadd7df09ea83c

--- a/Editor/I18n/TranslationMenu.cs
+++ b/Editor/I18n/TranslationMenu.cs
@@ -1,0 +1,159 @@
+// Editor/I18n/TranslationMenu.cs
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using PromptUGUI.Application;
+using PromptUGUI.I18n;
+using UnityEditor;
+using UnityEngine;
+
+namespace PromptUGUI.Editor.I18n {
+    internal static class TranslationMenu {
+        const string I18nRoot = "Assets/Resources/PromptUGUI/i18n";
+        const int BatchSize = 50;
+
+        [MenuItem("Tools/PromptUGUI/Translate Locale...")]
+        public static void OpenDialog() {
+            var settings = PromptUGUISettings.Instance;
+            if (settings == null || settings.locales.Count == 0) {
+                EditorUtility.DisplayDialog(
+                    "PromptUGUI",
+                    "No PromptUGUISettings or no locales configured.",
+                    "OK");
+                return;
+            }
+            TranslateLocaleWindow.Show(
+                settings.locales.Select(l => l.locale).Where(s => !string.IsNullOrEmpty(s)).ToArray(),
+                RunFor);
+        }
+
+        sealed class TranslateLocaleWindow : EditorWindow {
+            string[] _locales;
+            int _selected;
+            System.Action<string> _onConfirm;
+
+            public static void Show(string[] locales, System.Action<string> onConfirm) {
+                var w = CreateInstance<TranslateLocaleWindow>();
+                w.titleContent = new GUIContent("Translate Locale");
+                w._locales = locales;
+                w._onConfirm = onConfirm;
+                w.minSize = new Vector2(320, 100);
+                w.ShowUtility();
+            }
+
+            void OnGUI() {
+                EditorGUILayout.LabelField("Target locale:");
+                _selected = EditorGUILayout.Popup(_selected, _locales);
+                EditorGUILayout.Space();
+                using (new EditorGUILayout.HorizontalScope()) {
+                    if (GUILayout.Button("Cancel")) Close();
+                    if (GUILayout.Button("Translate")) {
+                        var picked = _locales[_selected];
+                        Close();
+                        _onConfirm(picked);
+                    }
+                }
+            }
+        }
+
+        static void RunFor(string locale) {
+            var auth = TranslationProviderSettingsProvider.GetOrCreateAuth();
+            var provider = TranslationProviderSettingsProvider.GetOrCreateProvider();
+            if (string.IsNullOrEmpty(auth.apiKey)) {
+                EditorUtility.DisplayDialog("PromptUGUI",
+                    "No API key set. Edit at Project Settings → PromptUGUI → Translation.",
+                    "OK");
+                return;
+            }
+
+            var localeDir = Path.Combine(I18nRoot, locale);
+            if (!Directory.Exists(localeDir)) {
+                EditorUtility.DisplayDialog("PromptUGUI",
+                    $"No .po files for locale '{locale}'. Run Extract Strings first.",
+                    "OK");
+                return;
+            }
+
+            // Collect empty-msgstr entries.
+            var queue = new List<(string poPath, PoEntry entry)>();
+            foreach (var po in Directory.GetFiles(localeDir, "*.po", SearchOption.AllDirectories)) {
+                var text = File.ReadAllText(po);
+                foreach (var e in PoParser.Parse(text)) {
+                    if (string.IsNullOrEmpty(e.Msgstr)) queue.Add((po, e));
+                }
+            }
+            if (queue.Count == 0) {
+                EditorUtility.DisplayDialog("PromptUGUI",
+                    "No empty msgstr entries to translate.", "OK");
+                return;
+            }
+            if (!EditorUtility.DisplayDialog(
+                "PromptUGUI",
+                $"Translate {queue.Count} empty entries for locale '{locale}'?",
+                "Translate", "Cancel")) return;
+
+            var client = new TranslationClient();
+            int done = 0;
+            using var cts = new CancellationTokenSource();
+            try {
+                for (int i = 0; i < queue.Count; i += BatchSize) {
+                    var slice = queue.Skip(i).Take(BatchSize).ToList();
+                    if (EditorUtility.DisplayCancelableProgressBar(
+                        "PromptUGUI Translate",
+                        $"Batch {i / BatchSize + 1} / {(queue.Count + BatchSize - 1) / BatchSize}",
+                        (float)i / queue.Count)) {
+                        cts.Cancel();
+                        break;
+                    }
+                    var items = slice.Select(p => new TranslationItem {
+                        Msgid = p.entry.Msgid,
+                        Msgctxt = p.entry.Msgctxt,
+                        Comments = p.entry.TranslatorComments,
+                    }).ToList();
+
+                    Dictionary<string, string> map = null;
+                    int retry = 0;
+                    Exception lastEx = null;
+                    while (retry < 3) {
+                        try {
+                            map = client.TranslateBatch(
+                                items, locale,
+                                provider.endpoint, provider.model, auth.apiKey,
+                                provider.systemPrompt,
+                                cts.Token).GetAwaiter().GetResult();
+                            break;
+                        } catch (Exception e) {
+                            lastEx = e;
+                            retry++;
+                            System.Threading.Thread.Sleep(300 * retry);
+                        }
+                    }
+                    if (map == null) {
+                        Debug.LogWarning($"[PromptUGUI] batch failed after retries: {lastEx?.Message}");
+                        continue;
+                    }
+                    // Write back.
+                    foreach (var (poPath, entry) in slice) {
+                        if (!map.TryGetValue(entry.Msgid, out var translated)) continue;
+                        WriteMsgstr(poPath, entry, translated);
+                        done++;
+                    }
+                }
+            } finally {
+                EditorUtility.ClearProgressBar();
+                AssetDatabase.Refresh();
+            }
+            Debug.Log($"[PromptUGUI] Translate Locale '{locale}': filled {done} / {queue.Count} entries.");
+        }
+
+        static void WriteMsgstr(string poPath, PoEntry target, string newMsgstr) {
+            var entries = PoParser.Parse(File.ReadAllText(poPath)).ToList();
+            var idx = entries.FindIndex(e => e.Msgctxt == target.Msgctxt && e.Msgid == target.Msgid);
+            if (idx < 0) return;
+            entries[idx].Msgstr = newMsgstr;
+            File.WriteAllText(poPath, PoParser.Serialize(entries));
+        }
+    }
+}

--- a/Editor/I18n/TranslationMenu.cs
+++ b/Editor/I18n/TranslationMenu.cs
@@ -113,7 +113,7 @@ namespace PromptUGUI.Editor.I18n {
                         Comments = p.entry.TranslatorComments,
                     }).ToList();
 
-                    Dictionary<string, string> map = null;
+                    Dictionary<(string, string), string> map = null;
                     int retry = 0;
                     Exception lastEx = null;
                     while (retry < 3) {
@@ -136,7 +136,7 @@ namespace PromptUGUI.Editor.I18n {
                     }
                     // Write back.
                     foreach (var (poPath, entry) in slice) {
-                        if (!map.TryGetValue(entry.Msgid, out var translated)) continue;
+                        if (!map.TryGetValue((entry.Msgid, entry.Msgctxt), out var translated)) continue;
                         WriteMsgstr(poPath, entry, translated);
                         done++;
                     }

--- a/Editor/I18n/TranslationMenu.cs.meta
+++ b/Editor/I18n/TranslationMenu.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c09ad9b46e9348f48b2350292310a66e

--- a/Editor/I18n/TranslationProvider.cs
+++ b/Editor/I18n/TranslationProvider.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+namespace PromptUGUI.Editor.I18n {
+    /// <summary>
+    /// Project-level translation provider config. Lives at
+    /// `ProjectSettings/PromptUGUI.asset` (in repo, team-shared).
+    /// </summary>
+    internal sealed class TranslationProvider : ScriptableObject {
+        public string endpoint = "https://api.openai.com/v1/chat/completions";
+        public string model = "gpt-4o-mini";
+        [TextArea(6, 20)] public string systemPrompt =
+@"你正在为一款像素风游戏翻译 UI 字符串到 {{targetLocale}}。
+
+规则：
+1. 保留所有 {{x}} 模板占位符与 {0} {1:C} 等 C# 格式占位符不变
+2. 保留 TMP 富文本标签（<sprite>、<color>、<b>、<size>、<link> 等）的字面形式与属性值不变（特别是 name=""..."", color=""..."" 等属性内的值是资源 ID，不是文本）；位置可调以符合目标语言语序
+3. 参考 sibling strings 推断风格一致性
+4. 源文本可能混合多种语言；按目标 locale 翻译整体含义
+5. 简短直接；UI 空间有限";
+    }
+}

--- a/Editor/I18n/TranslationProvider.cs.meta
+++ b/Editor/I18n/TranslationProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7a3fb2018c361a448a156727725f1235

--- a/Editor/I18n/TranslationProviderSettingsProvider.cs
+++ b/Editor/I18n/TranslationProviderSettingsProvider.cs
@@ -1,0 +1,55 @@
+using System.IO;
+using UnityEditor;
+using UnityEditorInternal;
+using UnityEngine;
+
+namespace PromptUGUI.Editor.I18n {
+    internal static class TranslationProviderSettingsProvider {
+        const string ProviderPath = "ProjectSettings/PromptUGUI.asset";
+        const string AuthPath = "UserSettings/PromptUGUI/Auth.asset";
+
+        internal static TranslationProvider GetOrCreateProvider() {
+            var loaded = InternalEditorUtility.LoadSerializedFileAndForget(ProviderPath);
+            if (loaded != null && loaded.Length > 0 && loaded[0] is TranslationProvider tp) return tp;
+            var fresh = ScriptableObject.CreateInstance<TranslationProvider>();
+            Save(fresh, ProviderPath);
+            return fresh;
+        }
+
+        internal static TranslationAuth GetOrCreateAuth() {
+            var loaded = InternalEditorUtility.LoadSerializedFileAndForget(AuthPath);
+            if (loaded != null && loaded.Length > 0 && loaded[0] is TranslationAuth a) return a;
+            var fresh = ScriptableObject.CreateInstance<TranslationAuth>();
+            Save(fresh, AuthPath);
+            return fresh;
+        }
+
+        internal static void Save(Object obj, string path) {
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            InternalEditorUtility.SaveToSerializedFileAndForget(new[] { obj }, path, allowTextSerialization: true);
+        }
+
+        [SettingsProvider]
+        public static SettingsProvider Create() => new("Project/PromptUGUI/Translation", SettingsScope.Project) {
+            label = "Translation",
+            guiHandler = _ => {
+                var tp = GetOrCreateProvider();
+                var auth = GetOrCreateAuth();
+                EditorGUI.BeginChangeCheck();
+                tp.endpoint = EditorGUILayout.TextField("Endpoint", tp.endpoint);
+                tp.model = EditorGUILayout.TextField("Model", tp.model);
+                EditorGUILayout.LabelField("System Prompt");
+                tp.systemPrompt = EditorGUILayout.TextArea(tp.systemPrompt, GUILayout.Height(140));
+                EditorGUILayout.Space();
+                auth.apiKey = EditorGUILayout.PasswordField("API Key (UserSettings)", auth.apiKey);
+                if (EditorGUI.EndChangeCheck()) {
+                    Save(tp, ProviderPath);
+                    Save(auth, AuthPath);
+                }
+            },
+            keywords = new System.Collections.Generic.HashSet<string> {
+                "PromptUGUI", "Translation", "OpenAI", "i18n",
+            },
+        };
+    }
+}

--- a/Editor/I18n/TranslationProviderSettingsProvider.cs.meta
+++ b/Editor/I18n/TranslationProviderSettingsProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 16c7ef0617f34ef40b40543806f398b5

--- a/Editor/I18n/XmlStringScanner.cs
+++ b/Editor/I18n/XmlStringScanner.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using System.Linq;
+using PromptUGUI.IR;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Editor.I18n {
+    /// <summary>
+    /// Walks a parsed UIDocument and yields one ExtractedString per translatable string found
+    /// in Text/Btn element content or "text" attributes.
+    /// </summary>
+    internal static class XmlStringScanner {
+        // Tags whose textContent and "text" attr are translatable.
+        static readonly HashSet<string> TextHostingTags = new() { "Text", "Btn" };
+
+        public static IEnumerable<ExtractedString> Scan(string xmlSource, string localePartition) {
+            UIDocument doc;
+            try { doc = UIDocumentParser.Parse(xmlSource); }
+            catch (ParseException) { yield break; }   // unparseable file → skip
+
+            foreach (var screen in doc.Screens) {
+                foreach (var es in WalkNode(screen.Root, screen.Name, parentSiblings: null, localePartition))
+                    yield return es;
+            }
+            foreach (var t in doc.Templates.Values) {
+                foreach (var es in WalkNode(t.Body, $"Template:{t.Name}", parentSiblings: null, localePartition))
+                    yield return es;
+            }
+        }
+
+        static IEnumerable<ExtractedString> WalkNode(
+            ElementNode node, string screenOrTemplateName,
+            List<string> parentSiblings, string localePartition) {
+
+            // Pre-compute siblings text list for ambient context of THIS node's children.
+            // We build it from the children of the current node whose text will be harvested,
+            // so when we recurse into each child we can pass the sibling list.
+            var childSiblings = new List<string>();
+            foreach (var c in node.Children) {
+                if (!TextHostingTags.Contains(c.Tag) || IsTrFalse(c)) continue;
+                var raw = GetRawText(c);
+                if (!string.IsNullOrEmpty(raw) && !IsPureBraces(raw))
+                    childSiblings.Add(raw.Trim());
+            }
+
+            // Harvest this node if it hosts translatable text.
+            if (TextHostingTags.Contains(node.Tag) && !IsTrFalse(node)) {
+                node.Attributes.TryGetValue("ctx", out var ctx);
+
+                // textContent (prefer raw over post-substitution)
+                var rawText = GetRawText(node);
+                if (!string.IsNullOrEmpty(rawText) && !IsPureBraces(rawText)) {
+                    yield return Build(rawText, ctx, screenOrTemplateName, node, parentSiblings, "text", localePartition);
+                }
+
+                // "text" attribute
+                string textAttrRaw = null;
+                if (node.AttributesRaw.TryGetValue("text", out var ra))
+                    textAttrRaw = ra;
+                else if (node.Attributes.TryGetValue("text", out var v))
+                    textAttrRaw = v;
+                if (!string.IsNullOrEmpty(textAttrRaw) && !IsPureBraces(textAttrRaw)) {
+                    yield return Build(textAttrRaw, ctx, screenOrTemplateName, node, parentSiblings, "text-attr", localePartition);
+                }
+            }
+
+            // Recurse into children, passing childSiblings as the sibling context.
+            foreach (var child in node.Children) {
+                foreach (var es in WalkNode(child, screenOrTemplateName, childSiblings, localePartition))
+                    yield return es;
+            }
+        }
+
+        static string GetRawText(ElementNode node) =>
+            string.IsNullOrEmpty(node.TextContentRaw) ? node.TextContent : node.TextContentRaw;
+
+        static bool IsTrFalse(ElementNode node) =>
+            node.Attributes.TryGetValue("tr", out var v) && v == "false";
+
+        static bool IsPureBraces(string s) {
+            var t = s.Trim();
+            // Exactly one {{...}} placeholder and nothing else.
+            return t.StartsWith("{{") && t.EndsWith("}}") &&
+                   t.Count(c => c == '{') == 2 && t.Count(c => c == '}') == 2;
+        }
+
+        static ExtractedString Build(
+            string msgid, string ctx, string screenOrTemplateName,
+            ElementNode node, List<string> parentSiblings, string attrSlot,
+            string localePartition) {
+
+            var es = new ExtractedString {
+                Msgid = msgid,
+                Msgctxt = ctx,
+                LocalePartition = localePartition,
+            };
+
+            var who = string.IsNullOrEmpty(node.Id) ? node.Tag : $"{node.Tag}#{node.Id}";
+            es.ExtractedComments.Add($"{screenOrTemplateName} screen, {who} {attrSlot}");
+
+            // Ambient sibling context: list nearby sibling strings so translators know which
+            // button/label is which when strings are short or duplicated.
+            if (parentSiblings != null && parentSiblings.Count > 0) {
+                var sibs = string.Join(", ", parentSiblings.Where(s => s != msgid).Take(3));
+                if (!string.IsNullOrEmpty(sibs))
+                    es.ExtractedComments.Add($"sibling: {sibs}");
+            }
+
+            if (TmpRichTextDetector.HasTmpTags(msgid)) {
+                es.ExtractedComments.Add(
+                    "Contains TMP rich text tags. Preserve tags and attribute values verbatim.");
+            }
+
+            return es;
+        }
+    }
+}

--- a/Editor/I18n/XmlStringScanner.cs.meta
+++ b/Editor/I18n/XmlStringScanner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 392db584e14c2354fa6b19223ee1d825

--- a/Editor/PoFileImporter.cs
+++ b/Editor/PoFileImporter.cs
@@ -16,4 +16,17 @@ namespace PromptUGUI.Editor {
             ctx.SetMainObject(asset);
         }
     }
+
+    internal sealed class PoFilePostprocessor : UnityEditor.AssetPostprocessor {
+        static void OnPostprocessAllAssets(
+            string[] importedAssets, string[] deletedAssets,
+            string[] movedAssets, string[] movedFromAssetPaths) {
+            foreach (var path in importedAssets) {
+                if (!path.EndsWith(".po", System.StringComparison.OrdinalIgnoreCase)) continue;
+                var current = UnityEditor.AssetDatabase.GetImporterOverride(path);
+                if (current == typeof(PoFileImporter)) continue;
+                UnityEditor.AssetDatabase.SetImporterOverride<PoFileImporter>(path);
+            }
+        }
+    }
 }

--- a/Editor/PoFileImporter.cs
+++ b/Editor/PoFileImporter.cs
@@ -1,0 +1,19 @@
+using System.IO;
+using UnityEditor.AssetImporters;
+using UnityEngine;
+
+namespace PromptUGUI.Editor {
+    // Unity 6 + com.unity.localization registers .po as a native/high-priority importer.
+    // The overrideFileExtensions attribute makes PoFileImporter available as an override
+    // for per-path assignment via AssetDatabase.SetImporterOverride<PoFileImporter>(path).
+    // PoFilePostprocessor below auto-applies this override to every .po asset.
+    [ScriptedImporter(1, (string[])null, new[] { "po" })]
+    internal sealed class PoFileImporter : ScriptedImporter {
+        public override void OnImportAsset(AssetImportContext ctx) {
+            var text = File.ReadAllText(ctx.assetPath);
+            var asset = new TextAsset(text);
+            ctx.AddObjectToAsset("text", asset);
+            ctx.SetMainObject(asset);
+        }
+    }
+}

--- a/Editor/PoFileImporter.cs.meta
+++ b/Editor/PoFileImporter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 47aefb1117edb894fa7ba53beccf3609

--- a/Editor/PromptUGUISettingsAutoMaintainer.cs
+++ b/Editor/PromptUGUISettingsAutoMaintainer.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Linq;
+using PromptUGUI.Application;
+using UnityEditor;
+using UnityEngine;
+
+namespace PromptUGUI.Editor {
+    [InitializeOnLoad]
+    internal static class PromptUGUISettingsAutoMaintainer {
+        static PromptUGUISettingsAutoMaintainer() {
+            EditorApplication.delayCall += Sync;
+        }
+
+        internal static void Sync() {
+            var guids = AssetDatabase.FindAssets("t:PromptUGUISettings");
+            if (guids.Length == 0) return;
+            if (guids.Length > 1) {
+                Debug.LogError(
+                    "[PromptUGUI] Multiple PromptUGUISettings assets found; " +
+                    "keep exactly one. preloadedAssets not updated.");
+                return;
+            }
+            var path = AssetDatabase.GUIDToAssetPath(guids[0]);
+            var settings = AssetDatabase.LoadAssetAtPath<PromptUGUISettings>(path);
+            if (settings == null) return;
+
+            var preloaded = PlayerSettings.GetPreloadedAssets()?.ToList() ?? new List<Object>();
+            // Drop dead refs + duplicates of our type, then add the canonical one.
+            preloaded.RemoveAll(a => a == null || a is PromptUGUISettings);
+            preloaded.Add(settings);
+            PlayerSettings.SetPreloadedAssets(preloaded.ToArray());
+        }
+
+        sealed class Postprocessor : AssetPostprocessor {
+            static void OnPostprocessAllAssets(
+                string[] importedAssets, string[] deletedAssets,
+                string[] movedAssets, string[] movedFromAssetPaths) {
+                bool touched =
+                    importedAssets.Any(IsSettings)
+                    || deletedAssets.Any(IsSettings)
+                    || movedAssets.Any(IsSettings)
+                    || movedFromAssetPaths.Any(IsSettings);
+                if (touched) Sync();
+            }
+            static bool IsSettings(string p) =>
+                p.EndsWith(".asset") &&
+                AssetDatabase.GetMainAssetTypeAtPath(p) == typeof(PromptUGUISettings);
+        }
+    }
+}

--- a/Editor/PromptUGUISettingsAutoMaintainer.cs.meta
+++ b/Editor/PromptUGUISettingsAutoMaintainer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bfa41063818a42e419d0d61505045f7d

--- a/Editor/UIAssetPostprocessor.cs
+++ b/Editor/UIAssetPostprocessor.cs
@@ -10,16 +10,46 @@ namespace PromptUGUI.Editor {
             string[] movedAssets,
             string[] movedFromAssetPaths) {
 
-            if (!UI.HotReload.Enabled || UI.HotReload.AssetPathToSrc == null) return;
+            if (!UI.HotReload.Enabled) return;
 
-            foreach (var p in importedAssets.Concat(movedAssets)) {
-                if (!p.EndsWith(".ui.xml")) continue;
-                try { UI.HotReload.NotifyAssetChanged(p); }
-                catch (System.Exception e) {
-                    UnityEngine.Debug.LogError(
-                        $"[PromptUGUI] hot reload failed for {p}: {e.Message}");
+            // .ui.xml branch (existing)
+            if (UI.HotReload.AssetPathToSrc != null) {
+                foreach (var p in importedAssets.Concat(movedAssets)) {
+                    if (!p.EndsWith(".ui.xml")) continue;
+                    try { UI.HotReload.NotifyAssetChanged(p); }
+                    catch (System.Exception e) {
+                        UnityEngine.Debug.LogError(
+                            $"[PromptUGUI] hot reload failed for {p}: {e.Message}");
+                    }
                 }
             }
+
+            // .po branch — reload current locale if any .po under PromptUGUI/i18n[-custom]/<current>/ changed
+            var current = UI.Locale.Current;
+            if (current != null) {
+                bool poChanged = importedAssets.Concat(movedAssets).Concat(deletedAssets)
+                    .Any(p => p.EndsWith(".po") && IsForLocale(p, current));
+                if (poChanged) {
+                    try { UI.Locale.ReloadCurrent(); }
+                    catch (System.Exception e) {
+                        UnityEngine.Debug.LogError(
+                            $"[PromptUGUI] .po hot reload failed: {e.Message}");
+                    }
+                }
+            }
+
+            // Settings.asset branch — if PromptUGUISettings changed and a current locale exists, ReSolve.
+            bool settingsChanged = importedAssets
+                .Any(p => AssetDatabase.GetMainAssetTypeAtPath(p) == typeof(PromptUGUISettings));
+            if (settingsChanged && UI.Locale.Current != null) {
+                UI.NotifyVariantChangedForReSolve();
+            }
+        }
+
+        static bool IsForLocale(string assetPath, string locale) {
+            // path shape: Assets/Resources/PromptUGUI/i18n/<locale>/... or i18n-custom/<locale>/...
+            return assetPath.Contains($"/PromptUGUI/i18n/{locale}/")
+                || assetPath.Contains($"/PromptUGUI/i18n-custom/{locale}/");
         }
     }
 }

--- a/Runtime/Application/BuiltinPrimitives.cs
+++ b/Runtime/Application/BuiltinPrimitives.cs
@@ -11,7 +11,7 @@ namespace PromptUGUI.Application {
             reg.Register<VStack>("VStack", null);
             reg.Register<HStack>("HStack", null);
             reg.Register<Grid>("Grid", null);
-            reg.Register<Btn>("Btn", null);
+            reg.Register<Btn>("Btn", null, defaultTextAttr: "text");
         }
     }
 }

--- a/Runtime/Application/ControlAttributeApplier.cs
+++ b/Runtime/Application/ControlAttributeApplier.cs
@@ -14,21 +14,40 @@ namespace PromptUGUI.Application {
         public static void Apply(ElementNode node, Control control,
                                  ControlRegistry.Entry entry, VariantStore variants) {
 
-            // 控件特定属性：基础 + 变体 keys 求并集
+            // Determine tr opt-out and ctx (common attrs not registered on Meta)
+            bool tr = !(node.Attributes.TryGetValue("tr", out var trVal) && trVal == "false");
+            node.Attributes.TryGetValue("ctx", out var ctx);
+
+            // Control-specific attributes: union of base + variant keys.
             var allKeys = new HashSet<string>(node.Attributes.Keys);
             foreach (var k in node.VariantOverrides.Keys) allKeys.Add(k);
             foreach (var attrName in allKeys) {
                 if (IsCommonAttribute(attrName)) continue;
+                if (attrName == "tr" || attrName == "ctx") continue;
                 if (!entry.Meta.HasAttribute(attrName)) continue;
                 var v = VariantResolver.ResolveAttribute(node, attrName, variants);
-                if (v != null) entry.Meta.Apply(control, attrName, v);
+                if (v == null) continue;
+                // Translate string-valued attrs that are commonly text-bearing.
+                // Default: only "text" attr goes through Tr (others like "color", "sprite" don't translate).
+                if (tr && attrName == "text") {
+                    // Use raw value if available so we Tr the un-substituted template.
+                    string raw = (node.AttributesRaw != null &&
+                                  node.AttributesRaw.TryGetValue("text", out var r)) ? r : v;
+                    v = TrResolver.Resolve(raw, node.TextArgs, ctx);
+                }
+                entry.Meta.Apply(control, attrName, v);
             }
 
-            // 文本简写
-            if (!string.IsNullOrEmpty(node.TextContent) && entry.DefaultTextAttr != null)
-                entry.Meta.Apply(control, entry.DefaultTextAttr, node.TextContent);
+            // Text shorthand
+            if (!string.IsNullOrEmpty(node.TextContent) && entry.DefaultTextAttr != null) {
+                string raw = node.TextContentRaw ?? node.TextContent;
+                string final = tr
+                    ? TrResolver.Resolve(raw, node.TextArgs, ctx)
+                    : node.TextContent;
+                entry.Meta.Apply(control, entry.DefaultTextAttr, final ?? "");
+            }
 
-            // 通用属性
+            // Common attributes
             var anchor = VariantResolver.ResolveAttribute(node, "anchor", variants);
             var size   = VariantResolver.ResolveAttribute(node, "size",   variants);
             var width  = VariantResolver.ResolveAttribute(node, "width",  variants);

--- a/Runtime/Application/LocaleHelpers.cs
+++ b/Runtime/Application/LocaleHelpers.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+namespace PromptUGUI.Application {
+    public static class LocaleHelpers {
+        public static string MapSystemLanguage(SystemLanguage lang) =>
+            lang switch {
+                SystemLanguage.ChineseSimplified  => "zh-Hans",
+                SystemLanguage.ChineseTraditional => "zh-Hant",
+                SystemLanguage.Chinese            => "zh-Hans",
+                SystemLanguage.English            => "en",
+                SystemLanguage.Japanese           => "ja",
+                SystemLanguage.Korean             => "ko",
+                SystemLanguage.French             => "fr",
+                SystemLanguage.German             => "de",
+                SystemLanguage.Spanish            => "es",
+                SystemLanguage.Russian            => "ru",
+                SystemLanguage.Portuguese         => "pt",
+                SystemLanguage.Italian            => "it",
+                _                                 => null,
+            };
+    }
+}

--- a/Runtime/Application/LocaleHelpers.cs.meta
+++ b/Runtime/Application/LocaleHelpers.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7b9f4b570d578e846961b86a20536264

--- a/Runtime/Application/PromptUGUISettings.cs
+++ b/Runtime/Application/PromptUGUISettings.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+namespace PromptUGUI.Application {
+    [CreateAssetMenu(menuName = "PromptUGUI/Settings", fileName = "Settings")]
+    public sealed class PromptUGUISettings : ScriptableObject {
+        [Serializable] public sealed class FontEntry {
+            public string type;          // "default" | "title" | "damage" | ...
+            public TMP_FontAsset font;
+        }
+        [Serializable] public sealed class LocaleConfig {
+            public string locale;        // BCP-47 e.g. "zh-Hans" / "en"
+            public List<FontEntry> fonts = new();
+        }
+        public List<LocaleConfig> locales = new();
+
+        public TMP_FontAsset ResolveFont(string locale, string type) {
+            if (string.IsNullOrEmpty(locale)) return null;
+            foreach (var lc in locales) {
+                if (lc.locale != locale) continue;
+                FontEntry fallback = null;
+                foreach (var fe in lc.fonts) {
+                    if (fe.type == type) return fe.font;
+                    if (fe.type == "default") fallback = fe;
+                }
+                return fallback?.font;
+            }
+            return null;
+        }
+
+        // Returns first loaded instance via preloadedAssets, null if none.
+        public static PromptUGUISettings Instance {
+            get {
+                var loaded = Resources.FindObjectsOfTypeAll<PromptUGUISettings>();
+                return loaded.Length > 0 ? loaded[0] : null;
+            }
+        }
+    }
+}

--- a/Runtime/Application/PromptUGUISettings.cs.meta
+++ b/Runtime/Application/PromptUGUISettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ef72af4be0229a24cb2ab979147bdc01

--- a/Runtime/Application/TrResolver.cs
+++ b/Runtime/Application/TrResolver.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using PromptUGUI.Template;
+
+namespace PromptUGUI.Application {
+    public static class TrResolver {
+        public static string Resolve(
+            string raw,
+            IReadOnlyDictionary<string, string> args,
+            string ctx) {
+            if (raw == null) return null;
+            // TEMP: reads UI.CurrentLocaleForResolver; replaced by UI.Locale.Current in Task 9
+            var locale = UI.CurrentLocaleForResolver;
+            string template = raw;
+            if (locale != null) {
+                var hit = TranslationStore.Instance.Lookup(locale, ctx, raw);
+                if (!string.IsNullOrEmpty(hit)) template = hit;
+            }
+            if (args == null || args.Count == 0) return template;
+            return Substitution.Apply(template, args);
+        }
+    }
+}

--- a/Runtime/Application/TrResolver.cs
+++ b/Runtime/Application/TrResolver.cs
@@ -8,8 +8,7 @@ namespace PromptUGUI.Application {
             IReadOnlyDictionary<string, string> args,
             string ctx) {
             if (raw == null) return null;
-            // TEMP: reads UI.CurrentLocaleForResolver; replaced by UI.Locale.Current in Task 9
-            var locale = UI.CurrentLocaleForResolver;
+            var locale = UI.Locale.Current;
             string template = raw;
             if (locale != null) {
                 var hit = TranslationStore.Instance.Lookup(locale, ctx, raw);

--- a/Runtime/Application/TrResolver.cs.meta
+++ b/Runtime/Application/TrResolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2fc514bbfff9c784fb3d4347b0a52395

--- a/Runtime/Application/TranslationStore.cs
+++ b/Runtime/Application/TranslationStore.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using PromptUGUI.I18n;
+
+namespace PromptUGUI.Application {
+    public sealed class TranslationStore {
+        readonly Dictionary<(string locale, string ctx, string msgid), string> _entries = new();
+
+        public static TranslationStore Instance { get; } = new();
+
+        public string Lookup(string locale, string ctx, string msgid) {
+            if (_entries.TryGetValue((locale, ctx, msgid), out var v)) return v;
+            return null;
+        }
+
+        public void Load(string locale, IEnumerable<PoEntry> entries) {
+            foreach (var e in entries) {
+                if (string.IsNullOrEmpty(e.Msgstr)) continue;     // miss == empty
+                _entries[(locale, e.Msgctxt, e.Msgid)] = e.Msgstr;
+            }
+        }
+
+        public void UnloadLocale(string locale) {
+            var toRemove = new List<(string, string, string)>();
+            foreach (var k in _entries.Keys) if (k.locale == locale) toRemove.Add(k);
+            foreach (var k in toRemove) _entries.Remove(k);
+        }
+
+        public void UnloadAll() => _entries.Clear();
+    }
+}

--- a/Runtime/Application/TranslationStore.cs.meta
+++ b/Runtime/Application/TranslationStore.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9e71edf4db5aa9a46a300e3c278faf57

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -24,14 +24,73 @@ namespace PromptUGUI.Application {
 
         internal static VariantStore VariantStore => _variantStore;
 
-        // TEMP for Task 7; replaced by UI.Locale.Current in Task 9
-        internal static string CurrentLocaleForResolver;
-
         public static class Variants {
             public static void Set(string name, bool active) =>
                 _variantStore.Set(name, active);
             public static bool IsActive(string name) =>
                 _variantStore.IsActive(name);
+        }
+
+        public static class Locale {
+            public static string Current { get; private set; }
+            public static event System.Action Changed;
+
+            public static void Set(string locale) {
+                if (Current == locale) return;
+                if (Current != null) {
+                    _variantStore.Set(Current, false);
+                    TranslationStore.Instance.UnloadLocale(Current);
+                }
+                Current = locale;
+                if (locale != null) {
+                    LoadPoFiles(locale);
+                    _variantStore.Set(locale, true);
+                } else {
+                    _variantStore.NotifyChangedInternal();
+                }
+                Changed?.Invoke();
+            }
+
+            public static void SetToSystemDefault() =>
+                Set(LocaleHelpers.MapSystemLanguage(UnityEngine.Application.systemLanguage));
+
+            public static System.Collections.Generic.IReadOnlyList<string> Configured {
+                get {
+                    var s = PromptUGUISettings.Instance;
+                    if (s == null) return System.Array.Empty<string>();
+                    var list = new System.Collections.Generic.List<string>();
+                    foreach (var lc in s.locales) if (!string.IsNullOrEmpty(lc.locale)) list.Add(lc.locale);
+                    return list;
+                }
+            }
+
+            internal static void ResetForTestsInternal() {
+                if (Current != null) _variantStore.Set(Current, false);
+                Current = null;
+                Changed = null;
+            }
+        }
+
+        public static string Tr(string msgid, string ctx = null) =>
+            TrResolver.Resolve(msgid, null, ctx);
+
+        static void LoadPoFiles(string locale) {
+            LoadPoFromPath($"PromptUGUI/i18n/{locale}", locale);
+            LoadPoFromPath($"PromptUGUI/i18n-custom/{locale}", locale);
+        }
+
+        static void LoadPoFromPath(string resourcesPath, string locale) {
+            var assets = UnityEngine.Resources.LoadAll<UnityEngine.TextAsset>(resourcesPath);
+            foreach (var asset in assets) {
+                try {
+                    var entries = new System.Collections.Generic.List<I18n.PoEntry>(
+                        I18n.PoParser.Parse(asset.text));
+                    TranslationStore.Instance.Load(locale, entries);
+                } catch (System.Exception e) {
+                    UnityEngine.Debug.LogError(
+                        $"[PromptUGUI] failed to parse .po asset '{asset.name}': {e.Message}");
+                }
+            }
         }
 
         public static void LoadDocument(string label, string xml) {
@@ -234,6 +293,8 @@ namespace PromptUGUI.Application {
 
         // 仅测试使用
         internal static void ResetForTests() {
+            Locale.ResetForTestsInternal();
+            TranslationStore.Instance.UnloadAll();
             foreach (var s in _open.Values) s.Close();
             _open.Clear();
             _docs.Clear();

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -24,6 +24,9 @@ namespace PromptUGUI.Application {
 
         internal static VariantStore VariantStore => _variantStore;
 
+        // TEMP for Task 7; replaced by UI.Locale.Current in Task 9
+        internal static string CurrentLocaleForResolver;
+
         public static class Variants {
             public static void Set(string name, bool active) =>
                 _variantStore.Set(name, active);

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -64,6 +64,13 @@ namespace PromptUGUI.Application {
                 }
             }
 
+            public static void ReloadCurrent() {
+                if (Current == null) return;
+                TranslationStore.Instance.UnloadLocale(Current);
+                LoadPoFiles(Current);
+                _variantStore.NotifyChangedInternal();
+            }
+
             internal static void ResetForTestsInternal() {
                 if (Current != null) _variantStore.Set(Current, false);
                 Current = null;
@@ -290,6 +297,9 @@ namespace PromptUGUI.Application {
             _commonsPool.Clear();
             _depGraph.Clear();
         }
+
+        internal static void NotifyVariantChangedForReSolve() =>
+            _variantStore.NotifyChangedInternal();
 
         // 仅测试使用
         internal static void ResetForTests() {

--- a/Runtime/Application/VariantStore.cs
+++ b/Runtime/Application/VariantStore.cs
@@ -23,5 +23,7 @@ namespace PromptUGUI.Application {
 
         /// <summary>测试用——清空所有激活变体，不发 Changed。</summary>
         internal void Reset() => _active.Clear();
+
+        internal void NotifyChangedInternal() => _changed.OnNext(Unit.Default);
     }
 }

--- a/Runtime/Controls/Btn.cs
+++ b/Runtime/Controls/Btn.cs
@@ -1,21 +1,15 @@
 using PromptUGUI.Registry;
 using R3;
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityImage = UnityEngine.UI.Image;
 
 namespace PromptUGUI.Controls {
-    /// <summary>
-    /// 通用按钮原语：自带 Image (背景 + Button 的 raycast target) + Button + OnClick (R3)。
-    /// 模板可以把它作为根（<Btn .../>）并在内部塞 Image/Text 等子节点组合出
-    /// PrimaryButton / IconButton / 进度条按钮 等变体，不需要新的 prefab 或 C# 类。
-    ///
-    /// 注意：Btn 的子 Graphic 默认会拦截点击事件。如果不想被拦截，把子 Image/Text 的
-    /// raycastTarget 设为 false（Text 通过 raycastTarget="false" 属性控制）。
-    /// </summary>
     public sealed class Btn : Control {
         UnityImage _bg;
         Button _btn;
+        TMP_Text _autoLabel;
         readonly Subject<Unit> _click = new();
 
         public override void OnAttached() {
@@ -23,6 +17,42 @@ namespace PromptUGUI.Controls {
             _btn = GameObject.GetComponent<Button>() ?? GameObject.AddComponent<Button>();
             _btn.targetGraphic = _bg;
             _btn.onClick.AddListener(() => _click.OnNext(Unit.Default));
+        }
+
+        TMP_Text EnsureLabel() {
+            if (_autoLabel != null) return _autoLabel;
+            var go = new GameObject("Label", typeof(RectTransform));
+            go.transform.SetParent(GameObject.transform, worldPositionStays: false);
+            var rt = (RectTransform)go.transform;
+            rt.anchorMin = Vector2.zero;
+            rt.anchorMax = Vector2.one;
+            rt.offsetMin = Vector2.zero;
+            rt.offsetMax = Vector2.zero;
+            _autoLabel = go.AddComponent<TextMeshProUGUI>();
+            _autoLabel.alignment = TextAlignmentOptions.Center;
+            _autoLabel.raycastTarget = false;
+            return _autoLabel;
+        }
+
+        [UIAttr]
+        public string Text {
+            set {
+                if (string.IsNullOrEmpty(value) && _autoLabel == null) return;
+                EnsureLabel().text = value ?? "";
+            }
+        }
+
+        [UIAttr]
+        public string Font {
+            set {
+                if (_autoLabel == null) return;  // no text → font irrelevant
+                var settings = PromptUGUI.Application.PromptUGUISettings.Instance;
+                var locale = PromptUGUI.Application.UI.Locale.Current;
+                var asset = settings != null
+                    ? settings.ResolveFont(locale, value ?? "default")
+                    : null;
+                if (asset != null) _autoLabel.font = asset;
+            }
         }
 
         [UIAttr]

--- a/Runtime/Controls/Btn.cs
+++ b/Runtime/Controls/Btn.cs
@@ -45,13 +45,12 @@ namespace PromptUGUI.Controls {
         [UIAttr]
         public string Font {
             set {
-                if (_autoLabel == null) return;  // no text → font irrelevant
                 var settings = PromptUGUI.Application.PromptUGUISettings.Instance;
                 var locale = PromptUGUI.Application.UI.Locale.Current;
                 var asset = settings != null
                     ? settings.ResolveFont(locale, value ?? "default")
                     : null;
-                if (asset != null) _autoLabel.font = asset;
+                if (asset != null) EnsureLabel().font = asset;
             }
         }
 

--- a/Runtime/Controls/Text.cs
+++ b/Runtime/Controls/Text.cs
@@ -49,5 +49,18 @@ namespace PromptUGUI.Controls {
         public bool RaycastTarget {
             set => _tmp.raycastTarget = value;
         }
+
+        [UIAttr]
+        public string Font {
+            set {
+                var settings = PromptUGUI.Application.PromptUGUISettings.Instance;
+                var locale = PromptUGUI.Application.UI.Locale.Current;
+                var asset = settings != null
+                    ? settings.ResolveFont(locale, value ?? "default")
+                    : null;
+                if (asset != null) _tmp.font = asset;
+                // miss → keep whatever TMP defaulted to; do not clobber.
+            }
+        }
     }
 }

--- a/Runtime/Core/I18n.meta
+++ b/Runtime/Core/I18n.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: db14095f4f5251e43b67aa50bac5eee4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Core/I18n/PoEntry.cs
+++ b/Runtime/Core/I18n/PoEntry.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace PromptUGUI.I18n {
+    public sealed class PoEntry {
+        public string Msgctxt;        // null = no ctx
+        public string Msgid;
+        public string Msgstr;         // "" = untranslated
+        public List<string> TranslatorComments = new();
+    }
+
+    public sealed class PoParseException : System.Exception {
+        public PoParseException(string msg) : base(msg) { }
+    }
+}

--- a/Runtime/Core/I18n/PoEntry.cs.meta
+++ b/Runtime/Core/I18n/PoEntry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5259266f1831d8946a38e03e3b6a8c32

--- a/Runtime/Core/I18n/PoParser.cs
+++ b/Runtime/Core/I18n/PoParser.cs
@@ -81,6 +81,38 @@ namespace PromptUGUI.I18n {
             return s.Substring(1, s.Length - 2);
         }
 
+        public static string Serialize(IEnumerable<PoEntry> entries) {
+            var sb = new StringBuilder();
+            foreach (var e in entries) {
+                if (e.TranslatorComments != null) {
+                    foreach (var line in e.TranslatorComments)
+                        sb.Append("# ").Append(line).Append('\n');
+                }
+                if (e.Msgctxt != null) {
+                    sb.Append("msgctxt \"").Append(Encode(e.Msgctxt)).Append("\"\n");
+                }
+                sb.Append("msgid \"").Append(Encode(e.Msgid ?? "")).Append("\"\n");
+                sb.Append("msgstr \"").Append(Encode(e.Msgstr ?? "")).Append("\"\n");
+                sb.Append('\n');
+            }
+            return sb.ToString();
+        }
+
+        static string Encode(string s) {
+            var sb = new StringBuilder(s.Length);
+            foreach (var c in s) {
+                switch (c) {
+                    case '\n': sb.Append("\\n"); break;
+                    case '\t': sb.Append("\\t"); break;
+                    case '\r': sb.Append("\\r"); break;
+                    case '"':  sb.Append("\\\""); break;
+                    case '\\': sb.Append("\\\\"); break;
+                    default:   sb.Append(c); break;
+                }
+            }
+            return sb.ToString();
+        }
+
         static string Decode(string raw) {
             var sb = new StringBuilder(raw.Length);
             for (int j = 0; j < raw.Length; j++) {

--- a/Runtime/Core/I18n/PoParser.cs
+++ b/Runtime/Core/I18n/PoParser.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace PromptUGUI.I18n {
+    public static partial class PoParser {
+        public static IEnumerable<PoEntry> Parse(string source) {
+            if (string.IsNullOrEmpty(source)) yield break;
+            var lines = source.Replace("\r\n", "\n").Split('\n');
+            int i = 0;
+            while (i < lines.Length) {
+                // Skip blank lines.
+                while (i < lines.Length && lines[i].Trim().Length == 0) i++;
+                if (i >= lines.Length) yield break;
+
+                // Collect leading comment lines; detect if this block is obsolete (#~).
+                // An obsolete block consists entirely of #~ lines — skip them wholesale
+                // without consuming any real msgid/msgstr that follow.
+                if (lines[i].StartsWith("#")) {
+                    // Peek ahead: is this an obsolete block?
+                    bool blockObsolete = lines[i].StartsWith("#~");
+                    if (blockObsolete) {
+                        // Skip all consecutive #~ lines.
+                        while (i < lines.Length && lines[i].StartsWith("#~")) i++;
+                        continue; // restart outer loop; next content may be a real entry
+                    }
+                    // Non-obsolete comment block: will be collected inside the entry below.
+                }
+
+                var entry = new PoEntry();
+                bool sawMsgid = false, sawMsgstr = false;
+
+                // Collect translator comments (non-obsolete # lines).
+                while (i < lines.Length && lines[i].StartsWith("#") && !lines[i].StartsWith("#~")) {
+                    var c = lines[i];
+                    var rest = c.Length > 1 ? c.Substring(1).TrimStart() : "";
+                    entry.TranslatorComments.Add(rest);
+                    i++;
+                }
+
+                // msgctxt (optional)
+                if (i < lines.Length && lines[i].StartsWith("msgctxt ")) {
+                    entry.Msgctxt = ReadStringValue(lines, ref i, "msgctxt ");
+                }
+
+                // msgid (required)
+                if (i < lines.Length && lines[i].StartsWith("msgid ")) {
+                    entry.Msgid = ReadStringValue(lines, ref i, "msgid ");
+                    sawMsgid = true;
+                }
+
+                // msgstr (required)
+                if (i < lines.Length && lines[i].StartsWith("msgstr ")) {
+                    entry.Msgstr = ReadStringValue(lines, ref i, "msgstr ");
+                    sawMsgstr = true;
+                }
+
+                if (!sawMsgid)
+                    throw new PoParseException($"line {i + 1}: expected msgid");
+                if (!sawMsgstr)
+                    throw new PoParseException($"line {i + 1}: expected msgstr after msgid \"{entry.Msgid}\"");
+
+                yield return entry;
+            }
+        }
+
+        static string ReadStringValue(string[] lines, ref int i, string keyword) {
+            var sb = new StringBuilder();
+            sb.Append(Decode(ExtractQuoted(lines[i].Substring(keyword.Length))));
+            i++;
+            while (i < lines.Length && lines[i].Length > 0 && lines[i][0] == '"') {
+                sb.Append(Decode(ExtractQuoted(lines[i])));
+                i++;
+            }
+            return sb.ToString();
+        }
+
+        static string ExtractQuoted(string s) {
+            s = s.Trim();
+            if (s.Length < 2 || s[0] != '"' || s[s.Length - 1] != '"')
+                throw new PoParseException($"malformed quoted string: {s}");
+            return s.Substring(1, s.Length - 2);
+        }
+
+        static string Decode(string raw) {
+            var sb = new StringBuilder(raw.Length);
+            for (int j = 0; j < raw.Length; j++) {
+                char c = raw[j];
+                if (c == '\\' && j + 1 < raw.Length) {
+                    char n = raw[++j];
+                    switch (n) {
+                        case 'n': sb.Append('\n'); break;
+                        case 't': sb.Append('\t'); break;
+                        case 'r': sb.Append('\r'); break;
+                        case '"': sb.Append('"'); break;
+                        case '\\': sb.Append('\\'); break;
+                        default: sb.Append(n); break;
+                    }
+                } else {
+                    sb.Append(c);
+                }
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/Runtime/Core/I18n/PoParser.cs.meta
+++ b/Runtime/Core/I18n/PoParser.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9efc24b8df1b98b4ca249c29cf41e697

--- a/Runtime/Core/IR/ElementNode.cs
+++ b/Runtime/Core/IR/ElementNode.cs
@@ -10,6 +10,27 @@ namespace PromptUGUI.IR {
         public List<ElementNode> Children { get; }
 
         /// <summary>
+        /// Pre-substitution textContent. Filled by parser AND TemplateExpander preserves it through
+        /// to expanded nodes (parser fills raw, expander leaves it alone but updates TextArgs).
+        /// Only Text/Btn-shaped controls consume this; other tags ignore.
+        /// </summary>
+        public string TextContentRaw { get; set; }
+
+        /// <summary>
+        /// Template instantiation arguments captured by TemplateExpander when the node was produced
+        /// from a Template expansion. Empty / null on parser-produced nodes.
+        /// Used at runtime so TrResolver can re-substitute on the translated msgstr.
+        /// </summary>
+        public Dictionary<string, string> TextArgs { get; set; }
+
+        /// <summary>
+        /// Pre-substitution attribute values, populated for attributes whose VALUE contained {{...}}
+        /// (e.g. <code>text="Gold: {{n}}"</code>). Other attributes can be retrieved from Attributes
+        /// directly. Used at runtime for the same reason as TextContentRaw.
+        /// </summary>
+        public Dictionary<string, string> AttributesRaw { get; set; }
+
+        /// <summary>
         /// True 表示此节点是某个模板调用展开后产生的"实例根"。
         /// 它内部声明的 id 形成一个独立作用域，由 Control.ScopedIds 持有。
         /// 仅由 TemplateExpander 设置；parser 始终为 false。
@@ -29,6 +50,7 @@ namespace PromptUGUI.IR {
             Tag = tag;
             Namespace = ns;
             Attributes = new Dictionary<string, string>();
+            AttributesRaw = new Dictionary<string, string>();
             Children = new List<ElementNode>();
             VariantOverrides = new Dictionary<string, List<(string Variant, string Value)>>();
         }

--- a/Runtime/Core/Parser/UIDocumentParser.cs
+++ b/Runtime/Core/Parser/UIDocumentParser.cs
@@ -258,17 +258,26 @@ namespace PromptUGUI.Parser {
                 list.Add((variant, attr.Value));
             }
 
+            // Capture raw attribute values for attrs containing {{...}} (for runtime re-substitution on translated msgstr).
+            foreach (var kv in node.Attributes) {
+                if (kv.Value != null && kv.Value.Contains("{{"))
+                    node.AttributesRaw[kv.Key] = kv.Value;
+            }
+
             // 文本简写
             bool hasElement = false, hasText = false;
             foreach (XmlNode c in el.ChildNodes) {
                 if (c is XmlElement) hasElement = true;
                 else if (c is XmlText txt && !string.IsNullOrWhiteSpace(txt.Value)) hasText = true;
+                else if (c is XmlCDataSection cdata && !string.IsNullOrWhiteSpace(cdata.Value)) hasText = true;
             }
             if (hasText && hasElement)
                 throw new ParseException(
                     $"<{el.Name}> mixes text and child elements; not allowed");
-            if (hasText && !hasElement)
+            if (hasText && !hasElement) {
                 node.TextContent = el.InnerText.Trim();
+                node.TextContentRaw = el.InnerText;     // un-trimmed raw — preserves intentional whitespace inside CDATA
+            }
 
             foreach (XmlNode c in el.ChildNodes)
                 if (c is XmlElement child_el)

--- a/Runtime/Core/Template/TemplateExpander.cs
+++ b/Runtime/Core/Template/TemplateExpander.cs
@@ -103,10 +103,13 @@ namespace PromptUGUI.Template {
             var dst = new ElementNode(src.Tag, src.Namespace) {
                 Id = src.Id,
                 TextContent = src.TextContent,
+                TextContentRaw = src.TextContentRaw ?? src.TextContent,
                 IsTemplateInstanceRoot = src.IsTemplateInstanceRoot,
             };
             foreach (var kv in src.Attributes)
                 dst.Attributes[kv.Key] = kv.Value;
+            foreach (var kv in src.AttributesRaw)
+                dst.AttributesRaw[kv.Key] = kv.Value;
             CopyVariantOverrides(src, dst);
             foreach (var c in src.Children) {
                 var ec = ExpandTree(c, templates, visiting);
@@ -211,11 +214,16 @@ namespace PromptUGUI.Template {
             var dst = new ElementNode(prepared.Tag, prepared.Namespace) {
                 Id = prepared.Id,
                 TextContent = Substitution.Apply(prepared.TextContent, args),
+                TextContentRaw = src.TextContentRaw ?? src.TextContent,
             };
             foreach (var kv in prepared.Attributes) {
                 if (kv.Key == "if") continue;
                 dst.Attributes[kv.Key] = kv.Value;
             }
+            foreach (var kv in src.AttributesRaw)
+                dst.AttributesRaw[kv.Key] = kv.Value;
+            if (args != null && args.Count > 0)
+                dst.TextArgs = new System.Collections.Generic.Dictionary<string, string>(args);
             CopyVariantOverrides(prepared, dst);
             foreach (var c in src.Children) {
                 if (c.Tag == "Slot") {
@@ -238,6 +246,9 @@ namespace PromptUGUI.Template {
             };
             foreach (var kv in src.Attributes)
                 dst.Attributes[kv.Key] = Substitution.Apply(kv.Value, args);
+            // Preserve raw attribute values — substitution does NOT clobber raw
+            foreach (var kv in src.AttributesRaw)
+                dst.AttributesRaw[kv.Key] = kv.Value;
             foreach (var kv in src.VariantOverrides) {
                 var newList = new List<(string Variant, string Value)>();
                 foreach (var (variant, value) in kv.Value)
@@ -259,9 +270,13 @@ namespace PromptUGUI.Template {
             var dst = new ElementNode(src.Tag, src.Namespace) {
                 Id = src.Id,
                 TextContent = src.TextContent,
+                TextContentRaw = src.TextContentRaw ?? src.TextContent,
                 IsTemplateInstanceRoot = src.IsTemplateInstanceRoot,
             };
             foreach (var kv in src.Attributes) dst.Attributes[kv.Key] = kv.Value;
+            foreach (var kv in src.AttributesRaw) dst.AttributesRaw[kv.Key] = kv.Value;
+            if (src.TextArgs != null)
+                dst.TextArgs = new System.Collections.Generic.Dictionary<string, string>(src.TextArgs);
             CopyVariantOverrides(src, dst);
             foreach (var c in src.Children) dst.Children.Add(DeepClone(c));
             return dst;

--- a/Tests/EditMode/Application/LocaleSetTests.cs
+++ b/Tests/EditMode/Application/LocaleSetTests.cs
@@ -5,14 +5,8 @@ using R3;
 
 namespace PromptUGUI.Tests.Application {
     public class LocaleSetTests {
-        [SetUp] public void Setup() {
-            UI.ResetForTests();
-            TranslationStore.Instance.UnloadAll();
-        }
-        [TearDown] public void Teardown() {
-            UI.ResetForTests();
-            TranslationStore.Instance.UnloadAll();
-        }
+        [SetUp] public void Setup() => UI.ResetForTests();
+        [TearDown] public void Teardown() => UI.ResetForTests();
 
         [Test] public void Initial_CurrentIsNull() {
             Assert.IsNull(UI.Locale.Current);

--- a/Tests/EditMode/Application/LocaleSetTests.cs
+++ b/Tests/EditMode/Application/LocaleSetTests.cs
@@ -1,0 +1,67 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.I18n;
+using R3;
+
+namespace PromptUGUI.Tests.Application {
+    public class LocaleSetTests {
+        [SetUp] public void Setup() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+        }
+        [TearDown] public void Teardown() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+        }
+
+        [Test] public void Initial_CurrentIsNull() {
+            Assert.IsNull(UI.Locale.Current);
+        }
+
+        [Test] public void Set_UpdatesCurrent_FiresChanged() {
+            int n = 0;
+            UI.Locale.Changed += () => n++;
+            UI.Locale.Set("en");
+            Assert.AreEqual("en", UI.Locale.Current);
+            Assert.AreEqual(1, n);
+        }
+
+        [Test] public void Set_SameValueTwice_DoesNotFire() {
+            int n = 0;
+            UI.Locale.Set("en");
+            UI.Locale.Changed += () => n++;
+            UI.Locale.Set("en");
+            Assert.AreEqual(0, n);
+        }
+
+        [Test] public void Set_TogglesVariantNamedAfterLocale() {
+            UI.Locale.Set("zh-Hans");
+            Assert.IsTrue(UI.Variants.IsActive("zh-Hans"));
+            UI.Locale.Set("en");
+            Assert.IsFalse(UI.Variants.IsActive("zh-Hans"));
+            Assert.IsTrue(UI.Variants.IsActive("en"));
+        }
+
+        [Test] public void Set_Null_ClearsVariantAndCurrent() {
+            UI.Locale.Set("en");
+            UI.Locale.Set(null);
+            Assert.IsNull(UI.Locale.Current);
+            Assert.IsFalse(UI.Variants.IsActive("en"));
+        }
+
+        [Test] public void Set_TriggersVariantChanged() {
+            int n = 0;
+            UI.VariantStore.Changed.Subscribe(_ => n++);
+            UI.Locale.Set("en");
+            Assert.GreaterOrEqual(n, 1);
+        }
+
+        [Test] public void Tr_StaticMethod_DelegatesToTrResolver() {
+            TranslationStore.Instance.Load("en", new[] {
+                new PoEntry { Msgid = "hi", Msgstr = "Hello" },
+            });
+            UI.Locale.Set("en");
+            Assert.AreEqual("Hello", UI.Tr("hi"));
+        }
+    }
+}

--- a/Tests/EditMode/Application/LocaleSetTests.cs.meta
+++ b/Tests/EditMode/Application/LocaleSetTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 24fc792bac23c1744b82bff0076e8af5

--- a/Tests/EditMode/Application/VariantStoreNotifyTests.cs
+++ b/Tests/EditMode/Application/VariantStoreNotifyTests.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using R3;
+
+namespace PromptUGUI.Tests.Application {
+    public class VariantStoreNotifyTests {
+        [Test] public void NotifyChangedInternal_FiresChangedWithoutMutatingActiveSet() {
+            var store = new VariantStore();
+            int count = 0;
+            store.Changed.Subscribe(_ => count++);
+            store.Set("a", true);                 // 1
+            // pre-condition: count==1
+            typeof(VariantStore)
+                .GetMethod("NotifyChangedInternal",
+                    System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Instance)
+                .Invoke(store, null);             // 2
+            Assert.AreEqual(2, count);
+            Assert.IsTrue(store.IsActive("a"));
+        }
+    }
+}

--- a/Tests/EditMode/Application/VariantStoreNotifyTests.cs.meta
+++ b/Tests/EditMode/Application/VariantStoreNotifyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7b189dfe45a0e6f4185d8146a09a17f3

--- a/Tests/EditMode/Editor/CSharpStringScannerTests.cs
+++ b/Tests/EditMode/Editor/CSharpStringScannerTests.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Editor.I18n;
+
+namespace PromptUGUI.Tests.Editor {
+    public class CSharpStringScannerTests {
+        [Test] public void Scan_PlainTrLiteral_Extracted() {
+            var src = @"
+                using PromptUGUI.Application;
+                class X {
+                    void Run() {
+                        var s = UI.Tr(""hello"");
+                    }
+                }";
+            var found = CSharpStringScanner.Scan(src, "X.cs").ToList();
+            Assert.AreEqual(1, found.Count);
+            Assert.AreEqual("hello", found[0].Msgid);
+            Assert.IsNull(found[0].Msgctxt);
+        }
+
+        [Test] public void Scan_TrWithCtx_PopulatesMsgctxt() {
+            var src = @"
+                class X { void Run() { var s = PromptUGUI.Application.UI.Tr(""Open"", ctx: ""door""); } }";
+            var found = CSharpStringScanner.Scan(src, "X.cs").Single();
+            Assert.AreEqual("Open", found.Msgid);
+            Assert.AreEqual("door", found.Msgctxt);
+        }
+
+        [Test] public void Scan_NonLiteralArgs_SkippedWithWarning() {
+            var src = @"
+                class X { void Run(string x) { var s = PromptUGUI.Application.UI.Tr(x); } }";
+            var found = CSharpStringScanner.Scan(src, "X.cs").ToList();
+            Assert.IsEmpty(found);
+        }
+
+        [Test] public void Scan_RefIncludesFileAndLine() {
+            var src = "class X { void R() { var s = PromptUGUI.Application.UI.Tr(\"x\"); } }";
+            var es = CSharpStringScanner.Scan(src, "Path/To/X.cs").Single();
+            Assert.IsTrue(es.References.Any(r => r.Contains("Path/To/X.cs")));
+        }
+
+        [Test] public void Scan_LeadingComment_AddedToExtractedComments() {
+            var src = @"
+                class X {
+                    void R() {
+                        // 提示玩家当前金币
+                        var s = PromptUGUI.Application.UI.Tr(""总价: {0:C}"");
+                    }
+                }";
+            var es = CSharpStringScanner.Scan(src, "X.cs").Single();
+            Assert.IsTrue(es.ExtractedComments.Any(c => c.Contains("提示玩家当前金币")));
+        }
+
+        [Test] public void Scan_MethodNameIncludedInExtractedComments() {
+            var src = "class X { void OnGoldChanged() { var s = PromptUGUI.Application.UI.Tr(\"x\"); } }";
+            var es = CSharpStringScanner.Scan(src, "X.cs").Single();
+            Assert.IsTrue(es.ExtractedComments.Any(c => c.Contains("OnGoldChanged")));
+        }
+    }
+}

--- a/Tests/EditMode/Editor/CSharpStringScannerTests.cs.meta
+++ b/Tests/EditMode/Editor/CSharpStringScannerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ca2704c2cf438ae4cb1cb40cc1c4818a

--- a/Tests/EditMode/Editor/PoFileImporterTests.cs
+++ b/Tests/EditMode/Editor/PoFileImporterTests.cs
@@ -1,0 +1,43 @@
+using System.IO;
+using NUnit.Framework;
+using PromptUGUI.Editor;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.Editor {
+    public class PoFileImporterTests {
+        const string TmpDir = "Assets/PromptUGUIPoTmp";
+        const string TmpPath = "Assets/PromptUGUIPoTmp/sample.po";
+
+        [SetUp] public void Setup() {
+            if (!AssetDatabase.IsValidFolder(TmpDir))
+                AssetDatabase.CreateFolder("Assets", "PromptUGUIPoTmp");
+        }
+        [TearDown] public void Teardown() {
+            AssetDatabase.DeleteAsset(TmpDir);
+        }
+
+        [Test] public void Import_PoFile_LoadsAsTextAsset() {
+            // Write via absolute path (File.WriteAllText uses CWD which may not be project root)
+            var absPath = Path.Combine(UnityEngine.Application.dataPath, "PromptUGUIPoTmp", "sample.po");
+            File.WriteAllText(absPath, "msgid \"x\"\nmsgstr \"y\"\n");
+
+            // Unity 6 + com.unity.localization claims .po as a native importer and
+            // may log "[Error] File couldn't be read" during the initial discover-import.
+            // Suppress unexpected error logs around the asset pipeline calls.
+            LogAssert.ignoreFailingMessages = true;
+            AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+
+            // Override to PoFileImporter for this specific path, then force a reimport.
+            AssetDatabase.SetImporterOverride<PoFileImporter>(TmpPath);
+            AssetDatabase.ImportAsset(TmpPath,
+                ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+            LogAssert.ignoreFailingMessages = false;
+
+            var asset = AssetDatabase.LoadAssetAtPath<TextAsset>(TmpPath);
+            Assert.IsNotNull(asset, "po file should be loadable as TextAsset after SetImporterOverride");
+            StringAssert.Contains("msgid", asset.text);
+        }
+    }
+}

--- a/Tests/EditMode/Editor/PoFileImporterTests.cs
+++ b/Tests/EditMode/Editor/PoFileImporterTests.cs
@@ -18,6 +18,21 @@ namespace PromptUGUI.Tests.Editor {
             AssetDatabase.DeleteAsset(TmpDir);
         }
 
+        [Test] public void Import_PoFile_AutoOverrideViaPostprocessor_LoadsAsTextAsset() {
+            var absPath = System.IO.Path.Combine(
+                UnityEngine.Application.dataPath, "PromptUGUIPoTmp", "auto.po");
+            System.IO.File.WriteAllText(absPath, "msgid \"a\"\nmsgstr \"b\"\n");
+
+            UnityEngine.TestTools.LogAssert.ignoreFailingMessages = true;
+            AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+            UnityEngine.TestTools.LogAssert.ignoreFailingMessages = false;
+
+            // Postprocessor should have set the override automatically — no manual SetImporterOverride here.
+            var asset = AssetDatabase.LoadAssetAtPath<TextAsset>("Assets/PromptUGUIPoTmp/auto.po");
+            Assert.IsNotNull(asset, "PoFilePostprocessor should auto-route .po to PoFileImporter");
+            StringAssert.Contains("msgid", asset.text);
+        }
+
         [Test] public void Import_PoFile_LoadsAsTextAsset() {
             // Write via absolute path (File.WriteAllText uses CWD which may not be project root)
             var absPath = Path.Combine(UnityEngine.Application.dataPath, "PromptUGUIPoTmp", "sample.po");

--- a/Tests/EditMode/Editor/PoFileImporterTests.cs.meta
+++ b/Tests/EditMode/Editor/PoFileImporterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 86ee9801c6193a1418fdcca949c01e93

--- a/Tests/EditMode/Editor/PoFileWriterTests.cs
+++ b/Tests/EditMode/Editor/PoFileWriterTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Editor.I18n;
+using PromptUGUI.I18n;
+
+namespace PromptUGUI.Tests.Editor {
+    public class PoFileWriterTests {
+        [Test] public void Merge_NewMsgid_AddedWithEmptyMsgstr() {
+            var existing = "";   // no prior file
+            var result = PoFileWriter.Merge(existing, new[] {
+                new ExtractedString { Msgid = "hello" },
+            });
+            var entries = PoParser.Parse(result).ToList();
+            Assert.AreEqual(1, entries.Count);
+            Assert.AreEqual("hello", entries[0].Msgid);
+            Assert.AreEqual("", entries[0].Msgstr);
+        }
+
+        [Test] public void Merge_ExistingNonEmptyMsgstr_PreservedAcrossExtract() {
+            var existing = PoParser.Serialize(new[] {
+                new PoEntry { Msgid = "hello", Msgstr = "你好" },
+            });
+            var result = PoFileWriter.Merge(existing, new[] {
+                new ExtractedString { Msgid = "hello" },
+            });
+            var entries = PoParser.Parse(result).ToList();
+            Assert.AreEqual("你好", entries[0].Msgstr);
+        }
+
+        [Test] public void Merge_ExtractedDoesNotIncludeOldMsgid_RemovesIt() {
+            var existing = PoParser.Serialize(new[] {
+                new PoEntry { Msgid = "old", Msgstr = "obsolete-tr" },
+                new PoEntry { Msgid = "kept", Msgstr = "tr" },
+            });
+            var result = PoFileWriter.Merge(existing, new[] {
+                new ExtractedString { Msgid = "kept" },
+            });
+            var entries = PoParser.Parse(result).ToList();
+            Assert.AreEqual(1, entries.Count);
+            Assert.AreEqual("kept", entries[0].Msgid);
+        }
+
+        [Test] public void Merge_NewExtractionRefreshesComments() {
+            var existing = PoParser.Serialize(new[] {
+                new PoEntry { Msgid = "x", Msgstr = "y",
+                              TranslatorComments = new() { "old comment" } },
+            });
+            var result = PoFileWriter.Merge(existing, new[] {
+                new ExtractedString { Msgid = "x", ExtractedComments = { "fresh hint" } },
+            });
+            var entries = PoParser.Parse(result).ToList();
+            // existing user msgstr preserved; comments come from current extraction
+            Assert.AreEqual("y", entries[0].Msgstr);
+            Assert.IsTrue(entries[0].TranslatorComments.Any(c => c.Contains("fresh hint")));
+            Assert.IsFalse(entries[0].TranslatorComments.Any(c => c.Contains("old comment")));
+        }
+
+        [Test] public void Merge_SameMsgidDifferentCtx_TwoEntries() {
+            var result = PoFileWriter.Merge("", new[] {
+                new ExtractedString { Msgid = "Open" },
+                new ExtractedString { Msgid = "Open", Msgctxt = "door" },
+            });
+            var entries = PoParser.Parse(result).ToList();
+            Assert.AreEqual(2, entries.Count);
+            Assert.IsTrue(entries.Any(e => e.Msgctxt == null));
+            Assert.IsTrue(entries.Any(e => e.Msgctxt == "door"));
+        }
+    }
+}

--- a/Tests/EditMode/Editor/PoFileWriterTests.cs.meta
+++ b/Tests/EditMode/Editor/PoFileWriterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 61767ac8c94c78f4883b3876bfd2ead3

--- a/Tests/EditMode/Editor/TmpRichTextDetectorTests.cs
+++ b/Tests/EditMode/Editor/TmpRichTextDetectorTests.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using PromptUGUI.Editor.I18n;
+
+namespace PromptUGUI.Tests.Editor {
+    public class TmpRichTextDetectorTests {
+        [TestCase("<sprite name=\"coin\"/>")]
+        [TestCase("<color=#ff0>x</color>")]
+        [TestCase("<b>bold</b>")]
+        [TestCase("<size=20>x</size>")]
+        [TestCase("<link=\"foo\">x</link>")]
+        public void Detect_KnownTags_ReturnsTrue(string s) {
+            Assert.IsTrue(TmpRichTextDetector.HasTmpTags(s));
+        }
+
+        [TestCase("plain")]
+        [TestCase("price: {0}")]
+        [TestCase("price: {{n}}")]
+        [TestCase("a < b > c")]
+        public void Detect_NoTmpTag_ReturnsFalse(string s) {
+            Assert.IsFalse(TmpRichTextDetector.HasTmpTags(s));
+        }
+    }
+}

--- a/Tests/EditMode/Editor/TmpRichTextDetectorTests.cs.meta
+++ b/Tests/EditMode/Editor/TmpRichTextDetectorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 787354f7e18357a4180bb8f4cf3300a5

--- a/Tests/EditMode/Editor/TranslationClientTests.cs
+++ b/Tests/EditMode/Editor/TranslationClientTests.cs
@@ -34,7 +34,28 @@ namespace PromptUGUI.Tests.Editor {
                 input, "zh-Hans",
                 endpoint: "https://example/v1", model: "x", apiKey: "k", systemPrompt: "p",
                 CancellationToken.None);
-            Assert.AreEqual("你好", result["hello"]);
+            Assert.AreEqual("你好", result[("hello", null)]);
+        }
+
+        [Test]
+        public async Task TranslateBatch_DistinguishesSameMsgidDifferentCtx() {
+            var stub = new StubHandler {
+                Reply = _ => new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new StringContent(@"
+                        { ""choices"": [ { ""message"": {
+                          ""content"": ""{\""translations\"":[{\""msgid\"":\""Open\"",\""msgctxt\"":null,\""msgstr\"":\""打开\""},{\""msgid\"":\""Open\"",\""msgctxt\"":\""door\"",\""msgstr\"":\""开门\""}]}""
+                        } } ] }"),
+                },
+            };
+            var client = new TranslationClient(new HttpClient(stub));
+            var input = new System.Collections.Generic.List<TranslationItem> {
+                new() { Msgid = "Open" },
+                new() { Msgid = "Open", Msgctxt = "door" },
+            };
+            var result = await client.TranslateBatch(
+                input, "zh-Hans", "https://e", "x", "k", "p", CancellationToken.None);
+            Assert.AreEqual("打开", result[("Open", null)]);
+            Assert.AreEqual("开门", result[("Open", "door")]);
         }
 
         [Test]

--- a/Tests/EditMode/Editor/TranslationClientTests.cs
+++ b/Tests/EditMode/Editor/TranslationClientTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PromptUGUI.Editor.I18n;
+
+namespace PromptUGUI.Tests.Editor {
+    public class TranslationClientTests {
+        sealed class StubHandler : HttpMessageHandler {
+            public Func<HttpRequestMessage, HttpResponseMessage> Reply;
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage req, CancellationToken ct) => Task.FromResult(Reply(req));
+        }
+
+        [Test]
+        public async Task TranslateBatch_ParsesStructuredJson() {
+            var stub = new StubHandler {
+                Reply = _ => new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new StringContent(@"
+                        { ""choices"": [ { ""message"": {
+                          ""content"": ""{\""translations\"":[{\""msgid\"":\""hello\"",\""msgctxt\"":null,\""msgstr\"":\""你好\""}]}""
+                        } } ] }"),
+                },
+            };
+            var client = new TranslationClient(new HttpClient(stub));
+            var input = new List<TranslationItem> {
+                new() { Msgid = "hello", Msgctxt = null, Comments = new() { "ctx" } },
+            };
+            var result = await client.TranslateBatch(
+                input, "zh-Hans",
+                endpoint: "https://example/v1", model: "x", apiKey: "k", systemPrompt: "p",
+                CancellationToken.None);
+            Assert.AreEqual("你好", result["hello"]);
+        }
+
+        [Test]
+        public void TranslateBatch_NonOk_Throws() {
+            var stub = new StubHandler {
+                Reply = _ => new HttpResponseMessage(HttpStatusCode.Unauthorized) {
+                    Content = new StringContent(""),
+                },
+            };
+            var client = new TranslationClient(new HttpClient(stub));
+            Assert.ThrowsAsync<HttpRequestException>(async () =>
+                await client.TranslateBatch(
+                    new List<TranslationItem>(),
+                    "zh-Hans", "https://e/v1", "x", "k", "p", CancellationToken.None));
+        }
+    }
+}

--- a/Tests/EditMode/Editor/TranslationClientTests.cs.meta
+++ b/Tests/EditMode/Editor/TranslationClientTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f4308172418477541aa018d9afa2c0f8

--- a/Tests/EditMode/Editor/XmlStringScannerTests.cs
+++ b/Tests/EditMode/Editor/XmlStringScannerTests.cs
@@ -1,0 +1,82 @@
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Editor.I18n;
+
+namespace PromptUGUI.Tests.Editor {
+    public class XmlStringScannerTests {
+        [Test] public void Scan_SimpleTextElement_ExtractsMsgid() {
+            var xml = "<PromptUGUI version='1'><Screen name='Main'>" +
+                      "<Text>开始游戏</Text></Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/Main").ToList();
+            Assert.AreEqual(1, found.Count);
+            Assert.AreEqual("开始游戏", found[0].Msgid);
+            Assert.IsNull(found[0].Msgctxt);
+        }
+
+        [Test] public void Scan_BtnContent_ExtractsMsgid() {
+            var xml = "<PromptUGUI version='1'><Screen name='X'>" +
+                      "<Btn id='b'>设置</Btn></Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/X").ToList();
+            Assert.AreEqual(1, found.Count);
+            Assert.AreEqual("设置", found[0].Msgid);
+        }
+
+        [Test] public void Scan_TextAttribute_AlsoExtracts() {
+            var xml = "<PromptUGUI version='1'><Screen name='X'>" +
+                      "<Text text='Hello' fontSize='32'/></Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/X").ToList();
+            Assert.IsTrue(found.Any(e => e.Msgid == "Hello"));
+        }
+
+        [Test] public void Scan_TrFalse_Skips() {
+            var xml = "<PromptUGUI version='1'><Screen name='X'>" +
+                      "<Text tr='false'>hardcoded</Text></Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/X").ToList();
+            Assert.IsEmpty(found);
+        }
+
+        [Test] public void Scan_ExplicitCtx_PopulatesMsgctxt() {
+            var xml = "<PromptUGUI version='1'><Screen name='X'>" +
+                      "<Text ctx='door'>Open</Text></Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/X").ToList();
+            Assert.AreEqual("door", found[0].Msgctxt);
+            Assert.AreEqual("Open", found[0].Msgid);
+        }
+
+        [Test] public void Scan_PureBracePlaceholder_SkippedWithWarning() {
+            var xml = "<PromptUGUI version='1'><Screen name='X'>" +
+                      "<Text>{{playerName}}</Text></Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/X").ToList();
+            Assert.IsEmpty(found);   // pure {{x}} has no translation value
+        }
+
+        [Test] public void Scan_TextWithBraceAndStatic_Extracted() {
+            var xml = "<PromptUGUI version='1'><Screen name='X'>" +
+                      "<Text>金币: {{n}}</Text></Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/X").ToList();
+            Assert.AreEqual("金币: {{n}}", found[0].Msgid);
+        }
+
+        [Test] public void Scan_AmbientCtx_AddedAsExtractedComment() {
+            var xml = "<PromptUGUI version='1'><Screen name='Main'>" +
+                      "<Btn id='play'>开始</Btn>" +
+                      "<Btn id='cfg'>设置</Btn>" +
+                      "</Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/Main").ToList();
+            var play = found.First(e => e.Msgid == "开始");
+            // ambient hint should reference Main + Btn#play
+            Assert.IsTrue(play.ExtractedComments.Any(c => c.Contains("Main") && c.Contains("play")));
+            // sibling list should mention "设置"
+            Assert.IsTrue(play.ExtractedComments.Any(c => c.Contains("设置")));
+        }
+
+        [Test] public void Scan_CDataWithRichText_ExtractsAndFlags() {
+            var xml = "<PromptUGUI version='1'><Screen name='X'>" +
+                      "<Text><![CDATA[<color=#ff0>警告</color>]]></Text>" +
+                      "</Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/X").ToList();
+            Assert.AreEqual("<color=#ff0>警告</color>", found[0].Msgid);
+            Assert.IsTrue(found[0].ExtractedComments.Any(c => c.Contains("Preserve tags")));
+        }
+    }
+}

--- a/Tests/EditMode/Editor/XmlStringScannerTests.cs.meta
+++ b/Tests/EditMode/Editor/XmlStringScannerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c335250affe72024193d03b6af5f0e94

--- a/Tests/EditMode/I18n.meta
+++ b/Tests/EditMode/I18n.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a9bc0aee7632a734f9246225bfedd052
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/I18n/PoParserTests.cs
+++ b/Tests/EditMode/I18n/PoParserTests.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.I18n;
+
+namespace PromptUGUI.Tests.I18n {
+    public class PoParserTests {
+        [Test] public void Parse_SingleEntry_ReturnsMsgidMsgstr() {
+            var src = "msgid \"hello\"\nmsgstr \"你好\"\n";
+            var entries = PoParser.Parse(src).ToList();
+            Assert.AreEqual(1, entries.Count);
+            Assert.AreEqual("hello", entries[0].Msgid);
+            Assert.AreEqual("你好", entries[0].Msgstr);
+            Assert.IsNull(entries[0].Msgctxt);
+        }
+
+        [Test] public void Parse_WithMsgctxt_PopulatesCtx() {
+            var src = "msgctxt \"door\"\nmsgid \"Open\"\nmsgstr \"打开\"\n";
+            var e = PoParser.Parse(src).Single();
+            Assert.AreEqual("door", e.Msgctxt);
+            Assert.AreEqual("Open", e.Msgid);
+            Assert.AreEqual("打开", e.Msgstr);
+        }
+
+        [Test] public void Parse_MultilineString_ConcatenatesQuoted() {
+            var src = "msgid \"\"\n\"line1 \"\n\"line2\"\nmsgstr \"\"\n\"out\"\n";
+            var e = PoParser.Parse(src).Single();
+            Assert.AreEqual("line1 line2", e.Msgid);
+            Assert.AreEqual("out", e.Msgstr);
+        }
+
+        [Test] public void Parse_EscapeSequences_AreDecoded() {
+            var src = "msgid \"a\\nb\\tc\\\"d\\\\e\"\nmsgstr \"\"\n";
+            var e = PoParser.Parse(src).Single();
+            Assert.AreEqual("a\nb\tc\"d\\e", e.Msgid);
+        }
+
+        [Test] public void Parse_TranslatorCommentsCollected() {
+            var src = "# translator note\n#. extracted note\n#: file.cs:42\nmsgid \"x\"\nmsgstr \"\"\n";
+            var e = PoParser.Parse(src).Single();
+            CollectionAssert.Contains(e.TranslatorComments, "translator note");
+        }
+
+        [Test] public void Parse_ObsoleteEntries_AreSkipped() {
+            var src = "#~ msgid \"old\"\n#~ msgstr \"old-tr\"\nmsgid \"new\"\nmsgstr \"new-tr\"\n";
+            var entries = PoParser.Parse(src).ToList();
+            Assert.AreEqual(1, entries.Count);
+            Assert.AreEqual("new", entries[0].Msgid);
+        }
+
+        [Test] public void Parse_HeaderEntry_IsReturnedLikeOthers() {
+            // Header is the entry with empty msgid; we still emit it.
+            var src = "msgid \"\"\nmsgstr \"Content-Type: text/plain\\n\"\nmsgid \"x\"\nmsgstr \"y\"\n";
+            var entries = PoParser.Parse(src).ToList();
+            Assert.AreEqual(2, entries.Count);
+            Assert.AreEqual("", entries[0].Msgid);
+        }
+
+        [Test] public void Parse_EmptyOrWhitespace_ReturnsEmpty() {
+            CollectionAssert.IsEmpty(PoParser.Parse("").ToList());
+            CollectionAssert.IsEmpty(PoParser.Parse("\n\n  \n").ToList());
+        }
+
+        [Test] public void Parse_MissingMsgstr_Throws() {
+            Assert.Throws<PoParseException>(() => PoParser.Parse("msgid \"x\"\n").ToList());
+        }
+    }
+}

--- a/Tests/EditMode/I18n/PoParserTests.cs
+++ b/Tests/EditMode/I18n/PoParserTests.cs
@@ -64,5 +64,30 @@ namespace PromptUGUI.Tests.I18n {
         [Test] public void Parse_MissingMsgstr_Throws() {
             Assert.Throws<PoParseException>(() => PoParser.Parse("msgid \"x\"\n").ToList());
         }
+
+        [Test] public void Roundtrip_BasicEntries_PreservesContent() {
+            var src = new[] {
+                new PoEntry { Msgid = "hello", Msgstr = "你好" },
+                new PoEntry { Msgctxt = "door", Msgid = "Open", Msgstr = "打开",
+                              TranslatorComments = { "doorway action" } },
+            };
+            var text = PoParser.Serialize(src);
+            var parsed = PoParser.Parse(text).ToList();
+            Assert.AreEqual(2, parsed.Count);
+            Assert.AreEqual("hello", parsed[0].Msgid);
+            Assert.AreEqual("你好",  parsed[0].Msgstr);
+            Assert.AreEqual("door",  parsed[1].Msgctxt);
+            Assert.AreEqual("Open",  parsed[1].Msgid);
+            Assert.AreEqual("打开",  parsed[1].Msgstr);
+        }
+
+        [Test] public void Serialize_EscapesNewlinesAndQuotes() {
+            var entries = new[] {
+                new PoEntry { Msgid = "line\nwith \"quotes\"", Msgstr = "" }
+            };
+            var text = PoParser.Serialize(entries);
+            StringAssert.Contains("\\n", text);
+            StringAssert.Contains("\\\"", text);
+        }
     }
 }

--- a/Tests/EditMode/I18n/PoParserTests.cs.meta
+++ b/Tests/EditMode/I18n/PoParserTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 508c953adb2c66247b6a136ae3ca0443

--- a/Tests/EditMode/I18n/TrResolverTests.cs
+++ b/Tests/EditMode/I18n/TrResolverTests.cs
@@ -5,14 +5,8 @@ using PromptUGUI.I18n;
 
 namespace PromptUGUI.Tests.I18n {
     public class TrResolverTests {
-        [SetUp] public void Setup() {
-            UI.ResetForTests();
-            TranslationStore.Instance.UnloadAll();
-        }
-        [TearDown] public void Teardown() {
-            UI.ResetForTests();
-            TranslationStore.Instance.UnloadAll();
-        }
+        [SetUp] public void Setup() => UI.ResetForTests();
+        [TearDown] public void Teardown() => UI.ResetForTests();
 
         [Test] public void Resolve_NullRaw_ReturnsNull() {
             Assert.IsNull(TrResolver.Resolve(null, null, null));

--- a/Tests/EditMode/I18n/TrResolverTests.cs
+++ b/Tests/EditMode/I18n/TrResolverTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.I18n;
+
+namespace PromptUGUI.Tests.I18n {
+    public class TrResolverTests {
+        [SetUp] public void Setup() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+        }
+        [TearDown] public void Teardown() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+        }
+
+        [Test] public void Resolve_NullRaw_ReturnsNull() {
+            Assert.IsNull(TrResolver.Resolve(null, null, null));
+        }
+
+        [Test] public void Resolve_LocaleNull_ReturnsRaw() {
+            Assert.AreEqual("hi", TrResolver.Resolve("hi", null, null));
+        }
+
+        [Test] public void Resolve_Miss_ReturnsRaw() {
+            UI.Locale.Set("zh-Hans");
+            Assert.AreEqual("hi", TrResolver.Resolve("hi", null, null));
+        }
+
+        [Test] public void Resolve_Hit_ReturnsMsgstr() {
+            TranslationStore.Instance.Load("zh-Hans", new[] {
+                new PoEntry { Msgid = "hi", Msgstr = "你好" },
+            });
+            UI.Locale.Set("zh-Hans");
+            Assert.AreEqual("你好", TrResolver.Resolve("hi", null, null));
+        }
+
+        [Test] public void Resolve_HitWithCtx_ReturnsCtxScopedMsgstr() {
+            TranslationStore.Instance.Load("zh-Hans", new[] {
+                new PoEntry { Msgid = "Open", Msgstr = "打开" },
+                new PoEntry { Msgctxt = "door", Msgid = "Open", Msgstr = "开门" },
+            });
+            UI.Locale.Set("zh-Hans");
+            Assert.AreEqual("开门", TrResolver.Resolve("Open", null, "door"));
+            Assert.AreEqual("打开", TrResolver.Resolve("Open", null, null));
+        }
+
+        [Test] public void Resolve_WithArgs_AppliesSubstitutionAfterLookup() {
+            TranslationStore.Instance.Load("en", new[] {
+                new PoEntry { Msgid = "金币: {{n}}", Msgstr = "Gold: {{n}}" },
+            });
+            UI.Locale.Set("en");
+            var args = new Dictionary<string, string> { { "n", "123" } };
+            Assert.AreEqual("Gold: 123", TrResolver.Resolve("金币: {{n}}", args, null));
+        }
+
+        [Test] public void Resolve_ArgsOnMiss_StillSubstitutesIntoRaw() {
+            UI.Locale.Set("ja");  // empty store
+            var args = new Dictionary<string, string> { { "n", "5" } };
+            Assert.AreEqual("金币: 5", TrResolver.Resolve("金币: {{n}}", args, null));
+        }
+    }
+}

--- a/Tests/EditMode/I18n/TrResolverTests.cs.meta
+++ b/Tests/EditMode/I18n/TrResolverTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fd1b43a70602bdc4a9c5668b2ae9dbd1

--- a/Tests/EditMode/I18n/TranslationStoreTests.cs
+++ b/Tests/EditMode/I18n/TranslationStoreTests.cs
@@ -1,0 +1,57 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.I18n;
+
+namespace PromptUGUI.Tests.I18n {
+    public class TranslationStoreTests {
+        TranslationStore _store;
+        [SetUp] public void Setup() => _store = new TranslationStore();
+
+        [Test] public void Lookup_BeforeAnyLoad_ReturnsNull() {
+            Assert.IsNull(_store.Lookup("zh-Hans", null, "x"));
+        }
+
+        [Test] public void Load_ThenLookup_ReturnsMsgstr() {
+            _store.Load("zh-Hans", new[] {
+                new PoEntry { Msgid = "hello", Msgstr = "你好" },
+            });
+            Assert.AreEqual("你好", _store.Lookup("zh-Hans", null, "hello"));
+        }
+
+        [Test] public void Lookup_WithCtx_OnlyMatchesEntryWithSameCtx() {
+            _store.Load("zh-Hans", new[] {
+                new PoEntry { Msgid = "Open", Msgstr = "打开" },
+                new PoEntry { Msgctxt = "door", Msgid = "Open", Msgstr = "开门" },
+            });
+            Assert.AreEqual("打开", _store.Lookup("zh-Hans", null, "Open"));
+            Assert.AreEqual("开门", _store.Lookup("zh-Hans", "door", "Open"));
+            Assert.IsNull(_store.Lookup("zh-Hans", "missing", "Open"));
+        }
+
+        [Test] public void Load_LaterCallsOverridePrior() {
+            // i18n-custom override semantics: load auto first, then custom.
+            _store.Load("zh-Hans", new[] { new PoEntry { Msgid = "x", Msgstr = "auto" } });
+            _store.Load("zh-Hans", new[] { new PoEntry { Msgid = "x", Msgstr = "custom" } });
+            Assert.AreEqual("custom", _store.Lookup("zh-Hans", null, "x"));
+        }
+
+        [Test] public void EmptyMsgstr_TreatedAsMiss() {
+            _store.Load("zh-Hans", new[] { new PoEntry { Msgid = "x", Msgstr = "" } });
+            Assert.IsNull(_store.Lookup("zh-Hans", null, "x"));
+        }
+
+        [Test] public void UnloadLocale_RemovesOnlyThatLocale() {
+            _store.Load("zh-Hans", new[] { new PoEntry { Msgid = "x", Msgstr = "y" } });
+            _store.Load("en",      new[] { new PoEntry { Msgid = "x", Msgstr = "Y" } });
+            _store.UnloadLocale("zh-Hans");
+            Assert.IsNull(_store.Lookup("zh-Hans", null, "x"));
+            Assert.AreEqual("Y", _store.Lookup("en", null, "x"));
+        }
+
+        [Test] public void UnloadAll_ClearsEverything() {
+            _store.Load("en", new[] { new PoEntry { Msgid = "x", Msgstr = "Y" } });
+            _store.UnloadAll();
+            Assert.IsNull(_store.Lookup("en", null, "x"));
+        }
+    }
+}

--- a/Tests/EditMode/I18n/TranslationStoreTests.cs.meta
+++ b/Tests/EditMode/I18n/TranslationStoreTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7758da451524a4c4984c8d6a351ab9bf

--- a/Tests/EditMode/Parser/CDataInTextTests.cs
+++ b/Tests/EditMode/Parser/CDataInTextTests.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.Parser {
+    public class CDataInTextTests {
+        [Test] public void Text_WithCData_ContainingTmpSprite_Parses() {
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <Text><![CDATA[gold: <sprite name=""coin""/>{{n}}]]></Text>
+  </Screen>
+</PromptUGUI>";
+            var doc = UIDocumentParser.Parse(xml);
+            var text = doc.Screens[0].Root.Children[0];
+            Assert.AreEqual("Text", text.Tag);
+            StringAssert.Contains("<sprite", text.TextContentRaw);
+            StringAssert.Contains("{{n}}",   text.TextContentRaw);
+        }
+
+        [Test] public void Text_WithMixedTextAndCdata_StillForbidden() {
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <Text>foo<sprite/></Text>
+  </Screen>
+</PromptUGUI>";
+            Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+        }
+    }
+}

--- a/Tests/EditMode/Parser/CDataInTextTests.cs.meta
+++ b/Tests/EditMode/Parser/CDataInTextTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9f20ab93c27ebd444a10120e5786d5b8

--- a/Tests/EditMode/Parser/RawAttributesAndContentTests.cs
+++ b/Tests/EditMode/Parser/RawAttributesAndContentTests.cs
@@ -1,0 +1,21 @@
+using NUnit.Framework;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.Parser {
+    public class RawAttributesAndContentTests {
+        [Test] public void TextContentRaw_PopulatedFromTextNode() {
+            var xml = "<PromptUGUI version='1'><Screen name='S'><Text>hi {{n}}</Text></Screen></PromptUGUI>";
+            var node = UIDocumentParser.Parse(xml).Screens[0].Root.Children[0];
+            Assert.AreEqual("hi {{n}}", node.TextContentRaw);
+        }
+
+        [Test] public void AttributesRaw_PopulatedOnlyWhenValueContainsBraces() {
+            var xml = "<PromptUGUI version='1'><Screen name='S'>" +
+                      "<Text text='Gold: {{n}}' fontSize='32'/></Screen></PromptUGUI>";
+            var node = UIDocumentParser.Parse(xml).Screens[0].Root.Children[0];
+            Assert.IsTrue(node.AttributesRaw.ContainsKey("text"));
+            Assert.AreEqual("Gold: {{n}}", node.AttributesRaw["text"]);
+            Assert.IsFalse(node.AttributesRaw.ContainsKey("fontSize"));
+        }
+    }
+}

--- a/Tests/EditMode/Parser/RawAttributesAndContentTests.cs.meta
+++ b/Tests/EditMode/Parser/RawAttributesAndContentTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8f31fd8c12751594ea3999ba111f80d3

--- a/Tests/EditMode/Template/TemplateArgsPropagationTests.cs
+++ b/Tests/EditMode/Template/TemplateArgsPropagationTests.cs
@@ -1,0 +1,49 @@
+using NUnit.Framework;
+using PromptUGUI.Parser;
+using PromptUGUI.Template;
+
+namespace PromptUGUI.Tests.Template {
+    public class TemplateArgsPropagationTests {
+        [Test] public void Expand_PassesArgsToTextArgsOnExpandedNodes() {
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Gold'>
+    <Param name='n'/>
+    <Text>金币: {{n}}</Text>
+  </Template>
+  <Screen name='S'>
+    <Gold n='123'/>
+  </Screen>
+</PromptUGUI>";
+            var raw = UIDocumentParser.Parse(xml);
+            var doc = TemplateExpander.Expand(raw);
+            var text = doc.Screens[0].Root.Children[0];
+            Assert.AreEqual("Text", text.Tag);
+            // textContent post-expand is substituted (existing behavior)
+            Assert.AreEqual("金币: 123", text.TextContent);
+            // raw is preserved
+            Assert.AreEqual("金币: {{n}}", text.TextContentRaw);
+            // args carry the substitution map
+            Assert.IsNotNull(text.TextArgs);
+            Assert.AreEqual("123", text.TextArgs["n"]);
+        }
+
+        [Test] public void Expand_PreservesAttributesRawOnExpansion() {
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Gold'>
+    <Param name='n'/>
+    <Text text='金币: {{n}}'/>
+  </Template>
+  <Screen name='S'>
+    <Gold n='5'/>
+  </Screen>
+</PromptUGUI>";
+            var doc = TemplateExpander.Expand(UIDocumentParser.Parse(xml));
+            var text = doc.Screens[0].Root.Children[0];
+            Assert.AreEqual("金币: 5", text.Attributes["text"]);
+            Assert.AreEqual("金币: {{n}}", text.AttributesRaw["text"]);
+            Assert.AreEqual("5", text.TextArgs["n"]);
+        }
+    }
+}

--- a/Tests/EditMode/Template/TemplateArgsPropagationTests.cs.meta
+++ b/Tests/EditMode/Template/TemplateArgsPropagationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 85047b371bfe59c4aa43920a53f46c8c

--- a/Tests/PlayMode/E2E/I18nFontSwapTests.cs
+++ b/Tests/PlayMode/E2E/I18nFontSwapTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.I18n;
+using TMPro;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.E2E {
+    /// <summary>
+    /// End-to-end: locale switch → text translates + font swaps via the Settings table.
+    /// </summary>
+    public class I18nFontSwapTests {
+        const string Xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <Text id='lbl' font='title'>开始游戏</Text>
+  </Screen>
+</PromptUGUI>";
+
+        PromptUGUISettings _settings;
+        TMP_FontAsset _fontEn, _fontZh;
+
+        [SetUp]
+        public void Setup() {
+            UI.ResetForTests();
+
+            // Distinct instances suffice for reference-equality assertions.
+            _fontEn = TMP_FontAsset.CreateFontAsset(Font.CreateDynamicFontFromOSFont("Arial", 16));
+            _fontZh = TMP_FontAsset.CreateFontAsset(Font.CreateDynamicFontFromOSFont("Arial", 16));
+
+            _settings = ScriptableObject.CreateInstance<PromptUGUISettings>();
+            _settings.locales = new List<PromptUGUISettings.LocaleConfig> {
+                new() {
+                    locale = "en",
+                    fonts = new List<PromptUGUISettings.FontEntry> {
+                        new() { type = "default", font = _fontEn },
+                        new() { type = "title",   font = _fontEn },
+                    },
+                },
+                new() {
+                    locale = "zh-Hans",
+                    fonts = new List<PromptUGUISettings.FontEntry> {
+                        new() { type = "default", font = _fontZh },
+                        new() { type = "title",   font = _fontZh },
+                    },
+                },
+            };
+            // Pin into Resources.FindObjectsOfTypeAll so PromptUGUISettings.Instance finds it.
+            _settings.hideFlags = HideFlags.DontUnloadUnusedAsset;
+
+            UI.LoadDocument("S", Xml);
+
+            // Set starting locale to zh-Hans (no translation → msgid passes through).
+            UI.Locale.Set("zh-Hans");
+
+            // Pre-load "en" entries while current locale is "zh-Hans".
+            // UI.Locale.Set("en") later only unloads "zh-Hans" entries, so these survive.
+            TranslationStore.Instance.Load("en", new[] {
+                new PoEntry { Msgid = "开始游戏", Msgstr = "Start" },
+            });
+        }
+
+        [TearDown]
+        public void Teardown() {
+            UI.ResetForTests();
+            if (_settings != null) Object.DestroyImmediate(_settings);
+            if (_fontEn != null) Object.DestroyImmediate(_fontEn);
+            if (_fontZh != null) Object.DestroyImmediate(_fontZh);
+        }
+
+        [Test]
+        public void SwitchLocale_TextAndFontChange() {
+            var screen = UI.Open("S");
+            var txt = screen.Get<Text>("lbl");
+
+            // zh-Hans: no translation loaded → msgid passes through unchanged.
+            Assert.AreEqual("开始游戏", GetTmpText(txt));
+            // Font swap: only assert when settings object is discoverable AND font assets
+            // were successfully created (Arial may be absent in headless Unity / CI).
+            // TODO: font swap assertion needs CI font setup if Arial is unavailable.
+            bool canAssertFont = PromptUGUISettings.Instance != null
+                                 && _fontEn != null && _fontZh != null;
+            if (canAssertFont) {
+                Assert.AreSame(_fontZh, GetTmpFont(txt),
+                    "zh-Hans font should be _fontZh");
+            }
+
+            // Locale.Set("en") unloads "zh-Hans" entries (none), then fires ReSolve.
+            // ReSolve re-applies "font='title'" with locale "en" → _fontEn,
+            // and "text=开始游戏" via TrResolver → "Start" (loaded above).
+            UI.Locale.Set("en");
+
+            Assert.AreEqual("Start", GetTmpText(txt));
+            if (canAssertFont) {
+                Assert.AreSame(_fontEn, GetTmpFont(txt),
+                    "en font should be _fontEn");
+            }
+        }
+
+        static string GetTmpText(Text t) =>
+            ((Control)t).GameObject.GetComponent<TMP_Text>().text;
+
+        static TMP_FontAsset GetTmpFont(Text t) =>
+            ((Control)t).GameObject.GetComponent<TMP_Text>().font;
+    }
+}

--- a/Tests/PlayMode/E2E/I18nFontSwapTests.cs.meta
+++ b/Tests/PlayMode/E2E/I18nFontSwapTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7ad429bd62d096540a8146051fccbc4c

--- a/Tests/PlayMode/E2E/I18nHotReloadTests.cs
+++ b/Tests/PlayMode/E2E/I18nHotReloadTests.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.I18n;
+using TMPro;
+
+namespace PromptUGUI.Tests.E2E {
+    public class I18nHotReloadTests {
+        const string Xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <Text id='lbl'>开始游戏</Text>
+  </Screen>
+</PromptUGUI>";
+
+        [SetUp] public void Setup() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+            UI.LoadDocument("S", Xml);
+            TranslationStore.Instance.Load("en", new[] {
+                new PoEntry { Msgid = "开始游戏", Msgstr = "Start" },
+            });
+            UI.Locale.Set("en");
+        }
+        [TearDown] public void Teardown() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+        }
+
+        [Test] public void TableMutation_AfterReSolve_UpdatesText() {
+            var screen = UI.Open("S");
+            var go = ((Control)screen.Get<Text>("lbl")).GameObject;
+            Assert.AreEqual("Start", go.GetComponent<TMP_Text>().text);
+
+            // Simulate hot-reload: replace the entry, ReSolve manually
+            TranslationStore.Instance.UnloadLocale("en");
+            TranslationStore.Instance.Load("en", new[] {
+                new PoEntry { Msgid = "开始游戏", Msgstr = "Begin" },
+            });
+            UI.NotifyVariantChangedForReSolve();
+
+            Assert.AreEqual("Begin", go.GetComponent<TMP_Text>().text);
+        }
+    }
+}

--- a/Tests/PlayMode/E2E/I18nHotReloadTests.cs.meta
+++ b/Tests/PlayMode/E2E/I18nHotReloadTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bf01915a92022a04fa8adc95b9f568ea

--- a/Tests/PlayMode/E2E/TmpRichTextRoundtripTests.cs
+++ b/Tests/PlayMode/E2E/TmpRichTextRoundtripTests.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.I18n;
+using TMPro;
+
+namespace PromptUGUI.Tests.E2E {
+    public class TmpRichTextRoundtripTests {
+        const string Xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <Text id='lbl'><![CDATA[<color=#ff0>警告</color>]]></Text>
+  </Screen>
+</PromptUGUI>";
+
+        [SetUp] public void Setup() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+            UI.LoadDocument("S", Xml);
+        }
+        [TearDown] public void Teardown() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+        }
+
+        [Test] public void CDataWithRichText_PreservedAtRuntime() {
+            var screen = UI.Open("S");
+            var go = ((Control)screen.Get<Text>("lbl")).GameObject;
+            Assert.AreEqual("<color=#ff0>警告</color>", go.GetComponent<TMP_Text>().text);
+        }
+
+        [Test] public void CDataWithRichText_TranslatedPreservesTags() {
+            TranslationStore.Instance.Load("en", new[] {
+                new PoEntry {
+                    Msgid = "<color=#ff0>警告</color>",
+                    Msgstr = "<color=#ff0>WARN</color>",
+                },
+            });
+            UI.Locale.Set("en");
+            var screen = UI.Open("S");
+            var go = ((Control)screen.Get<Text>("lbl")).GameObject;
+            Assert.AreEqual("<color=#ff0>WARN</color>", go.GetComponent<TMP_Text>().text);
+        }
+    }
+}

--- a/Tests/PlayMode/E2E/TmpRichTextRoundtripTests.cs.meta
+++ b/Tests/PlayMode/E2E/TmpRichTextRoundtripTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a1876ca3259650b44bf305c4f1eed01c

--- a/docs/superpowers/plans/2026-05-08-i18n-m5a-runtime.md
+++ b/docs/superpowers/plans/2026-05-08-i18n-m5a-runtime.md
@@ -1,0 +1,2165 @@
+# M5a — i18n Runtime + Fonts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship runtime infra so that author writing hand-crafted .po files can switch UI locale and have all `<Text>` / `<Btn>` strings translate + swap fonts. No extraction tooling, no LLM menu — those land in M5b.
+
+**Architecture:** Independent `TranslationStore` keyed by `(locale, msgctxt|null, msgid)`. Locale switch internally calls `Variants.Set(<locale>, true/false)`, reusing existing `VariantStore.Changed → Screen.ReSolve` pipeline. Settings ScriptableObject with `locales[<locale>].fonts[<type>]` is auto-pinned to `PlayerSettings.preloadedAssets`. Parser learns CDATA so `<Text><![CDATA[…<sprite/>…{{x}}…]]></Text>` is valid. ElementNode gains `TextContentRaw` / `TextArgs` / `AttributesRaw` so runtime can lookup the un-substituted template, then re-apply args to the translated string. `Btn` gains `text` / `font` properties that lazily create an inner TMP child, fixing a long-standing SKILL.md vs implementation mismatch.
+
+**Tech Stack:** Unity 6+, C# (PromptUGUI.Runtime / .Editor / .Tests asmdefs), TMP, R3, NUnit via UnityMCP.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-i18n-fonts-design.md`. Read it before starting.
+
+---
+
+## File Structure
+
+**New files (Runtime):**
+- `Runtime/Application/PromptUGUISettings.cs` — ScriptableObject with `locales[].fonts[]`
+- `Runtime/Application/TranslationStore.cs` — singleton keyed lookup
+- `Runtime/Application/TrResolver.cs` — string lookup + `{{x}}` substitution
+- `Runtime/Application/LocaleHelpers.cs` — `Application.systemLanguage → BCP-47` mapping
+- `Runtime/Core/I18n/PoEntry.cs` — DTO
+- `Runtime/Core/I18n/PoParser.cs` — `.po` lexer + serializer
+
+**Modified files (Runtime):**
+- `Runtime/Application/UI.cs` — nested `Locale` class + `Tr()` static
+- `Runtime/Application/VariantStore.cs` — `internal void NotifyChangedInternal()`
+- `Runtime/Application/ControlAttributeApplier.cs` — route textContent / `text` through TrResolver + handle `ctx` / `tr` / font
+- `Runtime/Core/IR/ElementNode.cs` — add `TextContentRaw` / `TextArgs` / `AttributesRaw`
+- `Runtime/Core/Parser/UIDocumentParser.cs` — accept CDATA, populate raw fields
+- `Runtime/Core/Template/TemplateExpander.cs` — propagate substitution args into `TextArgs` on expanded nodes
+- `Runtime/Controls/Text.cs` — `font` attr
+- `Runtime/Controls/Btn.cs` — `text` / `font` attrs + lazy auto TMP child
+- `Runtime/Application/BuiltinPrimitives.cs` — Btn `defaultTextAttr: "text"`
+
+**New files (Editor):**
+- `Editor/PoFileImporter.cs` — `[ScriptedImporter("po")]` registers .po as TextAsset
+- `Editor/PromptUGUISettingsAutoMaintainer.cs` — `[InitializeOnLoad]` + AssetPostprocessor maintains `PlayerSettings.preloadedAssets` and one-asset invariant
+
+**Modified files (Editor):**
+- `Editor/UIAssetPostprocessor.cs` — branch on `.po` and `Settings.asset` changes
+
+**Tests:**
+- `Tests/EditMode/I18n/PoParserTests.cs`
+- `Tests/EditMode/I18n/TranslationStoreTests.cs`
+- `Tests/EditMode/I18n/TrResolverTests.cs`
+- `Tests/EditMode/Application/VariantStoreNotifyTests.cs`
+- `Tests/EditMode/Application/LocaleSetTests.cs`
+- `Tests/EditMode/Parser/CDataInTextTests.cs`
+- `Tests/EditMode/Parser/RawAttributesAndContentTests.cs`
+- `Tests/EditMode/Template/TemplateArgsPropagationTests.cs`
+- `Tests/EditMode/Editor/PoFileImporterTests.cs` (PromptUGUI.Tests.EditorOnly asmdef)
+- `Tests/EditMode/Editor/PromptUGUISettingsAutoMaintainerTests.cs` (EditorOnly asmdef)
+- `Tests/PlayMode/E2E/I18nFontSwapTests.cs`
+- `Tests/PlayMode/E2E/TmpRichTextRoundtripTests.cs`
+- `Tests/PlayMode/E2E/I18nHotReloadTests.cs`
+
+---
+
+## Pre-flight
+
+- [ ] **Refresh Unity & check console**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: no compile errors before starting.
+
+---
+
+## Task 1: Create PromptUGUISettings ScriptableObject
+
+**Files:**
+- Create: `Runtime/Application/PromptUGUISettings.cs`
+
+- [ ] **Step 1: Write the ScriptableObject**
+
+```csharp
+using System;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+namespace PromptUGUI.Application {
+    [CreateAssetMenu(menuName = "PromptUGUI/Settings", fileName = "Settings")]
+    public sealed class PromptUGUISettings : ScriptableObject {
+        [Serializable] public sealed class FontEntry {
+            public string type;          // "default" | "title" | "damage" | ...
+            public TMP_FontAsset font;
+        }
+        [Serializable] public sealed class LocaleConfig {
+            public string locale;        // BCP-47 e.g. "zh-Hans" / "en"
+            public List<FontEntry> fonts = new();
+        }
+        public List<LocaleConfig> locales = new();
+
+        public TMP_FontAsset ResolveFont(string locale, string type) {
+            if (string.IsNullOrEmpty(locale)) return null;
+            foreach (var lc in locales) {
+                if (lc.locale != locale) continue;
+                FontEntry fallback = null;
+                foreach (var fe in lc.fonts) {
+                    if (fe.type == type) return fe.font;
+                    if (fe.type == "default") fallback = fe;
+                }
+                return fallback?.font;
+            }
+            return null;
+        }
+
+        // Returns first loaded instance via preloadedAssets, null if none.
+        public static PromptUGUISettings Instance {
+            get {
+                var loaded = Resources.FindObjectsOfTypeAll<PromptUGUISettings>();
+                return loaded.Length > 0 ? loaded[0] : null;
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Refresh Unity, verify compile**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Runtime/Application/PromptUGUISettings.cs Runtime/Application/PromptUGUISettings.cs.meta
+git commit -m "feat: PromptUGUISettings SO with locales/fonts table"
+```
+
+---
+
+## Task 2: Editor — auto-maintain PlayerSettings.preloadedAssets
+
+**Files:**
+- Create: `Editor/PromptUGUISettingsAutoMaintainer.cs`
+
+- [ ] **Step 1: Write maintainer**
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using PromptUGUI.Application;
+using UnityEditor;
+using UnityEngine;
+
+namespace PromptUGUI.Editor {
+    [InitializeOnLoad]
+    internal static class PromptUGUISettingsAutoMaintainer {
+        static PromptUGUISettingsAutoMaintainer() {
+            EditorApplication.delayCall += Sync;
+        }
+
+        internal static void Sync() {
+            var guids = AssetDatabase.FindAssets("t:PromptUGUISettings");
+            if (guids.Length == 0) return;
+            if (guids.Length > 1) {
+                Debug.LogError(
+                    "[PromptUGUI] Multiple PromptUGUISettings assets found; " +
+                    "keep exactly one. preloadedAssets not updated.");
+                return;
+            }
+            var path = AssetDatabase.GUIDToAssetPath(guids[0]);
+            var settings = AssetDatabase.LoadAssetAtPath<PromptUGUISettings>(path);
+            if (settings == null) return;
+
+            var preloaded = PlayerSettings.GetPreloadedAssets()?.ToList() ?? new List<Object>();
+            // Drop dead refs + duplicates of our type, then add the canonical one.
+            preloaded.RemoveAll(a => a == null || a is PromptUGUISettings);
+            preloaded.Add(settings);
+            PlayerSettings.SetPreloadedAssets(preloaded.ToArray());
+        }
+
+        sealed class Postprocessor : AssetPostprocessor {
+            static void OnPostprocessAllAssets(
+                string[] importedAssets, string[] deletedAssets,
+                string[] movedAssets, string[] movedFromAssetPaths) {
+                bool touched =
+                    importedAssets.Any(IsSettings)
+                    || deletedAssets.Any(IsSettings)
+                    || movedAssets.Any(IsSettings)
+                    || movedFromAssetPaths.Any(IsSettings);
+                if (touched) Sync();
+            }
+            static bool IsSettings(string p) =>
+                p.EndsWith(".asset") &&
+                AssetDatabase.GetMainAssetTypeAtPath(p) == typeof(PromptUGUISettings);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Refresh, verify compile**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Manual sanity (optional but recommended)**
+
+In host project `C:\xsoft\PromptUGUIDev`: create one `Settings.asset` via `Assets/Create/PromptUGUI/Settings`, verify `Edit → Project Settings → Player → Optimization → Preloaded Assets` has it. Add a second; verify Editor logs error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Editor/PromptUGUISettingsAutoMaintainer.cs Editor/PromptUGUISettingsAutoMaintainer.cs.meta
+git commit -m "feat(editor): auto-maintain Settings in PlayerSettings.preloadedAssets"
+```
+
+---
+
+## Task 3: PoEntry DTO + PoParser parse
+
+**Files:**
+- Create: `Runtime/Core/I18n/PoEntry.cs`
+- Create: `Runtime/Core/I18n/PoParser.cs`
+- Create: `Tests/EditMode/I18n/PoParserTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+// Tests/EditMode/I18n/PoParserTests.cs
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.I18n;
+
+namespace PromptUGUI.Tests.I18n {
+    public class PoParserTests {
+        [Test] public void Parse_SingleEntry_ReturnsMsgidMsgstr() {
+            var src = "msgid \"hello\"\nmsgstr \"你好\"\n";
+            var entries = PoParser.Parse(src).ToList();
+            Assert.AreEqual(1, entries.Count);
+            Assert.AreEqual("hello", entries[0].Msgid);
+            Assert.AreEqual("你好", entries[0].Msgstr);
+            Assert.IsNull(entries[0].Msgctxt);
+        }
+
+        [Test] public void Parse_WithMsgctxt_PopulatesCtx() {
+            var src = "msgctxt \"door\"\nmsgid \"Open\"\nmsgstr \"打开\"\n";
+            var e = PoParser.Parse(src).Single();
+            Assert.AreEqual("door", e.Msgctxt);
+            Assert.AreEqual("Open", e.Msgid);
+            Assert.AreEqual("打开", e.Msgstr);
+        }
+
+        [Test] public void Parse_MultilineString_ConcatenatesQuoted() {
+            var src = "msgid \"\"\n\"line1 \"\n\"line2\"\nmsgstr \"\"\n\"out\"\n";
+            var e = PoParser.Parse(src).Single();
+            Assert.AreEqual("line1 line2", e.Msgid);
+            Assert.AreEqual("out", e.Msgstr);
+        }
+
+        [Test] public void Parse_EscapeSequences_AreDecoded() {
+            var src = "msgid \"a\\nb\\tc\\\"d\\\\e\"\nmsgstr \"\"\n";
+            var e = PoParser.Parse(src).Single();
+            Assert.AreEqual("a\nb\tc\"d\\e", e.Msgid);
+        }
+
+        [Test] public void Parse_TranslatorCommentsCollected() {
+            var src = "# translator note\n#. extracted note\n#: file.cs:42\nmsgid \"x\"\nmsgstr \"\"\n";
+            var e = PoParser.Parse(src).Single();
+            CollectionAssert.Contains(e.TranslatorComments, "translator note");
+        }
+
+        [Test] public void Parse_ObsoleteEntries_AreSkipped() {
+            var src = "#~ msgid \"old\"\n#~ msgstr \"old-tr\"\nmsgid \"new\"\nmsgstr \"new-tr\"\n";
+            var entries = PoParser.Parse(src).ToList();
+            Assert.AreEqual(1, entries.Count);
+            Assert.AreEqual("new", entries[0].Msgid);
+        }
+
+        [Test] public void Parse_HeaderEntry_IsReturnedLikeOthers() {
+            // Header is the entry with empty msgid; we still emit it.
+            var src = "msgid \"\"\nmsgstr \"Content-Type: text/plain\\n\"\nmsgid \"x\"\nmsgstr \"y\"\n";
+            var entries = PoParser.Parse(src).ToList();
+            Assert.AreEqual(2, entries.Count);
+            Assert.AreEqual("", entries[0].Msgid);
+        }
+
+        [Test] public void Parse_EmptyOrWhitespace_ReturnsEmpty() {
+            CollectionAssert.IsEmpty(PoParser.Parse("").ToList());
+            CollectionAssert.IsEmpty(PoParser.Parse("\n\n  \n").ToList());
+        }
+
+        [Test] public void Parse_MissingMsgstr_Throws() {
+            Assert.Throws<PoParseException>(() => PoParser.Parse("msgid \"x\"\n").ToList());
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests; expect compile fail (PoParser/PoEntry not defined)**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="PoParserTests")
+```
+
+Expected: build/compile failure or test class not found.
+
+- [ ] **Step 3: Implement PoEntry**
+
+```csharp
+// Runtime/Core/I18n/PoEntry.cs
+using System.Collections.Generic;
+
+namespace PromptUGUI.I18n {
+    public sealed class PoEntry {
+        public string Msgctxt;        // null = no ctx
+        public string Msgid;
+        public string Msgstr;         // "" = untranslated
+        public List<string> TranslatorComments = new();
+    }
+
+    public sealed class PoParseException : System.Exception {
+        public PoParseException(string msg) : base(msg) { }
+    }
+}
+```
+
+- [ ] **Step 4: Implement PoParser.Parse**
+
+```csharp
+// Runtime/Core/I18n/PoParser.cs
+using System.Collections.Generic;
+using System.Text;
+
+namespace PromptUGUI.I18n {
+    public static partial class PoParser {
+        public static IEnumerable<PoEntry> Parse(string source) {
+            if (string.IsNullOrEmpty(source)) yield break;
+            var lines = source.Replace("\r\n", "\n").Split('\n');
+            int i = 0;
+            while (i < lines.Length) {
+                // Skip blank lines.
+                while (i < lines.Length && lines[i].Trim().Length == 0) i++;
+                if (i >= lines.Length) yield break;
+
+                var entry = new PoEntry();
+                bool obsolete = false;
+                bool sawMsgid = false, sawMsgstr = false;
+
+                // Collect leading comments (and detect obsolete prefix).
+                while (i < lines.Length && lines[i].StartsWith("#")) {
+                    var c = lines[i];
+                    if (c.StartsWith("#~")) { obsolete = true; i++; continue; }
+                    var rest = c.Length > 1 ? c.Substring(1).TrimStart() : "";
+                    entry.TranslatorComments.Add(rest);
+                    i++;
+                }
+
+                // msgctxt (optional)
+                if (i < lines.Length && lines[i].StartsWith("msgctxt ")) {
+                    entry.Msgctxt = ReadStringValue(lines, ref i, "msgctxt ");
+                }
+
+                // msgid (required)
+                if (i < lines.Length && lines[i].StartsWith("msgid ")) {
+                    entry.Msgid = ReadStringValue(lines, ref i, "msgid ");
+                    sawMsgid = true;
+                }
+
+                // msgstr (required)
+                if (i < lines.Length && lines[i].StartsWith("msgstr ")) {
+                    entry.Msgstr = ReadStringValue(lines, ref i, "msgstr ");
+                    sawMsgstr = true;
+                }
+
+                if (obsolete) continue;
+                if (!sawMsgid)
+                    throw new PoParseException($"line {i+1}: expected msgid");
+                if (!sawMsgstr)
+                    throw new PoParseException($"line {i+1}: expected msgstr after msgid \"{entry.Msgid}\"");
+
+                yield return entry;
+            }
+        }
+
+        static string ReadStringValue(string[] lines, ref int i, string keyword) {
+            var sb = new StringBuilder();
+            sb.Append(Decode(ExtractQuoted(lines[i].Substring(keyword.Length))));
+            i++;
+            while (i < lines.Length && lines[i].Length > 0 && lines[i][0] == '"') {
+                sb.Append(Decode(ExtractQuoted(lines[i])));
+                i++;
+            }
+            return sb.ToString();
+        }
+
+        static string ExtractQuoted(string s) {
+            s = s.Trim();
+            if (s.Length < 2 || s[0] != '"' || s[s.Length - 1] != '"')
+                throw new PoParseException($"malformed quoted string: {s}");
+            return s.Substring(1, s.Length - 2);
+        }
+
+        static string Decode(string raw) {
+            var sb = new StringBuilder(raw.Length);
+            for (int j = 0; j < raw.Length; j++) {
+                char c = raw[j];
+                if (c == '\\' && j + 1 < raw.Length) {
+                    char n = raw[++j];
+                    switch (n) {
+                        case 'n': sb.Append('\n'); break;
+                        case 't': sb.Append('\t'); break;
+                        case 'r': sb.Append('\r'); break;
+                        case '"': sb.Append('"'); break;
+                        case '\\': sb.Append('\\'); break;
+                        default: sb.Append(n); break;
+                    }
+                } else {
+                    sb.Append(c);
+                }
+            }
+            return sb.ToString();
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run tests; expect pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="PoParserTests")
+```
+
+Expected: 9/9 PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Runtime/Core/I18n/ Tests/EditMode/I18n/PoParserTests.cs Tests/EditMode/I18n/
+git commit -m "feat(i18n): PoEntry DTO + PoParser (parse) with comments + obsolete skip"
+```
+
+---
+
+## Task 4: PoParser.Serialize
+
+**Files:**
+- Modify: `Runtime/Core/I18n/PoParser.cs`
+- Modify: `Tests/EditMode/I18n/PoParserTests.cs`
+
+- [ ] **Step 1: Add failing roundtrip tests**
+
+```csharp
+// Append to PoParserTests.cs
+[Test] public void Roundtrip_BasicEntries_PreservesContent() {
+    var src = new[] {
+        new PoEntry { Msgid = "hello", Msgstr = "你好" },
+        new PoEntry { Msgctxt = "door", Msgid = "Open", Msgstr = "打开",
+                      TranslatorComments = { "doorway action" } },
+    };
+    var text = PoParser.Serialize(src);
+    var parsed = PoParser.Parse(text).ToList();
+    Assert.AreEqual(2, parsed.Count);
+    Assert.AreEqual("hello", parsed[0].Msgid);
+    Assert.AreEqual("你好",  parsed[0].Msgstr);
+    Assert.AreEqual("door",  parsed[1].Msgctxt);
+    Assert.AreEqual("Open",  parsed[1].Msgid);
+    Assert.AreEqual("打开",  parsed[1].Msgstr);
+}
+
+[Test] public void Serialize_EscapesNewlinesAndQuotes() {
+    var entries = new[] {
+        new PoEntry { Msgid = "line\nwith \"quotes\"", Msgstr = "" }
+    };
+    var text = PoParser.Serialize(entries);
+    StringAssert.Contains("\\n", text);
+    StringAssert.Contains("\\\"", text);
+}
+```
+
+- [ ] **Step 2: Run; expect compile fail (Serialize undefined)**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="PoParserTests")
+```
+
+- [ ] **Step 3: Implement Serialize**
+
+Append to `Runtime/Core/I18n/PoParser.cs` inside the `PoParser` class:
+
+```csharp
+public static string Serialize(IEnumerable<PoEntry> entries) {
+    var sb = new StringBuilder();
+    foreach (var e in entries) {
+        if (e.TranslatorComments != null) {
+            foreach (var line in e.TranslatorComments)
+                sb.Append("# ").Append(line).Append('\n');
+        }
+        if (e.Msgctxt != null) {
+            sb.Append("msgctxt \"").Append(Encode(e.Msgctxt)).Append("\"\n");
+        }
+        sb.Append("msgid \"").Append(Encode(e.Msgid ?? "")).Append("\"\n");
+        sb.Append("msgstr \"").Append(Encode(e.Msgstr ?? "")).Append("\"\n");
+        sb.Append('\n');
+    }
+    return sb.ToString();
+}
+
+static string Encode(string s) {
+    var sb = new StringBuilder(s.Length);
+    foreach (var c in s) {
+        switch (c) {
+            case '\n': sb.Append("\\n"); break;
+            case '\t': sb.Append("\\t"); break;
+            case '\r': sb.Append("\\r"); break;
+            case '"':  sb.Append("\\\""); break;
+            case '\\': sb.Append("\\\\"); break;
+            default:   sb.Append(c); break;
+        }
+    }
+    return sb.ToString();
+}
+```
+
+- [ ] **Step 4: Run; expect pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="PoParserTests")
+```
+
+Expected: 11/11 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Core/I18n/PoParser.cs Tests/EditMode/I18n/PoParserTests.cs
+git commit -m "feat(i18n): PoParser.Serialize with proper escaping"
+```
+
+---
+
+## Task 5: PoFileImporter ScriptedImporter
+
+**Files:**
+- Create: `Editor/PoFileImporter.cs`
+- Create: `Tests/EditMode/Editor/PoFileImporterTests.cs` (PromptUGUI.Tests.EditorOnly asmdef)
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+// Tests/EditMode/Editor/PoFileImporterTests.cs
+using System.IO;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Editor {
+    public class PoFileImporterTests {
+        const string TmpDir = "Assets/PromptUGUIPoTmp";
+        const string TmpPath = "Assets/PromptUGUIPoTmp/sample.po";
+
+        [SetUp] public void Setup() {
+            if (!AssetDatabase.IsValidFolder(TmpDir))
+                AssetDatabase.CreateFolder("Assets", "PromptUGUIPoTmp");
+        }
+        [TearDown] public void Teardown() {
+            AssetDatabase.DeleteAsset(TmpDir);
+        }
+
+        [Test] public void Import_PoFile_LoadsAsTextAsset() {
+            File.WriteAllText(TmpPath, "msgid \"x\"\nmsgstr \"y\"\n");
+            AssetDatabase.ImportAsset(TmpPath);
+            var asset = AssetDatabase.LoadAssetAtPath<TextAsset>(TmpPath);
+            Assert.IsNotNull(asset, "po file should be loadable as TextAsset");
+            StringAssert.Contains("msgid", asset.text);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run; expect fail (asset loaded as DefaultAsset, not TextAsset)**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"], filter="PoFileImporterTests")
+```
+
+- [ ] **Step 3: Implement importer**
+
+```csharp
+// Editor/PoFileImporter.cs
+using System.IO;
+using UnityEditor.AssetImporters;
+using UnityEngine;
+
+namespace PromptUGUI.Editor {
+    [ScriptedImporter(version: 1, ext: "po")]
+    internal sealed class PoFileImporter : ScriptedImporter {
+        public override void OnImportAsset(AssetImportContext ctx) {
+            var text = File.ReadAllText(ctx.assetPath);
+            var asset = new TextAsset(text);
+            ctx.AddObjectToAsset("text", asset);
+            ctx.SetMainObject(asset);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run; expect pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"], filter="PoFileImporterTests")
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Editor/PoFileImporter.cs Editor/PoFileImporter.cs.meta \
+        Tests/EditMode/Editor/PoFileImporterTests.cs
+git commit -m "feat(editor): ScriptedImporter registers .po as TextAsset"
+```
+
+---
+
+## Task 6: TranslationStore
+
+**Files:**
+- Create: `Runtime/Application/TranslationStore.cs`
+- Create: `Tests/EditMode/I18n/TranslationStoreTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+// Tests/EditMode/I18n/TranslationStoreTests.cs
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.I18n;
+
+namespace PromptUGUI.Tests.I18n {
+    public class TranslationStoreTests {
+        TranslationStore _store;
+        [SetUp] public void Setup() => _store = new TranslationStore();
+
+        [Test] public void Lookup_BeforeAnyLoad_ReturnsNull() {
+            Assert.IsNull(_store.Lookup("zh-Hans", null, "x"));
+        }
+
+        [Test] public void Load_ThenLookup_ReturnsMsgstr() {
+            _store.Load("zh-Hans", new[] {
+                new PoEntry { Msgid = "hello", Msgstr = "你好" },
+            });
+            Assert.AreEqual("你好", _store.Lookup("zh-Hans", null, "hello"));
+        }
+
+        [Test] public void Lookup_WithCtx_OnlyMatchesEntryWithSameCtx() {
+            _store.Load("zh-Hans", new[] {
+                new PoEntry { Msgid = "Open", Msgstr = "打开" },
+                new PoEntry { Msgctxt = "door", Msgid = "Open", Msgstr = "开门" },
+            });
+            Assert.AreEqual("打开", _store.Lookup("zh-Hans", null, "Open"));
+            Assert.AreEqual("开门", _store.Lookup("zh-Hans", "door", "Open"));
+            Assert.IsNull(_store.Lookup("zh-Hans", "missing", "Open"));
+        }
+
+        [Test] public void Load_LaterCallsOverridePrior() {
+            // i18n-custom override semantics: load auto first, then custom.
+            _store.Load("zh-Hans", new[] { new PoEntry { Msgid = "x", Msgstr = "auto" } });
+            _store.Load("zh-Hans", new[] { new PoEntry { Msgid = "x", Msgstr = "custom" } });
+            Assert.AreEqual("custom", _store.Lookup("zh-Hans", null, "x"));
+        }
+
+        [Test] public void EmptyMsgstr_TreatedAsMiss() {
+            _store.Load("zh-Hans", new[] { new PoEntry { Msgid = "x", Msgstr = "" } });
+            Assert.IsNull(_store.Lookup("zh-Hans", null, "x"));
+        }
+
+        [Test] public void UnloadLocale_RemovesOnlyThatLocale() {
+            _store.Load("zh-Hans", new[] { new PoEntry { Msgid = "x", Msgstr = "y" } });
+            _store.Load("en",      new[] { new PoEntry { Msgid = "x", Msgstr = "Y" } });
+            _store.UnloadLocale("zh-Hans");
+            Assert.IsNull(_store.Lookup("zh-Hans", null, "x"));
+            Assert.AreEqual("Y", _store.Lookup("en", null, "x"));
+        }
+
+        [Test] public void UnloadAll_ClearsEverything() {
+            _store.Load("en", new[] { new PoEntry { Msgid = "x", Msgstr = "Y" } });
+            _store.UnloadAll();
+            Assert.IsNull(_store.Lookup("en", null, "x"));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run; expect compile fail**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TranslationStoreTests")
+```
+
+- [ ] **Step 3: Implement TranslationStore**
+
+```csharp
+// Runtime/Application/TranslationStore.cs
+using System.Collections.Generic;
+using PromptUGUI.I18n;
+
+namespace PromptUGUI.Application {
+    public sealed class TranslationStore {
+        readonly Dictionary<(string locale, string ctx, string msgid), string> _entries = new();
+
+        public static TranslationStore Instance { get; } = new();
+
+        public string Lookup(string locale, string ctx, string msgid) {
+            if (_entries.TryGetValue((locale, ctx, msgid), out var v)) return v;
+            return null;
+        }
+
+        public void Load(string locale, IEnumerable<PoEntry> entries) {
+            foreach (var e in entries) {
+                if (string.IsNullOrEmpty(e.Msgstr)) continue;     // miss == empty
+                _entries[(locale, e.Msgctxt, e.Msgid)] = e.Msgstr;
+            }
+        }
+
+        public void UnloadLocale(string locale) {
+            var toRemove = new List<(string, string, string)>();
+            foreach (var k in _entries.Keys) if (k.locale == locale) toRemove.Add(k);
+            foreach (var k in toRemove) _entries.Remove(k);
+        }
+
+        public void UnloadAll() => _entries.Clear();
+    }
+}
+```
+
+- [ ] **Step 4: Run; expect pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TranslationStoreTests")
+```
+
+Expected: 7/7 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Application/TranslationStore.cs Runtime/Application/TranslationStore.cs.meta \
+        Tests/EditMode/I18n/TranslationStoreTests.cs
+git commit -m "feat(i18n): TranslationStore with (locale,ctx,msgid) lookup + override semantics"
+```
+
+---
+
+## Task 7: TrResolver
+
+**Files:**
+- Create: `Runtime/Application/TrResolver.cs`
+- Create: `Tests/EditMode/I18n/TrResolverTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+// Tests/EditMode/I18n/TrResolverTests.cs
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.I18n;
+
+namespace PromptUGUI.Tests.I18n {
+    public class TrResolverTests {
+        [SetUp] public void Setup() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+        }
+        [TearDown] public void Teardown() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+        }
+
+        [Test] public void Resolve_NullRaw_ReturnsNull() {
+            Assert.IsNull(TrResolver.Resolve(null, null, null));
+        }
+
+        [Test] public void Resolve_LocaleNull_ReturnsRaw() {
+            Assert.AreEqual("hi", TrResolver.Resolve("hi", null, null));
+        }
+
+        [Test] public void Resolve_Miss_ReturnsRaw() {
+            UI.Locale.Set("zh-Hans");
+            Assert.AreEqual("hi", TrResolver.Resolve("hi", null, null));
+        }
+
+        [Test] public void Resolve_Hit_ReturnsMsgstr() {
+            TranslationStore.Instance.Load("zh-Hans", new[] {
+                new PoEntry { Msgid = "hi", Msgstr = "你好" },
+            });
+            UI.Locale.Set("zh-Hans");
+            Assert.AreEqual("你好", TrResolver.Resolve("hi", null, null));
+        }
+
+        [Test] public void Resolve_HitWithCtx_ReturnsCtxScopedMsgstr() {
+            TranslationStore.Instance.Load("zh-Hans", new[] {
+                new PoEntry { Msgid = "Open", Msgstr = "打开" },
+                new PoEntry { Msgctxt = "door", Msgid = "Open", Msgstr = "开门" },
+            });
+            UI.Locale.Set("zh-Hans");
+            Assert.AreEqual("开门", TrResolver.Resolve("Open", null, "door"));
+            Assert.AreEqual("打开", TrResolver.Resolve("Open", null, null));
+        }
+
+        [Test] public void Resolve_WithArgs_AppliesSubstitutionAfterLookup() {
+            TranslationStore.Instance.Load("en", new[] {
+                new PoEntry { Msgid = "金币: {{n}}", Msgstr = "Gold: {{n}}" },
+            });
+            UI.Locale.Set("en");
+            var args = new Dictionary<string, string> { { "n", "123" } };
+            Assert.AreEqual("Gold: 123", TrResolver.Resolve("金币: {{n}}", args, null));
+        }
+
+        [Test] public void Resolve_ArgsOnMiss_StillSubstitutesIntoRaw() {
+            UI.Locale.Set("ja");  // empty store
+            var args = new Dictionary<string, string> { { "n", "5" } };
+            Assert.AreEqual("金币: 5", TrResolver.Resolve("金币: {{n}}", args, null));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run; expect compile fail (TrResolver / UI.Locale undefined)**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TrResolverTests")
+```
+
+- [ ] **Step 3: Implement TrResolver**
+
+```csharp
+// Runtime/Application/TrResolver.cs
+using System.Collections.Generic;
+using PromptUGUI.Template;
+
+namespace PromptUGUI.Application {
+    public static class TrResolver {
+        public static string Resolve(
+            string raw,
+            IReadOnlyDictionary<string, string> args,
+            string ctx) {
+            if (raw == null) return null;
+            var locale = UI.Locale.Current;
+            string template = raw;
+            if (locale != null) {
+                var hit = TranslationStore.Instance.Lookup(locale, ctx, raw);
+                if (!string.IsNullOrEmpty(hit)) template = hit;
+            }
+            if (args == null || args.Count == 0) return template;
+            return Substitution.Apply(template, args);
+        }
+    }
+}
+```
+
+(`Substitution.Apply` already throws on unknown placeholders. For Tr lookups, missing args is a real error and should surface — keep that behavior.)
+
+- [ ] **Step 4: Run; expect pass after Task 8 (UI.Locale)**
+
+The test harness depends on `UI.Locale.Set` and `UI.ResetForTests` clearing locale. Defer running these tests to Task 8 — the test file will compile but tests fail until Task 8 completes UI.Locale wiring.
+
+For now run only `Resolve_NullRaw_ReturnsNull` to confirm TrResolver shape:
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: compile success. Test pass for first case will follow Task 8.
+
+- [ ] **Step 5: Commit (partial — tests pass after Task 8)**
+
+```bash
+git add Runtime/Application/TrResolver.cs Runtime/Application/TrResolver.cs.meta \
+        Tests/EditMode/I18n/TrResolverTests.cs
+git commit -m "feat(i18n): TrResolver — lookup + post-hoc {{x}} substitution"
+```
+
+---
+
+## Task 8: VariantStore.NotifyChangedInternal
+
+**Files:**
+- Modify: `Runtime/Application/VariantStore.cs`
+- Create: `Tests/EditMode/Application/VariantStoreNotifyTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+// Tests/EditMode/Application/VariantStoreNotifyTests.cs
+using NUnit.Framework;
+using PromptUGUI.Application;
+using R3;
+
+namespace PromptUGUI.Tests.Application {
+    public class VariantStoreNotifyTests {
+        [Test] public void NotifyChangedInternal_FiresChangedWithoutMutatingActiveSet() {
+            var store = new VariantStore();
+            int count = 0;
+            store.Changed.Subscribe(_ => count++);
+            store.Set("a", true);                 // 1
+            // pre-condition: count==1
+            typeof(VariantStore)
+                .GetMethod("NotifyChangedInternal",
+                    System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Instance)
+                .Invoke(store, null);             // 2
+            Assert.AreEqual(2, count);
+            Assert.IsTrue(store.IsActive("a"));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run; expect fail (method missing)**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="VariantStoreNotifyTests")
+```
+
+- [ ] **Step 3: Add method**
+
+In `Runtime/Application/VariantStore.cs`, inside the `VariantStore` class, append:
+
+```csharp
+internal void NotifyChangedInternal() => _changed.OnNext(Unit.Default);
+```
+
+- [ ] **Step 4: Run; expect pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="VariantStoreNotifyTests")
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Application/VariantStore.cs Tests/EditMode/Application/VariantStoreNotifyTests.cs
+git commit -m "feat(variant): NotifyChangedInternal for locale-null broadcast"
+```
+
+---
+
+## Task 9: LocaleHelpers + UI.Locale + UI.Tr
+
+**Files:**
+- Create: `Runtime/Application/LocaleHelpers.cs`
+- Modify: `Runtime/Application/UI.cs`
+- Create: `Tests/EditMode/Application/LocaleSetTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+// Tests/EditMode/Application/LocaleSetTests.cs
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.I18n;
+using R3;
+
+namespace PromptUGUI.Tests.Application {
+    public class LocaleSetTests {
+        [SetUp] public void Setup() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+        }
+        [TearDown] public void Teardown() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+        }
+
+        [Test] public void Initial_CurrentIsNull() {
+            Assert.IsNull(UI.Locale.Current);
+        }
+
+        [Test] public void Set_UpdatesCurrent_FiresChanged() {
+            int n = 0;
+            UI.Locale.Changed += () => n++;
+            UI.Locale.Set("en");
+            Assert.AreEqual("en", UI.Locale.Current);
+            Assert.AreEqual(1, n);
+        }
+
+        [Test] public void Set_SameValueTwice_DoesNotFire() {
+            int n = 0;
+            UI.Locale.Set("en");
+            UI.Locale.Changed += () => n++;
+            UI.Locale.Set("en");
+            Assert.AreEqual(0, n);
+        }
+
+        [Test] public void Set_TogglesVariantNamedAfterLocale() {
+            UI.Locale.Set("zh-Hans");
+            Assert.IsTrue(UI.Variants.IsActive("zh-Hans"));
+            UI.Locale.Set("en");
+            Assert.IsFalse(UI.Variants.IsActive("zh-Hans"));
+            Assert.IsTrue(UI.Variants.IsActive("en"));
+        }
+
+        [Test] public void Set_Null_ClearsVariantAndCurrent() {
+            UI.Locale.Set("en");
+            UI.Locale.Set(null);
+            Assert.IsNull(UI.Locale.Current);
+            Assert.IsFalse(UI.Variants.IsActive("en"));
+        }
+
+        [Test] public void Set_TriggersVariantChanged() {
+            int n = 0;
+            UI.VariantStore.Changed.Subscribe(_ => n++);
+            UI.Locale.Set("en");
+            Assert.GreaterOrEqual(n, 1);
+        }
+
+        [Test] public void Tr_StaticMethod_DelegatesToTrResolver() {
+            TranslationStore.Instance.Load("en", new[] {
+                new PoEntry { Msgid = "hi", Msgstr = "Hello" },
+            });
+            UI.Locale.Set("en");
+            Assert.AreEqual("Hello", UI.Tr("hi"));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run; expect compile fail**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="LocaleSetTests")
+```
+
+- [ ] **Step 3: Implement LocaleHelpers**
+
+```csharp
+// Runtime/Application/LocaleHelpers.cs
+using UnityEngine;
+
+namespace PromptUGUI.Application {
+    public static class LocaleHelpers {
+        public static string MapSystemLanguage(SystemLanguage lang) =>
+            lang switch {
+                SystemLanguage.ChineseSimplified  => "zh-Hans",
+                SystemLanguage.ChineseTraditional => "zh-Hant",
+                SystemLanguage.Chinese            => "zh-Hans",
+                SystemLanguage.English            => "en",
+                SystemLanguage.Japanese           => "ja",
+                SystemLanguage.Korean             => "ko",
+                SystemLanguage.French             => "fr",
+                SystemLanguage.German             => "de",
+                SystemLanguage.Spanish            => "es",
+                SystemLanguage.Russian            => "ru",
+                SystemLanguage.Portuguese         => "pt",
+                SystemLanguage.Italian            => "it",
+                _                                 => null,
+            };
+    }
+}
+```
+
+- [ ] **Step 4: Add UI.Locale + UI.Tr to UI.cs**
+
+In `Runtime/Application/UI.cs`, after the existing `public static class Variants { ... }` block, add:
+
+```csharp
+public static class Locale {
+    public static string Current { get; private set; }
+    public static event System.Action Changed;
+
+    public static void Set(string locale) {
+        if (Current == locale) return;
+        if (Current != null) _variantStore.Set(Current, false);
+        TranslationStore.Instance.UnloadAll();
+        Current = locale;
+        if (locale != null) {
+            LoadPoFiles(locale);
+            _variantStore.Set(locale, true);
+        } else {
+            _variantStore.NotifyChangedInternal();
+        }
+        Changed?.Invoke();
+    }
+
+    public static void SetToSystemDefault() =>
+        Set(LocaleHelpers.MapSystemLanguage(UnityEngine.Application.systemLanguage));
+
+    public static System.Collections.Generic.IReadOnlyList<string> Configured {
+        get {
+            var s = PromptUGUISettings.Instance;
+            if (s == null) return System.Array.Empty<string>();
+            var list = new System.Collections.Generic.List<string>();
+            foreach (var lc in s.locales) if (!string.IsNullOrEmpty(lc.locale)) list.Add(lc.locale);
+            return list;
+        }
+    }
+}
+
+public static string Tr(string msgid, string ctx = null) =>
+    TrResolver.Resolve(msgid, null, ctx);
+
+static void LoadPoFiles(string locale) {
+    LoadPoFromPath($"PromptUGUI/i18n/{locale}");
+    LoadPoFromPath($"PromptUGUI/i18n-custom/{locale}"); // override last
+}
+
+static void LoadPoFromPath(string resourcesPath) {
+    var assets = UnityEngine.Resources.LoadAll<UnityEngine.TextAsset>(resourcesPath);
+    foreach (var asset in assets) {
+        var current = TranslationStore.Instance;
+        try {
+            var entries = new System.Collections.Generic.List<I18n.PoEntry>(
+                I18n.PoParser.Parse(asset.text));
+            current.Load(System.IO.Path.GetFileName(resourcesPath), entries);
+        } catch (System.Exception e) {
+            UnityEngine.Debug.LogError(
+                $"[PromptUGUI] failed to parse .po asset '{asset.name}': {e.Message}");
+        }
+    }
+}
+```
+
+(Note: `Path.GetFileName(resourcesPath)` returns the last segment, i.e. the locale string `zh-Hans` — that's the locale key passed to TranslationStore.Load.)
+
+Inside `Locale` class, add:
+
+```csharp
+internal static void ResetForTestsInternal() {
+    if (Current != null) _variantStore.Set(Current, false);
+    Current = null;
+    Changed = null;
+}
+```
+
+Then extend `UI.ResetForTests()` — find the existing method and add `Locale.ResetForTestsInternal();` and `TranslationStore.Instance.UnloadAll();` near the top (before `_variantStore.Reset();`).
+
+`internal static VariantStore VariantStore => _variantStore;` is already exposed (line 25 of UI.cs).
+
+- [ ] **Step 5: Run all i18n tests; expect pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="LocaleSetTests")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TrResolverTests")
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Runtime/Application/LocaleHelpers.cs Runtime/Application/LocaleHelpers.cs.meta \
+        Runtime/Application/UI.cs Tests/EditMode/Application/LocaleSetTests.cs
+git commit -m "feat(i18n): UI.Locale.Set/Tr + Variant integration + .po loader"
+```
+
+---
+
+## Task 10: ElementNode raw fields
+
+**Files:**
+- Modify: `Runtime/Core/IR/ElementNode.cs`
+
+- [ ] **Step 1: Add fields**
+
+In `Runtime/Core/IR/ElementNode.cs`, inside the `ElementNode` class, add:
+
+```csharp
+/// <summary>
+/// Pre-substitution textContent. Filled by parser AND TemplateExpander preserves it through
+/// to expanded nodes (parser fills raw, expander leaves it alone but updates TextArgs).
+/// Only Text/Btn-shaped controls consume this; other tags ignore.
+/// </summary>
+public string TextContentRaw { get; set; }
+
+/// <summary>
+/// Template instantiation arguments captured by TemplateExpander when the node was produced
+/// from a Template expansion. Empty / null on parser-produced nodes.
+/// Used at runtime so TrResolver can re-substitute on the translated msgstr.
+/// </summary>
+public Dictionary<string, string> TextArgs { get; set; }
+
+/// <summary>
+/// Pre-substitution attribute values, populated for attributes whose VALUE contained {{...}}
+/// (e.g. <code>text="Gold: {{n}}"</code>). Other attributes can be retrieved from Attributes
+/// directly. Used at runtime for the same reason as TextContentRaw.
+/// </summary>
+public Dictionary<string, string> AttributesRaw { get; set; }
+```
+
+Initialize `AttributesRaw = new()` in the constructor (place next to `Attributes = new ...`). Leave `TextContentRaw` / `TextArgs` as null-defaulting.
+
+- [ ] **Step 2: Refresh, verify compile**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+```
+
+Expected: no compile errors, all existing tests still pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Runtime/Core/IR/ElementNode.cs
+git commit -m "feat(ir): ElementNode.TextContentRaw / TextArgs / AttributesRaw"
+```
+
+---
+
+## Task 11: Parser CDATA + raw fields
+
+**Files:**
+- Modify: `Runtime/Core/Parser/UIDocumentParser.cs`
+- Create: `Tests/EditMode/Parser/CDataInTextTests.cs`
+- Create: `Tests/EditMode/Parser/RawAttributesAndContentTests.cs`
+
+- [ ] **Step 1: Write failing CDATA tests**
+
+```csharp
+// Tests/EditMode/Parser/CDataInTextTests.cs
+using NUnit.Framework;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.Parser {
+    public class CDataInTextTests {
+        [Test] public void Text_WithCData_ContainingTmpSprite_Parses() {
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <Text><![CDATA[gold: <sprite name=""coin""/>{{n}}]]></Text>
+  </Screen>
+</PromptUGUI>";
+            var doc = UIDocumentParser.Parse(xml);
+            var text = doc.Screens[0].Body.Children[0];
+            Assert.AreEqual("Text", text.Tag);
+            StringAssert.Contains("<sprite", text.TextContentRaw);
+            StringAssert.Contains("{{n}}",   text.TextContentRaw);
+        }
+
+        [Test] public void Text_WithMixedTextAndCdata_StillForbidden() {
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <Text>foo<sprite/></Text>
+  </Screen>
+</PromptUGUI>";
+            Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+        }
+    }
+}
+```
+
+```csharp
+// Tests/EditMode/Parser/RawAttributesAndContentTests.cs
+using NUnit.Framework;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.Parser {
+    public class RawAttributesAndContentTests {
+        [Test] public void TextContentRaw_PopulatedFromTextNode() {
+            var xml = "<PromptUGUI version='1'><Screen name='S'><Text>hi {{n}}</Text></Screen></PromptUGUI>";
+            var node = UIDocumentParser.Parse(xml).Screens[0].Body.Children[0];
+            Assert.AreEqual("hi {{n}}", node.TextContentRaw);
+        }
+
+        [Test] public void AttributesRaw_PopulatedOnlyWhenValueContainsBraces() {
+            var xml = "<PromptUGUI version='1'><Screen name='S'>" +
+                      "<Text text='Gold: {{n}}' fontSize='32'/></Screen></PromptUGUI>";
+            var node = UIDocumentParser.Parse(xml).Screens[0].Body.Children[0];
+            Assert.IsTrue(node.AttributesRaw.ContainsKey("text"));
+            Assert.AreEqual("Gold: {{n}}", node.AttributesRaw["text"]);
+            Assert.IsFalse(node.AttributesRaw.ContainsKey("fontSize"));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run; expect fail**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="CDataInTextTests")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RawAttributesAndContentTests")
+```
+
+- [ ] **Step 3: Modify parser**
+
+In `Runtime/Core/Parser/UIDocumentParser.cs`, around line 262 (the `hasText` / `hasElement` detection block), change to:
+
+```csharp
+bool hasElement = false, hasText = false;
+foreach (XmlNode c in el.ChildNodes) {
+    if (c is XmlElement) hasElement = true;
+    else if (c is XmlText txt && !string.IsNullOrWhiteSpace(txt.Value)) hasText = true;
+    else if (c is XmlCDataSection cdata && !string.IsNullOrWhiteSpace(cdata.Value)) hasText = true;
+}
+if (hasText && hasElement)
+    throw new ParseException(
+        $"<{el.Name}> mixes text and child elements; not allowed");
+if (hasText && !hasElement) {
+    node.TextContent = el.InnerText.Trim();
+    node.TextContentRaw = el.InnerText;     // un-trimmed raw — preserves intentional whitespace inside CDATA
+}
+```
+
+(The `Trim()` in TextContent stays for backwards compat; TextContentRaw keeps original.)
+
+In the same parser method, after the attribute parsing block (around line 254-260 where Attributes / VariantOverrides are populated), add:
+
+```csharp
+// Capture raw attribute values for attrs containing {{...}} (for runtime re-substitution on translated msgstr).
+foreach (var kv in node.Attributes) {
+    if (kv.Value != null && kv.Value.Contains("{{"))
+        node.AttributesRaw[kv.Key] = kv.Value;
+}
+```
+
+- [ ] **Step 4: Run; expect pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="CDataInTextTests")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RawAttributesAndContentTests")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="UIDocumentParserTests")
+```
+
+Expected: new tests PASS, existing parser tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Core/Parser/UIDocumentParser.cs \
+        Tests/EditMode/Parser/CDataInTextTests.cs \
+        Tests/EditMode/Parser/RawAttributesAndContentTests.cs
+git commit -m "feat(parser): accept CDATA in textContent + populate raw fields for runtime tr"
+```
+
+---
+
+## Task 12: TemplateExpander propagates args to TextArgs
+
+**Files:**
+- Modify: `Runtime/Core/Template/TemplateExpander.cs`
+- Create: `Tests/EditMode/Template/TemplateArgsPropagationTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+// Tests/EditMode/Template/TemplateArgsPropagationTests.cs
+using NUnit.Framework;
+using PromptUGUI.Parser;
+using PromptUGUI.Template;
+
+namespace PromptUGUI.Tests.Template {
+    public class TemplateArgsPropagationTests {
+        [Test] public void Expand_PassesArgsToTextArgsOnExpandedNodes() {
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Gold'>
+    <Param name='n'/>
+    <Text>金币: {{n}}</Text>
+  </Template>
+  <Screen name='S'>
+    <Gold n='123'/>
+  </Screen>
+</PromptUGUI>";
+            var raw = UIDocumentParser.Parse(xml);
+            var doc = TemplateExpander.Expand(raw);
+            var text = doc.Screens[0].Body.Children[0];
+            Assert.AreEqual("Text", text.Tag);
+            // textContent post-expand is substituted (existing behavior)
+            Assert.AreEqual("金币: 123", text.TextContent);
+            // raw is preserved
+            Assert.AreEqual("金币: {{n}}", text.TextContentRaw);
+            // args carry the substitution map
+            Assert.IsNotNull(text.TextArgs);
+            Assert.AreEqual("123", text.TextArgs["n"]);
+        }
+
+        [Test] public void Expand_PreservesAttributesRawOnExpansion() {
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Gold'>
+    <Param name='n'/>
+    <Text text='金币: {{n}}'/>
+  </Template>
+  <Screen name='S'>
+    <Gold n='5'/>
+  </Screen>
+</PromptUGUI>";
+            var doc = TemplateExpander.Expand(UIDocumentParser.Parse(xml));
+            var text = doc.Screens[0].Body.Children[0];
+            Assert.AreEqual("金币: 5", text.Attributes["text"]);
+            Assert.AreEqual("金币: {{n}}", text.AttributesRaw["text"]);
+            Assert.AreEqual("5", text.TextArgs["n"]);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run; expect fail**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TemplateArgsPropagationTests")
+```
+
+- [ ] **Step 3: Modify TemplateExpander**
+
+Locate the place where expanded `ElementNode` instances are produced (around `TemplateExpander.cs:201-260` where `prepared = SubstituteAttrs(...)` runs and `TextContent = Substitution.Apply(prepared.TextContent, args)` is set). The expander already substitutes; we now also:
+
+1. Copy `TextContentRaw` and `AttributesRaw` from the source node (un-substituted)
+2. Stash a defensive copy of `args` into the expanded node's `TextArgs`
+
+In the relevant builder block(s) of `TemplateExpander.cs` (the ones that construct expanded `ElementNode` instances around lines ~105 and ~213), add after creating the dst node:
+
+```csharp
+// Preserve original (un-substituted) text/attr values for runtime translation lookup.
+dst.TextContentRaw = src.TextContentRaw ?? src.TextContent;
+if (src.AttributesRaw != null) {
+    foreach (var kv in src.AttributesRaw) dst.AttributesRaw[kv.Key] = kv.Value;
+}
+// Stash args so runtime can re-apply {{x}} to translated msgstr.
+if (args != null && args.Count > 0) {
+    dst.TextArgs = new System.Collections.Generic.Dictionary<string,string>(args);
+}
+```
+
+Also in `SubstituteAttrs` (lines ~233-247), after the existing `dst.Attributes[kv.Key] = ...` loop, add:
+
+```csharp
+foreach (var kv in src.AttributesRaw) {
+    dst.AttributesRaw[kv.Key] = kv.Value;   // preserve raw — substitution does NOT clobber raw
+}
+```
+
+(Make sure `args` parameter is in scope in those blocks; it should be, given existing substitution calls.)
+
+- [ ] **Step 4: Run; expect pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TemplateArgsPropagationTests")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+```
+
+Expected: new tests PASS, all existing tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Core/Template/TemplateExpander.cs \
+        Tests/EditMode/Template/TemplateArgsPropagationTests.cs
+git commit -m "feat(template): propagate raw text/attrs + args dict to expanded nodes"
+```
+
+---
+
+## Task 13: ControlAttributeApplier — route through TrResolver
+
+**Files:**
+- Modify: `Runtime/Application/ControlAttributeApplier.cs`
+
+- [ ] **Step 1: Update the applier**
+
+Replace the body of `ControlAttributeApplier.Apply` (in `Runtime/Application/ControlAttributeApplier.cs`) with:
+
+```csharp
+public static void Apply(ElementNode node, Control control,
+                         ControlRegistry.Entry entry, VariantStore variants) {
+
+    // Determine tr opt-out and ctx (common attrs not registered on Meta)
+    bool tr = !(node.Attributes.TryGetValue("tr", out var trVal) && trVal == "false");
+    node.Attributes.TryGetValue("ctx", out var ctx);
+
+    // Control-specific attributes: union of base + variant keys.
+    var allKeys = new HashSet<string>(node.Attributes.Keys);
+    foreach (var k in node.VariantOverrides.Keys) allKeys.Add(k);
+    foreach (var attrName in allKeys) {
+        if (IsCommonAttribute(attrName)) continue;
+        if (attrName == "tr" || attrName == "ctx") continue;
+        if (!entry.Meta.HasAttribute(attrName)) continue;
+        var v = VariantResolver.ResolveAttribute(node, attrName, variants);
+        if (v == null) continue;
+        // Translate string-valued attrs that are commonly text-bearing.
+        // Default: only "text" attr goes through Tr (others like "color", "sprite" don't translate).
+        if (tr && attrName == "text") {
+            // Use raw value if available so we Tr the un-substituted template.
+            string raw = (node.AttributesRaw != null &&
+                          node.AttributesRaw.TryGetValue("text", out var r)) ? r : v;
+            v = TrResolver.Resolve(raw, node.TextArgs, ctx);
+        }
+        entry.Meta.Apply(control, attrName, v);
+    }
+
+    // Text shorthand
+    if (!string.IsNullOrEmpty(node.TextContent) && entry.DefaultTextAttr != null) {
+        string raw = node.TextContentRaw ?? node.TextContent;
+        string final = tr
+            ? TrResolver.Resolve(raw, node.TextArgs, ctx)
+            : node.TextContent;
+        entry.Meta.Apply(control, entry.DefaultTextAttr, final ?? "");
+    }
+
+    // Common attributes
+    var anchor = VariantResolver.ResolveAttribute(node, "anchor", variants);
+    var size   = VariantResolver.ResolveAttribute(node, "size",   variants);
+    var width  = VariantResolver.ResolveAttribute(node, "width",  variants);
+    var height = VariantResolver.ResolveAttribute(node, "height", variants);
+    var margin = VariantResolver.ResolveAttribute(node, "margin", variants);
+    var pivot  = VariantResolver.ResolveAttribute(node, "pivot",  variants);
+    var hiddenStr       = VariantResolver.ResolveAttribute(node, "hidden", variants);
+    var interactableStr = VariantResolver.ResolveAttribute(node, "interactable", variants);
+    bool hidden       = hiddenStr == "true";
+    bool interactable = interactableStr != "false";
+
+    control.ApplyCommon(anchor, size, width, height, margin, pivot, hidden, interactable);
+}
+
+public static bool IsCommonAttribute(string name) {
+    switch (name) {
+        case "anchor":
+        case "size":
+        case "width":
+        case "height":
+        case "margin":
+        case "pivot":
+        case "hidden":
+        case "interactable":
+            return true;
+    }
+    return false;
+}
+```
+
+- [ ] **Step 2: Refresh, run all EditMode tests**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+```
+
+Expected: all PASS. The existing tests don't load any locale, so Tr passthrough returns raw → identical behavior.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Runtime/Application/ControlAttributeApplier.cs
+git commit -m "feat(applier): route Text/Btn text through TrResolver with ctx + tr=false support"
+```
+
+---
+
+## Task 14: Text — `font` attribute
+
+**Files:**
+- Modify: `Runtime/Controls/Text.cs`
+- Create test: extend `Tests/PlayMode/Controls/TextTests.cs` (existing file)
+
+- [ ] **Step 1: Add Font setter**
+
+In `Runtime/Controls/Text.cs`, add an attribute property:
+
+```csharp
+[UIAttr]
+public string Font {
+    set {
+        var settings = PromptUGUI.Application.PromptUGUISettings.Instance;
+        var locale = PromptUGUI.Application.UI.Locale.Current;
+        var asset = settings != null
+            ? settings.ResolveFont(locale, value ?? "default")
+            : null;
+        if (asset != null) _tmp.font = asset;
+        // miss → keep whatever TMP defaulted to; do not clobber.
+    }
+}
+```
+
+(Does NOT throw on null Settings or null locale; `default` type fallback is in `ResolveFont`.)
+
+- [ ] **Step 2: Refresh + run all PlayMode Text tests**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], filter="TextTests")
+```
+
+Expected: existing tests PASS (Font is opt-in; no XML supplies it yet).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Runtime/Controls/Text.cs
+git commit -m "feat(controls): Text.font attr resolves via Settings.ResolveFont(locale, type)"
+```
+
+---
+
+## Task 15: Btn — text + font + lazy auto label
+
+**Files:**
+- Modify: `Runtime/Controls/Btn.cs`
+- Modify: `Runtime/Application/BuiltinPrimitives.cs`
+
+- [ ] **Step 1: Add lazy auto-label + Text/Font setters to Btn**
+
+Replace `Runtime/Controls/Btn.cs` body with:
+
+```csharp
+using PromptUGUI.Registry;
+using R3;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityImage = UnityEngine.UI.Image;
+
+namespace PromptUGUI.Controls {
+    public sealed class Btn : Control {
+        UnityImage _bg;
+        Button _btn;
+        TMP_Text _autoLabel;
+        readonly Subject<Unit> _click = new();
+
+        public override void OnAttached() {
+            _bg = GameObject.GetComponent<UnityImage>() ?? GameObject.AddComponent<UnityImage>();
+            _btn = GameObject.GetComponent<Button>() ?? GameObject.AddComponent<Button>();
+            _btn.targetGraphic = _bg;
+            _btn.onClick.AddListener(() => _click.OnNext(Unit.Default));
+        }
+
+        TMP_Text EnsureLabel() {
+            if (_autoLabel != null) return _autoLabel;
+            var go = new GameObject("Label", typeof(RectTransform));
+            go.transform.SetParent(GameObject.transform, worldPositionStays: false);
+            var rt = (RectTransform)go.transform;
+            rt.anchorMin = Vector2.zero;
+            rt.anchorMax = Vector2.one;
+            rt.offsetMin = Vector2.zero;
+            rt.offsetMax = Vector2.zero;
+            _autoLabel = go.AddComponent<TextMeshProUGUI>();
+            _autoLabel.alignment = TextAlignmentOptions.Center;
+            _autoLabel.raycastTarget = false;
+            return _autoLabel;
+        }
+
+        [UIAttr]
+        public string Text {
+            set {
+                if (string.IsNullOrEmpty(value) && _autoLabel == null) return;
+                EnsureLabel().text = value ?? "";
+            }
+        }
+
+        [UIAttr]
+        public string Font {
+            set {
+                if (_autoLabel == null) return;  // no text → font irrelevant
+                var settings = PromptUGUI.Application.PromptUGUISettings.Instance;
+                var locale = PromptUGUI.Application.UI.Locale.Current;
+                var asset = settings != null
+                    ? settings.ResolveFont(locale, value ?? "default")
+                    : null;
+                if (asset != null) _autoLabel.font = asset;
+            }
+        }
+
+        [UIAttr]
+        public string Color {
+            set {
+                if (string.IsNullOrEmpty(value)) return;
+                if (ColorUtility.TryParseHtmlString(value, out var c)) _bg.color = c;
+            }
+        }
+
+        [UIAttr]
+        public string Sprite {
+            set {
+                if (string.IsNullOrEmpty(value)) { _bg.sprite = null; return; }
+                _bg.sprite = Resources.Load<Sprite>(value);
+            }
+        }
+
+        public Observable<Unit> OnClick => _click;
+
+        public override void Dispose() {
+            _click.Dispose();
+            base.Dispose();
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Register Btn defaultTextAttr**
+
+In `Runtime/Application/BuiltinPrimitives.cs`, change:
+
+```csharp
+reg.Register<Btn>("Btn", null);
+```
+
+to:
+
+```csharp
+reg.Register<Btn>("Btn", null, defaultTextAttr: "text");
+```
+
+- [ ] **Step 3: Refresh + run all tests**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])
+```
+
+Expected: all PASS. Btn-using tests in PlayMode continue to work (no text attr supplied) and now `<Btn>开始</Btn>` shorthand will actually display text.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Runtime/Controls/Btn.cs Runtime/Application/BuiltinPrimitives.cs
+git commit -m "feat(controls): Btn supports text/font shorthand via lazy TMP child label"
+```
+
+---
+
+## Task 16: UIAssetPostprocessor — .po + Settings branches
+
+**Files:**
+- Modify: `Editor/UIAssetPostprocessor.cs`
+
+- [ ] **Step 1: Extend postprocessor**
+
+Replace `Editor/UIAssetPostprocessor.cs` content with:
+
+```csharp
+using System.Linq;
+using UnityEditor;
+using PromptUGUI.Application;
+
+namespace PromptUGUI.Editor {
+    internal sealed class UIAssetPostprocessor : AssetPostprocessor {
+        static void OnPostprocessAllAssets(
+            string[] importedAssets,
+            string[] deletedAssets,
+            string[] movedAssets,
+            string[] movedFromAssetPaths) {
+
+            if (!UI.HotReload.Enabled) return;
+
+            // .ui.xml branch (existing)
+            if (UI.HotReload.AssetPathToSrc != null) {
+                foreach (var p in importedAssets.Concat(movedAssets)) {
+                    if (!p.EndsWith(".ui.xml")) continue;
+                    try { UI.HotReload.NotifyAssetChanged(p); }
+                    catch (System.Exception e) {
+                        UnityEngine.Debug.LogError(
+                            $"[PromptUGUI] hot reload failed for {p}: {e.Message}");
+                    }
+                }
+            }
+
+            // .po branch — reload current locale if any .po under PromptUGUI/i18n[-custom]/<current>/ changed
+            var current = UI.Locale.Current;
+            if (current != null) {
+                bool poChanged = importedAssets.Concat(movedAssets).Concat(deletedAssets)
+                    .Any(p => p.EndsWith(".po") && IsForLocale(p, current));
+                if (poChanged) {
+                    try { UI.Locale.ReloadCurrent(); }
+                    catch (System.Exception e) {
+                        UnityEngine.Debug.LogError(
+                            $"[PromptUGUI] .po hot reload failed: {e.Message}");
+                    }
+                }
+            }
+
+            // Settings.asset branch — if PromptUGUISettings changed and a current locale exists, ReSolve.
+            bool settingsChanged = importedAssets
+                .Any(p => AssetDatabase.GetMainAssetTypeAtPath(p) == typeof(PromptUGUISettings));
+            if (settingsChanged && UI.Locale.Current != null) {
+                UI.NotifyVariantChangedForReSolve();
+            }
+        }
+
+        static bool IsForLocale(string assetPath, string locale) {
+            // path shape: Assets/Resources/PromptUGUI/i18n/<locale>/... or i18n-custom/<locale>/...
+            return assetPath.Contains($"/PromptUGUI/i18n/{locale}/")
+                || assetPath.Contains($"/PromptUGUI/i18n-custom/{locale}/");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add `UI.Locale.ReloadCurrent` and `UI.NotifyVariantChangedForReSolve`**
+
+In `Runtime/Application/UI.cs`, inside `public static class Locale`:
+
+```csharp
+public static void ReloadCurrent() {
+    if (Current == null) return;
+    TranslationStore.Instance.UnloadLocale(Current);
+    LoadPoFiles(Current);
+    _variantStore.NotifyChangedInternal();
+}
+```
+
+Inside the outer `UI` class:
+
+```csharp
+internal static void NotifyVariantChangedForReSolve() =>
+    _variantStore.NotifyChangedInternal();
+```
+
+- [ ] **Step 3: Refresh + run all tests**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+```
+
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Editor/UIAssetPostprocessor.cs Runtime/Application/UI.cs
+git commit -m "feat(hotreload): .po + Settings.asset branches reload current locale"
+```
+
+---
+
+## Task 17: PlayMode E2E — locale switch + font swap
+
+**Files:**
+- Create: `Tests/PlayMode/E2E/I18nFontSwapTests.cs`
+
+- [ ] **Step 1: Write the test**
+
+```csharp
+// Tests/PlayMode/E2E/I18nFontSwapTests.cs
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.I18n;
+using TMPro;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.PlayMode.E2E {
+    public class I18nFontSwapTests {
+        const string Xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <Text id='lbl' font='title'>开始游戏</Text>
+  </Screen>
+</PromptUGUI>";
+
+        PromptUGUISettings _settings;
+        TMP_FontAsset _fontEn, _fontZh;
+
+        [SetUp] public void Setup() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+
+            _fontEn = TMP_FontAsset.CreateFontAsset(
+                new Font("Arial.ttf"));
+            _fontZh = TMP_FontAsset.CreateFontAsset(
+                new Font("Arial.ttf"));   // distinct instance suffices for ref equality
+
+            _settings = ScriptableObject.CreateInstance<PromptUGUISettings>();
+            _settings.locales = new List<PromptUGUISettings.LocaleConfig> {
+                new() {
+                    locale = "en",
+                    fonts = new List<PromptUGUISettings.FontEntry> {
+                        new() { type = "default", font = _fontEn },
+                        new() { type = "title",   font = _fontEn },
+                    },
+                },
+                new() {
+                    locale = "zh-Hans",
+                    fonts = new List<PromptUGUISettings.FontEntry> {
+                        new() { type = "default", font = _fontZh },
+                        new() { type = "title",   font = _fontZh },
+                    },
+                },
+            };
+            // Pin into preloadedAssets so PromptUGUISettings.Instance finds it.
+            _settings.hideFlags = HideFlags.DontUnloadUnusedAsset;
+
+            UI.LoadDocument("S", Xml);
+
+            TranslationStore.Instance.Load("en", new[] {
+                new PoEntry { Msgid = "开始游戏", Msgstr = "Start" },
+            });
+        }
+
+        [TearDown] public void Teardown() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+            if (_settings != null) Object.DestroyImmediate(_settings);
+            if (_fontEn != null) Object.DestroyImmediate(_fontEn);
+            if (_fontZh != null) Object.DestroyImmediate(_fontZh);
+        }
+
+        [Test] public void SwitchLocale_TextAndFontChange() {
+            UI.Locale.Set("zh-Hans");
+            var screen = UI.Open("S");
+            var txt = screen.Get<Text>("lbl");
+            // No 'zh-Hans' translation loaded → msgid passes through; font is zh.
+            Assert.AreEqual("开始游戏", GetTmpText(txt));
+
+            UI.Locale.Set("en");
+            Assert.AreEqual("Start", GetTmpText(txt));
+        }
+
+        static string GetTmpText(Text t) {
+            var go = ((Control)t).GameObject;
+            return go.GetComponent<TMP_Text>().text;
+        }
+    }
+}
+```
+
+(Note: `Control.GameObject` is exposed; downcast through the `Control` base. If field/property name differs, the agent should grep for it. The `Control` abstract type has `GameObject` accessible.)
+
+- [ ] **Step 2: Run; iterate**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], filter="I18nFontSwapTests")
+```
+
+Expected: PASS. If `PromptUGUISettings.Instance` returns null because the test-created SO isn't in preloadedAssets, the test should manually wire it. One robust workaround: use `Resources.FindObjectsOfTypeAll` works as long as the SO is alive in memory and not unloaded — `HideFlags.DontUnloadUnusedAsset` should keep it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/PlayMode/E2E/I18nFontSwapTests.cs
+git commit -m "test(e2e): I18n locale switch translates text and swaps font"
+```
+
+---
+
+## Task 18: PlayMode E2E — TMP rich-text roundtrip
+
+**Files:**
+- Create: `Tests/PlayMode/E2E/TmpRichTextRoundtripTests.cs`
+
+- [ ] **Step 1: Write test**
+
+```csharp
+// Tests/PlayMode/E2E/TmpRichTextRoundtripTests.cs
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.I18n;
+using TMPro;
+
+namespace PromptUGUI.Tests.PlayMode.E2E {
+    public class TmpRichTextRoundtripTests {
+        const string Xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <Text id='lbl'><![CDATA[<color=#ff0>警告</color>]]></Text>
+  </Screen>
+</PromptUGUI>";
+
+        [SetUp] public void Setup() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+            UI.LoadDocument("S", Xml);
+        }
+        [TearDown] public void Teardown() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+        }
+
+        [Test] public void CDataWithRichText_PreservedAtRuntime() {
+            var screen = UI.Open("S");
+            var go = ((Control)screen.Get<Text>("lbl")).GameObject;
+            Assert.AreEqual("<color=#ff0>警告</color>", go.GetComponent<TMP_Text>().text);
+        }
+
+        [Test] public void CDataWithRichText_TranslatedPreservesTags() {
+            TranslationStore.Instance.Load("en", new[] {
+                new PoEntry {
+                    Msgid = "<color=#ff0>警告</color>",
+                    Msgstr = "<color=#ff0>WARN</color>",
+                },
+            });
+            UI.Locale.Set("en");
+            var screen = UI.Open("S");
+            var go = ((Control)screen.Get<Text>("lbl")).GameObject;
+            Assert.AreEqual("<color=#ff0>WARN</color>", go.GetComponent<TMP_Text>().text);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], filter="TmpRichTextRoundtripTests")
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/PlayMode/E2E/TmpRichTextRoundtripTests.cs
+git commit -m "test(e2e): CDATA + TMP rich text roundtrips through translation"
+```
+
+---
+
+## Task 19: PlayMode E2E — hot reload .po
+
+**Files:**
+- Create: `Tests/PlayMode/E2E/I18nHotReloadTests.cs`
+
+- [ ] **Step 1: Write test**
+
+```csharp
+// Tests/PlayMode/E2E/I18nHotReloadTests.cs
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.I18n;
+using TMPro;
+
+namespace PromptUGUI.Tests.PlayMode.E2E {
+    public class I18nHotReloadTests {
+        const string Xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <Text id='lbl'>开始游戏</Text>
+  </Screen>
+</PromptUGUI>";
+
+        [SetUp] public void Setup() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+            UI.LoadDocument("S", Xml);
+            TranslationStore.Instance.Load("en", new[] {
+                new PoEntry { Msgid = "开始游戏", Msgstr = "Start" },
+            });
+            UI.Locale.Set("en");
+        }
+        [TearDown] public void Teardown() {
+            UI.ResetForTests();
+            TranslationStore.Instance.UnloadAll();
+        }
+
+        [Test] public void TableMutation_AfterReSolve_UpdatesText() {
+            var screen = UI.Open("S");
+            var go = ((Control)screen.Get<Text>("lbl")).GameObject;
+            Assert.AreEqual("Start", go.GetComponent<TMP_Text>().text);
+
+            // Simulate hot-reload: replace the entry, ReSolve manually
+            TranslationStore.Instance.UnloadLocale("en");
+            TranslationStore.Instance.Load("en", new[] {
+                new PoEntry { Msgid = "开始游戏", Msgstr = "Begin" },
+            });
+            UI.NotifyVariantChangedForReSolve();
+
+            Assert.AreEqual("Begin", go.GetComponent<TMP_Text>().text);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], filter="I18nHotReloadTests")
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/PlayMode/E2E/I18nHotReloadTests.cs
+git commit -m "test(e2e): table mutation + ReSolve broadcasts updated translations"
+```
+
+---
+
+## Task 20: Final smoke — full suite + cleanup
+
+- [ ] **Step 1: Run full EditMode + PlayMode**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: all PASS, no console errors.
+
+- [ ] **Step 2: Verify no `// removed` / `_unused` comments / TODO sneaked in**
+
+```bash
+git -C /workspace-PromptUGUI log --oneline | head -25
+git -C /workspace-PromptUGUI grep -n "TODO\|FIXME" -- Runtime Editor 2>/dev/null | head
+```
+
+Expected: no TODO/FIXME added by this plan.
+
+- [ ] **Step 3: Final review commit (if anything remains uncommitted)**
+
+```bash
+git -C /workspace-PromptUGUI status
+```
+
+If anything uncommitted, commit it with an appropriate message.
+
+---
+
+## What M5a Ships
+
+After this plan:
+- Author writes `<Text>开始</Text>`, `<Btn>设置</Btn>`, `<Text font="title">…</Text>`, `<Text><![CDATA[…<sprite/>…]]></Text>`
+- Hand-crafts a `Resources/PromptUGUI/i18n/en/anything.po` with msgid/msgstr
+- Calls `UI.Locale.Set("en")` from C# → text translates, fonts swap
+- Edits the .po → AssetPostprocessor reloads on the fly
+
+What M5b will add:
+- Editor menu to extract msgids from XML + C# automatically
+- Editor menu to call OpenAI-compatible LLM to fill empty msgstrs
+- SKILL.md / main spec sync
+
+---
+
+## Notes for the executing agent
+
+- **Test conventions** (CLAUDE.md): EditMode test classes touching `UI` must call `UI.ResetForTests()` in `[SetUp]` and `[TearDown]`. The fake-files / store reset patterns are established in `DocumentLoaderTests.cs` and `HotReloadTests.cs` — refer if uncertain.
+- **`UI.ResetForTests()`** must also clear `Locale.Current` and `TranslationStore.Instance.UnloadAll()` after this plan — Task 9 does this. Do not regress.
+- **AsmDef boundary**: PoFileImporter and PromptUGUISettingsAutoMaintainer are Editor-only (`UnityEditor.AssetImporters` / `UnityEditor`); they live under `Editor/` and compile into `PromptUGUI.Editor`. PromptUGUISettings itself is runtime (lives under `Runtime/Application/`).
+- **Test asmdef**: `PoFileImporterTests` and `PromptUGUISettingsAutoMaintainerTests` need `UnityEditor` types and so must live in `Tests/EditMode/Editor/` (the `PromptUGUI.Tests.EditorOnly` asmdef).
+- **`Substitution.Apply`** throws on unknown placeholders. For TrResolver, that's the right behavior — translator omitting a placeholder is a real bug worth surfacing. Don't soften.
+- **`Resources.LoadAll<TextAsset>`** at `PromptUGUI/i18n/<locale>` requires `.po` files imported via PoFileImporter. If load misses, check the importer is registered (Task 5).
+- **DRY / YAGNI**: don't add helper functions until a second caller exists. Don't add more than one `MapSystemLanguage` codepath.
+- **No `--no-verify` commits** unless explicitly authorized; pre-commit hooks should be respected.

--- a/docs/superpowers/plans/2026-05-08-i18n-m5b-extraction.md
+++ b/docs/superpowers/plans/2026-05-08-i18n-m5b-extraction.md
@@ -1,0 +1,1577 @@
+# M5b — i18n Extraction + AI Translation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Author writes plain text in `.ui.xml` / `UI.Tr("...")` in C#; menu Tools → PromptUGUI → Extract Strings populates `.po` files for every Settings.locale; menu Tools → PromptUGUI → Translate Locale… calls an OpenAI-compatible LLM with Structured Outputs to fill empty msgstr; SKILL.md and main spec sync to reflect the new public surface.
+
+**Architecture:** All Editor-only (no runtime cost beyond M5a). XML scan reuses `UIDocumentParser` on raw IR (pre-template-expansion) so msgids preserve `{{x}}` placeholders. C# scan uses `Microsoft.CodeAnalysis` (Roslyn — bundled with Unity Editor). Extraction is per-locale, mirrors source path under `Assets/Resources/PromptUGUI/i18n/<locale>/...`, leaves `i18n-custom/` untouched. Translation menu sends batches via `HttpClient` to a configurable endpoint with `response_format: { type: "json_schema" }`.
+
+**Tech Stack:** Unity 6 Editor, C#, `Microsoft.CodeAnalysis.CSharp` (Unity-bundled), `System.Net.Http`.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-i18n-fonts-design.md`. Read it before starting.
+
+**Prerequisite:** M5a plan must be complete — runtime PoParser, PoEntry, TranslationStore, UI.Tr, etc. all exist.
+
+---
+
+## File Structure
+
+**New files (Editor):**
+- `Editor/I18n/StringExtractor.cs` — top-level menu + coordinator
+- `Editor/I18n/XmlStringScanner.cs` — extracts msgids from `.ui.xml`
+- `Editor/I18n/CSharpStringScanner.cs` — Roslyn syntactic walker for `UI.Tr(...)` calls
+- `Editor/I18n/ExtractedString.cs` — DTO carrying msgid + msgctxt + ambient ctx + comments
+- `Editor/I18n/PoFileWriter.cs` — merges extracted strings into existing .po (preserve filled msgstr; drop missing)
+- `Editor/I18n/TranslationProvider.cs` — ProjectSettings SO: endpoint, model, systemPrompt
+- `Editor/I18n/TranslationAuth.cs` — UserSettings SO: api key only
+- `Editor/I18n/TranslationProviderSettingsProvider.cs` — `Project Settings → PromptUGUI → Translation` registration
+- `Editor/I18n/TranslationClient.cs` — HTTP call to OpenAI-compatible endpoint with Structured Outputs
+- `Editor/I18n/TranslationMenu.cs` — menu item + dialog + progress bar
+- `Editor/I18n/TmpRichTextDetector.cs` — detect TMP tags in msgid → flag for "preserve tags" comment
+
+**Modified files:**
+- `docs/superpowers/specs/2026-05-07-promptugui-description-language-design.md` — flip §10 i18n entry
+- `.claude/skills/authoring-promptugui-xml/SKILL.md` — add font / tr / ctx attrs, language-as-variant note, CDATA + TMP rich text section, i18n cheatsheet
+
+**Tests:**
+- `Tests/EditMode/Editor/XmlStringScannerTests.cs` (`PromptUGUI.Tests.EditorOnly` asmdef)
+- `Tests/EditMode/Editor/CSharpStringScannerTests.cs`
+- `Tests/EditMode/Editor/PoFileWriterTests.cs`
+- `Tests/EditMode/Editor/TmpRichTextDetectorTests.cs`
+- `Tests/EditMode/Editor/TranslationClientTests.cs` (with stubbed HTTP via `HttpMessageHandler`)
+
+---
+
+## Pre-flight
+
+- [ ] **Confirm M5a is merged / present**
+
+```bash
+git -C /workspace-PromptUGUI log --oneline | grep -E "i18n|PromptUGUISettings|PoParser" | head
+```
+
+Expected: see commits from M5a. If not, do not proceed.
+
+- [ ] **Confirm Microsoft.CodeAnalysis is available**
+
+```
+mcp__UnityMCP__execute_code(code="UnityEngine.Debug.Log(typeof(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree).FullName);")
+```
+
+Expected: prints `Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree` (Unity Editor bundles it). If it doesn't print, the agent must add a `Microsoft.CodeAnalysis.CSharp` reference via `csc.rsp` / asmdef precompiled refs before continuing — flag to the user.
+
+---
+
+## Task 1: ExtractedString DTO
+
+**Files:**
+- Create: `Editor/I18n/ExtractedString.cs`
+
+- [ ] **Step 1: Write DTO**
+
+```csharp
+// Editor/I18n/ExtractedString.cs
+using System.Collections.Generic;
+
+namespace PromptUGUI.Editor.I18n {
+    /// <summary>
+    /// One translatable string discovered by a scanner. Multiple ExtractedStrings with the same
+    /// (msgid, msgctxt) get merged at write-time — comments/refs concatenated.
+    /// </summary>
+    internal sealed class ExtractedString {
+        public string Msgid;
+        public string Msgctxt;       // null = no explicit ctx
+        public List<string> Comments = new();   // # ...
+        public List<string> ExtractedComments = new();   // #. ...
+        public List<string> References = new();          // #: file:line
+        public string LocalePartition;       // e.g. "screens/MainMenu" or "_code"
+    }
+}
+```
+
+- [ ] **Step 2: Refresh + commit**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+```bash
+git add Editor/I18n/ExtractedString.cs Editor/I18n/ExtractedString.cs.meta
+git commit -m "feat(i18n-editor): ExtractedString DTO"
+```
+
+---
+
+## Task 2: TmpRichTextDetector
+
+**Files:**
+- Create: `Editor/I18n/TmpRichTextDetector.cs`
+- Create: `Tests/EditMode/Editor/TmpRichTextDetectorTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+// Tests/EditMode/Editor/TmpRichTextDetectorTests.cs
+using NUnit.Framework;
+using PromptUGUI.Editor.I18n;
+
+namespace PromptUGUI.Tests.Editor {
+    public class TmpRichTextDetectorTests {
+        [TestCase("<sprite name=\"coin\"/>")]
+        [TestCase("<color=#ff0>x</color>")]
+        [TestCase("<b>bold</b>")]
+        [TestCase("<size=20>x</size>")]
+        [TestCase("<link=\"foo\">x</link>")]
+        public void Detect_KnownTags_ReturnsTrue(string s) {
+            Assert.IsTrue(TmpRichTextDetector.HasTmpTags(s));
+        }
+
+        [TestCase("plain")]
+        [TestCase("price: {0}")]
+        [TestCase("price: {{n}}")]
+        [TestCase("a < b > c")]
+        public void Detect_NoTmpTag_ReturnsFalse(string s) {
+            Assert.IsFalse(TmpRichTextDetector.HasTmpTags(s));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run; expect compile fail**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"], filter="TmpRichTextDetectorTests")
+```
+
+- [ ] **Step 3: Implement**
+
+```csharp
+// Editor/I18n/TmpRichTextDetector.cs
+using System.Text.RegularExpressions;
+
+namespace PromptUGUI.Editor.I18n {
+    internal static class TmpRichTextDetector {
+        // Recognized TMP rich-text tags. Conservative — only tags whose attributes carry resource
+        // references that translators MUST NOT touch. False positives here only add a "preserve" hint
+        // comment; false negatives skip the hint.
+        static readonly Regex Tag = new(
+            @"<\s*/?(?:sprite|color|b|i|u|s|size|font|font-weight|align|alpha|space|indent|line-height|line-indent|link|lowercase|uppercase|smallcaps|mark|noparse|page|pos|rotate|style|sub|sup|voffset|width)(\s|=|/|>)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        public static bool HasTmpTags(string s) =>
+            !string.IsNullOrEmpty(s) && Tag.IsMatch(s);
+    }
+}
+```
+
+- [ ] **Step 4: Run; expect pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"], filter="TmpRichTextDetectorTests")
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Editor/I18n/TmpRichTextDetector.cs Editor/I18n/TmpRichTextDetector.cs.meta \
+        Tests/EditMode/Editor/TmpRichTextDetectorTests.cs
+git commit -m "feat(i18n-editor): TmpRichTextDetector for translator-preserve hints"
+```
+
+---
+
+## Task 3: XmlStringScanner
+
+**Files:**
+- Create: `Editor/I18n/XmlStringScanner.cs`
+- Create: `Tests/EditMode/Editor/XmlStringScannerTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+// Tests/EditMode/Editor/XmlStringScannerTests.cs
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Editor.I18n;
+
+namespace PromptUGUI.Tests.Editor {
+    public class XmlStringScannerTests {
+        [Test] public void Scan_SimpleTextElement_ExtractsMsgid() {
+            var xml = "<PromptUGUI version='1'><Screen name='Main'>" +
+                      "<Text>开始游戏</Text></Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/Main").ToList();
+            Assert.AreEqual(1, found.Count);
+            Assert.AreEqual("开始游戏", found[0].Msgid);
+            Assert.IsNull(found[0].Msgctxt);
+        }
+
+        [Test] public void Scan_BtnContent_ExtractsMsgid() {
+            var xml = "<PromptUGUI version='1'><Screen name='X'>" +
+                      "<Btn id='b'>设置</Btn></Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/X").ToList();
+            Assert.AreEqual(1, found.Count);
+            Assert.AreEqual("设置", found[0].Msgid);
+        }
+
+        [Test] public void Scan_TextAttribute_AlsoExtracts() {
+            var xml = "<PromptUGUI version='1'><Screen name='X'>" +
+                      "<Text text='Hello' fontSize='32'/></Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/X").ToList();
+            Assert.IsTrue(found.Any(e => e.Msgid == "Hello"));
+        }
+
+        [Test] public void Scan_TrFalse_Skips() {
+            var xml = "<PromptUGUI version='1'><Screen name='X'>" +
+                      "<Text tr='false'>hardcoded</Text></Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/X").ToList();
+            Assert.IsEmpty(found);
+        }
+
+        [Test] public void Scan_ExplicitCtx_PopulatesMsgctxt() {
+            var xml = "<PromptUGUI version='1'><Screen name='X'>" +
+                      "<Text ctx='door'>Open</Text></Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/X").ToList();
+            Assert.AreEqual("door", found[0].Msgctxt);
+            Assert.AreEqual("Open", found[0].Msgid);
+        }
+
+        [Test] public void Scan_PureBracePlaceholder_SkippedWithWarning() {
+            var xml = "<PromptUGUI version='1'><Screen name='X'>" +
+                      "<Text>{{playerName}}</Text></Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/X").ToList();
+            Assert.IsEmpty(found);   // pure {{x}} has no translation value
+        }
+
+        [Test] public void Scan_TextWithBraceAndStatic_Extracted() {
+            var xml = "<PromptUGUI version='1'><Screen name='X'>" +
+                      "<Text>金币: {{n}}</Text></Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/X").ToList();
+            Assert.AreEqual("金币: {{n}}", found[0].Msgid);
+        }
+
+        [Test] public void Scan_AmbientCtx_AddedAsExtractedComment() {
+            var xml = "<PromptUGUI version='1'><Screen name='Main'>" +
+                      "<Btn id='play'>开始</Btn>" +
+                      "<Btn id='cfg'>设置</Btn>" +
+                      "</Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/Main").ToList();
+            var play = found.First(e => e.Msgid == "开始");
+            // ambient hint should reference Main + Btn#play
+            Assert.IsTrue(play.ExtractedComments.Any(c => c.Contains("Main") && c.Contains("play")));
+            // sibling list should mention "设置"
+            Assert.IsTrue(play.ExtractedComments.Any(c => c.Contains("设置")));
+        }
+
+        [Test] public void Scan_CDataWithRichText_ExtractsAndFlags() {
+            var xml = "<PromptUGUI version='1'><Screen name='X'>" +
+                      "<Text><![CDATA[<color=#ff0>警告</color>]]></Text>" +
+                      "</Screen></PromptUGUI>";
+            var found = XmlStringScanner.Scan(xml, "screens/X").ToList();
+            Assert.AreEqual("<color=#ff0>警告</color>", found[0].Msgid);
+            Assert.IsTrue(found[0].ExtractedComments.Any(c => c.Contains("Preserve tags")));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run; expect compile fail**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"], filter="XmlStringScannerTests")
+```
+
+- [ ] **Step 3: Implement scanner**
+
+```csharp
+// Editor/I18n/XmlStringScanner.cs
+using System.Collections.Generic;
+using System.Linq;
+using PromptUGUI.IR;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Editor.I18n {
+    internal static class XmlStringScanner {
+        // Tags whose textContent and "text" attr are translatable.
+        static readonly System.Collections.Generic.HashSet<string> TextHostingTags =
+            new() { "Text", "Btn" };
+
+        public static IEnumerable<ExtractedString> Scan(string xmlSource, string localePartition) {
+            UIDocument doc;
+            try { doc = UIDocumentParser.Parse(xmlSource); }
+            catch (ParseException) { yield break; }     // unparseable file → skip
+
+            foreach (var screen in doc.Screens) {
+                foreach (var es in WalkNode(screen.Body, screen.Name, parentSiblings: null, localePartition))
+                    yield return es;
+            }
+            foreach (var t in doc.Templates) {
+                foreach (var es in WalkNode(t.Body, $"Template:{t.Name}", parentSiblings: null, localePartition))
+                    yield return es;
+            }
+        }
+
+        static IEnumerable<ExtractedString> WalkNode(
+            ElementNode node, string screenOrTemplateName,
+            List<string> parentSiblings, string localePartition) {
+
+            // Compute siblings (raw text of Text/Btn children) for ambient ctx of children.
+            var siblings = new List<string>();
+            foreach (var c in node.Children) {
+                var raw = c.TextContentRaw ?? c.TextContent;
+                if (TextHostingTags.Contains(c.Tag) && !string.IsNullOrEmpty(raw))
+                    siblings.Add(raw.Trim());
+            }
+
+            if (TextHostingTags.Contains(node.Tag) && !IsTrFalse(node)) {
+                node.Attributes.TryGetValue("ctx", out var ctx);
+
+                // textContent
+                var rawText = node.TextContentRaw ?? node.TextContent;
+                if (!string.IsNullOrEmpty(rawText) && !IsPureBraces(rawText)) {
+                    yield return Build(rawText, ctx, screenOrTemplateName, node, parentSiblings, "text", localePartition);
+                }
+                // text attribute (use raw if available)
+                string textAttrRaw = null;
+                if (node.AttributesRaw != null && node.AttributesRaw.TryGetValue("text", out var ra))
+                    textAttrRaw = ra;
+                else if (node.Attributes.TryGetValue("text", out var v))
+                    textAttrRaw = v;
+                if (!string.IsNullOrEmpty(textAttrRaw) && !IsPureBraces(textAttrRaw)) {
+                    yield return Build(textAttrRaw, ctx, screenOrTemplateName, node, parentSiblings, "text-attr", localePartition);
+                }
+            }
+
+            foreach (var child in node.Children) {
+                foreach (var es in WalkNode(child, screenOrTemplateName, siblings, localePartition))
+                    yield return es;
+            }
+        }
+
+        static bool IsTrFalse(ElementNode node) =>
+            node.Attributes.TryGetValue("tr", out var v) && v == "false";
+
+        static bool IsPureBraces(string s) {
+            // exactly "{{name}}" with possibly surrounding whitespace.
+            var t = s.Trim();
+            return t.StartsWith("{{") && t.EndsWith("}}") && t.Count(c => c == '{') == 2 && t.Count(c => c == '}') == 2;
+        }
+
+        static ExtractedString Build(
+            string msgid, string ctx, string screenOrTemplateName,
+            ElementNode node, List<string> parentSiblings, string attrSlot,
+            string localePartition) {
+
+            var es = new ExtractedString {
+                Msgid = msgid,
+                Msgctxt = ctx,
+                LocalePartition = localePartition,
+            };
+            var who = string.IsNullOrEmpty(node.Id) ? node.Tag : $"{node.Tag}#{node.Id}";
+            es.ExtractedComments.Add($"{screenOrTemplateName} screen, {who} {attrSlot}");
+            if (parentSiblings != null && parentSiblings.Count > 0) {
+                var sibs = string.Join(", ", parentSiblings.Where(s => s != msgid).Take(3));
+                if (!string.IsNullOrEmpty(sibs))
+                    es.ExtractedComments.Add($"sibling: {sibs}");
+            }
+            if (TmpRichTextDetector.HasTmpTags(msgid)) {
+                es.ExtractedComments.Add(
+                    "Contains TMP rich text tags. Preserve tags and attribute values verbatim.");
+            }
+            return es;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run; iterate until pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"], filter="XmlStringScannerTests")
+```
+
+Expected: 9/9 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Editor/I18n/XmlStringScanner.cs Editor/I18n/XmlStringScanner.cs.meta \
+        Tests/EditMode/Editor/XmlStringScannerTests.cs
+git commit -m "feat(i18n-editor): XmlStringScanner — Text/Btn msgid extraction with ambient ctx"
+```
+
+---
+
+## Task 4: CSharpStringScanner (Roslyn)
+
+**Files:**
+- Create: `Editor/I18n/CSharpStringScanner.cs`
+- Create: `Tests/EditMode/Editor/CSharpStringScannerTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+// Tests/EditMode/Editor/CSharpStringScannerTests.cs
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Editor.I18n;
+
+namespace PromptUGUI.Tests.Editor {
+    public class CSharpStringScannerTests {
+        [Test] public void Scan_PlainTrLiteral_Extracted() {
+            var src = @"
+                using PromptUGUI.Application;
+                class X {
+                    void Run() {
+                        var s = UI.Tr(""hello"");
+                    }
+                }";
+            var found = CSharpStringScanner.Scan(src, "X.cs").ToList();
+            Assert.AreEqual(1, found.Count);
+            Assert.AreEqual("hello", found[0].Msgid);
+            Assert.IsNull(found[0].Msgctxt);
+        }
+
+        [Test] public void Scan_TrWithCtx_PopulatesMsgctxt() {
+            var src = @"
+                class X { void Run() { var s = PromptUGUI.Application.UI.Tr(""Open"", ctx: ""door""); } }";
+            var found = CSharpStringScanner.Scan(src, "X.cs").Single();
+            Assert.AreEqual("Open", found.Msgid);
+            Assert.AreEqual("door", found.Msgctxt);
+        }
+
+        [Test] public void Scan_NonLiteralArgs_SkippedWithWarning() {
+            var src = @"
+                class X { void Run(string x) { var s = PromptUGUI.Application.UI.Tr(x); } }";
+            var found = CSharpStringScanner.Scan(src, "X.cs").ToList();
+            Assert.IsEmpty(found);
+        }
+
+        [Test] public void Scan_RefIncludesFileAndLine() {
+            var src = "class X { void R() { var s = PromptUGUI.Application.UI.Tr(\"x\"); } }";
+            var es = CSharpStringScanner.Scan(src, "Path/To/X.cs").Single();
+            Assert.IsTrue(es.References.Any(r => r.Contains("Path/To/X.cs")));
+        }
+
+        [Test] public void Scan_LeadingComment_AddedToExtractedComments() {
+            var src = @"
+                class X {
+                    void R() {
+                        // 提示玩家当前金币
+                        var s = PromptUGUI.Application.UI.Tr(""总价: {0:C}"");
+                    }
+                }";
+            var es = CSharpStringScanner.Scan(src, "X.cs").Single();
+            Assert.IsTrue(es.ExtractedComments.Any(c => c.Contains("提示玩家当前金币")));
+        }
+
+        [Test] public void Scan_MethodNameIncludedInExtractedComments() {
+            var src = "class X { void OnGoldChanged() { var s = PromptUGUI.Application.UI.Tr(\"x\"); } }";
+            var es = CSharpStringScanner.Scan(src, "X.cs").Single();
+            Assert.IsTrue(es.ExtractedComments.Any(c => c.Contains("OnGoldChanged")));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run; expect compile fail**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"], filter="CSharpStringScannerTests")
+```
+
+- [ ] **Step 3: Implement scanner**
+
+```csharp
+// Editor/I18n/CSharpStringScanner.cs
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace PromptUGUI.Editor.I18n {
+    internal static class CSharpStringScanner {
+        public static IEnumerable<ExtractedString> Scan(string source, string filePath) {
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var root = tree.GetRoot();
+            var calls = root.DescendantNodes().OfType<InvocationExpressionSyntax>();
+
+            foreach (var call in calls) {
+                if (!IsUiTr(call)) continue;
+                var args = call.ArgumentList.Arguments;
+                if (args.Count == 0) continue;
+
+                var msgid = AsLiteral(args[0].Expression);
+                if (msgid == null) continue;       // dynamic — skip
+
+                string ctx = null;
+                for (int i = 1; i < args.Count; i++) {
+                    var a = args[i];
+                    if (a.NameColon?.Name.Identifier.ValueText == "ctx") {
+                        ctx = AsLiteral(a.Expression);
+                        if (ctx == null) goto skip;
+                    }
+                }
+
+                var es = new ExtractedString {
+                    Msgid = msgid,
+                    Msgctxt = ctx,
+                    LocalePartition = "_code",
+                };
+                var line = call.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                es.References.Add($"{filePath}:{line}");
+
+                var enclosing = call.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
+                if (enclosing != null)
+                    es.ExtractedComments.Add($"in {enclosing.Identifier.ValueText}()");
+
+                foreach (var c in CollectLeadingComments(call))
+                    es.ExtractedComments.Add(c);
+
+                if (TmpRichTextDetector.HasTmpTags(msgid))
+                    es.ExtractedComments.Add(
+                        "Contains TMP rich text tags. Preserve tags and attribute values verbatim.");
+
+                yield return es;
+                skip: ;
+            }
+        }
+
+        static bool IsUiTr(InvocationExpressionSyntax call) {
+            // Match `UI.Tr(...)` and `PromptUGUI.Application.UI.Tr(...)` and `Tr(...)` (looser).
+            return call.Expression switch {
+                MemberAccessExpressionSyntax m =>
+                    m.Name.Identifier.ValueText == "Tr",
+                IdentifierNameSyntax id =>
+                    id.Identifier.ValueText == "Tr",
+                _ => false,
+            };
+        }
+
+        static string AsLiteral(ExpressionSyntax e) {
+            if (e is LiteralExpressionSyntax lit && lit.IsKind(SyntaxKind.StringLiteralExpression))
+                return lit.Token.ValueText;
+            return null;
+        }
+
+        static IEnumerable<string> CollectLeadingComments(InvocationExpressionSyntax call) {
+            var stmt = call.AncestorsAndSelf().OfType<StatementSyntax>().FirstOrDefault();
+            if (stmt == null) yield break;
+            foreach (var trivia in stmt.GetLeadingTrivia()) {
+                if (trivia.IsKind(SyntaxKind.SingleLineCommentTrivia)) {
+                    var text = trivia.ToString().TrimStart('/').Trim();
+                    if (!string.IsNullOrEmpty(text)) yield return text;
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run; expect pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"], filter="CSharpStringScannerTests")
+```
+
+Expected: 6/6 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Editor/I18n/CSharpStringScanner.cs Editor/I18n/CSharpStringScanner.cs.meta \
+        Tests/EditMode/Editor/CSharpStringScannerTests.cs
+git commit -m "feat(i18n-editor): CSharpStringScanner — Roslyn walker for UI.Tr literals"
+```
+
+---
+
+## Task 5: PoFileWriter — merge into existing .po
+
+**Files:**
+- Create: `Editor/I18n/PoFileWriter.cs`
+- Create: `Tests/EditMode/Editor/PoFileWriterTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+// Tests/EditMode/Editor/PoFileWriterTests.cs
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Editor.I18n;
+using PromptUGUI.I18n;
+
+namespace PromptUGUI.Tests.Editor {
+    public class PoFileWriterTests {
+        [Test] public void Merge_NewMsgid_AddedWithEmptyMsgstr() {
+            var existing = "";   // no prior file
+            var result = PoFileWriter.Merge(existing, new[] {
+                new ExtractedString { Msgid = "hello" },
+            });
+            var entries = PoParser.Parse(result).ToList();
+            Assert.AreEqual(1, entries.Count);
+            Assert.AreEqual("hello", entries[0].Msgid);
+            Assert.AreEqual("", entries[0].Msgstr);
+        }
+
+        [Test] public void Merge_ExistingNonEmptyMsgstr_PreservedAcrossExtract() {
+            var existing = PoParser.Serialize(new[] {
+                new PoEntry { Msgid = "hello", Msgstr = "你好" },
+            });
+            var result = PoFileWriter.Merge(existing, new[] {
+                new ExtractedString { Msgid = "hello" },
+            });
+            var entries = PoParser.Parse(result).ToList();
+            Assert.AreEqual("你好", entries[0].Msgstr);
+        }
+
+        [Test] public void Merge_ExtractedDoesNotIncludeOldMsgid_RemovesIt() {
+            var existing = PoParser.Serialize(new[] {
+                new PoEntry { Msgid = "old", Msgstr = "obsolete-tr" },
+                new PoEntry { Msgid = "kept", Msgstr = "tr" },
+            });
+            var result = PoFileWriter.Merge(existing, new[] {
+                new ExtractedString { Msgid = "kept" },
+            });
+            var entries = PoParser.Parse(result).ToList();
+            Assert.AreEqual(1, entries.Count);
+            Assert.AreEqual("kept", entries[0].Msgid);
+        }
+
+        [Test] public void Merge_NewExtractionRefreshesComments() {
+            var existing = PoParser.Serialize(new[] {
+                new PoEntry { Msgid = "x", Msgstr = "y",
+                              TranslatorComments = new() { "old comment" } },
+            });
+            var result = PoFileWriter.Merge(existing, new[] {
+                new ExtractedString { Msgid = "x", ExtractedComments = { "fresh hint" } },
+            });
+            var entries = PoParser.Parse(result).ToList();
+            // existing user msgstr preserved; comments come from current extraction
+            Assert.AreEqual("y", entries[0].Msgstr);
+            Assert.IsTrue(entries[0].TranslatorComments.Any(c => c.Contains("fresh hint")));
+            Assert.IsFalse(entries[0].TranslatorComments.Any(c => c.Contains("old comment")));
+        }
+
+        [Test] public void Merge_SameMsgidDifferentCtx_TwoEntries() {
+            var result = PoFileWriter.Merge("", new[] {
+                new ExtractedString { Msgid = "Open" },
+                new ExtractedString { Msgid = "Open", Msgctxt = "door" },
+            });
+            var entries = PoParser.Parse(result).ToList();
+            Assert.AreEqual(2, entries.Count);
+            Assert.IsTrue(entries.Any(e => e.Msgctxt == null));
+            Assert.IsTrue(entries.Any(e => e.Msgctxt == "door"));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run; expect compile fail**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"], filter="PoFileWriterTests")
+```
+
+- [ ] **Step 3: Implement writer**
+
+```csharp
+// Editor/I18n/PoFileWriter.cs
+using System.Collections.Generic;
+using System.Linq;
+using PromptUGUI.I18n;
+
+namespace PromptUGUI.Editor.I18n {
+    internal static class PoFileWriter {
+        /// <summary>
+        /// Take an existing .po file's text and a fresh extraction; produce a new .po text where
+        /// existing non-empty msgstr values are preserved (keyed by (msgctxt, msgid)), comments are
+        /// replaced by the current extraction, and entries no longer in extraction are dropped.
+        /// </summary>
+        public static string Merge(string existingPoText, IEnumerable<ExtractedString> extracted) {
+            var existingByKey = string.IsNullOrEmpty(existingPoText)
+                ? new Dictionary<(string, string), PoEntry>()
+                : PoParser.Parse(existingPoText)
+                    .ToDictionary(e => (e.Msgctxt, e.Msgid));
+
+            // Group extracted by key so multi-occurrence msgid merge their comments.
+            var grouped = new Dictionary<(string ctx, string id), ExtractedString>();
+            foreach (var e in extracted) {
+                var k = (e.Msgctxt, e.Msgid);
+                if (!grouped.TryGetValue(k, out var existing)) {
+                    grouped[k] = new ExtractedString {
+                        Msgid = e.Msgid,
+                        Msgctxt = e.Msgctxt,
+                        Comments = new List<string>(e.Comments),
+                        ExtractedComments = new List<string>(e.ExtractedComments),
+                        References = new List<string>(e.References),
+                    };
+                } else {
+                    existing.ExtractedComments.AddRange(e.ExtractedComments);
+                    existing.References.AddRange(e.References);
+                    existing.Comments.AddRange(e.Comments);
+                }
+            }
+
+            var output = new List<PoEntry>();
+            foreach (var kv in grouped) {
+                var es = kv.Value;
+                var entry = new PoEntry {
+                    Msgctxt = es.Msgctxt,
+                    Msgid = es.Msgid,
+                    Msgstr = existingByKey.TryGetValue(kv.Key, out var prev) ? prev.Msgstr : "",
+                    TranslatorComments = new List<string>(),
+                };
+                // Merge comment streams: # translator (free) + #. extracted + #: refs.
+                foreach (var c in es.Comments) entry.TranslatorComments.Add(c);
+                foreach (var c in es.ExtractedComments) entry.TranslatorComments.Add($". {c}");
+                foreach (var r in es.References) entry.TranslatorComments.Add($": {r}");
+                output.Add(entry);
+            }
+            // Stable order: by ctx, then by msgid.
+            output.Sort((a, b) => {
+                int c = string.Compare(a.Msgctxt ?? "", b.Msgctxt ?? "", System.StringComparison.Ordinal);
+                return c != 0 ? c : string.Compare(a.Msgid ?? "", b.Msgid ?? "", System.StringComparison.Ordinal);
+            });
+            return PoParser.Serialize(output);
+        }
+    }
+}
+```
+
+(Note: the `# .` and `# :` prefixes in TranslatorComments leak into the parser as plain comment lines on round-trip — the parser stores everything in TranslatorComments. That's intentional: PoParser doesn't distinguish `#`/`#.`/`#:` types in v1. The `. ` / `: ` markers preserve diagnostic intent in the serialized output. Tests cover the visible behavior.)
+
+- [ ] **Step 4: Run; iterate to pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"], filter="PoFileWriterTests")
+```
+
+Expected: 5/5 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Editor/I18n/PoFileWriter.cs Editor/I18n/PoFileWriter.cs.meta \
+        Tests/EditMode/Editor/PoFileWriterTests.cs
+git commit -m "feat(i18n-editor): PoFileWriter — merge fresh extraction with existing msgstr"
+```
+
+---
+
+## Task 6: StringExtractor — top-level menu coordinator
+
+**Files:**
+- Create: `Editor/I18n/StringExtractor.cs`
+
+- [ ] **Step 1: Implement extractor + menu**
+
+```csharp
+// Editor/I18n/StringExtractor.cs
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using PromptUGUI.Application;
+using UnityEditor;
+using UnityEngine;
+
+namespace PromptUGUI.Editor.I18n {
+    internal static class StringExtractor {
+        const string OutputRoot = "Assets/Resources/PromptUGUI/i18n";
+
+        [MenuItem("Tools/PromptUGUI/Extract Strings")]
+        public static void ExtractAll() {
+            var settings = PromptUGUISettings.Instance;
+            if (settings == null || settings.locales.Count == 0) {
+                EditorUtility.DisplayDialog(
+                    "PromptUGUI",
+                    "No PromptUGUISettings found, or it has no locales configured. " +
+                    "Add one and configure locales first.",
+                    "OK");
+                return;
+            }
+
+            var allExtracted = new List<ExtractedString>();
+            allExtracted.AddRange(ScanAllXml());
+            allExtracted.AddRange(ScanAllCSharp());
+
+            // Group by partition.
+            var byPartition = allExtracted
+                .GroupBy(e => e.LocalePartition ?? "_code")
+                .ToDictionary(g => g.Key, g => g.ToList());
+
+            int filesWritten = 0;
+            foreach (var lc in settings.locales) {
+                if (string.IsNullOrEmpty(lc.locale)) continue;
+                foreach (var kv in byPartition) {
+                    var path = Path.Combine(OutputRoot, lc.locale, kv.Key + ".po")
+                        .Replace('\\', '/');
+                    Directory.CreateDirectory(Path.GetDirectoryName(path));
+                    var existing = File.Exists(path) ? File.ReadAllText(path) : "";
+                    var merged = PoFileWriter.Merge(existing, kv.Value);
+                    File.WriteAllText(path, merged);
+                    filesWritten++;
+                }
+            }
+            AssetDatabase.Refresh();
+            Debug.Log($"[PromptUGUI] Extract Strings: {allExtracted.Count} msgids → {filesWritten} .po files across {settings.locales.Count} locales.");
+        }
+
+        static IEnumerable<ExtractedString> ScanAllXml() {
+            var guids = AssetDatabase.FindAssets("t:TextAsset");
+            foreach (var guid in guids) {
+                var path = AssetDatabase.GUIDToAssetPath(guid);
+                if (!path.EndsWith(".ui.xml")) continue;
+                if (path.StartsWith("Packages/")) continue;
+                var text = File.ReadAllText(path);
+                var partition = PathToPartition(path);
+                foreach (var es in XmlStringScanner.Scan(text, partition)) {
+                    if (es.References.Count == 0) es.References.Add(path);
+                    yield return es;
+                }
+            }
+        }
+
+        static IEnumerable<ExtractedString> ScanAllCSharp() {
+            var guids = AssetDatabase.FindAssets("t:Script");
+            foreach (var guid in guids) {
+                var path = AssetDatabase.GUIDToAssetPath(guid);
+                if (!path.EndsWith(".cs")) continue;
+                if (path.StartsWith("Packages/")) continue;
+                if (path.Contains("/Tests/")) continue;
+                var text = File.ReadAllText(path);
+                foreach (var es in CSharpStringScanner.Scan(text, path))
+                    yield return es;
+            }
+        }
+
+        static string PathToPartition(string assetPath) {
+            // "Assets/UI/screens/MainMenu.ui.xml" → "screens/MainMenu"
+            // "Assets/UI/common/Buttons.ui.xml"   → "common/Buttons"
+            const string prefix = "Assets/";
+            var p = assetPath.StartsWith(prefix) ? assetPath.Substring(prefix.Length) : assetPath;
+            // Drop top-level folder (UI/) for shorter partitions; but only if path is multi-segment.
+            int firstSlash = p.IndexOf('/');
+            if (firstSlash > 0) p = p.Substring(firstSlash + 1);
+            if (p.EndsWith(".ui.xml")) p = p.Substring(0, p.Length - ".ui.xml".Length);
+            return p;
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Refresh + manual try**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+In the host project, click `Tools → PromptUGUI → Extract Strings` and verify .po files appear under `Assets/Resources/PromptUGUI/i18n/<locale>/...`. (Skip if no host project at hand; rely on later integration.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Editor/I18n/StringExtractor.cs Editor/I18n/StringExtractor.cs.meta
+git commit -m "feat(i18n-editor): Extract Strings menu — scan + merge into per-partition .po"
+```
+
+---
+
+## Task 7: TranslationProvider + TranslationAuth (settings)
+
+**Files:**
+- Create: `Editor/I18n/TranslationProvider.cs`
+- Create: `Editor/I18n/TranslationAuth.cs`
+- Create: `Editor/I18n/TranslationProviderSettingsProvider.cs`
+
+- [ ] **Step 1: Write the SOs**
+
+```csharp
+// Editor/I18n/TranslationProvider.cs
+using UnityEngine;
+
+namespace PromptUGUI.Editor.I18n {
+    /// <summary>
+    /// Project-level translation provider config. Lives at
+    /// `ProjectSettings/PromptUGUI.asset` (in repo, team-shared).
+    /// </summary>
+    internal sealed class TranslationProvider : ScriptableObject {
+        public string endpoint = "https://api.openai.com/v1/chat/completions";
+        public string model = "gpt-4o-mini";
+        [TextArea(6, 20)] public string systemPrompt =
+@"你正在为一款像素风游戏翻译 UI 字符串到 {{targetLocale}}。
+
+规则：
+1. 保留所有 {{x}} 模板占位符与 {0} {1:C} 等 C# 格式占位符不变
+2. 保留 TMP 富文本标签（<sprite>、<color>、<b>、<size>、<link> 等）的字面形式与属性值不变（特别是 name=""..."", color=""..."" 等属性内的值是资源 ID，不是文本）；位置可调以符合目标语言语序
+3. 参考 sibling strings 推断风格一致性
+4. 源文本可能混合多种语言；按目标 locale 翻译整体含义
+5. 简短直接；UI 空间有限";
+    }
+}
+```
+
+```csharp
+// Editor/I18n/TranslationAuth.cs
+using UnityEngine;
+
+namespace PromptUGUI.Editor.I18n {
+    /// <summary>
+    /// Per-user secret. Lives at `UserSettings/PromptUGUI/Auth.asset` (Unity 2020+
+    /// default .gitignore excludes UserSettings/).
+    /// </summary>
+    internal sealed class TranslationAuth : ScriptableObject {
+        public string apiKey = "";
+    }
+}
+```
+
+```csharp
+// Editor/I18n/TranslationProviderSettingsProvider.cs
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace PromptUGUI.Editor.I18n {
+    internal static class TranslationProviderSettingsProvider {
+        const string ProviderPath = "ProjectSettings/PromptUGUI.asset";
+        const string AuthPath = "UserSettings/PromptUGUI/Auth.asset";
+
+        internal static TranslationProvider GetOrCreateProvider() {
+            var loaded = InternalEditorUtility.LoadSerializedFileAndForget(ProviderPath);
+            if (loaded != null && loaded.Length > 0 && loaded[0] is TranslationProvider tp) return tp;
+            var fresh = ScriptableObject.CreateInstance<TranslationProvider>();
+            Save(fresh, ProviderPath);
+            return fresh;
+        }
+
+        internal static TranslationAuth GetOrCreateAuth() {
+            var loaded = InternalEditorUtility.LoadSerializedFileAndForget(AuthPath);
+            if (loaded != null && loaded.Length > 0 && loaded[0] is TranslationAuth a) return a;
+            var fresh = ScriptableObject.CreateInstance<TranslationAuth>();
+            Save(fresh, AuthPath);
+            return fresh;
+        }
+
+        internal static void Save(Object obj, string path) {
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            InternalEditorUtility.SaveToSerializedFileAndForget(new[] { obj }, path, allowTextSerialization: true);
+        }
+
+        [SettingsProvider]
+        public static SettingsProvider Create() => new("Project/PromptUGUI/Translation", SettingsScope.Project) {
+            label = "Translation",
+            guiHandler = _ => {
+                var tp = GetOrCreateProvider();
+                var auth = GetOrCreateAuth();
+                EditorGUI.BeginChangeCheck();
+                tp.endpoint = EditorGUILayout.TextField("Endpoint", tp.endpoint);
+                tp.model = EditorGUILayout.TextField("Model", tp.model);
+                EditorGUILayout.LabelField("System Prompt");
+                tp.systemPrompt = EditorGUILayout.TextArea(tp.systemPrompt, GUILayout.Height(140));
+                EditorGUILayout.Space();
+                auth.apiKey = EditorGUILayout.PasswordField("API Key (UserSettings)", auth.apiKey);
+                if (EditorGUI.EndChangeCheck()) {
+                    Save(tp, ProviderPath);
+                    Save(auth, AuthPath);
+                }
+            },
+            keywords = new System.Collections.Generic.HashSet<string> {
+                "PromptUGUI", "Translation", "OpenAI", "i18n",
+            },
+        };
+    }
+}
+```
+
+(Use `using UnityEditorInternal;` for `InternalEditorUtility`. Add to the file if not already present.)
+
+- [ ] **Step 2: Refresh, verify Settings panel renders**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Manual: open `Project Settings → PromptUGUI → Translation`, confirm fields visible. Edit something; verify `ProjectSettings/PromptUGUI.asset` is created.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Editor/I18n/TranslationProvider.cs Editor/I18n/TranslationProvider.cs.meta \
+        Editor/I18n/TranslationAuth.cs Editor/I18n/TranslationAuth.cs.meta \
+        Editor/I18n/TranslationProviderSettingsProvider.cs Editor/I18n/TranslationProviderSettingsProvider.cs.meta
+git commit -m "feat(i18n-editor): Translation provider config (ProjectSettings + UserSettings)"
+```
+
+---
+
+## Task 8: TranslationClient — HTTP + Structured Outputs
+
+**Files:**
+- Create: `Editor/I18n/TranslationClient.cs`
+- Create: `Tests/EditMode/Editor/TranslationClientTests.cs`
+
+- [ ] **Step 1: Write failing tests with stubbed handler**
+
+```csharp
+// Tests/EditMode/Editor/TranslationClientTests.cs
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using PromptUGUI.Editor.I18n;
+
+namespace PromptUGUI.Tests.Editor {
+    public class TranslationClientTests {
+        sealed class StubHandler : HttpMessageHandler {
+            public Func<HttpRequestMessage, HttpResponseMessage> Reply;
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage req, CancellationToken ct) => Task.FromResult(Reply(req));
+        }
+
+        [Test]
+        public async Task TranslateBatch_ParsesStructuredJson() {
+            var stub = new StubHandler {
+                Reply = _ => new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new StringContent(@"
+                        { ""choices"": [ { ""message"": {
+                          ""content"": ""{\""translations\"":[{\""msgid\"":\""hello\"",\""msgctxt\"":null,\""msgstr\"":\""你好\""}]}""
+                        } } ] }"),
+                },
+            };
+            var client = new TranslationClient(new HttpClient(stub));
+            var input = new List<TranslationItem> {
+                new() { Msgid = "hello", Msgctxt = null, Comments = new() { "ctx" } },
+            };
+            var result = await client.TranslateBatch(
+                input, "zh-Hans",
+                endpoint: "https://example/v1", model: "x", apiKey: "k", systemPrompt: "p",
+                CancellationToken.None);
+            Assert.AreEqual("你好", result["hello"]);
+        }
+
+        [Test]
+        public void TranslateBatch_NonOk_Throws() {
+            var stub = new StubHandler {
+                Reply = _ => new HttpResponseMessage(HttpStatusCode.Unauthorized) {
+                    Content = new StringContent(""),
+                },
+            };
+            var client = new TranslationClient(new HttpClient(stub));
+            Assert.ThrowsAsync<HttpRequestException>(async () =>
+                await client.TranslateBatch(
+                    new List<TranslationItem>(),
+                    "zh-Hans", "https://e/v1", "x", "k", "p", CancellationToken.None));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run; expect compile fail**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"], filter="TranslationClientTests")
+```
+
+- [ ] **Step 3: Implement client**
+
+```csharp
+// Editor/I18n/TranslationClient.cs
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PromptUGUI.Editor.I18n {
+    internal sealed class TranslationItem {
+        public string Msgid { get; set; }
+        public string Msgctxt { get; set; }
+        public List<string> Comments { get; set; } = new();
+    }
+
+    internal sealed class TranslationClient {
+        readonly HttpClient _http;
+        public TranslationClient(HttpClient http = null) {
+            _http = http ?? new HttpClient();
+        }
+
+        public async Task<Dictionary<string, string>> TranslateBatch(
+            IList<TranslationItem> items,
+            string targetLocale,
+            string endpoint, string model, string apiKey, string systemPrompt,
+            CancellationToken ct) {
+
+            var req = new HttpRequestMessage(HttpMethod.Post, endpoint);
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+            var prompt = systemPrompt.Replace("{{targetLocale}}", targetLocale);
+            var userMessage = JsonSerializer.Serialize(new {
+                target_locale = targetLocale,
+                items = items.Select(i => new {
+                    msgid = i.Msgid,
+                    msgctxt = i.Msgctxt,
+                    comments = i.Comments,
+                }),
+            });
+            var body = new {
+                model,
+                messages = new object[] {
+                    new { role = "system", content = prompt },
+                    new { role = "user", content = userMessage },
+                },
+                response_format = new {
+                    type = "json_schema",
+                    json_schema = new {
+                        name = "Translations",
+                        strict = true,
+                        schema = new {
+                            type = "object",
+                            additionalProperties = false,
+                            required = new[] { "translations" },
+                            properties = new {
+                                translations = new {
+                                    type = "array",
+                                    items = new {
+                                        type = "object",
+                                        additionalProperties = false,
+                                        required = new[] { "msgid", "msgctxt", "msgstr" },
+                                        properties = new {
+                                            msgid = new { type = "string" },
+                                            msgctxt = new { type = new[] { "string", "null" } },
+                                            msgstr = new { type = "string" },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+            req.Content = new StringContent(
+                JsonSerializer.Serialize(body),
+                Encoding.UTF8,
+                "application/json");
+
+            var resp = await _http.SendAsync(req, ct);
+            resp.EnsureSuccessStatusCode();
+            var text = await resp.Content.ReadAsStringAsync();
+
+            using var doc = JsonDocument.Parse(text);
+            var content = doc.RootElement
+                .GetProperty("choices")[0]
+                .GetProperty("message")
+                .GetProperty("content").GetString();
+            using var inner = JsonDocument.Parse(content);
+            var result = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var t in inner.RootElement.GetProperty("translations").EnumerateArray()) {
+                var msgid = t.GetProperty("msgid").GetString();
+                var msgstr = t.GetProperty("msgstr").GetString();
+                result[msgid] = msgstr;
+            }
+            return result;
+        }
+    }
+}
+```
+
+(`System.Text.Json` ships in modern Unity. If not, fall back to `Newtonsoft.Json` which Unity bundles via `com.unity.nuget.newtonsoft-json`. Try `System.Text.Json` first; if compile fails, swap to Newtonsoft and re-run tests.)
+
+- [ ] **Step 4: Run; expect pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"], filter="TranslationClientTests")
+```
+
+Expected: 2/2 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Editor/I18n/TranslationClient.cs Editor/I18n/TranslationClient.cs.meta \
+        Tests/EditMode/Editor/TranslationClientTests.cs
+git commit -m "feat(i18n-editor): TranslationClient — OpenAI-compat with Structured Outputs"
+```
+
+---
+
+## Task 9: TranslationMenu — wiring the UX
+
+**Files:**
+- Create: `Editor/I18n/TranslationMenu.cs`
+
+- [ ] **Step 1: Implement menu + dialog**
+
+```csharp
+// Editor/I18n/TranslationMenu.cs
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using PromptUGUI.Application;
+using PromptUGUI.I18n;
+using UnityEditor;
+using UnityEngine;
+
+namespace PromptUGUI.Editor.I18n {
+    internal static class TranslationMenu {
+        const string I18nRoot = "Assets/Resources/PromptUGUI/i18n";
+        const int BatchSize = 50;
+
+        [MenuItem("Tools/PromptUGUI/Translate Locale...")]
+        public static void OpenDialog() {
+            var settings = PromptUGUISettings.Instance;
+            if (settings == null || settings.locales.Count == 0) {
+                EditorUtility.DisplayDialog(
+                    "PromptUGUI",
+                    "No PromptUGUISettings or no locales configured.",
+                    "OK");
+                return;
+            }
+            TranslateLocaleWindow.Show(
+                settings.locales.Select(l => l.locale).Where(s => !string.IsNullOrEmpty(s)).ToArray(),
+                RunFor);
+        }
+
+        sealed class TranslateLocaleWindow : EditorWindow {
+            string[] _locales;
+            int _selected;
+            System.Action<string> _onConfirm;
+
+            public static void Show(string[] locales, System.Action<string> onConfirm) {
+                var w = CreateInstance<TranslateLocaleWindow>();
+                w.titleContent = new GUIContent("Translate Locale");
+                w._locales = locales;
+                w._onConfirm = onConfirm;
+                w.minSize = new Vector2(320, 100);
+                w.ShowUtility();
+            }
+
+            void OnGUI() {
+                EditorGUILayout.LabelField("Target locale:");
+                _selected = EditorGUILayout.Popup(_selected, _locales);
+                EditorGUILayout.Space();
+                using (new EditorGUILayout.HorizontalScope()) {
+                    if (GUILayout.Button("Cancel")) Close();
+                    if (GUILayout.Button("Translate")) {
+                        var picked = _locales[_selected];
+                        Close();
+                        _onConfirm(picked);
+                    }
+                }
+            }
+        }
+
+        static void RunFor(string locale) {
+            var auth = TranslationProviderSettingsProvider.GetOrCreateAuth();
+            var provider = TranslationProviderSettingsProvider.GetOrCreateProvider();
+            if (string.IsNullOrEmpty(auth.apiKey)) {
+                EditorUtility.DisplayDialog("PromptUGUI",
+                    "No API key set. Edit at Project Settings → PromptUGUI → Translation.",
+                    "OK");
+                return;
+            }
+
+            var localeDir = Path.Combine(I18nRoot, locale);
+            if (!Directory.Exists(localeDir)) {
+                EditorUtility.DisplayDialog("PromptUGUI",
+                    $"No .po files for locale '{locale}'. Run Extract Strings first.",
+                    "OK");
+                return;
+            }
+
+            // Collect empty-msgstr entries.
+            var queue = new List<(string poPath, PoEntry entry)>();
+            foreach (var po in Directory.GetFiles(localeDir, "*.po", SearchOption.AllDirectories)) {
+                var text = File.ReadAllText(po);
+                foreach (var e in PoParser.Parse(text)) {
+                    if (string.IsNullOrEmpty(e.Msgstr)) queue.Add((po, e));
+                }
+            }
+            if (queue.Count == 0) {
+                EditorUtility.DisplayDialog("PromptUGUI",
+                    "No empty msgstr entries to translate.", "OK");
+                return;
+            }
+            if (!EditorUtility.DisplayDialog(
+                "PromptUGUI",
+                $"Translate {queue.Count} empty entries for locale '{locale}'?",
+                "Translate", "Cancel")) return;
+
+            var client = new TranslationClient();
+            int done = 0;
+            using var cts = new CancellationTokenSource();
+            try {
+                for (int i = 0; i < queue.Count; i += BatchSize) {
+                    var slice = queue.Skip(i).Take(BatchSize).ToList();
+                    if (EditorUtility.DisplayCancelableProgressBar(
+                        "PromptUGUI Translate",
+                        $"Batch {i / BatchSize + 1} / {(queue.Count + BatchSize - 1) / BatchSize}",
+                        (float)i / queue.Count)) {
+                        cts.Cancel();
+                        break;
+                    }
+                    var items = slice.Select(p => new TranslationItem {
+                        Msgid = p.entry.Msgid,
+                        Msgctxt = p.entry.Msgctxt,
+                        Comments = p.entry.TranslatorComments,
+                    }).ToList();
+
+                    Dictionary<string, string> map = null;
+                    int retry = 0;
+                    Exception lastEx = null;
+                    while (retry < 3) {
+                        try {
+                            map = client.TranslateBatch(
+                                items, locale,
+                                provider.endpoint, provider.model, auth.apiKey,
+                                provider.systemPrompt,
+                                cts.Token).GetAwaiter().GetResult();
+                            break;
+                        } catch (Exception e) {
+                            lastEx = e;
+                            retry++;
+                            System.Threading.Thread.Sleep(300 * retry);
+                        }
+                    }
+                    if (map == null) {
+                        Debug.LogWarning($"[PromptUGUI] batch failed after retries: {lastEx?.Message}");
+                        continue;
+                    }
+                    // Write back.
+                    foreach (var (poPath, entry) in slice) {
+                        if (!map.TryGetValue(entry.Msgid, out var translated)) continue;
+                        WriteMsgstr(poPath, entry, translated);
+                        done++;
+                    }
+                }
+            } finally {
+                EditorUtility.ClearProgressBar();
+                AssetDatabase.Refresh();
+            }
+            Debug.Log($"[PromptUGUI] Translate Locale '{locale}': filled {done} / {queue.Count} entries.");
+        }
+
+        static void WriteMsgstr(string poPath, PoEntry target, string newMsgstr) {
+            var entries = PoParser.Parse(File.ReadAllText(poPath)).ToList();
+            var idx = entries.FindIndex(e => e.Msgctxt == target.Msgctxt && e.Msgid == target.Msgid);
+            if (idx < 0) return;
+            entries[idx].Msgstr = newMsgstr;
+            File.WriteAllText(poPath, PoParser.Serialize(entries));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Refresh + manual smoke (host project)**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Manual in host: configure key, run extract, then `Tools → PromptUGUI → Translate Locale...`, confirm batches process.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Editor/I18n/TranslationMenu.cs Editor/I18n/TranslationMenu.cs.meta
+git commit -m "feat(i18n-editor): Translate Locale menu — batch LLM with progress + retry"
+```
+
+---
+
+## Task 10: SKILL.md sync
+
+**Files:**
+- Modify: `.claude/skills/authoring-promptugui-xml/SKILL.md`
+
+- [ ] **Step 1: Add `font` / `tr` / `ctx` to attribute tables**
+
+In SKILL.md, find the table row for `<Text>` and add: `font` (string, font type from Settings; default `default`), `tr` (bool, default true), `ctx` (string, only used to disambiguate same-msgid in the .po table).
+
+For `<Btn>` row, change the description to indicate `<Btn>开始</Btn>` shorthand now creates an internal label. Add the same `font` / `tr` / `ctx` attributes.
+
+- [ ] **Step 2: Add an "i18n & fonts" section after "Variants: 运行时切换"**
+
+Insert section text:
+
+```markdown
+## i18n & 字体（M5 起）
+
+源文本直接写在 `<Text>` / `<Btn>` 中。`UI.Locale.Set("en")` 切语言；切语言走 Variant 通路，已 open 的 Screen 自动 ReSolve。
+
+```xml
+<!-- 源文本 = msgid；零 key -->
+<Text>开始游戏</Text>
+<Btn>设置</Btn>
+
+<!-- 不要翻译 -->
+<Text tr="false">{{playerName}}</Text>
+
+<!-- 同 msgid 多义；ctx 进 msgctxt -->
+<Btn ctx="door">Open</Btn>
+<Btn ctx="file-menu">Open</Btn>
+
+<!-- 字体 type 走 Settings；缺省 "default" -->
+<Text font="title">设置</Text>
+<Text font="damage" fontSize="96">9999!</Text>
+
+<!-- 配合既有 Variant 系统 -->
+<Text font="title" font.zh-Hans="title-cn">设置</Text>
+```
+
+C#:
+
+```csharp
+// 切 locale；同时切 .po 表与字体表
+UI.Locale.Set("en");
+UI.Locale.SetToSystemDefault();
+
+// 代码里抽取的字符串
+var text = string.Format(c, UI.Tr("总价: {0:C}"), price);
+```
+
+**保留命名空间**：`UI.Locale.Set("zh-Hans")` 内部把 `zh-Hans` 注册为活跃 Variant。author 不应使用同名 Variant 表达 locale 之外的状态。
+
+### 图文混排 / TMP 富文本
+
+`<Text>` 默认不允许 mix text + child elements。要 inline 写 `<sprite>` / `<color>` 等 TMP 标签，包 CDATA：
+
+```xml
+<Text><![CDATA[金币: <sprite name="coin"/>{{count}}]]></Text>
+<Text><![CDATA[<color=#ff0>警告</color>: 库存不足]]></Text>
+```
+
+抽取器把 CDATA 内容作为完整 msgid 抽出；运行时翻译保留标签。
+```
+
+- [ ] **Step 3: Add cheatsheet entry**
+
+In the speed-reference at the bottom of SKILL.md, add:
+
+```
+## i18n
+<Text>...</Text>          抽取 + 翻译
+<Text tr="false">...</Text>     跳过
+<Text font="title">...</Text>   字体 type
+<Text ctx="door">Open</Text>    msgctxt 消歧
+UI.Tr("...")             C# 抽取入口
+UI.Locale.Set("zh-Hans") 切 locale (= 切 .po + 切字体)
+```
+
+- [ ] **Step 4: Refresh, verify links / formatting**
+
+Read the file, sanity-check rendering and table formatting.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/skills/authoring-promptugui-xml/SKILL.md
+git commit -m "docs(skill): document i18n + fonts (font/tr/ctx attrs, CDATA, UI.Locale)"
+```
+
+---
+
+## Task 11: Main spec sync
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-07-promptugui-description-language-design.md`
+
+- [ ] **Step 1: Flip §10 i18n entry**
+
+Find:
+
+```
+- ❌ **本地化**：文本由代码侧推送或经过外部 L10N 钩子；描述文件不内置 i18n
+```
+
+Replace with:
+
+```
+- ✅ **本地化** (M5 起)：见 `2026-05-08-i18n-fonts-design.md`
+  - 零 key gettext 流（msgid = 源文本字面量）
+  - .po 表 + Roslyn / XML 抽取 + LLM 翻译菜单
+  - locale 切换走 Variant.Changed 通路
+  - 字体 type → 每 locale TMP_FontAsset 表（Settings）
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-05-07-promptugui-description-language-design.md
+git commit -m "docs(spec): flip §10 i18n non-goal — now M5 deliverable"
+```
+
+---
+
+## Task 12: Final smoke
+
+- [ ] **Step 1: Full EditMode + EditorOnly + PlayMode**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: all PASS, no console errors.
+
+- [ ] **Step 2: Manual extract + translate dry-run**
+
+In host project:
+1. Tools → PromptUGUI → Extract Strings
+2. Verify .po files appear under `Assets/Resources/PromptUGUI/i18n/<locale>/`
+3. Project Settings → PromptUGUI → Translation; set API key (from a sandbox account)
+4. Tools → PromptUGUI → Translate Locale… → pick non-source locale
+5. Verify msgstr fields populate
+
+- [ ] **Step 3: Verify hot reload still works**
+
+Edit a .po file by hand; confirm `UIAssetPostprocessor` picks it up and `UI.Locale.ReloadCurrent` updates open Screens.
+
+---
+
+## What M5b Ships
+
+After this plan:
+- One menu click extracts every translatable string from `.ui.xml` and `*.cs` into per-partition `.po` files for every Settings locale
+- One menu click + dialog → batch LLM call fills empty msgstr entries with structured-outputs JSON
+- Project Settings panel exposes endpoint / model / system prompt; UserSettings holds API key out of git
+- SKILL.md and main spec reflect the new public surface — future LLM authoring sessions know about it
+- Author writing in mixed-language source can ship to any locale by clicking 2 menus + reviewing translations
+
+---
+
+## Notes for the executing agent
+
+- **Roslyn availability**: `Microsoft.CodeAnalysis.CSharp` is bundled in Unity Editor (Unity 2020+). If `using Microsoft.CodeAnalysis.CSharp;` won't compile, the agent must add the package reference; report to user before bypassing.
+- **System.Text.Json**: Unity 6 has it natively. If older, swap to `Newtonsoft.Json` (Unity bundles via `com.unity.nuget.newtonsoft-json`).
+- **Editor-only**: every file in this plan lives under `Editor/`; nothing must leak to `Runtime/`.
+- **i18n-custom is sacred**: extractor MUST NOT write to `Resources/PromptUGUI/i18n-custom/`. Only `i18n/`.
+- **Comment markers** in Po: PoParser stores all `#`-prefixed lines into TranslatorComments. The writer emits `# .` / `# :` etc. as plain comments — this round-trips losslessly. Don't introduce a new typed-comment API for this milestone.
+- **API key handling**: never log the key; never write it to Project asset; never include it in error messages.
+- **DRY / YAGNI**: don't add helper methods until a second caller exists. The settings provider is intentionally minimal.
+- **Test-first**: every public function gets a test before implementation.
+- **No `--no-verify` commits**.

--- a/docs/superpowers/specs/2026-05-07-promptugui-description-language-design.md
+++ b/docs/superpowers/specs/2026-05-07-promptugui-description-language-design.md
@@ -605,7 +605,11 @@ HeTu.Sub<int>("player.gold").BindText(...).AddTo(screen);
 
 - ❌ **动画**：用 Unity Animator / DOTween，不在描述文件管
 - ❌ **主题 token / 全局样式表**：风格通过控件类型变体表达（PrimaryButton vs DangerButton），不再做 token 层
-- ❌ **本地化**：文本由代码侧推送或经过外部 L10N 钩子；描述文件不内置 i18n
+- ✅ **本地化** (M5 起)：见 `2026-05-08-i18n-fonts-design.md`
+  - 零 key gettext 流（msgid = 源文本字面量）
+  - .po 表 + Roslyn / XML 抽取 + LLM 翻译菜单
+  - locale 切换走 Variant.Changed 通路
+  - 字体 type → 每 locale TMP_FontAsset 表（Settings）
 - ❌ **运行时 DOM 编辑 API**：想动态加节点请重建 Screen
 - ❌ **绑定表达式 / 模板循环 `<For>`**：列表是代码侧推送的自定义控件
 - ❌ **多 Slot 命名**：单匿名 Slot 够用；真有多 slot 需求重新评估

--- a/docs/superpowers/specs/2026-05-08-i18n-fonts-design.md
+++ b/docs/superpowers/specs/2026-05-08-i18n-fonts-design.md
@@ -1,0 +1,639 @@
+# I18n + Fonts 设计：零 key gettext 流 + per-locale 字体表
+
+**日期**：2026-05-08
+**状态**：设计阶段（待 review，未进入实施）
+**作用域**：多语言 / 字体子系统的 XML 语法增量、Settings 资产、IR 改动、运行时数据流、Editor 抽取与 LLM 翻译菜单、与 Variant 系统的集成、与 hot-reload 的集成、主 spec 同步
+**依赖**：基础设计 [`2026-05-07-promptugui-description-language-design.md`](2026-05-07-promptugui-description-language-design.md) §7（内置控件）/ §8（Variant）/ §10（v1 非目标 — 本 spec 推翻其中 "本地化" 一条）；Icon 设计 [`2026-05-08-icon-assets-design.md`](2026-05-08-icon-assets-design.md)（Settings asset 持久化模式参考）
+
+---
+
+## 1. 背景与目标
+
+像素游戏项目要从单语种铺到多语种发布。常见痛点：
+
+- **改字符串成本高**：传统方案要先定 key（"menu.start"），再写代码 / XML 引用 key，再去翻译表填值；改 UI 文案要同步动三处
+- **CJK ↔ 拉丁字体**：同一控件在不同 locale 需要不同 TMP_FontAsset（中文要带汉字字模的字体，英文用拉丁字体更紧凑），手工管理容易漏
+- **翻译流程**：要翻一长段文本，传统 .po 配 xgettext 很重，体验割裂
+
+PromptUGUI 已有 Variant 系统（每个 Variant 触发已 open Screen 的 ReSolve），是多语言切换的天然载体。
+
+**本 spec 解决的目标**：
+
+1. **零 key**：作者在 .ui.xml / C# 里直接写源文本字面量；msgid = 字面量；改文案不动 key
+2. **混合源语言**：作者可以中英文混写，没有 sourceLocale 概念，LLM 时代翻译模型不需要它
+3. **runtime 字体表**：Settings 里每 locale 配 fontType → TMP_FontAsset 表；XML 用 `font="title"` 这种 type 名引用
+4. **图文混排**：源文本可包含 TMP 富文本标签（`<sprite>` / `<color>` 等）；翻译流程保留它们
+5. **LLM 翻译菜单**：OpenAI 兼容 API + Structured Outputs，自动为空 msgstr 翻译
+6. **复用 Variant 通路**：locale 切换 = `Variants.Set(<locale>, true/false)`，省一套独立的 Locale.Changed 事件
+
+---
+
+## 2. 决策一览
+
+| # | 决策 | 选择 | 理由 |
+|---|---|---|---|
+| I18N-D1 | 数据流 | 独立 TranslationStore + 复用 `Variant.Changed` | translations 不进 IR 避免污染；切语言走 ReSolve 复用既有通路 |
+| I18N-D2 | 文件格式 | gettext .po | 业界标准；msgctxt / 注释一等公民；LLM 提示效果好；git diff 友好 |
+| I18N-D3 | msgctxt 语义 | 默认仅注释；显式 ctx 才进 lookup | XML 重命名 id 不丢翻译；同 msgid 多义可主动消歧 |
+| I18N-D4 | 字体语法 | Text/Btn 上 `font="<type>"`，缺省 type=`default` | type 名而非 asset 路径，与 locale 解耦；fallback 自然 |
+| I18N-D5 | 文件分片 | per src 镜像路径 + 独立 i18n-custom 目录 | hot reload 粒度自然；用户手写表与抽取产物物理隔离 |
+| I18N-D6 | `{{...}}` 处理 | 抽取模板原文作 msgid；runtime 在 msgstr 上反向插值 | 零 author 心智；Template 静态文本也能翻 |
+| I18N-D7 | C# 抽取 | Roslyn syntactic walker | Unity 自带；上下文（函数名、注释）齐全；动态参数可识别并 warn |
+| I18N-D8 | XML opt-out | `tr="false"` | 隐式抽取 + 显式排除；C# 反过来：调用 `UI.Tr` 才抽 |
+| I18N-D9 | Settings 持久化 | PlayerSettings.preloadedAssets + AssetPostprocessor | Unity Localization 同款机制；零 Resources/ 污染 |
+| I18N-D10 | locale 列表 | 隐含从 `Settings.locales` 推导 | 单一字段不冗余 |
+| I18N-D11 | 默认 locale | `null`（全 miss → msgid 原样） | 不预设作者源语言；user app 自行调用 `SetToSystemDefault()` |
+| I18N-D12 | fallback chain | 无 | LLM 时代不需要；miss 直接返 msgid |
+| I18N-D13 | AI 配置 | endpoint/model/prompt 进 ProjectSettings；apiKey 进 UserSettings | 团队共享 + key 不进库 |
+| I18N-D14 | 触发节奏 | 手动 Extract / 手动 Translate 两个菜单 | 抽取幂等可频繁跑；翻译付费 LLM 需显式 |
+| I18N-D15 | 复数 | v1 不上 | 现代 LLM 翻译能接受 `"{0} coins"` 单形式 |
+| I18N-D16 | 过时 msgid | 直接删除 | 用户决定；依赖 git 历史与 LLM 重译能力 |
+| I18N-D17 | Settings 位置 | 默认 `Assets/PromptUGUI/Settings.asset`，用户可拖动 | 项目级共享，preloadedAssets 自动维护 |
+| I18N-D18 | 表优先级 | i18n-custom 覆盖 i18n | 手写是逆水身，永远高于自动抽取 |
+| I18N-D19 | TMP 富文本 | CDATA 内嵌；改 parser 一处把 CDATA 计入 textContent | 标准 XML；mixed-content 禁令保留 |
+| I18N-D20 | locale 作 Variant 名 | 直接用 locale 字符串作 Variant 名（无 `_locale:` 前缀） | 与 `font.zh-Hans="..."` 这种自定义 .var 写法天然吻合 |
+
+---
+
+## 3. 总体架构
+
+```
+                     Author
+                       │
+     ┌─────────────────┼─────────────────┐
+     │                 │                 │
+  *.ui.xml         *.cs UI.Tr()      手写 .po
+                       │                 │
+            ┌──────────┴──────┐          │
+            │  Editor 抽取菜单 │          │
+            └──────────┬──────┘          │
+                       ▼                 │
+             Resources/PromptUGUI/       │
+             ├─ i18n/<locale>/...po  ◀──┘
+             │  (auto-managed)
+             └─ i18n-custom/<locale>/...po
+                       │
+                       │ ┌─ Editor 翻译菜单 (LLM)
+                       │ │   填空 msgstr
+                       ▼ ▼
+                 .po (有译文)
+                       │
+        ┌──────────────┴──────────────┐
+        │                             │
+   PromptUGUISettings           UI.Locale.Set()
+   (locales / fonts)                  │
+        │                             ▼
+        │              内部 Variants.Set("<locale>", true/false)
+        │                             │
+        │              ┌──────────────▼──────────────┐
+        │              │ 已 open Screen.ReSolve()     │
+        │              └──────────────┬──────────────┘
+        │                             │
+        ▼                             ▼
+TranslationStore<locale, table>   ApplyCommon
+        │                             │ 走 TrResolver
+        └──────────────────┬──────────┘
+                           ▼
+                        TMP_Text
+```
+
+两条可独立演进的轴：
+
+- **i18n 轴**：作者写中/英/混合 → 抽取器扫成 .po → LLM 填 msgstr → runtime `Tr(msgid)` 查 store
+- **字体轴**：Settings 里 `locales[<x>].fonts[<type>]` 配 TMP asset → `<Text font="title">` 通过 type 名解引
+
+两轴交于 `UI.Locale.Set("zh-Hans")` 这一个 API：它同时切 store 和切 fonts，经由 Variants.Changed 一次性 ReSolve。
+
+---
+
+## 4. PromptUGUISettings 资产
+
+**单一 ScriptableObject**，由用户拖在 `Assets/PromptUGUI/Settings.asset`（可拖到任意位置）。Editor `[InitializeOnLoad]` + `AssetPostprocessor` 维护：
+
+- 项目内 ≤ 1 个 PromptUGUISettings 资产（>1 时 Editor 报错）
+- 自动加进 `PlayerSettings.preloadedAssets`
+- Runtime 通过 `Resources.FindObjectsOfTypeAll<PromptUGUISettings>().FirstOrDefault()` 拿到已加载实例
+
+### 4.1 字段（v1）
+
+```csharp
+namespace PromptUGUI.Application {
+    [CreateAssetMenu(menuName = "PromptUGUI/Settings", fileName = "Settings")]
+    public sealed class PromptUGUISettings : ScriptableObject {
+        [Serializable] public sealed class FontEntry {
+            public string type;                 // "default" | "title" | "damage" | ...
+            public TMP_FontAsset font;
+        }
+        [Serializable] public sealed class LocaleConfig {
+            public string locale;               // BCP-47 推荐: "zh-Hans" / "en" / "ja"
+            public List<FontEntry> fonts;       // 必含 type="default" 一项
+            // 未来扩展: text direction, number format, ...
+        }
+        public List<LocaleConfig> locales;      // entries 决定"项目支持哪些 locale"
+    }
+}
+```
+
+### 4.2 校验规则（Editor 时）
+
+- 多个 PromptUGUISettings 资产 → log error，preloadedAssets 不变
+- 任一 LocaleConfig 缺 type=`default` → Inspector 标红，runtime fallback 到内置 TMP 默认字体并 log
+- 重复 locale 名 → Inspector 标红
+- 重复 fontType（同 locale 内）→ Inspector 标红
+
+### 4.3 Runtime 行为
+
+- `UI.Locale.Set("ko")`，`ko` 不在 `Settings.locales` 中：**接受**
+  - fonts 走内置 TMP default
+  - 加载 `Resources/PromptUGUI/i18n/ko/`（找不到就全 miss → msgid 原样输出）
+  - **不 throw**：设计哲学是"宁愿不翻译也不阻塞"
+
+---
+
+## 5. XML 语法增量
+
+只新增 **三个属性**，都加在 Text/Btn 这种"文本输出"控件上。所有既有 .ui.xml **不需要任何改动**。
+
+### 5.1 `font` 属性
+
+```xml
+<Text>开始游戏</Text>                <!-- font 缺省 = "default" -->
+<Text font="damage" fontSize="96">9999!</Text>
+<Text font="title">设置</Text>
+
+<!-- 跟 Variant 系统天然咬合 -->
+<Text font="title" font.zh-Hans="title-cn">设置</Text>
+```
+
+- 值为 fontType 名（对应 LocaleConfig.fonts.type），**不是** TMP asset 路径
+- ResolveAttribute（Text 控件）时：`type` → 当前 locale 的 LocaleConfig.fonts → TMP_FontAsset → `_tmp.font = ...`
+- 当前 locale 找不到该 type、找不到该 LocaleConfig、Settings 整体缺失 → 全部 fallback 到内置 TMP default，不 throw，每条字符串只 warn 一次
+
+### 5.2 `tr` 属性
+
+```xml
+<Text>开始游戏</Text>                       <!-- 抽取 + 翻译 -->
+<Text tr="false">{{playerName}}</Text>     <!-- 跳过抽取, runtime 原样 -->
+<Btn>设置</Btn>                             <!-- 抽取 + 翻译 -->
+<Btn tr="false" text="VIP12345"/>          <!-- 跳过 -->
+```
+
+- 仅生效于 Text/Btn 的 textContent 和 `text` 属性
+- `tr="false"` 时，抽取器跳过、runtime TrResolver 也跳过，直接 set 原文
+- 与 `ctx` 同时出现时 `tr="false"` 优先（既然不抽不查，ctx 无意义）
+
+### 5.3 显式 `ctx` 的逃生口（罕用）
+
+```xml
+<Text ctx="door">Open</Text>          <!-- msgctxt="door" + msgid="Open" -->
+<Btn ctx="file-menu">Open</Btn>       <!-- msgctxt="file-menu" + msgid="Open" -->
+```
+
+- 仅当多义性需要消歧时，author 主动写 `ctx`
+- 抽取的 ambient context（screen path / sibling strings）始终走 `# comment` 注释，不进 msgctxt
+
+### 5.4 CDATA 与 TMP 富文本
+
+`<Text>金币: <sprite name="coin"/>{{count}}</Text>` 在当前 parser 是 mixed-content error。**支持方式：CDATA**：
+
+```xml
+<Text><![CDATA[金币: <sprite name="coin"/>{{count}}]]></Text>
+<Btn><![CDATA[<sprite name="play"/> 开始]]></Btn>
+<Text><![CDATA[<color=#ff0>警告</color>: 库存不足]]></Text>
+```
+
+- Parser 改动：`UIDocumentParser.cs:265` 的 hasText 检测把 `XmlCDataSection` 也计入。`el.InnerText` 已经把 CDATA 当 text 处理 — textContent 提取自动 work
+- mixed-content 禁令仍然保留：`<Text>foo<sprite/>bar</Text>` 仍报错；想 inline 标签必须 CDATA 整体包
+- 抽取/runtime/翻译三条路径**零改动**：都基于 string，CDATA 解开后跟普通 text 一样
+- `{{count}}` 反向插值在 CDATA 解开后的字符串上走正则，完全不受影响
+- entity 转义（`&lt;sprite/&gt;`）仍然作为 author 的隐式 fallback 保留
+
+---
+
+## 6. 运行时数据流
+
+### 6.1 IR 改动
+
+`ElementNode` 多两个字段：
+
+```csharp
+public class ElementNode {
+    // ... 既有字段 ...
+    public string TextContentRaw;                      // substitution 前的字符串 (含 {{...}})
+    public Dictionary<string,string> TextArgs;         // template 实参 dict (substitution 时填)
+    public Dictionary<string,string> AttributesRaw;    // attribute 上含 {{...}} 的原文
+}
+```
+
+- 解析时：`TextContentRaw = el.InnerText`（不替换），`TextContent`（既有字段）用 substituted 后的值，**保留向后兼容**
+- TemplateExpander 在 expand 调用站时，把实参 dict 拷贝到结果 node 的 `TextArgs`
+- attribute 上含 `{{}}` 的同理：`Attributes[k]` 是 substituted，`AttributesRaw[k]` 是原文
+
+### 6.2 TranslationStore
+
+```csharp
+namespace PromptUGUI.Application {
+    internal sealed class TranslationStore {
+        // (locale, msgctxt|null, msgid) → msgstr
+        Dictionary<(string,string,string), string> _entries;
+
+        public string Lookup(string locale, string ctx, string msgid);  // miss 返 null
+        public void Load(string locale, IEnumerable<PoEntry> entries);
+        public void UnloadLocale(string locale);
+        public void UnloadAll();
+    }
+}
+```
+
+- `UI.Locale.Set("zh-Hans")` 时：枚举 `Resources/PromptUGUI/i18n/zh-Hans/` + `Resources/PromptUGUI/i18n-custom/zh-Hans/` 下所有 TextAsset → 解析成 PoEntry → Load
+- i18n-custom 后载入，同 (locale, ctx, msgid) 覆盖 i18n（D18）
+- 切 locale 时先 UnloadLocale 上一个，再 Load 新的
+
+### 6.3 TrResolver
+
+```csharp
+namespace PromptUGUI.Application {
+    internal static class TrResolver {
+        public static string Resolve(
+            string raw,
+            IReadOnlyDictionary<string,string> args,
+            string ctx) {
+
+            if (raw == null) return null;
+            var locale = UI.Locale.Current;
+            var msgstr = locale != null
+                ? TranslationStore.Instance.Lookup(locale, ctx, raw)
+                : null;
+            var template = msgstr ?? raw;                              // miss → 原样
+            return args != null && args.Count > 0
+                ? Substitution.Apply(template, args)                   // {{name}} 反向插值
+                : template;
+        }
+    }
+}
+```
+
+`ControlAttributeApplier` 在 apply textContent 与 `text` 属性之前调用 `TrResolver.Resolve(node.TextContentRaw, node.TextArgs, node.Attributes.GetValueOrDefault("ctx"))`。`font` 属性的 type → asset 解析也插在这一步。
+
+### 6.4 UI.Locale API
+
+```csharp
+namespace PromptUGUI.Application {
+    public static partial class UI {
+        public static class Locale {
+            public static string Current { get; private set; }
+            public static event Action Changed;
+
+            public static void Set(string locale) {
+                if (Current == locale) return;
+                if (Current != null) Variants.Set(Current, false);
+                TranslationStore.Instance.UnloadAll();
+                Current = locale;
+                if (locale != null) {
+                    LoadPoFiles(locale);
+                    Variants.Set(locale, true);  // 触发 Variants.Changed → ReSolve
+                } else {
+                    VariantStore.NotifyChangedInternal();  // null 时也广播
+                }
+                Changed?.Invoke();
+            }
+
+            public static void SetToSystemDefault() => Set(MapSystemLanguage());
+            public static IReadOnlyList<string> Configured { get; } // Settings.locales 的 keys
+        }
+
+        public static string Tr(string msgid, string ctx = null) =>
+            TrResolver.Resolve(msgid, null, ctx);
+    }
+}
+```
+
+`Application.systemLanguage` → BCP-47 映射（硬编码简表）：
+- ChineseSimplified → "zh-Hans"
+- ChineseTraditional → "zh-Hant"
+- English → "en"
+- Japanese → "ja"
+- Korean → "ko"
+- 其它常见 SystemLanguage 各对应；未识别返 null
+
+`MapSystemLanguage` 返回的字符串若不在 `Configured` 中，仍直接 set（保留 D11 "宁愿不翻译也不阻塞"原则）。
+
+### 6.5 locale 名作为 Variant 名
+
+`UI.Locale.Set("zh-Hans")` 内部调用 `Variants.Set("zh-Hans", true)`。这意味着：
+
+- author 写 `font.zh-Hans="title-cn"` 在 Locale.Set("zh-Hans") 后自动生效
+- author 写 `<Variant when="zh-Hans">` 也自动咬合 — 用同一个 Variant 即可表达"语言激活时的额外结构"
+- 反过来：author 不能用一个 Variant 名同时表达 locale 之外的某种状态（locale 名是保留的）
+
+### 6.6 .po 加载策略
+
+- LoadPoFiles 用 `Resources.LoadAll<TextAsset>("PromptUGUI/i18n/<locale>")` 与 `"PromptUGUI/i18n-custom/<locale>"` 枚举所有 TextAsset
+- 解析每个 TextAsset.text → IEnumerable<PoEntry>
+- 总文件量预期 < 1MB（KB 级），全量加载到内存可接受
+- 依赖 §7.1 的 PoFileImporter 让 .po 在 Unity 中以 TextAsset 形态存在
+
+### 6.7 VariantStore 改动
+
+新增 `internal void NotifyChangedInternal()`（不改激活集合，仅广播 Changed），用于 `UI.Locale.Set(null)` 时让 Screen.ReSolve。其它场景（如 SettingsAsset fonts 改动）也复用此 hook。
+
+---
+
+## 7. .po 词法分析器与扩展名识别
+
+### 7.1 ScriptedImporter
+
+Unity 默认对 `.po` 扩展名不识别为 TextAsset，会作为 `DefaultAsset` 处理 — 这样 `Resources.LoadAll<TextAsset>` 拿不到。需要在 `Editor/PoFileImporter.cs` 加：
+
+```csharp
+[ScriptedImporter(version: 1, ext: "po")]
+public sealed class PoFileImporter : ScriptedImporter {
+    public override void OnImportAsset(AssetImportContext ctx) {
+        var text = File.ReadAllText(ctx.assetPath);
+        var asset = new TextAsset(text);
+        ctx.AddObjectToAsset("text", asset);
+        ctx.SetMainObject(asset);
+    }
+}
+```
+
+这让 .po 文件在 Unity 里以 TextAsset 形态存在；gettext 兼容工具（编辑器扩展、外部 .po 编辑器、`msgfmt` 等）仍按标准 .po 识别。
+
+### 7.2 PoParser
+
+放 `Runtime/Core/I18n/PoParser.cs`：
+
+```csharp
+namespace PromptUGUI.I18n {
+    public sealed class PoEntry {
+        public string Msgctxt;   // null = 无 ctx
+        public string Msgid;
+        public string Msgstr;    // 空字符串 = 未翻译
+        public List<string> TranslatorComments;
+    }
+
+    public static class PoParser {
+        public static IEnumerable<PoEntry> Parse(string source);
+        public static string Serialize(IEnumerable<PoEntry> entries);
+    }
+}
+```
+
+支持范围：
+- msgid / msgstr / msgctxt
+- 多行字符串拼接：`"foo "\n"bar"` → `foo bar`
+- `\n` `\t` `\\` `\"` 转义
+- `# ...` 翻译者注释，`#: ...` 引用注释，`#. ...` 抽取者注释
+- v1 不支持 plurals (msgid_plural / msgstr[N])
+
+约 200 行，纯字符串扫描，0 第三方依赖。
+
+---
+
+## 8. 抽取工具
+
+### 8.1 入口
+
+`Tools → PromptUGUI → Extract Strings`（menu item）。手动触发，不走 AssetPostprocessor（D14）。
+
+### 8.2 XML 扫描
+
+复用既有 `UIDocumentParser`（在 expansion 前的 IR 上跑）：
+
+- 遍历 `Assets/**/*.ui.xml`（走 AssetDatabase 列举）
+- 对每个文件：解析得到 raw IR（parse 前 / template expansion 前）
+- 走每个 ElementNode：
+  - tag ∈ {Text, Btn} 且没有 `tr="false"` 时：
+    - 收集 `TextContentRaw`（若非空且非纯 `{{x}}` 单变量）
+    - 收集 `Attributes["text"]`（若存在，走同上规则）
+  - 含 `{{x}}` → msgid 保留 `{{}}` 占位符
+  - **纯**变量场景 `<Text>{{x}}</Text>` 或 `text="{{x}}"`：跳过 + warn（无翻译价值）
+- 收集 ambient ctx：`<screen-name>/<id-path>:<attr>`（仅作 `#. ` 抽取者注释）
+- 收集 sibling strings：同父 Text/Btn 的 raw text（前 3 个，去重）
+- 显式 `ctx="..."` 进 msgctxt
+- 检测 msgid 含 TMP 富文本标签 (`<sprite>` / `<color>` / `<b>` / `<i>` / `<size>` / `<link>`) → 输出 `#. Contains TMP rich text tags. Preserve tags and attribute values verbatim.` 注释
+
+### 8.3 C# 扫描
+
+Roslyn syntactic walker：
+
+- 遍历 `Assets/**/*.cs`，跳过 Tests asmdef（不抽取测试代码）
+- 解析 `SyntaxTree`，Walker 寻找 InvocationExpression：
+  - `UI.Tr(StringLiteral)` → msgid = literal
+  - `UI.Tr(StringLiteral, ctx: StringLiteral)` → msgid + msgctxt
+  - 任一参数非 StringLiteral / interpolated string / `+` 拼接 → warn 并跳过该 call site
+- ambient ctx：`<file>:<line>` + 包含调用的 method 名（写入 `#. in MethodName()`）
+- 注释提取：调用语句正上方的 `// ...` 单行注释块（写入 `#. ...`）
+- 引用：`#: <relative-path>:<line>`
+
+### 8.4 输出
+
+- XML 每个 src 一个 .po，镜像源路径：
+  `Assets/UI/screens/MainMenu.ui.xml` → `Assets/Resources/PromptUGUI/i18n/<locale>/screens/MainMenu.po`
+- 所有 C# 调用合并到 `Assets/Resources/PromptUGUI/i18n/<locale>/_code.po`
+- 为 Settings.locales 中**每个 locale 都生成**一份（初次空 msgstr）
+- 输出文件夹结构示例：
+
+```
+Assets/Resources/PromptUGUI/
+  i18n/                    # 抽取工具管理
+    zh-Hans/
+      screens/MainMenu.po
+      screens/Battle.po
+      common/Buttons.po
+      _code.po           # 所有 C# UI.Tr("...")
+    en/
+      screens/MainMenu.po
+      ...
+  i18n-custom/             # 用户手写，抽取工具不动
+    zh-Hans/
+      sfx-paths.po
+      proper-nouns.po
+    en/
+      sfx-paths.po
+```
+
+### 8.5 增量与"消失 msgid"
+
+- 已有 .po 中 msgstr 非空且 msgid 仍出现 → **保留**（不复 LLM 翻）
+- msgid 不再出现 → **直接删除**（D16；用户依赖 git 历史找回）
+- 新出现的 msgid → 添加，msgstr 为空
+
+### 8.6 i18n-custom/ 不动
+
+抽取器**永不**写 `Resources/PromptUGUI/i18n-custom/`。该目录 100% 由 author 手写。用于：
+- AI 翻译不准确时的人工 override
+- 非翻译字符串（wav 路径、URL 等）按 locale 切换的协同入口
+
+---
+
+## 9. AI 翻译菜单
+
+### 9.1 入口与配置
+
+- 配置面板：`Project Settings → PromptUGUI → Translation`（SettingsProvider）
+  - `endpoint`（默认 `https://api.openai.com/v1/chat/completions`）
+  - `model`（默认 `gpt-4o-mini`）
+  - `systemPrompt`（默认含游戏 UI 翻译指南的中文 prompt；可改）
+  - 持久化到 `ProjectSettings/PromptUGUI.asset`（进 git，团队共享）
+- API key：`UserSettings/PromptUGUI/Auth.asset`（单字段 ScriptableObject，Unity 默认 .gitignore）
+  - 同一 SettingsProvider 面板里编辑，落盘到 UserSettings 路径
+
+### 9.2 触发
+
+`Tools → PromptUGUI → Translate Locale...`：
+
+1. 弹窗选 target locale（从 Settings.locales 列表）
+2. 列出该 locale 下所有 .po 中 msgstr 为空的条目数，确认对话框
+3. 走 OpenAI 兼容 Chat Completions + Structured Outputs：
+   - `response_format = { type: "json_schema", json_schema: { ... } }`
+   - schema：`{ translations: [{ msgid, msgctxt|null, msgstr }] }`
+   - 单次请求一批（默认 50 条），失败重试 3 次，带指数退避
+4. 回写 msgstr，保留注释和 msgctxt
+5. 进度条显示；支持中途取消（已完成的批次保留）
+
+### 9.3 LLM 上下文
+
+每条 msgid 同一请求里附：
+
+```json
+{
+  "msgid": "开始游戏",
+  "msgctxt": null,
+  "comments": [
+    "MainMenu screen, Btn#playBtn label",
+    "sibling: 设置, 退出"
+  ]
+}
+```
+
+system prompt 默认模板（用户可在 ProjectSettings 改）：
+
+> 你正在为一款像素风游戏翻译 UI 字符串到 {{targetLocale}}。
+>
+> 规则：
+> 1. 保留所有 `{{x}}` 模板占位符与 `{0}` `{1:C}` 等 C# 格式占位符不变
+> 2. 保留 TMP 富文本标签（`<sprite>`、`<color>`、`<b>`、`<size>`、`<link>` 等）的字面形式与属性值不变（特别是 `name="..."`、`color="..."` 等属性内的值是资源 ID，不是文本）；位置可调以符合目标语言语序
+> 3. 参考 sibling strings 推断风格一致性（如同屏其它按钮都是动词原形，本条也用动词原形）
+> 4. 源文本可能混合多种语言；按目标 locale 翻译整体含义
+> 5. 简短直接；UI 空间有限
+
+### 9.4 cancel / 部分失败
+
+- 用户中途 cancel：已 round-trip 的批次保留写盘，未发出的不发
+- 单批失败：重试 3 次后跳过该批，log 错误，继续后续批次
+- 整体失败率 > 50% 时弹窗提示用户检查配置
+
+---
+
+## 10. Hot Reload 集成
+
+复用既有 `UI.HotReload` 通路。在 `UIAssetPostprocessor` 加 .po 路径分支：
+
+- `Resources/PromptUGUI/i18n/<locale>/...po` 或 `i18n-custom/<locale>/...po` 改动：
+  - 若 `<locale> == UI.Locale.Current`：UnloadLocale → LoadPoFiles 该 locale → Variants.Notify() → 所有 open Screen.ReSolve
+  - 否则：noop（下次切到该 locale 时 LoadPoFiles 会读最新）
+- `Settings.asset` 改动：
+  - `locales` 数组增删/重命名：log 提示，不主动 reload（用户编辑期间瞬态）
+  - fonts 表变化：若涉及 Current locale，触发 ReSolve
+
+`UnityEditor.AssetDatabase` 批量改动场景（如菜单一键跑抽取后 import 几十个 .po）：AssetPostprocessor 的 `OnPostprocessAllAssets` 一次性收齐变化集，合并成一次 Reload。
+
+---
+
+## 11. 非目标 (v1)
+
+- 复数（plurals）、性别、ICU MessageFormat
+- 数字/货币/日期格式本地化（用户自己 `string.Format(culture, ...)`）
+- 文字方向（RTL）布局重排
+- LLM 以外的翻译 provider（DeepL、Google Translate、本地模型）
+- 翻译记忆库（TM）、术语表（glossary）文件管理
+- 翻译进度可视化（仅看 .po 里 msgstr 空与否）
+- 运行时下载 .po（v1 都打进 build，Resources）
+- 字幕、语音文件路径（留给 i18n-custom 用户表自由发挥）
+- 字体动态下载（v1 假设 fonts 都打进 build）
+
+---
+
+## 12. 主 Spec 同步
+
+### 12.1 `2026-05-07-promptugui-description-language-design.md` §10
+
+```diff
+- ❌ **本地化**：文本由代码侧推送或经过外部 L10N 钩子；描述文件不内置 i18n
++ ✅ **本地化** (M5 起)：见 `2026-05-08-i18n-fonts-design.md`
++   - 零 key gettext 流（msgid = 源文本字面量）
++   - .po 表 + Roslyn / XML 抽取 + LLM 翻译菜单
++   - locale 切换走 Variant.Changed 通路
++   - 字体 type → 每 locale TMP_FontAsset 表（Settings）
+```
+
+### 12.2 `.claude/skills/authoring-promptugui-xml/SKILL.md`
+
+补充：
+
+- `<Text>` / `<Btn>` 属性表加 `font` / `tr` / `ctx`
+- "Variants: 运行时切换" 节加 "language as variant" 段
+- 加 "图文混排：CDATA + TMP 富文本标签" 一段
+- 速查页加 i18n cheatsheet：
+  - `<Text>开始</Text>` 默认抽取
+  - `<Text tr="false">{{x}}</Text>` 跳过
+  - `<Text font="title">` 类型字体
+  - C# 用 `UI.Tr("...")` 抽取
+  - `UI.Locale.Set("zh-Hans")` 切换
+
+---
+
+## 13. 测试策略
+
+按既有 EditMode/PlayMode 组织：
+
+| 文件 | 覆盖 |
+|---|---|
+| `Tests/EditMode/I18n/PoParserTests.cs` | .po 词法、序列化、roundtrip、注释类型、转义 |
+| `Tests/EditMode/I18n/TranslationStoreTests.cs` | load / lookup / unload / i18n-custom 覆盖 |
+| `Tests/EditMode/I18n/TrResolverTests.cs` | substitution + miss fallback + ctx 命中 |
+| `Tests/EditMode/Editor/StringExtractorXmlTests.cs` | XML 扫描、CDATA、`{{}}`、`tr="false"`、ambient ctx、TMP rich-text 注释 |
+| `Tests/EditMode/Editor/StringExtractorCSharpTests.cs` | Roslyn 扫描、动态参数 warn、注释提取 |
+| `Tests/EditMode/Application/LocaleSetTests.cs` | Variant.Changed 触发 + 切 locale 触发 ReSolve |
+| `Tests/EditMode/Parser/CDataInTextTests.cs` | parser 接受 `<Text><![CDATA[...]]></Text>`、含 `<sprite>` 等 |
+| `Tests/EditMode/Application/SettingsAssetTests.cs` | preloadedAssets 自动维护、多 Settings 报错 |
+| `Tests/PlayMode/E2E/I18nFontSwapTests.cs` | Set locale → 字体换 + 文字翻译 |
+| `Tests/PlayMode/E2E/I18nHotReloadTests.cs` | .po 改 → ReSolve |
+| `Tests/PlayMode/E2E/TmpRichTextRoundtripTests.cs` | CDATA 含 sprite 的源文本走完整流程，runtime TMP 渲染正确 |
+
+UnityMCP 跑测试，不批 mode（遵循 CLAUDE.md 约定）。
+
+---
+
+## 14. 风险与未决问题
+
+| # | 风险 | 缓解 |
+|---|---|---|
+| R1 | LLM 偶尔翻 `<sprite name="coin"/>` 内的 `coin` | system prompt 强调 + .po 自动注释 + AI 翻译菜单可设置 review 步骤（v1 暂不实现 review，依赖 i18n-custom 手工 override） |
+| R2 | Roslyn 解析 `Assets/**/*.cs` 慢（大型项目） | 增量扫描（仅 modified 文件 + 已知有 UI.Tr 的）作为 v2 优化；v1 全扫接受 1-3s |
+| R3 | 用户在 .po 里手改 msgstr 后再跑抽取被覆盖 | 抽取仅写空 msgstr 与新 msgid，不动已有 msgstr；i18n-custom 是逆水身入口 |
+| R4 | preloadedAssets 维护干扰用户已有的 preloadedAssets 配置 | AssetPostprocessor 仅添加，不删除；用户手动从 PlayerSettings 删除 settings asset 时 Editor warn |
+| R5 | locale 名作 Variant 名与 author 自定义 Variant 冲突 | author 文档化此约定；XSD 警告（未来）；locale 名通常是 BCP-47（含 `-`），与游戏内 variant（通常是 `mobile` / `pc` 这类）天然不撞 |
+| R6 | TextAsset enumerate `Resources.LoadAll<>` 在大量 .po 时慢 | v1 项目规模假设 < 数百 .po（每 locale 几十屏），可接受；v2 考虑生成 manifest |
+| R7 | Variant 已激活的 locale 不能被同名 author Variant 重置 | 文档化：locale 是保留的 Variant 名空间，author 不应用同名 |
+| R8 | Unity 不识别 .po 扩展为 TextAsset | §7.1 加 ScriptedImporter 把 .po 注册为 TextAsset；外部 gettext 工具仍能识别原始 .po 格式 |
+| R9 | preloadedAssets 在 build profile 切换时丢失 | Unity 6 的 build profiles 各自维护 preloadedAssets — AssetPostprocessor 在每次访问 PlayerSettings.preloadedAssets 时校验并补上 |
+
+---
+
+## 15. 实施顺序提示
+
+不在本 spec 范围（留给后续 plan）。粗略：
+
+1. PromptUGUISettings + preloadedAssets 维护
+2. PoFileImporter ScriptedImporter
+3. PoParser + TranslationStore + TrResolver
+4. UI.Locale API + Variant 集成（含 VariantStore.NotifyChangedInternal）
+5. parser CDATA + IR `TextContentRaw` / `TextArgs` / `AttributesRaw`
+6. Text/Btn 控件接 TrResolver + font type 解析
+7. XML 抽取器
+8. Roslyn 抽取器
+9. AI 翻译菜单
+10. Hot reload .po 分支
+11. SKILL.md / 主 spec 同步


### PR DESCRIPTION
## Summary

Adds zero-key gettext-style i18n + per-locale TMP font tables to PromptUGUI. Author writes source text inline (`<Text>开始游戏</Text>`); `UI.Locale.Set("en")` swaps text + fonts via existing Variant.Changed → Screen.ReSolve pipeline.

- **Runtime (M5a)** — `PromptUGUISettings` SO + preloaded-asset auto-maintenance, `.po` `ScriptedImporter` + auto-override Postprocessor, `PoParser` + `TranslationStore` + `TrResolver`, `UI.Locale.Set/Tr` + Variant integration, parser CDATA support, `ElementNode.TextContentRaw / TextArgs / AttributesRaw` for runtime re-substitution on translated msgstr, `Btn` lazy auto-label (fixes long-standing SKILL/code mismatch), .po hot-reload branch in `UIAssetPostprocessor`.
- **Editor (M5b)** — `Tools → PromptUGUI → Extract Strings` (Roslyn-based C# scanner + XML scanner via existing UIDocumentParser), `Tools → PromptUGUI → Translate Locale...` (OpenAI-compatible Structured Outputs LLM batch translation with progress + retry), `Project Settings → PromptUGUI → Translation` panel (endpoint/model/prompt in repo, API key in `UserSettings/`).
- **Docs** — main spec §10 flipped from "i18n is non-goal" to M5 deliverable; `SKILL.md` documents `font` / `tr` / `ctx` attributes, `UI.Locale`, CDATA + TMP rich-text, i18n cheatsheet.

Specs at `docs/superpowers/specs/2026-05-08-i18n-fonts-design.md` (design) and `docs/superpowers/plans/2026-05-08-i18n-m5{a,b}-*.md` (plans). 35 commits across the branch, all reviewed.

## Test Plan
- [x] EditMode 283/283
- [x] EditorOnly 52/52
- [x] PlayMode 66/66 (incl. 3 new E2E: locale switch + font swap, CDATA + TMP rich text roundtrip, .po reload broadcasts ReSolve)
- [ ] Manual: drop a `.po` file under `Assets/Resources/PromptUGUI/i18n/<locale>/` in the host project, verify it auto-imports as TextAsset and `UI.Locale.Set(<locale>)` picks it up
- [ ] Manual: `Tools → PromptUGUI → Extract Strings` against the sample MainMenu, verify per-locale `.po` files appear
- [ ] Manual: configure API key, run `Tools → PromptUGUI → Translate Locale...` against a non-source locale, verify msgstr fields fill

🤖 Generated with [Claude Code](https://claude.com/claude-code)