### PR TITLE
feat: Addressable IconSet preloader (UseAddressableSpriteAtlasIconResolver)

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -428,6 +428,8 @@ await IconResolverHelpers.UseAddressableSpriteAtlasIconResolver("MyIcons");
 
 Returns `Awaitable` — `await` it before opening any Screen that contains `<Icon>`, since `UI.IconResolver` is set inside the continuation. The loaded handle is held static and released either on a second `UseAddressableSpriteAtlasIconResolver` call (swap label/locale) or on `UI.ResetForTests`. Only visible when `PROMPTUGUI_HAS_ADDRESSABLES` is defined.
 
+`Sprite` references returned from `UI.IconResolver` are only valid while the current handle is held — releasing the handle (label swap, reset) unloads the underlying `SpriteAtlas`. Do not cache the returned `Sprite` in your own fields across such calls; resolve via `UI.IconResolver` (or rely on `<Icon name>` re-resolving on Variant changes) each time you need it.
+
 To use a fully custom backend, set `UI.IconResolver` directly with your own `(key → Sprite)` lookup.
 
 ### Open / Close / Get

--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -414,7 +414,21 @@ IconResolverHelpers.UseSpriteAtlasIconResolver();
 IconResolverHelpers.UseSpriteAtlasIconResolver(new[] { uiIconSet, artIconSet });
 ```
 
-The helper builds a `(set:icon) → Sprite` lookup from each IconSet's SpriteAtlas. To use a different backend (Addressables, custom), set `UI.IconResolver` directly.
+The helper builds a `(set:icon) → Sprite` lookup from each IconSet's SpriteAtlas.
+
+**Addressables variant** (when `com.unity.addressables` ≥ 1.0 is installed):
+
+```csharp
+// Tag your IconSet assets in Addressables with label="IconSets".
+// Addressables auto-pulls the referenced SpriteAtlas as a dependency.
+await IconResolverHelpers.UseAddressableSpriteAtlasIconResolver();
+// Or custom label:
+await IconResolverHelpers.UseAddressableSpriteAtlasIconResolver("MyIcons");
+```
+
+Returns `Awaitable` — `await` it before opening any Screen that contains `<Icon>`, since `UI.IconResolver` is set inside the continuation. The loaded handle is held static and released either on a second `UseAddressableSpriteAtlasIconResolver` call (swap label/locale) or on `UI.ResetForTests`. Only visible when `PROMPTUGUI_HAS_ADDRESSABLES` is defined.
+
+To use a fully custom backend, set `UI.IconResolver` directly with your own `(key → Sprite)` lookup.
 
 ### Open / Close / Get
 

--- a/Runtime/Application/AddressableIconResolverHelper.cs
+++ b/Runtime/Application/AddressableIconResolverHelper.cs
@@ -1,0 +1,64 @@
+#if PROMPTUGUI_HAS_ADDRESSABLES
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
+
+namespace PromptUGUI.Application
+{
+    public static partial class IconResolverHelpers
+    {
+        // Held alive so the IconSet refs (and their dependent SpriteAtlas) stay
+        // loaded for the lifetime of UI.IconResolver. Released on second-call /
+        // UI.ResetForTests. (PROMPTUGUI_HAS_ADDRESSABLES only.)
+        private static AsyncOperationHandle<IList<IconSet>>? _addressableIconHandle;
+        // Static; intentionally survives UI.ResetForTests so we don't double-subscribe
+        // OnReset across test sessions.
+        private static bool _addressableResetHooked;
+
+        // Test observation point. Tests assert the increment to verify Release was
+        // called, without inspecting Addressables internals.
+        internal static int _testReleaseCount;
+
+        public static async Awaitable UseAddressableSpriteAtlasIconResolver(
+            string label = "IconSets")
+        {
+            ReleaseAddressableIconHandle();
+            HookResetOnce();
+
+            var handle = Addressables.LoadAssetsAsync<IconSet>(label, null);
+            _addressableIconHandle = handle;
+            var sets = await handle.Task;
+            var snapshot = new List<IconSet>(sets ?? Array.Empty<IconSet>());
+
+            void Rebuild()
+            {
+                var map = BuildLookup(snapshot);
+                UI.IconResolver = key => map.TryGetValue(key, out var sp) ? sp : null;
+            }
+            Rebuild();
+#if UNITY_EDITOR
+            UI.HotReload.IconResolverRebuilder = Rebuild;
+#endif
+        }
+
+        private static void HookResetOnce()
+        {
+            if (_addressableResetHooked) return;
+            UI.OnReset += ReleaseAddressableIconHandle;
+            _addressableResetHooked = true;
+        }
+
+        private static void ReleaseAddressableIconHandle()
+        {
+            if (_addressableIconHandle.HasValue && _addressableIconHandle.Value.IsValid())
+            {
+                Addressables.Release(_addressableIconHandle.Value);
+                _testReleaseCount++;
+            }
+            _addressableIconHandle = null;
+        }
+    }
+}
+#endif

--- a/Runtime/Application/AddressableIconResolverHelper.cs.meta
+++ b/Runtime/Application/AddressableIconResolverHelper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 745ada3fcabbfa34ab10c7eecd17e6e8

--- a/Runtime/Application/IconResolverHelpers.cs
+++ b/Runtime/Application/IconResolverHelpers.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace PromptUGUI.Application
 {
-    public static class IconResolverHelpers
+    public static partial class IconResolverHelpers
     {
         public static void UseSpriteAtlasIconResolver(string resourcesSubpath = "IconSets")
         {

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -410,7 +410,7 @@ namespace PromptUGUI.Application
         // ResetForTests 末尾触发；let helpers (e.g. AddressableIconResolverHelper)
         // 释放 Addressables 句柄等外部资源。订阅者必须在 ResetForTests 自身把状态
         // 清空之后再跑，所以 Invoke 放在方法尾部。
-        internal static event Action OnReset;
+        internal static event System.Action OnReset;
 
         // 仅测试使用
         internal static void ResetForTests()

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using PromptUGUI.IR;
 using PromptUGUI.Parser;
@@ -406,6 +407,11 @@ namespace PromptUGUI.Application
             return null;
         }
 
+        // ResetForTests 末尾触发；let helpers (e.g. AddressableIconResolverHelper)
+        // 释放 Addressables 句柄等外部资源。订阅者必须在 ResetForTests 自身把状态
+        // 清空之后再跑，所以 Invoke 放在方法尾部。
+        internal static event Action OnReset;
+
         // 仅测试使用
         internal static void ResetForTests()
         {
@@ -427,6 +433,7 @@ namespace PromptUGUI.Application
             HotReload.IconResolverRebuilder = null;
             HotReload.Enabled = true;
 #endif
+            OnReset?.Invoke();
         }
 
         private static ControlRegistry CreateRegistryWithBuiltins()

--- a/Tests/EditMode/Addressables/AddressableIconResolverTests.cs
+++ b/Tests/EditMode/Addressables/AddressableIconResolverTests.cs
@@ -1,0 +1,82 @@
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using UnityEditor.AddressableAssets;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.Addressables
+{
+    /// <summary>
+    /// Wiring smoke tests for IconResolverHelpers.UseAddressableSpriteAtlasIconResolver.
+    ///
+    /// End-to-end "label → IconSet → IconResolver returns sprite" is NOT tested
+    /// in EditMode: AsyncOperationHandle continuations need the player-loop
+    /// SynchronizationContext which is absent in EditMode test runners. Same
+    /// limitation documented in AddressableResolverTests. The synchronous prefix
+    /// of the async method (release-previous-handle, start-load, store-handle,
+    /// hook-reset) is what gets covered here.
+    ///
+    /// FixtureLabel intentionally doesn't resolve to any registered asset, so
+    /// Addressables logs an InvalidKeyException synchronously inside LoadAssetsAsync.
+    /// Each test declares the expected error via LogAssert.Expect; Unity Test
+    /// Framework consumes the matched entry instead of failing the test on it.
+    /// </summary>
+    public class AddressableIconResolverTests
+    {
+        private const string FixtureLabel = "promptugui-test/icons";
+        private static readonly Regex InvalidKeyError = new(".*InvalidKeyException.*");
+
+        [SetUp]
+        public void Setup()
+        {
+            UI.ResetForTests();
+            // Ensure AddressableAssetSettings exists; without it
+            // Addressables.LoadAssetsAsync throws synchronously in a fresh project.
+            _ = AddressableAssetSettingsDefaultObject.Settings
+                ?? AddressableAssetSettingsDefaultObject.GetSettings(true);
+            IconResolverHelpers._testReleaseCount = 0;
+        }
+
+        [TearDown]
+        public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Invocation_returns_an_awaitable()
+        {
+            LogAssert.Expect(LogType.Error, InvalidKeyError);
+            var awaitable =
+                IconResolverHelpers.UseAddressableSpriteAtlasIconResolver(FixtureLabel);
+            Assert.IsNotNull(awaitable,
+                "UseAddressableSpriteAtlasIconResolver should return non-null Awaitable");
+            // Note: Awaitable intentionally not awaited; underlying AsyncOperationHandle
+            // remains pending until TearDown's ResetForTests releases it. We don't
+            // assert on UI.IconResolver state — its post-await value depends on
+            // whether LoadAssetsAsync completed synchronously (rare but possible),
+            // which is a C# state-machine detail rather than this helper's contract.
+        }
+
+        [Test]
+        public void Releases_previous_handle_on_second_call()
+        {
+            LogAssert.Expect(LogType.Error, InvalidKeyError);
+            LogAssert.Expect(LogType.Error, InvalidKeyError);
+            _ = IconResolverHelpers.UseAddressableSpriteAtlasIconResolver(FixtureLabel);
+            var beforeSecond = IconResolverHelpers._testReleaseCount;
+            _ = IconResolverHelpers.UseAddressableSpriteAtlasIconResolver(FixtureLabel);
+            Assert.AreEqual(beforeSecond + 1, IconResolverHelpers._testReleaseCount,
+                "Second call should release the first call's handle exactly once");
+        }
+
+        [Test]
+        public void ResetForTests_releases_handle()
+        {
+            LogAssert.Expect(LogType.Error, InvalidKeyError);
+            _ = IconResolverHelpers.UseAddressableSpriteAtlasIconResolver(FixtureLabel);
+            var beforeReset = IconResolverHelpers._testReleaseCount;
+            UI.ResetForTests();
+            Assert.AreEqual(beforeReset + 1, IconResolverHelpers._testReleaseCount,
+                "ResetForTests should trigger OnReset → helper releases the handle");
+        }
+    }
+}

--- a/Tests/EditMode/Addressables/AddressableIconResolverTests.cs.meta
+++ b/Tests/EditMode/Addressables/AddressableIconResolverTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f49b6618308736c478527eeb32b69977

--- a/Tests/EditMode/Application/UIResetEventTests.cs
+++ b/Tests/EditMode/Application/UIResetEventTests.cs
@@ -1,0 +1,33 @@
+using System;
+using NUnit.Framework;
+using PromptUGUI.Application;
+
+namespace PromptUGUI.Tests.Application
+{
+    public class UIResetEventTests
+    {
+        [SetUp]
+        public void Setup() => UI.ResetForTests();
+
+        [TearDown]
+        public void Teardown() => UI.ResetForTests();
+
+        [Test]
+        public void OnReset_event_fires_after_reset()
+        {
+            var fired = 0;
+            Action handler = () => fired++;
+            UI.OnReset += handler;
+            try
+            {
+                UI.ResetForTests();
+                Assert.AreEqual(1, fired,
+                    "UI.OnReset should fire exactly once per ResetForTests call");
+            }
+            finally
+            {
+                UI.OnReset -= handler;
+            }
+        }
+    }
+}

--- a/Tests/EditMode/Application/UIResetEventTests.cs.meta
+++ b/Tests/EditMode/Application/UIResetEventTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3f5a81359d6550a43b9e8e86bf209c8e

--- a/docs~/superpowers/plans/2026-05-12-addressable-icon-resolver.md
+++ b/docs~/superpowers/plans/2026-05-12-addressable-icon-resolver.md
@@ -1,0 +1,573 @@
+# Addressable Icon Resolver Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `IconResolverHelpers.UseAddressableSpriteAtlasIconResolver(label)` — async preload of `IconSet` ScriptableObjects from Addressables, auto-pulling the referenced `SpriteAtlas` as Addressables dependency.
+
+**Architecture:** Add `UI.OnReset` internal event so Helper can hook handle cleanup into `ResetForTests` without UI.cs knowing about Addressables. Extend `IconResolverHelpers` as a `partial class` via new `Runtime/Application/AddressableIconResolverHelper.cs` (gated by `PROMPTUGUI_HAS_ADDRESSABLES`). Method returns `Awaitable` (not `Awaitable<T>`) because `UI.IconResolver` is sync — callers must `await` before opening any `<Icon>`-containing Screen.
+
+**Tech Stack:** Unity 6 `UnityEngine.Awaitable`, `UnityEngine.AddressableAssets` (com.unity.addressables ≥ 1.0), NUnit EditMode test runner, Unity MCP for compile/test cycles.
+
+**Spec:** [`docs~/superpowers/specs/2026-05-12-addressable-icon-resolver-design.md`](../specs/2026-05-12-addressable-icon-resolver-design.md)
+
+---
+
+## File Structure
+
+**New files:**
+- `Runtime/Application/AddressableIconResolverHelper.cs` — entire file under `#if PROMPTUGUI_HAS_ADDRESSABLES`; defines `partial class IconResolverHelpers` with the new method, the static handle field, the cleanup hook, and the internal test counter.
+- `Tests/EditMode/Application/UIResetEventTests.cs` — single test for the new `UI.OnReset` event; lives in the non-Addressables EditMode assembly so it runs without Addressables installed.
+- `Tests/EditMode/Addressables/AddressableIconResolverTests.cs` — three tests for the Addressable helper, mirroring the EditMode-async-limitation pattern from existing `AddressableResolverTests.cs`.
+
+**Modified files:**
+- `Runtime/Application/UI.cs` — add `internal static event Action OnReset` and `OnReset?.Invoke()` at the end of `ResetForTests()`.
+- `Runtime/Application/IconResolverHelpers.cs` — change `public static class` → `public static partial class`.
+- `.claude/skills/authoring-promptugui-xml/SKILL.md` — append Addressables icon helper section after the existing two `UseSpriteAtlasIconResolver` examples (around line 417).
+
+**Unchanged:** `Samples~/`, all other Runtime / Editor / test files, existing `IconResolverTests.cs` and `AddressableResolverTests.cs`.
+
+---
+
+## Task 1: Add `UI.OnReset` event with red-first test
+
+**Files:**
+- Create: `Tests/EditMode/Application/UIResetEventTests.cs`
+- Modify: `Runtime/Application/UI.cs` (around lines 410–430, inside `ResetForTests`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/EditMode/Application/UIResetEventTests.cs`:
+
+```csharp
+using System;
+using NUnit.Framework;
+using PromptUGUI.Application;
+
+namespace PromptUGUI.Tests.Application
+{
+    public class UIResetEventTests
+    {
+        [SetUp]
+        public void Setup() => UI.ResetForTests();
+
+        [TearDown]
+        public void Teardown() => UI.ResetForTests();
+
+        [Test]
+        public void OnReset_event_fires_after_reset()
+        {
+            var fired = 0;
+            Action handler = () => fired++;
+            UI.OnReset += handler;
+            try
+            {
+                UI.ResetForTests();
+                Assert.AreEqual(1, fired,
+                    "UI.OnReset should fire exactly once per ResetForTests call");
+            }
+            finally
+            {
+                UI.OnReset -= handler;
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Refresh Unity and verify the test fails to compile**
+
+Run (deferred MCP tools — load first if needed via `ToolSearch(query="select:refresh_unity,read_console,run_tests", max_results=3)`):
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: compile error along the lines of `'UI' does not contain a definition for 'OnReset'`. If no compile error appears, stop and investigate — the test isn't actually exercising the new API.
+
+- [ ] **Step 3: Add the event and the invoke**
+
+In `Runtime/Application/UI.cs`, add the event declaration. The natural spot is right above `ResetForTests` (line ~409). Edit:
+
+```csharp
+        // 仅测试使用
+        internal static void ResetForTests()
+```
+
+to:
+
+```csharp
+        // ResetForTests 末尾触发；let helpers (e.g. AddressableIconResolverHelper)
+        // 释放 Addressables 句柄等外部资源。订阅者必须在 ResetForTests 自身把状态
+        // 清空之后再跑，所以 Invoke 放在方法尾部。
+        internal static event Action OnReset;
+
+        // 仅测试使用
+        internal static void ResetForTests()
+```
+
+Then add the invoke at the end of `ResetForTests` — directly inside the `#if UNITY_EDITOR` ... `#endif` block's closing brace (so it fires regardless of Editor/Player). The current tail is:
+
+```csharp
+#if UNITY_EDITOR
+            HotReload.AssetPathToSrc = null;
+            HotReload.IconResolverRebuilder = null;
+            HotReload.Enabled = true;
+#endif
+        }
+```
+
+Change to:
+
+```csharp
+#if UNITY_EDITOR
+            HotReload.AssetPathToSrc = null;
+            HotReload.IconResolverRebuilder = null;
+            HotReload.Enabled = true;
+#endif
+            OnReset?.Invoke();
+        }
+```
+
+Also ensure `using System;` is present at the top of `UI.cs` (it almost certainly is for `Action`, but verify). If not, add it.
+
+- [ ] **Step 4: Refresh and run the test**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="UIResetEventTests")
+```
+
+Expected: 0 compile errors. `OnReset_event_fires_after_reset` passes.
+
+- [ ] **Step 5: Run the full EditMode suite to make sure nothing else broke**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+```
+
+Expected: all green. (`ResetForTests` is called in many `[SetUp]` / `[TearDown]` — adding `OnReset?.Invoke()` with no subscribers is a no-op, but verify.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Runtime/Application/UI.cs Tests/EditMode/Application/UIResetEventTests.cs
+git commit -m "$(cat <<'EOF'
+feat: add internal UI.OnReset event triggered by ResetForTests
+
+Hook point for runtime helpers (e.g. forthcoming Addressable icon
+resolver) that need to release external resources when tests reset
+global state. Event fires after all of ResetForTests' own cleanup
+so subscribers observe a freshly-reset UI.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Make `IconResolverHelpers` a partial class
+
+This is a single-character refactor required before Task 3 can extend the class from a separate file. No new test — Task 1's full-suite run already covers regression.
+
+**Files:**
+- Modify: `Runtime/Application/IconResolverHelpers.cs:7`
+
+- [ ] **Step 1: Change class declaration**
+
+Edit `Runtime/Application/IconResolverHelpers.cs` line 7:
+
+```csharp
+    public static class IconResolverHelpers
+```
+
+to:
+
+```csharp
+    public static partial class IconResolverHelpers
+```
+
+- [ ] **Step 2: Refresh and verify clean compile**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Run existing IconResolver tests**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="IconResolverTests")
+```
+
+Expected: all 5 existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Runtime/Application/IconResolverHelpers.cs
+git commit -m "$(cat <<'EOF'
+refactor: make IconResolverHelpers a partial class
+
+Prep for the Addressables-gated extension file; no behavior change.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Addressable Icon Resolver — tests + implementation
+
+**Files:**
+- Create: `Tests/EditMode/Addressables/AddressableIconResolverTests.cs`
+- Create: `Runtime/Application/AddressableIconResolverHelper.cs`
+
+- [ ] **Step 1: Write the three failing tests**
+
+Create `Tests/EditMode/Addressables/AddressableIconResolverTests.cs`:
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application;
+using UnityEditor.AddressableAssets;
+
+namespace PromptUGUI.Tests.Addressables
+{
+    /// <summary>
+    /// Wiring smoke tests for IconResolverHelpers.UseAddressableSpriteAtlasIconResolver.
+    ///
+    /// End-to-end "label → IconSet → IconResolver returns sprite" is NOT tested
+    /// in EditMode: AsyncOperationHandle continuations need the player-loop
+    /// SynchronizationContext which is absent in EditMode test runners. Same
+    /// limitation documented in AddressableResolverTests. The synchronous prefix
+    /// of the async method (release-previous-handle, start-load, store-handle,
+    /// hook-reset) is what gets covered here.
+    /// </summary>
+    public class AddressableIconResolverTests
+    {
+        private const string FixtureLabel = "promptugui-test/icons";
+
+        [SetUp]
+        public void Setup()
+        {
+            UI.ResetForTests();
+            // Ensure AddressableAssetSettings exists; without it
+            // Addressables.LoadAssetsAsync throws synchronously in a fresh project.
+            _ = AddressableAssetSettingsDefaultObject.Settings
+                ?? AddressableAssetSettingsDefaultObject.GetSettings(true);
+            IconResolverHelpers._testReleaseCount = 0;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UI.ResetForTests();
+        }
+
+        [Test]
+        public void Invocation_returns_an_awaitable()
+        {
+            var awaitable =
+                IconResolverHelpers.UseAddressableSpriteAtlasIconResolver(FixtureLabel);
+            Assert.IsNotNull(awaitable,
+                "UseAddressableSpriteAtlasIconResolver should return non-null Awaitable");
+            // Note: Awaitable intentionally not awaited; underlying AsyncOperationHandle
+            // remains pending until TearDown's ResetForTests releases it. We don't
+            // assert on UI.IconResolver state — its post-await value depends on
+            // whether LoadAssetsAsync completed synchronously (rare but possible),
+            // which is a C# state-machine detail rather than this helper's contract.
+        }
+
+        [Test]
+        public void Releases_previous_handle_on_second_call()
+        {
+            _ = IconResolverHelpers.UseAddressableSpriteAtlasIconResolver(FixtureLabel);
+            var beforeSecond = IconResolverHelpers._testReleaseCount;
+            _ = IconResolverHelpers.UseAddressableSpriteAtlasIconResolver(FixtureLabel);
+            Assert.AreEqual(beforeSecond + 1, IconResolverHelpers._testReleaseCount,
+                "Second call should release the first call's handle exactly once");
+        }
+
+        [Test]
+        public void ResetForTests_releases_handle()
+        {
+            _ = IconResolverHelpers.UseAddressableSpriteAtlasIconResolver(FixtureLabel);
+            var beforeReset = IconResolverHelpers._testReleaseCount;
+            UI.ResetForTests();
+            Assert.AreEqual(beforeReset + 1, IconResolverHelpers._testReleaseCount,
+                "ResetForTests should trigger OnReset → helper releases the handle");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Refresh and verify the tests fail to compile**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: compile errors referencing `UseAddressableSpriteAtlasIconResolver` and `_testReleaseCount` not found on `IconResolverHelpers`. If only one of the two errors appears, something is off — both APIs are missing.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Runtime/Application/AddressableIconResolverHelper.cs`:
+
+```csharp
+#if PROMPTUGUI_HAS_ADDRESSABLES
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
+
+namespace PromptUGUI.Application
+{
+    public static partial class IconResolverHelpers
+    {
+        // Held alive so the IconSet refs (and their dependent SpriteAtlas) stay
+        // loaded for the lifetime of UI.IconResolver. Released on second-call /
+        // UI.ResetForTests. (PROMPTUGUI_HAS_ADDRESSABLES only.)
+        private static AsyncOperationHandle<IList<IconSet>>? _addressableIconHandle;
+        private static bool _addressableResetHooked;
+
+        // Test observation point. Tests assert the increment to verify Release was
+        // called, without inspecting Addressables internals.
+        internal static int _testReleaseCount;
+
+        public static async Awaitable UseAddressableSpriteAtlasIconResolver(
+            string label = "IconSets")
+        {
+            ReleaseAddressableIconHandle();
+            HookResetOnce();
+
+            var handle = Addressables.LoadAssetsAsync<IconSet>(label, null);
+            _addressableIconHandle = handle;
+            var sets = await handle.Task;
+            var snapshot = new List<IconSet>(sets ?? Array.Empty<IconSet>());
+
+            void Rebuild()
+            {
+                var map = BuildLookup(snapshot);
+                UI.IconResolver = key => map.TryGetValue(key, out var sp) ? sp : null;
+            }
+            Rebuild();
+#if UNITY_EDITOR
+            UI.HotReload.IconResolverRebuilder = Rebuild;
+#endif
+        }
+
+        private static void HookResetOnce()
+        {
+            if (_addressableResetHooked) return;
+            UI.OnReset += ReleaseAddressableIconHandle;
+            _addressableResetHooked = true;
+        }
+
+        private static void ReleaseAddressableIconHandle()
+        {
+            if (_addressableIconHandle.HasValue && _addressableIconHandle.Value.IsValid())
+            {
+                Addressables.Release(_addressableIconHandle.Value);
+                _testReleaseCount++;
+            }
+            _addressableIconHandle = null;
+        }
+    }
+}
+#endif
+```
+
+Notes on the code:
+- `partial class` merges with the body in `IconResolverHelpers.cs`; `BuildLookup` (private static there) is reachable from this file because partials share the same class scope.
+- `AsyncOperationHandle<T>` is a value-type struct; `?` makes it nullable so we can represent "no handle yet" without inventing a sentinel.
+- `Addressables.LoadAssetsAsync<IconSet>(label, null)` — the `null` second parameter is the per-item callback; we don't need it.
+- `await handle.Task` — chosen over `await handle` for Addressables version compatibility (existing `AddressableResolverHelper.cs` uses the same `.Task` pattern; see the comment there).
+- Failures (label not found, type mismatch, etc.) surface as exceptions when the caller awaits the method's `Awaitable`. We don't catch them — same as `UseAddressableResolver()`.
+- `_testReleaseCount` is `internal` (visible to the Addressables test asmdef via `[InternalsVisibleTo]` already declared in `Runtime/AssemblyInfo.cs`).
+
+- [ ] **Step 4: Refresh and run the new tests**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode.Addressables"], filter="AddressableIconResolverTests")
+```
+
+Expected: 0 compile errors. All 3 tests pass:
+- `Invocation_returns_an_awaitable`
+- `Releases_previous_handle_on_second_call`
+- `ResetForTests_releases_handle`
+
+- [ ] **Step 5: Run the full Addressables EditMode suite to confirm no regression in `AddressableResolverTests`**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode.Addressables"])
+```
+
+Expected: all green (the existing `AddressableResolverTests` shouldn't be affected by this change).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Runtime/Application/AddressableIconResolverHelper.cs Tests/EditMode/Addressables/AddressableIconResolverTests.cs
+git commit -m "$(cat <<'EOF'
+feat: add Addressables-backed IconSet preloader
+
+IconResolverHelpers.UseAddressableSpriteAtlasIconResolver(label="IconSets")
+loads all IconSets tagged with the given Addressables label and wires
+them into UI.IconResolver. Addressables pulls the dependent SpriteAtlas
+as a transitive dependency, so callers only tag IconSets.
+
+Handle is held in a static field for the resolver's lifetime (sprite
+refs depend on atlas residency). Second call to this method releases
+the previous handle; UI.OnReset (fired by ResetForTests) also releases.
+Gated by PROMPTUGUI_HAS_ADDRESSABLES.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Update SKILL.md
+
+CLAUDE.md mandates that new public C# API surface gets SKILL.md coverage in the same PR. This is a new API surface, not a transparent default.
+
+**Files:**
+- Modify: `.claude/skills/authoring-promptugui-xml/SKILL.md` (around line 417)
+
+- [ ] **Step 1: Locate the insertion point**
+
+The current "Icon system setup" block ends (around line 417) with:
+
+```markdown
+The helper builds a `(set:icon) → Sprite` lookup from each IconSet's SpriteAtlas. To use a different backend (Addressables, custom), set `UI.IconResolver` directly.
+```
+
+That last sentence's "(Addressables, custom)" hint is now stale — Addressables is a first-class helper. Replace the trailing sentence and append the new section.
+
+- [ ] **Step 2: Apply the edit**
+
+Replace:
+
+```markdown
+The helper builds a `(set:icon) → Sprite` lookup from each IconSet's SpriteAtlas. To use a different backend (Addressables, custom), set `UI.IconResolver` directly.
+```
+
+with:
+
+````markdown
+The helper builds a `(set:icon) → Sprite` lookup from each IconSet's SpriteAtlas.
+
+**Addressables variant** (when `com.unity.addressables` ≥ 1.0 is installed):
+
+```csharp
+// Tag your IconSet assets in Addressables with label="IconSets".
+// Addressables auto-pulls the referenced SpriteAtlas as a dependency.
+await IconResolverHelpers.UseAddressableSpriteAtlasIconResolver();
+// Or custom label:
+await IconResolverHelpers.UseAddressableSpriteAtlasIconResolver("MyIcons");
+```
+
+Returns `Awaitable` — `await` it before opening any Screen that contains `<Icon>`, since `UI.IconResolver` is set inside the continuation. The loaded handle is held static and released either on a second `UseAddressableSpriteAtlasIconResolver` call (swap label/locale) or on `UI.ResetForTests`. Only visible when `PROMPTUGUI_HAS_ADDRESSABLES` is defined.
+
+To use a fully custom backend, set `UI.IconResolver` directly with your own `(key → Sprite)` lookup.
+````
+
+- [ ] **Step 3: Verify no other SKILL.md sections referenced the old "Addressables, custom" sentence**
+
+```bash
+grep -n "Addressables, custom" /workspace-PromptUGUI/.claude/skills/authoring-promptugui-xml/SKILL.md
+```
+
+Expected: no matches (the old phrasing was unique to that one sentence). If matches appear elsewhere, update those too.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/authoring-promptugui-xml/SKILL.md
+git commit -m "$(cat <<'EOF'
+doc: document UseAddressableSpriteAtlasIconResolver in SKILL.md
+
+Promote Addressables from "do it yourself by setting UI.IconResolver"
+to a first-class helper with usage example and lifecycle notes.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Lint + full test sweep
+
+Per CLAUDE.md: "Always check lint after write code." Per project workflow: full EditMode + PlayMode runs before declaring done.
+
+**Files:** none modified unless lint reports something.
+
+- [ ] **Step 1: Run lint (whitespace + style + analyzers, all at warn severity)**
+
+```bash
+cd .lint && dotnet restore PromptUGUI.Lint.slnx
+dotnet format whitespace PromptUGUI.Lint.slnx
+dotnet format style       PromptUGUI.Lint.slnx
+dotnet format analyzers   PromptUGUI.Lint.slnx
+dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+Expected: `--verify-no-changes` returns exit code 0. Per CLAUDE.md, do NOT pass `--severity info` to `dotnet format analyzers` — the listed Unity-breaking auto-fixers (CA1822, CA1846, CA2016, IDE0032, IDE0044) will damage the codebase.
+
+If lint applied any whitespace/style fixes, stage and commit them separately:
+
+```bash
+cd /workspace-PromptUGUI
+git status
+git add -p   # review hunks
+git commit -m "$(cat <<'EOF'
+chore: lint pass for addressable icon resolver
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 2: Run all three EditMode test assemblies + PlayMode**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode.Addressables"])
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])
+```
+
+Expected: all green. If any test fails, do NOT proceed to the next task — diagnose using `mcp__UnityMCP__read_console(action="get", types=["error"])` and the test runner output; fix the root cause; re-run.
+
+- [ ] **Step 3: Final git status check**
+
+```bash
+git status
+git log --oneline -5
+```
+
+Expected: clean working tree; commit log shows (in order) the OnReset event, the partial refactor, the Addressable helper + tests, the SKILL.md update, and (optionally) the lint pass.
+
+---
+
+## Notes for the executing engineer
+
+- **Test execution is via Unity MCP only.** Do not invoke `Unity.exe -batchmode` or similar. If `mcp__UnityMCP__run_tests` is unavailable, reconnect MCP or stop and ask the user.
+- **Forbidden: `mcp__UnityMCP__execute_menu_item(menu_path="Assets/Reimport All")`** — pops a blocking modal in Unity that the user must dismiss manually. Use `refresh_unity(mode="force", scope="all")` instead.
+- **After every code edit, refresh first, then `read_console` for errors before running tests.** Compile errors won't appear in the test runner output — they'll just look like missing test assemblies.
+- **Filter tests by class name** with `filter="ClassName"` (substring match) for fast iteration during red-green cycles.
+- **Don't release the Addressables handle in the `await` continuation.** The handle must outlive the method — its lifecycle is owned by the helper's static field, not the method scope. (This is the opposite of `UseAddressableResolver()` which releases right after extracting `.text`.)
+- **Partial class scope:** Once Task 2 lands, `BuildLookup` (declared `private static` in `IconResolverHelpers.cs`) is reachable from `AddressableIconResolverHelper.cs` — partials share the same class scope. If a name-collision appears at compile time, the new file may have accidentally re-declared something.
+- **EditMode tests cannot `await` the Addressable handle.** Don't try; the player-loop SynchronizationContext doesn't exist. Tests assert on the synchronous prefix and on side effects observable from sync code (the `_testReleaseCount` counter). This is the same limitation `AddressableResolverTests.cs` already documents.

--- a/docs~/superpowers/specs/2026-05-12-addressable-icon-resolver-design.md
+++ b/docs~/superpowers/specs/2026-05-12-addressable-icon-resolver-design.md
@@ -1,0 +1,236 @@
+# Addressable IconSet Resolver 设计
+
+**日期**：2026-05-12
+**状态**：设计阶段（待 review，未进入实施）
+**作用域**：在 `IconResolverHelpers` 上新增 Addressables 路径的 IconSet 加载入口，让 user 把 IconSet（含其依赖的 SpriteAtlas）放进 Addressables 自动下载/加载。仅增量新代码 + `UI.ResetForTests()` 加一个内部 reset 事件钩子。不动现有 `UseSpriteAtlasIconResolver` 两个重载的行为。
+**依赖**：[`2026-05-08-icon-assets-design.md`](2026-05-08-icon-assets-design.md)（IconSet / IconResolver 形状）+ [`2026-05-11-addressable-resolver-async-load-design.md`](2026-05-11-addressable-resolver-async-load-design.md)（Addressables helper 风格与 `PROMPTUGUI_HAS_ADDRESSABLES` 条件编译）。
+
+---
+
+## 1. 背景
+
+当前 `IconResolverHelpers` 有两个同步入口：
+
+- `UseSpriteAtlasIconResolver(string resourcesSubpath = "IconSets")` —— `Resources.LoadAll<IconSet>` 枚举资源目录
+- `UseSpriteAtlasIconResolver(IEnumerable<IconSet> sets)` —— 调用方直接喂 IconSet 引用
+
+像素游戏的实际工程里，IconSet 加上它指向的 SpriteAtlas 体积可观（几 MB 起步），常被放进 Addressables Group 走按需下载 / 远端 CDN。`UI.UseAddressableResolver()` 已经把 `.ui.xml` 通道接入 Addressables；本设计补齐 IconSet 通道。
+
+设计上的两点差异决定了 API 形状不能直接照搬 `UseAddressableResolver()`：
+
+1. **IconResolver 是同步的**（`Func<string, Sprite>`），它在 `<Icon name>` setter 里被调用，调用点不能 `await`。所以 IconSet 必须在 Screen 打开之前**预加载**，方法签名要返回 `Awaitable` 让 user `await` 一次完成预加载。
+2. **句柄必须常驻**。`IconSet.Entries` 里的 `Sprite` 是 SpriteAtlas 的子对象引用，Addressables 一旦 release 句柄，atlas 被卸载，sprite 失效。所以本 helper 要把句柄存为 static 字段，跟 IconSet 生命周期一致。
+
+---
+
+## 2. 决策一览
+
+| # | 决策 | 选择 | 理由 |
+|---|---|---|---|
+| AI-D1 | API 形状 | `IconResolverHelpers` 上新增 `public static async Awaitable UseAddressableSpriteAtlasIconResolver(string label = "IconSets")` | 同名族延续 `UseSpriteAtlasIconResolver`，参数语义跟 Resources 版本的 `resourcesSubpath="IconSets"` 对齐 |
+| AI-D2 | 资产发现方式 | `Addressables.LoadAssetsAsync<IconSet>(label, callback: null)` —— 按 label 拉全部 | IconSet 数量通常 < 10，列表 API 比单 key 多次调用简单；user 在 Addressables 里给 IconSet 资产打 label 即可，与 Resources 版本"丢进文件夹"对称 |
+| AI-D3 | SpriteAtlas 是否需要额外标记 | 不需要 | Addressables 跟踪 asset 依赖：加载 IconSet 会自动把 `entries[i].sprite` 引用的 SpriteAtlas 作为依赖一起加载 |
+| AI-D4 | 异步签名 | 返回 `Awaitable`（非泛型，无 result） | IconResolver 是 sync 的；本方法只是预加载副作用，没有要 yield 的 result |
+| AI-D5 | 句柄生命周期 | static 字段保留 `AsyncOperationHandle<IList<IconSet>>`；二次调用本方法先 release 旧句柄；`UI.ResetForTests()` 触发新增的内部 `OnReset` 事件，helper 在事件里 release | sprite 引用依赖 atlas 常驻；ResetForTests 是测试间隔离的契约位置，把句柄清理塞在那里跟现有 `IconResolverRebuilder = null` 同位 |
+| AI-D6 | `UI.OnReset` 事件可见性 | `internal static event Action OnReset` | 测试和 helper 都在 Runtime asmdef，不需要 public；与 `AwaitableHelpers` 一样用 `InternalsVisibleTo` 走通 |
+| AI-D7 | HotReload 协议 | 设置 `UI.HotReload.IconResolverRebuilder = Rebuild`；Rebuild 不重新走 Addressables，只从已缓存的 IconSet 列表重新 `BuildLookup` | 本地 Editor `IconAtlasSyncer` 改 `IconSet.entries` 后 ScriptableObject 已更新，引用不变；不需要重新发起 Addressables 请求 |
+| AI-D8 | 加载失败语义 | `Addressables.LoadAssetsAsync` 失败（label 不存在 / 资源类型错）→ `await` 抛异常透传给调用方 | 跟 `UseAddressableResolver()` 一致，让调用方决定要不要重试 / fallback |
+| AI-D9 | 空结果语义 | label 命中 0 个 IconSet → 不抛异常，`UI.IconResolver` 被设为返回 null 的查表函数 | 跟 `UseSpriteAtlasIconResolver(Array.Empty<IconSet>())` 现有行为对齐（参见 `IconResolverTests.UseSpriteAtlasIconResolver_with_empty_list_builds_resolver`） |
+| AI-D10 | Editor reverse mapping | 不做 | XML 走的 `AssetPathToSrc` 是为 `.ui.xml` 热重载；IconSet 的热重载入口是 `IconAtlasSyncer` 直接调 `UI.HotReload.NotifyIconAssetsChanged()`，跟资产路径无关 |
+| AI-D11 | 文件位置 | `Runtime/Application/AddressableIconResolverHelper.cs`，整文件 `#if PROMPTUGUI_HAS_ADDRESSABLES` 包住；类用 `public static partial class IconResolverHelpers`，与 `IconResolverHelpers.cs` 同名合并 | 镜像 `AddressableResolverHelper.cs` 的模式（也是 partial class 形式接到 `UI`） |
+| AI-D12 | SKILL.md 更新 | 在 "Icon system setup" 段落追加 Addressables 用法示例 | CLAUDE.md 要求 public C# API 变更同步 SKILL；新 API 不属于"transparent default"豁免 |
+
+---
+
+## 3. 完整使用示例
+
+启动期（Addressables 路径）：
+
+```csharp
+// 前置：项目装了 com.unity.addressables；
+//       SolarIconSet.asset / GameIconSet.asset 在 AA Group 里挂 label="IconSets"。
+//       注意 Addressables 会自动把它们引用的 SpriteAtlas 作为依赖一起打包/下载。
+
+UI.UseAddressableResolver();
+await IconResolverHelpers.UseAddressableSpriteAtlasIconResolver();   // 默认 label="IconSets"
+
+await UI.LoadDocumentAsync("screens/MainMenu");
+UI.Open("MainMenu");   // <Icon name="ui:heart"/> 此时已可解析
+```
+
+自定义 label：
+
+```csharp
+await IconResolverHelpers.UseAddressableSpriteAtlasIconResolver("MyIcons");
+```
+
+二次调用（切语言包 / 切主题）：
+
+```csharp
+await IconResolverHelpers.UseAddressableSpriteAtlasIconResolver("IconSets_zh");
+// 旧句柄已被 release，旧 IconSet / atlas 引用计数归零会被 Addressables 回收
+// （前提：场景里没有其他 user 代码持有那些 Sprite 引用）
+```
+
+---
+
+## 4. 公开 API 表
+
+| 状态 | 签名 | 说明 |
+|---|---|---|
+| 新增 | `public static async Awaitable IconResolverHelpers.UseAddressableSpriteAtlasIconResolver(string label = "IconSets")` | 仅在 `PROMPTUGUI_HAS_ADDRESSABLES` 下可见 |
+| 不变 | `IconResolverHelpers.UseSpriteAtlasIconResolver(string resourcesSubpath = "IconSets")` | Resources 路径 |
+| 不变 | `IconResolverHelpers.UseSpriteAtlasIconResolver(IEnumerable<IconSet> sets)` | 调用方直接喂 |
+| 新增（internal） | `internal static event Action UI.OnReset` | `ResetForTests` 触发；helper 用来 release 句柄 |
+
+---
+
+## 5. 落地细节
+
+### 5.1 `UI.OnReset` 钩子
+
+`Runtime/Application/UI.cs` 在现有 `ResetForTests()` 末尾加：
+
+```csharp
+internal static event Action OnReset;
+
+public static void ResetForTests() {
+    // ...现有逻辑：unload 所有 Screen、清 SourceResolver、IconResolver、HotReload.* ...
+
+    OnReset?.Invoke();
+}
+```
+
+事件在所有现有 reset 逻辑跑完之后触发——保证订阅者看到的是"刚 reset 完的状态"。
+
+### 5.2 `AddressableIconResolverHelper.cs`
+
+```csharp
+#if PROMPTUGUI_HAS_ADDRESSABLES
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
+
+namespace PromptUGUI.Application
+{
+    public static partial class IconResolverHelpers
+    {
+        private static AsyncOperationHandle<IList<IconSet>>? _addressableIconHandle;
+        private static bool _addressableResetHooked;
+        internal static int _testReleaseCount;   // tests-only observation point
+
+        public static async Awaitable UseAddressableSpriteAtlasIconResolver(
+            string label = "IconSets")
+        {
+            ReleaseAddressableIconHandle();   // 二次调用先放旧句柄
+            HookResetOnce();
+
+            var handle = Addressables.LoadAssetsAsync<IconSet>(label, null);
+            _addressableIconHandle = handle;
+            var sets = await handle.Task;   // 失败抛异常透传
+            var snapshot = new List<IconSet>(sets ?? Array.Empty<IconSet>());
+
+            void Rebuild() {
+                var map = BuildLookup(snapshot);
+                UI.IconResolver = key => map.TryGetValue(key, out var sp) ? sp : null;
+            }
+            Rebuild();
+#if UNITY_EDITOR
+            UI.HotReload.IconResolverRebuilder = Rebuild;
+#endif
+        }
+
+        private static void HookResetOnce() {
+            if (_addressableResetHooked) return;
+            UI.OnReset += ReleaseAddressableIconHandle;
+            _addressableResetHooked = true;
+        }
+
+        private static void ReleaseAddressableIconHandle() {
+            if (_addressableIconHandle.HasValue && _addressableIconHandle.Value.IsValid()) {
+                Addressables.Release(_addressableIconHandle.Value);
+                _testReleaseCount++;
+            }
+            _addressableIconHandle = null;
+        }
+    }
+}
+#endif
+```
+
+`BuildLookup` 在 `IconResolverHelpers.cs` 已经是 `private static`，partial class 合并后两边可见。
+
+### 5.3 SKILL.md 更新
+
+在 "Icon system setup" 段落（约 line 408 起）现有两个示例之后追加：
+
+````markdown
+Addressables 路径（项目装了 `com.unity.addressables` 时）：
+
+```csharp
+// 把 IconSet 资产在 Addressables 里打 label="IconSets"，
+// Addressables 会自动把它们引用的 SpriteAtlas 作为依赖一起打包。
+await IconResolverHelpers.UseAddressableSpriteAtlasIconResolver();
+// 或自定义 label：
+await IconResolverHelpers.UseAddressableSpriteAtlasIconResolver("MyIcons");
+```
+
+调用 await 后才能打开含 `<Icon>` 的 Screen。仅在 `PROMPTUGUI_HAS_ADDRESSABLES` 编译定义下可见。
+````
+
+---
+
+## 6. 测试策略
+
+新文件 `Tests/EditMode/Addressables/AddressableIconResolverTests.cs`（沿用 `AddressableResolverTests.cs` 的 EditMode 异步限制说明）：
+
+| 测试 | 断言 |
+|---|---|
+| `UseAddressableSpriteAtlasIconResolver_invocation_returns_an_awaitable` | 调用返回非 null `Awaitable`；不 await（EditMode 没有 player loop，Addressables 异步 continuation 不 resume） |
+| `UseAddressableSpriteAtlasIconResolver_with_unknown_label_does_not_set_resolver_synchronously` | 调用立刻返回 Awaitable 时 `UI.IconResolver` 还没被设（异步路径），不抛 |
+| `UseAddressableSpriteAtlasIconResolver_releases_previous_handle_on_second_call` | 连续调两次不抛；通过 helper 暴露的 `internal static int _testReleaseCount` 计数器验证 +1 |
+| `ResetForTests_releases_addressable_icon_handle` | 订阅 `UI.OnReset` 的 release 路径生效：调用方法一次 → `ResetForTests()` → `_testReleaseCount` +1 |
+| `OnReset_event_fires_after_reset` | EditMode 独立测试：订阅 `UI.OnReset`、调 `ResetForTests`、验证回调被调一次（覆盖 §5.1 钩子本身，不依赖 Addressables） |
+
+端到端"label → IconSet → IconResolver 返回正确 sprite"的验证留给 PlayMode（如果将来加 PlayMode 测试），EditMode 跑不出真正的 Addressables continuation —— 同 `AddressableResolverTests` 的注释。
+
+`Tests/EditMode/Application/IconResolverTests.cs` 现有行为完全不动。
+
+---
+
+## 7. 迁移与破坏性影响
+
+- 既有 `UseSpriteAtlasIconResolver` 两个重载行为不变，调用方零迁移。
+- 新增 `UI.OnReset` 是 internal event，对外部 user 不可见，不算 API 表面变化。
+- Samples 不动。Samples~/MainMenu 仍然走 Resources 路径，新示例不放进 sample，避免给 sample 加 Addressables 依赖。
+
+---
+
+## 8. 非目标 / 推迟
+
+- **AssetReference / AssetReferenceT<IconSet> 入口**：单独按 reference 加载更精确，但日常用法是"一次性预加载所有 IconSet"，label 入口已经覆盖。如果将来需要按需加载单个 IconSet，再扩。
+- **运行时切包热更**：本设计支持二次调用切换 label，但不处理"切换中已打开 Screen 的 Sprite 仍指向旧 atlas"的过渡帧——调用方负责在切换前关闭含 `<Icon>` 的 Screen，或接受切换瞬间的旧 sprite 显示。
+- **Addressables 反向映射**：IconSet 的热重载入口是 `IconAtlasSyncer` 直接广播 `NotifyIconAssetsChanged`，不像 `.ui.xml` 需要 path→key 反查。
+
+---
+
+## 9. 风险
+
+| 风险 | 影响 | 缓解 |
+|---|---|---|
+| `Addressables.LoadAssetsAsync<IconSet>` 在 label 命中 0 个时的返回值（null vs 空 list）随版本不同 | empty list 路径分支挂掉 | 实施时 `sets ?? Array.Empty<IconSet>()` 兜底 |
+| `UI.OnReset` event 多次订阅 | 同一 helper 加载多次后，reset 时 release 多次 | `_addressableResetHooked` 标志位防重复订阅 |
+| user 在场景里把 sprite 引用拷出去（缓存到自家 MonoBehaviour）后调用切换，旧 atlas 被卸载 | sprite 失效、显示白图 | 文档里写明：sprite 引用只在当前 IconResolver 生效期内有效；不持有缓存 |
+| Player 退出 / 域 reload 时 `_addressableIconHandle` 不被显式 release | Addressables 内部 ref count 没清；进程退出时 OS 回收，无实际泄漏 | 不缓解；与 Unity 引擎进程生命周期一致 |
+
+---
+
+## 10. 实施粒度（提示）
+
+writing-plans 阶段细化，大致 3 块：
+
+1. `UI.OnReset` event + `ResetForTests` 触发 + EditMode 测试（红→绿）
+2. `AddressableIconResolverHelper.cs` 新文件 + smoke 测试（红→绿）
+3. SKILL.md 更新 + lint pass + Unity MCP `run_tests` 全跑过


### PR DESCRIPTION
## Summary

- 新增 `IconResolverHelpers.UseAddressableSpriteAtlasIconResolver(label)` — 异步从 Addressables 预加载 IconSet，Addressables 自动把依赖的 SpriteAtlas 一起拉下来。镜像现有 `UI.UseAddressableResolver()` 的模式（仅在装了 `com.unity.addressables` ≥ 1.0 时可见，由 `PROMPTUGUI_HAS_ADDRESSABLES` 条件编译控制）。
- 句柄保留在静态字段里贯穿 `UI.IconResolver` 生命周期；二次调用或 `UI.ResetForTests()` 触发释放。释放钩子靠新增的 `internal static event UI.OnReset` —— Runtime helper 无需在 UI.cs 加 Addressables 类型耦合。

## Design / plan refs

- Spec: [`docs~/superpowers/specs/2026-05-12-addressable-icon-resolver-design.md`](https://github.com/Heerozh/PromptUGUI/blob/feat/addressable-icon-resolver/docs~/superpowers/specs/2026-05-12-addressable-icon-resolver-design.md)
- Plan: [`docs~/superpowers/plans/2026-05-12-addressable-icon-resolver.md`](https://github.com/Heerozh/PromptUGUI/blob/feat/addressable-icon-resolver/docs~/superpowers/plans/2026-05-12-addressable-icon-resolver.md)

## Test plan

- [x] EditMode (`PromptUGUI.Tests.EditMode`): 372/372 pass
- [x] EditorOnly (`PromptUGUI.Tests.EditorOnly`): 100/100 pass
- [x] Addressables EditMode (`PromptUGUI.Tests.EditMode.Addressables`): 8/8 pass (含 3 个新增 smoke tests + 5 个 existing)
- [x] PlayMode (`PromptUGUI.Tests.PlayMode`): 69/69 pass
- [x] Lint: `dotnet format --verify-no-changes --severity warn` 干净
- [x] SKILL.md 同步更新（CLAUDE.md 要求 public API 改动必须同期更新作者向 SKILL）

## Notes

- EditMode 测试只覆盖同步前缀（创建句柄 / 第二次调用 release / OnReset 释放）—— `AsyncOperationHandle.continuation` 需要 player-loop SynchronizationContext，EditMode 没有，跟 `AddressableResolverTests` 同样的限制。
- 失败 label 在测试里通过 `LogAssert.Expect(LogType.Error, ".*InvalidKeyException.*")` 消化，每次调用一个 Expect。
- Commits 拆成 6 个递进步骤（OnReset event → partial refactor → impl + tests → docs → meta files → review polish）。如需 squash 合并，merge 时用 `--squash` 即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)