### PR TITLE
feat: Locale (PO) Addressable Resolver + SetAsync

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -321,6 +321,32 @@ var text = string.Format(c, UI.Tr("Total: {0:C}"), price);
 
 **Reserved namespace**: `UI.Locale.Set("zh-Hans")` internally registers `zh-Hans` as an active Variant. Authors must NOT reuse a Variant of the same name to express anything other than locale state.
 
+**.po file location**
+
+By default `.po` files live in `Assets/Resources/PromptUGUI/i18n/<locale>/` or
+`/PromptUGUI/i18n-custom/<locale>/`. Files anywhere under those paths are
+picked up by `Resources.LoadAll<TextAsset>`; subfolder names are ignored.
+
+When the project ships `.po` via Addressables, call
+`UI.Locale.UseAddressableResolver()` at boot. The resolver loads every TextAsset
+whose Addressables **label matches the locale string** (so `Locale.Set("zh-Hans")`
+loads everything labelled `zh-Hans`). Files can live anywhere. Only available
+when `com.unity.addressables` ≥ 1.0 is installed (gated by
+`PROMPTUGUI_HAS_ADDRESSABLES`).
+
+```csharp
+UI.Locale.UseAddressableResolver();
+UI.Locale.Set("zh-Hans");                  // sync; UI shows msgid briefly during download
+// or:
+await UI.Locale.SetAsync("zh-Hans");       // awaits download + parse + ReSolve
+```
+
+`Locale.Set` returns immediately after issuing the load. While the download is
+in flight, open Screens briefly fall back to msgid text; when the load
+completes the locale variant flips on and all open Screens re-resolve to the
+translated strings. `SetAsync` returns only after that re-resolve completes —
+use it when you need to read `UI.Tr(...)` immediately after switching locales.
+
 ### Inline sprites / TMP rich text
 
 `<Text>` does not allow mixing text + child elements by default. To inline TMP tags like `<sprite>` / `<color>`, wrap them in CDATA:
@@ -589,6 +615,8 @@ C# CANVAS     UI.CanvasConfigurator = (canvas, name) => { ... }  worldCamera / s
 <Text ctx="door">Open</Text>     msgctxt disambiguation
 UI.Tr("...")                     C# extraction entry point
 UI.Locale.Set("zh-Hans")         switch locale (= switch .po + switch font)
+UI.Locale.SetAsync("zh-Hans")    awaitable variant; completes after .po load + ReSolve
+UI.Locale.UseAddressableResolver() load .po via Addressables, label = locale string
 ```
 
 ## Worked end-to-end example

--- a/Runtime/Application/LocaleAddressableResolverHelper.cs
+++ b/Runtime/Application/LocaleAddressableResolverHelper.cs
@@ -1,0 +1,58 @@
+#if PROMPTUGUI_HAS_ADDRESSABLES
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using PromptUGUI.I18n;
+
+namespace PromptUGUI.Application
+{
+    public static partial class UI
+    {
+        public static partial class Locale
+        {
+            /// <summary>
+            /// 把 PoResolver 设为按 label=locale 加载所有 .po TextAsset 的 Addressables 实现。
+            /// Set("zh-Hans") → Addressables.LoadAssetsAsync&lt;TextAsset&gt;("zh-Hans", null)。
+            /// 仅在装了 com.unity.addressables 时存在（PROMPTUGUI_HAS_ADDRESSABLES 编译定义）。
+            ///
+            /// 注意 fire-and-forget 模型下 Set 返回后 UI 还看到 msgid，要等下载完才切译文；
+            /// 想避免闪烁用 await Locale.SetAsync(...)。
+            /// </summary>
+            public static void UseAddressableResolver()
+            {
+                PoResolver = LoadPoFromAddressablesAsync;
+            }
+
+            private static async Awaitable<IEnumerable<PoEntry>> LoadPoFromAddressablesAsync(
+                string locale)
+            {
+                var handle = Addressables.LoadAssetsAsync<TextAsset>(locale, null);
+                try
+                {
+                    var assets = await handle.Task;
+                    var entries = new List<PoEntry>();
+                    foreach (var ta in assets ?? Array.Empty<TextAsset>())
+                    {
+                        if (ta == null) continue;
+                        try
+                        {
+                            foreach (var e in PoParser.Parse(ta.text)) entries.Add(e);
+                        }
+                        catch (Exception ex)
+                        {
+                            Debug.LogError(
+                                $"[PromptUGUI] failed to parse .po asset '{ta.name}': {ex.Message}");
+                        }
+                    }
+                    return entries;
+                }
+                finally
+                {
+                    if (handle.IsValid()) Addressables.Release(handle);
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Runtime/Application/LocaleAddressableResolverHelper.cs.meta
+++ b/Runtime/Application/LocaleAddressableResolverHelper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 79ee26902f7d3dd45a9f3793cd496eb7

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -21,7 +21,7 @@ namespace PromptUGUI.Application
         // `Resources/PromptUGUI/i18n-custom/{locale}/`. Set to an in-memory resolver
         // (e.g. `_ => System.Linq.Enumerable.Empty<PoEntry>()`) to isolate tests from
         // the host project's PO assets.
-        public static System.Func<string, IEnumerable<I18n.PoEntry>> PoResolver { get; set; }
+        public static System.Func<string, UnityEngine.Awaitable<IEnumerable<I18n.PoEntry>>> PoResolver { get; set; }
 
         // Invoked from Screen.Open() right after the Canvas + CanvasScaler + GraphicRaycaster
         // are added and renderMode is set to ScreenSpaceOverlay. Use to switch renderMode,
@@ -40,7 +40,7 @@ namespace PromptUGUI.Application
                 VariantStore.IsActive(name);
         }
 
-        public static class Locale
+        public static partial class Locale
         {
             public static string Current { get; private set; }
             public static event System.Action Changed;
@@ -56,14 +56,13 @@ namespace PromptUGUI.Application
                 Current = locale;
                 if (locale != null)
                 {
-                    LoadPoFiles(locale);
-                    VariantStore.Set(locale, true);
+                    _ = LoadPoFilesAndApplyAsyncLogged(locale);
                 }
                 else
                 {
                     VariantStore.NotifyChangedInternal();
+                    Changed?.Invoke();
                 }
-                Changed?.Invoke();
             }
 
             public static void SetToSystemDefault() =>
@@ -111,9 +110,43 @@ namespace PromptUGUI.Application
             public static void ReloadCurrent()
             {
                 if (Current == null) return;
+                _ = ReloadCurrentAsyncLogged();
+            }
+
+            internal static async UnityEngine.Awaitable LoadPoFilesAndApplyAsync(string locale)
+            {
+                await LoadPoFilesAsync(locale);
+                // Task 2 will insert: if (Current != locale) return;  (race guard)
+                VariantStore.Set(locale, true);
+                Changed?.Invoke();
+            }
+
+            private static async UnityEngine.Awaitable LoadPoFilesAndApplyAsyncLogged(string locale)
+            {
+                try { await LoadPoFilesAndApplyAsync(locale); }
+                catch (System.Exception e)
+                {
+                    UnityEngine.Debug.LogError(
+                        $"[PromptUGUI] locale load failed for '{locale}': {e}");
+                }
+            }
+
+            internal static async UnityEngine.Awaitable ReloadCurrentAsyncInternal()
+            {
+                if (Current == null) return;
                 TranslationStore.Instance.UnloadLocale(Current);
-                LoadPoFiles(Current);
+                await LoadPoFilesAsync(Current);
                 VariantStore.NotifyChangedInternal();
+            }
+
+            private static async UnityEngine.Awaitable ReloadCurrentAsyncLogged()
+            {
+                try { await ReloadCurrentAsyncInternal(); }
+                catch (System.Exception e)
+                {
+                    UnityEngine.Debug.LogError(
+                        $"[PromptUGUI] locale reload failed for '{Current}': {e}");
+                }
             }
 
             internal static void ResetForTestsInternal()
@@ -127,20 +160,21 @@ namespace PromptUGUI.Application
         public static string Tr(string msgid, string ctx = null) =>
             TrResolver.Resolve(msgid, null, ctx);
 
-        private static void LoadPoFiles(string locale)
+        private static async UnityEngine.Awaitable LoadPoFilesAsync(string locale)
         {
             if (PoResolver != null)
             {
-                var entries = PoResolver(locale);
+                var entries = await PoResolver(locale);
+                // Task 2 will insert: if (Current != locale) return;  (race guard)
                 if (entries != null)
                     TranslationStore.Instance.Load(locale, entries);
                 return;
             }
-            LoadPoFromPath($"PromptUGUI/i18n/{locale}", locale);
-            LoadPoFromPath($"PromptUGUI/i18n-custom/{locale}", locale);
+            LoadPoFromResourcesPath($"PromptUGUI/i18n/{locale}", locale);
+            LoadPoFromResourcesPath($"PromptUGUI/i18n-custom/{locale}", locale);
         }
 
-        private static void LoadPoFromPath(string resourcesPath, string locale)
+        private static void LoadPoFromResourcesPath(string resourcesPath, string locale)
         {
             var assets = UnityEngine.Resources.LoadAll<UnityEngine.TextAsset>(resourcesPath);
             foreach (var asset in assets)

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -65,6 +65,26 @@ namespace PromptUGUI.Application
                 }
             }
 
+            public static async UnityEngine.Awaitable SetAsync(string locale)
+            {
+                if (Current == locale) return;
+                if (Current != null)
+                {
+                    VariantStore.Set(Current, false);
+                    TranslationStore.Instance.UnloadLocale(Current);
+                }
+                Current = locale;
+                if (locale != null)
+                {
+                    await LoadPoFilesAndApplyAsync(locale);
+                }
+                else
+                {
+                    VariantStore.NotifyChangedInternal();
+                    Changed?.Invoke();
+                }
+            }
+
             public static void SetToSystemDefault() =>
                 Set(LocaleHelpers.MapSystemLanguage(UnityEngine.Application.systemLanguage));
 
@@ -113,10 +133,16 @@ namespace PromptUGUI.Application
                 _ = ReloadCurrentAsyncLogged();
             }
 
+            public static async UnityEngine.Awaitable ReloadCurrentAsync()
+            {
+                if (Current == null) return;
+                await ReloadCurrentAsyncInternal();
+            }
+
             internal static async UnityEngine.Awaitable LoadPoFilesAndApplyAsync(string locale)
             {
                 await LoadPoFilesAsync(locale);
-                // Task 2 will insert: if (Current != locale) return;  (race guard)
+                if (Current != locale) return;              // race guard: don't flip variant for stale
                 VariantStore.Set(locale, true);
                 Changed?.Invoke();
             }
@@ -165,7 +191,7 @@ namespace PromptUGUI.Application
             if (PoResolver != null)
             {
                 var entries = await PoResolver(locale);
-                // Task 2 will insert: if (Current != locale) return;  (race guard)
+                if (Locale.Current != locale) return;          // race guard: stale load
                 if (entries != null)
                     TranslationStore.Instance.Load(locale, entries);
                 return;

--- a/Tests/EditMode/Addressables/LocaleAddressableResolverTests.cs
+++ b/Tests/EditMode/Addressables/LocaleAddressableResolverTests.cs
@@ -1,0 +1,66 @@
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using UnityEditor.AddressableAssets;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.Addressables
+{
+    /// <summary>
+    /// Wiring smoke tests for UI.Locale.UseAddressableResolver.
+    ///
+    /// End-to-end "label='zh-Hans' → .po TextAssets → TranslationStore" is NOT
+    /// tested in EditMode: AsyncOperationHandle continuations need the player-loop
+    /// SynchronizationContext, which is absent in EditMode test runners. Same
+    /// limitation documented in AddressableResolverTests. Tests here cover only
+    /// the synchronous registration prefix: PoResolver is non-null after the
+    /// call, and invoking it returns a non-null Awaitable.
+    ///
+    /// 'zh-Hans' intentionally doesn't resolve to any registered asset, so
+    /// Addressables logs an InvalidKeyException synchronously inside
+    /// LoadAssetsAsync. The invocation test declares the expected error via
+    /// LogAssert.Expect; Unity Test Framework consumes the matched entry
+    /// instead of failing the test on it.
+    /// </summary>
+    public class LocaleAddressableResolverTests
+    {
+        private static readonly Regex InvalidKeyError = new(".*InvalidKeyException.*");
+
+        [SetUp]
+        public void Setup()
+        {
+            UI.ResetForTests();
+            // Ensure AddressableAssetSettings exists; without it
+            // Addressables.LoadAssetsAsync throws synchronously in a fresh project.
+            _ = AddressableAssetSettingsDefaultObject.Settings
+                ?? AddressableAssetSettingsDefaultObject.GetSettings(true);
+        }
+
+        [TearDown]
+        public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void UseAddressableResolver_sets_PoResolver()
+        {
+            Assert.IsNull(UI.PoResolver,
+                "PoResolver should be null after ResetForTests");
+            UI.Locale.UseAddressableResolver();
+            Assert.IsNotNull(UI.PoResolver,
+                "PoResolver should be set after UseAddressableResolver");
+        }
+
+        [Test]
+        public void PoResolver_invocation_after_register_returns_awaitable()
+        {
+            LogAssert.Expect(LogType.Error, InvalidKeyError);
+            UI.Locale.UseAddressableResolver();
+            var awaitable = UI.PoResolver("zh-Hans");
+            Assert.IsNotNull(awaitable,
+                "Registered resolver should return a non-null Awaitable. " +
+                "Not awaited — EditMode has no player loop, the Addressables " +
+                "AsyncOperationHandle won't resume; TearDown's ResetForTests " +
+                "releases the handle.");
+        }
+    }
+}

--- a/Tests/EditMode/Addressables/LocaleAddressableResolverTests.cs.meta
+++ b/Tests/EditMode/Addressables/LocaleAddressableResolverTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f4d6a1bbb472b884ab4691118d474cf2

--- a/Tests/EditMode/Application/LocaleSetAsyncTests.cs
+++ b/Tests/EditMode/Application/LocaleSetAsyncTests.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.I18n;
+
+namespace PromptUGUI.Tests.Application
+{
+    public class LocaleSetAsyncTests
+    {
+        [SetUp] public void Setup() => UI.ResetForTests();
+        [TearDown] public void Teardown() => UI.ResetForTests();
+
+        [Test]
+        public void Set_with_completed_PoResolver_loads_translations_synchronously()
+        {
+            // Sync-completed Awaitable: integral regression contract that the new
+            // async PoResolver shape keeps sync-completion semantics for callers
+            // who don't actually need to defer (Resources path, in-memory tests).
+            UI.PoResolver = _ => AwaitableHelpers.Completed<IEnumerable<PoEntry>>(new[]
+            {
+                new PoEntry { Msgid = "hi", Msgstr = "Hello" },
+            });
+            UI.Locale.Set("en");
+            Assert.AreEqual("en", UI.Locale.Current);
+            Assert.AreEqual("Hello", UI.Tr("hi"),
+                "Sync-completed PoResolver path must populate TranslationStore " +
+                "before Set returns (preserves pre-async-shape behavior).");
+        }
+    }
+}

--- a/Tests/EditMode/Application/LocaleSetAsyncTests.cs
+++ b/Tests/EditMode/Application/LocaleSetAsyncTests.cs
@@ -26,5 +26,104 @@ namespace PromptUGUI.Tests.Application
                 "Sync-completed PoResolver path must populate TranslationStore " +
                 "before Set returns (preserves pre-async-shape behavior).");
         }
+
+        [Test]
+        public void SetAsync_with_completed_PoResolver_loads_translations()
+        {
+            UI.PoResolver = _ => AwaitableHelpers.Completed<IEnumerable<PoEntry>>(new[]
+            {
+                new PoEntry { Msgid = "hi", Msgstr = "Bonjour" },
+            });
+            UI.Locale.SetAsync("fr").GetAwaiter().GetResult();
+            Assert.AreEqual("fr", UI.Locale.Current);
+            Assert.AreEqual("Bonjour", UI.Tr("hi"));
+        }
+
+        [Test]
+        public void SetAsync_propagates_resolver_exception()
+        {
+            UI.PoResolver = _ =>
+                AwaitableHelpers.Faulted<IEnumerable<PoEntry>>(
+                    new System.IO.IOException("boom"));
+            var ex = Assert.Throws<System.IO.IOException>(
+                () => UI.Locale.SetAsync("en").GetAwaiter().GetResult(),
+                "SetAsync should surface resolver exceptions to the awaiting caller");
+            StringAssert.Contains("boom", ex.Message);
+        }
+
+        [Test]
+        public void Set_fire_and_forget_logs_error_on_resolver_throw()
+        {
+            UI.PoResolver = _ =>
+                AwaitableHelpers.Faulted<IEnumerable<PoEntry>>(
+                    new System.IO.IOException("boom-sync"));
+            UnityEngine.TestTools.LogAssert.Expect(
+                UnityEngine.LogType.Error,
+                new System.Text.RegularExpressions.Regex(
+                    "locale load failed for 'en'.*boom-sync"));
+            UI.Locale.Set("en");
+            // Locale.Current still advances even when load fails — caller can retry.
+            Assert.AreEqual("en", UI.Locale.Current);
+        }
+
+        [Test]
+        public void Set_rapid_consecutive_with_pending_resolver_discards_stale_load()
+        {
+            // Race scenario: Set("zh-Hans") starts a deferred load; before it
+            // completes, Set("en") supersedes it. When the zh-Hans load finally
+            // resolves, the guard inside LoadPoFilesAsync must drop the result.
+            var srcZh = new UnityEngine.AwaitableCompletionSource<IEnumerable<PoEntry>>();
+            var srcEn = new UnityEngine.AwaitableCompletionSource<IEnumerable<PoEntry>>();
+            UI.PoResolver = locale =>
+                locale == "zh-Hans" ? srcZh.Awaitable : srcEn.Awaitable;
+
+            UI.Locale.Set("zh-Hans");
+            UI.Locale.Set("en");
+            Assert.AreEqual("en", UI.Locale.Current);
+
+            // Resume en first, then zh — the guard must drop zh entries.
+            srcEn.SetResult(new[] { new PoEntry { Msgid = "hi", Msgstr = "Hello" } });
+            srcZh.SetResult(new[] { new PoEntry { Msgid = "hi", Msgstr = "你好" } });
+
+            Assert.AreEqual("Hello", UI.Tr("hi"),
+                "Race guard must keep en translations; zh-Hans load is stale.");
+            Assert.IsFalse(UI.Variants.IsActive("zh-Hans"),
+                "Stale zh-Hans load must not flip its variant back on.");
+        }
+
+        [Test]
+        public void ReloadCurrentAsync_with_completed_PoResolver_reloads_translations()
+        {
+            // Initial load: "hi" → "Hello"
+            UI.PoResolver = _ => AwaitableHelpers.Completed<IEnumerable<PoEntry>>(new[]
+            {
+                new PoEntry { Msgid = "hi", Msgstr = "Hello" },
+            });
+            UI.Locale.Set("en");
+            Assert.AreEqual("Hello", UI.Tr("hi"));
+
+            // Swap the resolver to return a new translation, then ReloadCurrent.
+            UI.PoResolver = _ => AwaitableHelpers.Completed<IEnumerable<PoEntry>>(new[]
+            {
+                new PoEntry { Msgid = "hi", Msgstr = "Howdy" },
+            });
+            UI.Locale.ReloadCurrentAsync().GetAwaiter().GetResult();
+            Assert.AreEqual("Howdy", UI.Tr("hi"));
+        }
+
+        [Test]
+        public void ReloadCurrentAsync_returns_immediately_when_Current_is_null()
+        {
+            // Current is null after ResetForTests; ReloadCurrentAsync should be a no-op
+            // (no resolver invocation, no exception).
+            var invocations = 0;
+            UI.PoResolver = _ =>
+            {
+                invocations++;
+                return AwaitableHelpers.Completed<IEnumerable<PoEntry>>(System.Array.Empty<PoEntry>());
+            };
+            UI.Locale.ReloadCurrentAsync().GetAwaiter().GetResult();
+            Assert.AreEqual(0, invocations);
+        }
     }
 }

--- a/Tests/EditMode/Application/LocaleSetAsyncTests.cs.meta
+++ b/Tests/EditMode/Application/LocaleSetAsyncTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a5b1c2d3e4f5061728394a5b6c7d8e9f

--- a/Tests/EditMode/Application/LocaleSetAsyncTests.cs.meta
+++ b/Tests/EditMode/Application/LocaleSetAsyncTests.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: a5b1c2d3e4f5061728394a5b6c7d8e9f
+guid: 25e432ab67d1abcbd3dbed5c496095b8

--- a/Tests/PlayMode/E2E/I18nFontSwapTests.cs
+++ b/Tests/PlayMode/E2E/I18nFontSwapTests.cs
@@ -28,7 +28,8 @@ namespace PromptUGUI.Tests.E2E
         public void Setup()
         {
             UI.ResetForTests();
-            UI.PoResolver = _ => System.Linq.Enumerable.Empty<PoEntry>();
+            UI.PoResolver = _ => AwaitableHelpers.Completed<System.Collections.Generic.IEnumerable<PoEntry>>(
+                System.Array.Empty<PoEntry>());
 
             // Distinct instances suffice for reference-equality assertions.
             _fontEn = TMP_FontAsset.CreateFontAsset(Font.CreateDynamicFontFromOSFont("Arial", 16));

--- a/Tests/PlayMode/E2E/I18nHotReloadTests.cs
+++ b/Tests/PlayMode/E2E/I18nHotReloadTests.cs
@@ -19,7 +19,8 @@ namespace PromptUGUI.Tests.E2E
         public void Setup()
         {
             UI.ResetForTests();
-            UI.PoResolver = _ => System.Linq.Enumerable.Empty<PoEntry>();
+            UI.PoResolver = _ => AwaitableHelpers.Completed<System.Collections.Generic.IEnumerable<PoEntry>>(
+                System.Array.Empty<PoEntry>());
             TranslationStore.Instance.UnloadAll();
             UI.LoadDocument("S", Xml);
             TranslationStore.Instance.Load("en", new[] {

--- a/docs~/superpowers/plans/2026-05-12-locale-addressable-resolver.md
+++ b/docs~/superpowers/plans/2026-05-12-locale-addressable-resolver.md
@@ -1,0 +1,856 @@
+# Locale (PO) Addressable Resolver Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `UI.Locale.UseAddressableResolver()` so the .po loading channel can pull from Addressables (label = locale). Make `UI.PoResolver` async-shaped; sync `Locale.Set`/`ReloadCurrent` become fire-and-forget wrappers that auto-trigger ReSolve when the download completes. Add `SetAsync` / `ReloadCurrentAsync` for callers that need ordering.
+
+**Architecture:** Three layers. (1) `UI.PoResolver` switches from `Func<string, IEnumerable<PoEntry>>` to `Func<string, Awaitable<IEnumerable<PoEntry>>>`; sync resolvers wrap result via `AwaitableHelpers.Completed(...)` and keep synchronous semantics. (2) `Locale.Set(locale)` stays `void` but fires `_ = LoadPoFilesAndApplyAsyncLogged(locale)`; a `Current != locale` guard inside the async helper discards stale loads from rapid consecutive calls. (3) `Runtime/Application/LocaleAddressableResolverHelper.cs` (gated by `PROMPTUGUI_HAS_ADDRESSABLES`) registers a PoResolver that calls `Addressables.LoadAssetsAsync<TextAsset>(locale, null)` and parses every returned `.po` TextAsset.
+
+**Tech Stack:** Unity 6 `UnityEngine.Awaitable` / `AwaitableCompletionSource`, `UnityEngine.AddressableAssets` (com.unity.addressables ≥ 1.0), R3 (Cysharp) `Subject`/`Observable`, NUnit EditMode test runner, Unity MCP for compile/test cycles.
+
+**Spec:** [`docs~/superpowers/specs/2026-05-12-locale-addressable-resolver-design.md`](../specs/2026-05-12-locale-addressable-resolver-design.md)
+
+---
+
+## File Structure
+
+**New files:**
+- `Runtime/Application/LocaleAddressableResolverHelper.cs` — entire file under `#if PROMPTUGUI_HAS_ADDRESSABLES`; defines `partial class UI { partial class Locale { ... } }` with `UseAddressableResolver()` + the private `LoadPoFromAddressablesAsync` helper.
+- `Tests/EditMode/Application/LocaleSetAsyncTests.cs` — tests for the new `Set` / `SetAsync` / `ReloadCurrentAsync` semantics + race guard + error path. Does NOT depend on Addressables (uses in-memory async resolvers).
+- `Tests/EditMode/Addressables/LocaleAddressableResolverTests.cs` — two wiring smoke tests for the Addressable helper, mirroring the EditMode-async-limitation pattern from existing `AddressableResolverTests.cs`.
+
+**Modified files:**
+- `Runtime/Application/UI.cs` —
+  - Line 24: change `Func<string, IEnumerable<I18n.PoEntry>>` → `Func<string, Awaitable<IEnumerable<I18n.PoEntry>>>`.
+  - Line 43: change `public static class Locale` → `public static partial class Locale`.
+  - Lines 48–67 (`Set`): body becomes fire-and-forget wrapper.
+  - Lines 111–117 (`ReloadCurrent`): body becomes fire-and-forget wrapper.
+  - Lines 130–141 (`LoadPoFiles`): converted to `async Awaitable LoadPoFilesAsync`; sync helper renamed `LoadPoFromPath` → `LoadPoFromResourcesPath`.
+  - Add in Task 1 (internal/private): `LoadPoFilesAndApplyAsync` (internal), `LoadPoFilesAndApplyAsyncLogged` (private), `ReloadCurrentAsyncInternal` (internal), `ReloadCurrentAsyncLogged` (private).
+  - Add in Task 2 (public): `SetAsync`, `ReloadCurrentAsync` — both delegate to the internal helpers from Task 1.
+- `Tests/PlayMode/E2E/I18nHotReloadTests.cs:22` — migrate `PoResolver = _ => Enumerable.Empty<PoEntry>()` → async-completed form.
+- `Tests/PlayMode/E2E/I18nFontSwapTests.cs:31` — same migration.
+- `.claude/skills/authoring-promptugui-xml/SKILL.md` — append a `.po file location / Addressables` subsection inside the i18n section (around line 320, after the existing `UI.Locale.Set` example), and add one row to the i18n reference table (around line 591).
+
+**Unchanged:** `Samples~/`, `Runtime/Application/TranslationStore.cs`, `Runtime/Application/TrResolver.cs`, `Runtime/Core/I18n/PoParser.cs`, `Editor/UIAssetPostprocessor.cs` (Addressables .po hot reload is non-goal — see spec §8 / LAR-D13), all other Runtime / Editor / test files.
+
+---
+
+## Task 1: PoResolver async signature + LoadPoFilesAsync refactor
+
+Foundation. Drives a compile failure first by adding one test that requires the new signature; then changes the signature, refactors the sync `LoadPoFiles` to an async chain, makes `Locale` partial, and converts sync `Set`/`ReloadCurrent` to fire-and-forget wrappers. Public `SetAsync`/`ReloadCurrentAsync` and the race guard come in Task 2 — Task 1 stops at "the minimum required for green compile + existing tests still pass".
+
+**Files:**
+- Create: `Tests/EditMode/Application/LocaleSetAsyncTests.cs`
+- Modify: `Runtime/Application/UI.cs`
+- Modify: `Tests/PlayMode/E2E/I18nHotReloadTests.cs:22`
+- Modify: `Tests/PlayMode/E2E/I18nFontSwapTests.cs:31`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/EditMode/Application/LocaleSetAsyncTests.cs`:
+
+```csharp
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.I18n;
+
+namespace PromptUGUI.Tests.Application
+{
+    public class LocaleSetAsyncTests
+    {
+        [SetUp] public void Setup() => UI.ResetForTests();
+        [TearDown] public void Teardown() => UI.ResetForTests();
+
+        [Test]
+        public void Set_with_completed_PoResolver_loads_translations_synchronously()
+        {
+            // Sync-completed Awaitable: integral regression contract that the new
+            // async PoResolver shape keeps sync-completion semantics for callers
+            // who don't actually need to defer (Resources path, in-memory tests).
+            UI.PoResolver = _ => AwaitableHelpers.Completed<IEnumerable<PoEntry>>(new[]
+            {
+                new PoEntry { Msgid = "hi", Msgstr = "Hello" },
+            });
+            UI.Locale.Set("en");
+            Assert.AreEqual("en", UI.Locale.Current);
+            Assert.AreEqual("Hello", UI.Tr("hi"),
+                "Sync-completed PoResolver path must populate TranslationStore " +
+                "before Set returns (preserves pre-async-shape behavior).");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Refresh Unity and verify the test fails to compile**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: at least one error referencing line `UI.PoResolver = _ => AwaitableHelpers.Completed<IEnumerable<PoEntry>>(...)` — current type is `Func<string, IEnumerable<PoEntry>>` so the lambda body returning `Awaitable<IEnumerable<PoEntry>>` is incompatible. If the test compiles, the previous PoResolver type didn't change — re-read the file.
+
+- [ ] **Step 3: Change PoResolver signature, make `Locale` partial, refactor `LoadPoFiles`**
+
+Open `Runtime/Application/UI.cs`.
+
+3a. Line 24 — change PoResolver type:
+
+```csharp
+public static System.Func<string, UnityEngine.Awaitable<IEnumerable<I18n.PoEntry>>> PoResolver { get; set; }
+```
+
+3b. Line 43 — make Locale partial:
+
+```csharp
+public static partial class Locale
+{
+```
+
+3c. Lines 48–67 — replace the `Set` body with fire-and-forget:
+
+```csharp
+public static void Set(string locale)
+{
+    if (Current == locale) return;
+    if (Current != null)
+    {
+        VariantStore.Set(Current, false);
+        TranslationStore.Instance.UnloadLocale(Current);
+    }
+    Current = locale;
+    if (locale != null)
+    {
+        _ = LoadPoFilesAndApplyAsyncLogged(locale);
+    }
+    else
+    {
+        VariantStore.NotifyChangedInternal();
+        Changed?.Invoke();
+    }
+}
+```
+
+3d. Lines 111–117 — replace the `ReloadCurrent` body with fire-and-forget:
+
+```csharp
+public static void ReloadCurrent()
+{
+    if (Current == null) return;
+    _ = ReloadCurrentAsyncLogged();
+}
+```
+
+3e. Add the private async helpers inside the `Locale` class (anywhere after `ReloadCurrent`, before `ResetForTestsInternal`):
+
+```csharp
+internal static async UnityEngine.Awaitable LoadPoFilesAndApplyAsync(string locale)
+{
+    await LoadPoFilesAsync(locale);
+    // Task 2 will insert: if (Current != locale) return;  (race guard)
+    VariantStore.Set(locale, true);
+    Changed?.Invoke();
+}
+
+private static async UnityEngine.Awaitable LoadPoFilesAndApplyAsyncLogged(string locale)
+{
+    try { await LoadPoFilesAndApplyAsync(locale); }
+    catch (System.Exception e)
+    {
+        UnityEngine.Debug.LogError(
+            $"[PromptUGUI] locale load failed for '{locale}': {e}");
+    }
+}
+
+internal static async UnityEngine.Awaitable ReloadCurrentAsyncInternal()
+{
+    if (Current == null) return;
+    TranslationStore.Instance.UnloadLocale(Current);
+    await LoadPoFilesAsync(Current);
+    VariantStore.NotifyChangedInternal();
+}
+
+private static async UnityEngine.Awaitable ReloadCurrentAsyncLogged()
+{
+    try { await ReloadCurrentAsyncInternal(); }
+    catch (System.Exception e)
+    {
+        UnityEngine.Debug.LogError(
+            $"[PromptUGUI] locale reload failed for '{Current}': {e}");
+    }
+}
+```
+
+(Note `LoadPoFilesAndApplyAsync` and `ReloadCurrentAsyncInternal` are `internal` rather than `private` so Task 2's `SetAsync` / public `ReloadCurrentAsync` can call them without code duplication. `*Logged` wrappers stay `private` — they're the fire-and-forget tails for sync entry points only.)
+
+3f. Lines 130–160 — convert `LoadPoFiles` → `LoadPoFilesAsync` and rename `LoadPoFromPath` → `LoadPoFromResourcesPath`:
+
+```csharp
+private static async UnityEngine.Awaitable LoadPoFilesAsync(string locale)
+{
+    if (PoResolver != null)
+    {
+        var entries = await PoResolver(locale);
+        // Task 2 will insert: if (Current != locale) return;  (race guard)
+        if (entries != null)
+            TranslationStore.Instance.Load(locale, entries);
+        return;
+    }
+    LoadPoFromResourcesPath($"PromptUGUI/i18n/{locale}", locale);
+    LoadPoFromResourcesPath($"PromptUGUI/i18n-custom/{locale}", locale);
+}
+
+private static void LoadPoFromResourcesPath(string resourcesPath, string locale)
+{
+    var assets = UnityEngine.Resources.LoadAll<UnityEngine.TextAsset>(resourcesPath);
+    foreach (var asset in assets)
+    {
+        try
+        {
+            var entries = new System.Collections.Generic.List<I18n.PoEntry>(
+                I18n.PoParser.Parse(asset.text));
+            TranslationStore.Instance.Load(locale, entries);
+        }
+        catch (System.Exception e)
+        {
+            UnityEngine.Debug.LogError(
+                $"[PromptUGUI] failed to parse .po asset '{asset.name}': {e.Message}");
+        }
+    }
+}
+```
+
+The async marker on `LoadPoFilesAsync` is needed even when `PoResolver` is null — the method signature is `Awaitable`, so the compiler turns the `return` into a completed-Awaitable return. No state machine penalty when no `await` runs.
+
+- [ ] **Step 4: Migrate `Tests/PlayMode/E2E/I18nHotReloadTests.cs:22`**
+
+Open `Tests/PlayMode/E2E/I18nHotReloadTests.cs`. Find line 22:
+
+```csharp
+UI.PoResolver = _ => System.Linq.Enumerable.Empty<PoEntry>();
+```
+
+Replace with:
+
+```csharp
+UI.PoResolver = _ => AwaitableHelpers.Completed<System.Collections.Generic.IEnumerable<PoEntry>>(
+    System.Array.Empty<PoEntry>());
+```
+
+`AwaitableHelpers` is `internal` in `PromptUGUI.Application`; the PlayMode test assembly has `InternalsVisibleTo` access per `Runtime/AssemblyInfo.cs:5`.
+
+- [ ] **Step 5: Migrate `Tests/PlayMode/E2E/I18nFontSwapTests.cs:31`**
+
+Same replacement as Step 4, applied at line 31 of `I18nFontSwapTests.cs`.
+
+- [ ] **Step 6: Refresh and verify clean compile**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: zero errors. If any error mentions `LoadPoFiles` or `LoadPoFromPath` (the old names) — those are stale references; grep the codebase to confirm only the old definitions inside `UI.cs` were touched and other call sites still see the public surface (`Set` / `ReloadCurrent`).
+
+- [ ] **Step 7: Run the new test**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="LocaleSetAsyncTests")
+```
+
+Expected: 1 test pass (`Set_with_completed_PoResolver_loads_translations_synchronously`).
+
+- [ ] **Step 8: Regression — run the existing Locale + i18n EditMode tests**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="Locale")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="Translation")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TrResolver")
+```
+
+Expected: all green. `LocaleSetTests` covers `Set_UpdatesCurrent_FiresChanged`, `Set_TogglesVariantNamedAfterLocale`, etc. — these all rely on `Set` being effectively synchronous for the default (Resources) path. Because `LoadPoFilesAsync` doesn't `await` when `PoResolver` is null and the fire-and-forget call site `_ = LoadPoFilesAndApplyAsyncLogged(locale)` runs the entire async state machine synchronously up to the first real `await`, sync behavior is preserved. If any of these tests fail, the sync-completion contract is broken — diagnose before continuing.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Runtime/Application/UI.cs \
+        Tests/EditMode/Application/LocaleSetAsyncTests.cs \
+        Tests/PlayMode/E2E/I18nHotReloadTests.cs \
+        Tests/PlayMode/E2E/I18nFontSwapTests.cs
+git commit -m "$(cat <<'EOF'
+refactor: make UI.PoResolver async-shaped
+
+Switch PoResolver from sync IEnumerable<PoEntry> to async
+Awaitable<IEnumerable<PoEntry>>. Locale.Set/ReloadCurrent become fire-and-forget
+wrappers; sync-completed resolvers (Resources path) preserve existing behavior.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Public `SetAsync` + `ReloadCurrentAsync` + race guard (tests + impl)
+
+Add the two `*Async` public methods + the `Current != locale` race guard, driven by six new tests in `LocaleSetAsyncTests.cs`. Tests describe the full async surface; implementation is a tight set of changes to `UI.cs`.
+
+**Files:**
+- Modify: `Tests/EditMode/Application/LocaleSetAsyncTests.cs`
+- Modify: `Runtime/Application/UI.cs`
+
+- [ ] **Step 1: Write the six new tests**
+
+Append the following tests to `Tests/EditMode/Application/LocaleSetAsyncTests.cs` (inside the existing class body):
+
+```csharp
+        [Test]
+        public void SetAsync_with_completed_PoResolver_loads_translations()
+        {
+            UI.PoResolver = _ => AwaitableHelpers.Completed<IEnumerable<PoEntry>>(new[]
+            {
+                new PoEntry { Msgid = "hi", Msgstr = "Bonjour" },
+            });
+            UI.Locale.SetAsync("fr").GetAwaiter().GetResult();
+            Assert.AreEqual("fr", UI.Locale.Current);
+            Assert.AreEqual("Bonjour", UI.Tr("hi"));
+        }
+
+        [Test]
+        public void SetAsync_propagates_resolver_exception()
+        {
+            UI.PoResolver = _ =>
+                AwaitableHelpers.Faulted<IEnumerable<PoEntry>>(
+                    new System.IO.IOException("boom"));
+            var ex = Assert.Throws<System.IO.IOException>(
+                () => UI.Locale.SetAsync("en").GetAwaiter().GetResult(),
+                "SetAsync should surface resolver exceptions to the awaiting caller");
+            StringAssert.Contains("boom", ex.Message);
+        }
+
+        [Test]
+        public void Set_fire_and_forget_logs_error_on_resolver_throw()
+        {
+            UI.PoResolver = _ =>
+                AwaitableHelpers.Faulted<IEnumerable<PoEntry>>(
+                    new System.IO.IOException("boom-sync"));
+            UnityEngine.TestTools.LogAssert.Expect(
+                UnityEngine.LogType.Error,
+                new System.Text.RegularExpressions.Regex(
+                    "locale load failed for 'en'.*boom-sync"));
+            UI.Locale.Set("en");
+            // Locale.Current still advances even when load fails — caller can retry.
+            Assert.AreEqual("en", UI.Locale.Current);
+        }
+
+        [Test]
+        public void Set_rapid_consecutive_with_pending_resolver_discards_stale_load()
+        {
+            // Race scenario: Set("zh-Hans") starts a deferred load; before it
+            // completes, Set("en") supersedes it. When the zh-Hans load finally
+            // resolves, the guard inside LoadPoFilesAsync must drop the result.
+            var srcZh = new UnityEngine.AwaitableCompletionSource<IEnumerable<PoEntry>>();
+            var srcEn = new UnityEngine.AwaitableCompletionSource<IEnumerable<PoEntry>>();
+            UI.PoResolver = locale =>
+                locale == "zh-Hans" ? srcZh.Awaitable : srcEn.Awaitable;
+
+            UI.Locale.Set("zh-Hans");
+            UI.Locale.Set("en");
+            Assert.AreEqual("en", UI.Locale.Current);
+
+            // Resume en first, then zh — the guard must drop zh entries.
+            srcEn.SetResult(new[] { new PoEntry { Msgid = "hi", Msgstr = "Hello" } });
+            srcZh.SetResult(new[] { new PoEntry { Msgid = "hi", Msgstr = "你好" } });
+
+            Assert.AreEqual("Hello", UI.Tr("hi"),
+                "Race guard must keep en translations; zh-Hans load is stale.");
+            Assert.IsFalse(UI.Variants.IsActive("zh-Hans"),
+                "Stale zh-Hans load must not flip its variant back on.");
+        }
+
+        [Test]
+        public void ReloadCurrentAsync_with_completed_PoResolver_reloads_translations()
+        {
+            // Initial load: "hi" → "Hello"
+            UI.PoResolver = _ => AwaitableHelpers.Completed<IEnumerable<PoEntry>>(new[]
+            {
+                new PoEntry { Msgid = "hi", Msgstr = "Hello" },
+            });
+            UI.Locale.Set("en");
+            Assert.AreEqual("Hello", UI.Tr("hi"));
+
+            // Swap the resolver to return a new translation, then ReloadCurrent.
+            UI.PoResolver = _ => AwaitableHelpers.Completed<IEnumerable<PoEntry>>(new[]
+            {
+                new PoEntry { Msgid = "hi", Msgstr = "Howdy" },
+            });
+            UI.Locale.ReloadCurrentAsync().GetAwaiter().GetResult();
+            Assert.AreEqual("Howdy", UI.Tr("hi"));
+        }
+
+        [Test]
+        public void ReloadCurrentAsync_returns_immediately_when_Current_is_null()
+        {
+            // Current is null after ResetForTests; ReloadCurrentAsync should be a no-op
+            // (no resolver invocation, no exception).
+            var invocations = 0;
+            UI.PoResolver = _ =>
+            {
+                invocations++;
+                return AwaitableHelpers.Completed<IEnumerable<PoEntry>>(System.Array.Empty<PoEntry>());
+            };
+            UI.Locale.ReloadCurrentAsync().GetAwaiter().GetResult();
+            Assert.AreEqual(0, invocations);
+        }
+```
+
+- [ ] **Step 2: Refresh and verify the tests fail**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: compile errors for `UI.Locale.SetAsync(...)` and `UI.Locale.ReloadCurrentAsync()` — neither method exists yet as `public`. If the compile succeeds, Task 1 may have already promoted these — go check.
+
+- [ ] **Step 3: Add public `SetAsync` and `ReloadCurrentAsync`, insert the race guards**
+
+Open `Runtime/Application/UI.cs`. Inside `public static partial class Locale`, add the two new public methods immediately after `Set`:
+
+```csharp
+public static async UnityEngine.Awaitable SetAsync(string locale)
+{
+    if (Current == locale) return;
+    if (Current != null)
+    {
+        VariantStore.Set(Current, false);
+        TranslationStore.Instance.UnloadLocale(Current);
+    }
+    Current = locale;
+    if (locale != null)
+    {
+        await LoadPoFilesAndApplyAsync(locale);
+    }
+    else
+    {
+        VariantStore.NotifyChangedInternal();
+        Changed?.Invoke();
+    }
+}
+
+public static async UnityEngine.Awaitable ReloadCurrentAsync()
+{
+    if (Current == null) return;
+    await ReloadCurrentAsyncInternal();
+}
+```
+
+Add the race guard inside both async helpers from Task 1.
+
+3a. In `LoadPoFilesAsync` (created in Task 1, Step 3f), add the guard after the `await PoResolver(locale)` line:
+
+```csharp
+private static async UnityEngine.Awaitable LoadPoFilesAsync(string locale)
+{
+    if (PoResolver != null)
+    {
+        var entries = await PoResolver(locale);
+        if (Current != locale) return;          // race guard: stale load
+        if (entries != null)
+            TranslationStore.Instance.Load(locale, entries);
+        return;
+    }
+    LoadPoFromResourcesPath($"PromptUGUI/i18n/{locale}", locale);
+    LoadPoFromResourcesPath($"PromptUGUI/i18n-custom/{locale}", locale);
+}
+```
+
+3b. In `LoadPoFilesAndApplyAsync` (created in Task 1, Step 3e), add the guard after `await LoadPoFilesAsync`:
+
+```csharp
+internal static async UnityEngine.Awaitable LoadPoFilesAndApplyAsync(string locale)
+{
+    await LoadPoFilesAsync(locale);
+    if (Current != locale) return;              // race guard: don't flip variant for stale
+    VariantStore.Set(locale, true);
+    Changed?.Invoke();
+}
+```
+
+Both guards are necessary: the inner one prevents stale entries entering `TranslationStore`; the outer one prevents the stale locale's variant flipping back on. Without the inner guard, a stale load would pollute `TranslationStore.Instance` (entries from a locale that's no longer current); without the outer, even with empty entries the variant would be re-activated.
+
+- [ ] **Step 4: Refresh and run the six new tests**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="LocaleSetAsyncTests")
+```
+
+Expected: all 7 tests pass (1 from Task 1 + 6 new). If `Set_rapid_consecutive_with_pending_resolver_discards_stale_load` fails specifically and the others pass, EditMode may be unable to resume `AwaitableCompletionSource` continuations without a player loop. In that case, mark the test `[Ignore("EditMode lacks player-loop SynchronizationContext for AwaitableCompletionSource continuations; covered by PlayMode follow-up")]` and proceed — the guard itself is still implemented and visually inspectable in `LoadPoFilesAsync` / `LoadPoFilesAndApplyAsync`.
+
+- [ ] **Step 5: Regression — run all EditMode locale + i18n tests**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="Locale")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="Translation")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TrResolver")
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Runtime/Application/UI.cs Tests/EditMode/Application/LocaleSetAsyncTests.cs
+git commit -m "$(cat <<'EOF'
+feat: add Locale.SetAsync / ReloadCurrentAsync with race guard
+
+Public awaitable variants for callers that need ordering. Race guard inside
+LoadPoFilesAsync + LoadPoFilesAndApplyAsync drops loads whose locale no longer
+matches Current — prevents pollution from rapid consecutive Set() calls.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `LocaleAddressableResolverHelper.cs` — tests + implementation
+
+Wires Addressables into PoResolver. Tests + implementation written together (mirrors the `AddressableIconResolverHelper` plan structure: synchronous wiring is what gets exercised in EditMode; end-to-end "label → .po → TranslationStore" verification is an EditMode-async limitation documented inline).
+
+**Files:**
+- Create: `Tests/EditMode/Addressables/LocaleAddressableResolverTests.cs`
+- Create: `Runtime/Application/LocaleAddressableResolverHelper.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/EditMode/Addressables/LocaleAddressableResolverTests.cs`:
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application;
+using UnityEditor.AddressableAssets;
+
+namespace PromptUGUI.Tests.Addressables
+{
+    /// <summary>
+    /// Wiring smoke tests for UI.Locale.UseAddressableResolver.
+    ///
+    /// End-to-end "label='zh-Hans' → .po TextAssets → TranslationStore" is NOT
+    /// tested in EditMode: AsyncOperationHandle continuations need the player-loop
+    /// SynchronizationContext, which is absent in EditMode test runners. Same
+    /// limitation documented in AddressableResolverTests. Tests here cover only
+    /// the synchronous registration prefix: PoResolver is non-null after the
+    /// call, and invoking it returns a non-null Awaitable.
+    /// </summary>
+    public class LocaleAddressableResolverTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            UI.ResetForTests();
+            // Ensure AddressableAssetSettings exists; without it
+            // Addressables.LoadAssetsAsync throws synchronously in a fresh project.
+            _ = AddressableAssetSettingsDefaultObject.Settings
+                ?? AddressableAssetSettingsDefaultObject.GetSettings(true);
+        }
+
+        [TearDown]
+        public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void UseAddressableResolver_sets_PoResolver()
+        {
+            Assert.IsNull(UI.PoResolver,
+                "PoResolver should be null after ResetForTests");
+            UI.Locale.UseAddressableResolver();
+            Assert.IsNotNull(UI.PoResolver,
+                "PoResolver should be set after UseAddressableResolver");
+        }
+
+        [Test]
+        public void PoResolver_invocation_after_register_returns_awaitable()
+        {
+            UI.Locale.UseAddressableResolver();
+            var awaitable = UI.PoResolver("zh-Hans");
+            Assert.IsNotNull(awaitable,
+                "Registered resolver should return a non-null Awaitable. " +
+                "Not awaited — EditMode has no player loop, the Addressables " +
+                "AsyncOperationHandle won't resume; TearDown's ResetForTests " +
+                "releases the handle.");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Refresh and verify the tests fail to compile**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: compile error referencing `UI.Locale.UseAddressableResolver` not found. If no error, the helper may have leaked in from an earlier task — re-check.
+
+- [ ] **Step 3: Create `LocaleAddressableResolverHelper.cs`**
+
+Create `Runtime/Application/LocaleAddressableResolverHelper.cs`:
+
+```csharp
+#if PROMPTUGUI_HAS_ADDRESSABLES
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using PromptUGUI.I18n;
+
+namespace PromptUGUI.Application
+{
+    public static partial class UI
+    {
+        public static partial class Locale
+        {
+            /// <summary>
+            /// 把 PoResolver 设为按 label=locale 加载所有 .po TextAsset 的 Addressables 实现。
+            /// Set("zh-Hans") → Addressables.LoadAssetsAsync&lt;TextAsset&gt;("zh-Hans", null)。
+            /// 仅在装了 com.unity.addressables 时存在（PROMPTUGUI_HAS_ADDRESSABLES 编译定义）。
+            ///
+            /// 注意 fire-and-forget 模型下 Set 返回后 UI 还看到 msgid，要等下载完才切译文；
+            /// 想避免闪烁用 await Locale.SetAsync(...)。
+            /// </summary>
+            public static void UseAddressableResolver()
+            {
+                PoResolver = LoadPoFromAddressablesAsync;
+            }
+
+            private static async Awaitable<IEnumerable<PoEntry>> LoadPoFromAddressablesAsync(
+                string locale)
+            {
+                var handle = Addressables.LoadAssetsAsync<TextAsset>(locale, null);
+                try
+                {
+                    var assets = await handle.Task;
+                    var entries = new List<PoEntry>();
+                    foreach (var ta in assets ?? Array.Empty<TextAsset>())
+                    {
+                        if (ta == null) continue;
+                        try
+                        {
+                            foreach (var e in PoParser.Parse(ta.text)) entries.Add(e);
+                        }
+                        catch (Exception ex)
+                        {
+                            Debug.LogError(
+                                $"[PromptUGUI] failed to parse .po asset '{ta.name}': {ex.Message}");
+                        }
+                    }
+                    return entries;
+                }
+                finally
+                {
+                    if (handle.IsValid()) Addressables.Release(handle);
+                }
+            }
+        }
+    }
+}
+#endif
+```
+
+Three things to verify visually before refreshing:
+
+1. The whole file is under `#if PROMPTUGUI_HAS_ADDRESSABLES` — `LoadPoFromAddressablesAsync` references `Addressables.LoadAssetsAsync`, which doesn't exist when the package isn't installed.
+2. The file declares `partial class UI` AND nested `partial class Locale`, both `public static`. C# requires the `partial` modifier on every declaration that splits a type — both UI (already partial elsewhere) and Locale (made partial in Task 1).
+3. Release happens in `finally` — `assets` are parsed before release because `PoParser.Parse(ta.text)` reads the TextAsset's text. Once `.text` is captured, releasing the handle is safe (the parsed `PoEntry` list doesn't hold UnityEngine.Object references).
+
+- [ ] **Step 4: Refresh and run the new tests**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode.Addressables"], filter="LocaleAddressableResolverTests")
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Regression — run all three EditMode assemblies**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode.Addressables"])
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Runtime/Application/LocaleAddressableResolverHelper.cs \
+        Tests/EditMode/Addressables/LocaleAddressableResolverTests.cs
+git commit -m "$(cat <<'EOF'
+feat: add UI.Locale.UseAddressableResolver
+
+Addressables-backed PoResolver: Set('zh-Hans') loads all TextAssets with
+Addressables label='zh-Hans', parses them, and feeds TranslationStore.
+Gated by PROMPTUGUI_HAS_ADDRESSABLES.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: SKILL.md update
+
+Per CLAUDE.md ("Public C# API surface changes" requires SKILL.md sync) and spec §5.3 / LAR-D14. Two edits in `.claude/skills/authoring-promptugui-xml/SKILL.md`: add the Addressables subsection inside the i18n section, and add the reference-table row at the bottom.
+
+**Files:**
+- Modify: `.claude/skills/authoring-promptugui-xml/SKILL.md`
+
+- [ ] **Step 1: Locate the i18n examples block**
+
+Open `.claude/skills/authoring-promptugui-xml/SKILL.md`. The i18n section starts around line 287. The code block ending with `UI.Locale.SetToSystemDefault();` is around lines 312–319. The reference table is around line 585.
+
+- [ ] **Step 2: Append the .po file location / Addressables subsection**
+
+Find this existing line (the "Reserved namespace" paragraph that closes the locale-switching example):
+
+```markdown
+**Reserved namespace**: `UI.Locale.Set("zh-Hans")` internally registers `zh-Hans` as an active Variant. Authors must NOT reuse a Variant of the same name to express anything other than locale state.
+```
+
+After that line, insert two blank lines and the following subsection:
+
+````markdown
+**.po file location**
+
+By default `.po` files live in `Assets/Resources/PromptUGUI/i18n/<locale>/` or
+`/PromptUGUI/i18n-custom/<locale>/`. Files anywhere under those paths are
+picked up by `Resources.LoadAll<TextAsset>`; subfolder names are ignored.
+
+When the project ships `.po` via Addressables, call
+`UI.Locale.UseAddressableResolver()` at boot. The resolver loads every TextAsset
+whose Addressables **label matches the locale string** (so `Locale.Set("zh-Hans")`
+loads everything labelled `zh-Hans`). Files can live anywhere. Only available
+when `com.unity.addressables` ≥ 1.0 is installed (gated by
+`PROMPTUGUI_HAS_ADDRESSABLES`).
+
+```csharp
+UI.Locale.UseAddressableResolver();
+UI.Locale.Set("zh-Hans");                  // sync; UI shows msgid briefly during download
+// or:
+await UI.Locale.SetAsync("zh-Hans");       // awaits download + parse + ReSolve
+```
+
+`Locale.Set` returns immediately after issuing the load. While the download is
+in flight, open Screens briefly fall back to msgid text; when the load
+completes the locale variant flips on and all open Screens re-resolve to the
+translated strings. `SetAsync` returns only after that re-resolve completes —
+use it when you need to read `UI.Tr(...)` immediately after switching locales.
+````
+
+- [ ] **Step 3: Update the i18n reference table**
+
+Find the table block around line 585:
+
+```markdown
+UI.Tr("...")                     C# extraction entry point
+UI.Locale.Set("zh-Hans")         switch locale (= switch .po + switch font)
+```
+
+Append two rows after the `UI.Locale.Set` line:
+
+```markdown
+UI.Locale.SetAsync("zh-Hans")    awaitable variant; completes after .po load + ReSolve
+UI.Locale.UseAddressableResolver()   load .po via Addressables, label = locale string
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/authoring-promptugui-xml/SKILL.md
+git commit -m "$(cat <<'EOF'
+docs: SKILL.md addressable locale + SetAsync
+
+Document the new Locale.UseAddressableResolver / SetAsync surface in the
+authoring guide so LLM authors discover the addressable-backed PO path.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Lint + full test sweep
+
+Per CLAUDE.md: "Always check lint after write code." Per project workflow: full EditMode + PlayMode runs before declaring done.
+
+**Files:** none modified unless lint reports something.
+
+- [ ] **Step 1: Run lint (whitespace + style + analyzers, all at warn severity)**
+
+```bash
+cd .lint && dotnet restore PromptUGUI.Lint.slnx
+dotnet format whitespace PromptUGUI.Lint.slnx
+dotnet format style       PromptUGUI.Lint.slnx
+dotnet format analyzers   PromptUGUI.Lint.slnx
+dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+Expected: `--verify-no-changes` returns exit code 0. Per CLAUDE.md, do NOT pass `--severity info` to `dotnet format analyzers` — the listed Unity-breaking auto-fixers (CA1822, CA1846, CA2016, IDE0032, IDE0044) will damage the codebase.
+
+If lint applied any whitespace/style fixes, stage and commit them separately:
+
+```bash
+cd /workspace-PromptUGUI
+git status
+git add -p   # review hunks
+git commit -m "$(cat <<'EOF'
+chore: lint pass for locale addressable resolver
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 2: Run all three EditMode test assemblies + PlayMode**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode.Addressables"])
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])
+```
+
+Expected: all green. If any test fails, do NOT proceed to the next task — diagnose using `mcp__UnityMCP__read_console(action="get", types=["error"])` and the test runner output; fix the root cause; re-run.
+
+- [ ] **Step 3: Final git status check**
+
+```bash
+git status
+git log --oneline -6
+```
+
+Expected: clean working tree; commit log shows (in order) the PoResolver async refactor, the SetAsync + race guard, the Addressables helper, the SKILL.md update, and (optionally) the lint pass.
+
+---
+
+## Notes for the executing engineer
+
+- **Test execution is via Unity MCP only.** Do not invoke `Unity.exe -batchmode` or similar. If `mcp__UnityMCP__run_tests` is unavailable, reconnect MCP or stop and ask the user.
+- **Forbidden: `mcp__UnityMCP__execute_menu_item(menu_path="Assets/Reimport All")`** — pops a blocking modal in Unity that the user must dismiss manually. Use `refresh_unity(mode="force", scope="all")` instead.
+- **After every code edit, refresh first, then `read_console` for errors before running tests.** Compile errors won't appear in the test runner output — they'll just look like missing test assemblies.
+- **Filter tests by class name** with `filter="ClassName"` (substring match) for fast iteration during red-green cycles.
+- **Locale stays sync on Resources path.** The whole point of the `AwaitableHelpers.Completed(...)` wrapping in `LoadPoFilesAsync` is to keep the existing sync-completion contract. If `LocaleSetTests` regresses (any test in there that calls `UI.Locale.Set("...")` then synchronously asserts on `UI.Tr(...)`), that contract is broken — investigate before papering over with `await SetAsync`.
+- **Race guard is two lines, two places.** `LoadPoFilesAsync` after `await PoResolver(locale)` and `LoadPoFilesAndApplyAsync` after `await LoadPoFilesAsync(locale)`. Both are needed: the inner protects TranslationStore from stale entries; the outer protects VariantStore from stale flips.
+- **AwaitableCompletionSource resumption in EditMode** is an open question — see Task 2 Step 4 fallback. If the race guard test specifically can't run in EditMode, `[Ignore]` it and document a follow-up PlayMode test rather than weakening the implementation.
+- **`AwaitableHelpers` is internal.** Test assemblies (EditMode + EditMode.Addressables + PlayMode) have `InternalsVisibleTo` from `Runtime/AssemblyInfo.cs`. External library consumers must use `AwaitableCompletionSource<T>` (public Unity 6 API) — that migration is documented in spec §7.1.
+- **Addressables call is bounded.** Unlike `UseAddressableResolver()` (documents) which loads per-key on every `LoadDocumentAsync` call, the locale resolver loads everything labelled `<locale>` at every `Set(locale)`. Caller-controlled scope: keep the per-locale `.po` count reasonable. Released immediately after parse (unlike icon resolver's permanent handle).

--- a/docs~/superpowers/specs/2026-05-12-locale-addressable-resolver-design.md
+++ b/docs~/superpowers/specs/2026-05-12-locale-addressable-resolver-design.md
@@ -1,0 +1,398 @@
+# Locale (PO) Addressable Resolver 设计
+
+**日期**：2026-05-12
+**状态**：设计阶段（待 review，未进入实施）
+**作用域**：在 `UI.Locale` 上新增 Addressables 路径的 .po 加载入口，让 user 把 .po 资产放进 Addressables 走按需下载 / 远端 CDN。把 `UI.PoResolver` 委托形状改成异步，给 `Locale.Set` / `Locale.ReloadCurrent` 增加 `*Async` 同名变体，sync 入口走 fire-and-forget。仅 Resources 默认路径行为完全不变。
+**依赖**：[`2026-05-08-i18n-fonts-design.md`](2026-05-08-i18n-fonts-design.md)（PO / Locale / Tr 流水线）+ [`2026-05-11-addressable-resolver-async-load-design.md`](2026-05-11-addressable-resolver-async-load-design.md)（Addressables helper 风格与 `PROMPTUGUI_HAS_ADDRESSABLES` 条件编译）+ [`2026-05-12-addressable-icon-resolver-design.md`](2026-05-12-addressable-icon-resolver-design.md)（`UI.OnReset` event 钩子）。
+
+---
+
+## 1. 背景
+
+`UI.UseAddressableResolver()` 接通了 `.ui.xml` → Addressables，`IconResolverHelpers.UseAddressableSpriteAtlasIconResolver()` 接通了 IconSet → Addressables。剩下的 i18n 通道目前只能从 `Resources/PromptUGUI/i18n/<locale>/`、`Resources/PromptUGUI/i18n-custom/<locale>/` 加载，不能走 Addressables。像素游戏出海后语言包按需下载是常见需求，本设计补齐这一通道。
+
+跟图标 resolver 的关键差异：
+
+1. **每个 locale 都要单独按需加载**。不像 IconSet 一次性预加载所有，PO 每切一种语言加载对应的子集 —— 所以 helper 不是"启动时预加载一次"模型，而是"`Set(locale)` 时按 label=`locale` 触发加载"模型。
+2. **`Locale.Set` 调用点不能 `await`**。今天 `Set` 是 `void`，被业务代码、UI 按钮、System Language 检测、自动初始化等等多处同步调用。强行改成 `async Awaitable` 会牵连一大片调用方。所以 sync `Set` 必须保留，内部把异步加载 fire-and-forget；同时新增 `SetAsync` 满足"等加载完再继续"的场景。
+
+---
+
+## 2. 决策一览
+
+| # | 决策 | 选择 | 理由 |
+|---|---|---|---|
+| LAR-D1 | API 入口形状 | `UI.Locale.UseAddressableResolver()` —— 无 label 参数，硬规则 `label = locale` | 跟 user 期望一致；`Set("zh-Hans")` 就是去拉 label `"zh-Hans"` 的 TextAsset。把 label namespace（"i18n/zh-Hans"）这类灵活性推迟到将来真有需求时 |
+| LAR-D2 | `PoResolver` 委托形状 | 改成 `Func<string, Awaitable<IEnumerable<PoEntry>>>` —— 异步签名 | 跟 `SourceResolver` 一样的"sync 路径返回已完成 Awaitable，async 路径返回真异步"统一模型；Resources 默认实现走 `AwaitableHelpers.Completed(...)`，对 caller 透明 |
+| LAR-D3 | `Locale.Set` 语义 | 保持 `void`，内部 fire-and-forget；sync resolver 路径整条链同步走完（已完成 Awaitable 首个 await 不让步），异步路径返回后由 player loop 回调完成 | 不破坏现有调用模式；行为退化与 `UseAddressableResolver()`/`UseResourcesResolver()` 二者之间的差异自然形成 |
+| LAR-D4 | 新增 `Locale.SetAsync` | `public static Awaitable SetAsync(string locale)` —— 真异步变体，加载完成后才 return | 给"切换后立刻 `UI.Tr` 取译文"的代码路径用；fire-and-forget 路径会在加载完成前看到 msgid 原文（短暂闪烁） |
+| LAR-D5 | 新增 `Locale.ReloadCurrentAsync` | 同理 | `ReloadCurrent` 也是 fire-and-forget 包装，`ReloadCurrentAsync` 是真异步变体；Editor 端 `UIAssetPostprocessor` 继续调 sync 版（fire-and-forget），用户代码可以 await async 版 |
+| LAR-D6 | `Set` 触发顺序 | 1) flip 旧 locale variant off + UnloadLocale → ReSolve（短暂闪烁回 msgid）；2) `Current = locale`；3) fire-and-forget 加载新 .po → `TranslationStore.Load` → flip 新 locale variant on → ReSolve（最终译文落屏）；4) `Changed?.Invoke()` 在加载完成后才触发 | 整个流程跟今天的 sync 行为对齐，只是步骤 3-4 可能在异步路径上后置；ReSolve 复用 VariantStore.Changed pipeline（`ControlAttributeApplier.cs:41,51` 在 ReSolve 里重新走 `TrResolver.Resolve(...)`），UI 文字自动更新 |
+| LAR-D7 | 资产发现方式 | `Addressables.LoadAssetsAsync<TextAsset>(locale, callback: null)` —— 按 label 拉全部 .po TextAsset | 跟 icon resolver 对称；user 在 AA Group 里给每个 .po 资产打 label = locale 字符串 |
+| LAR-D8 | 句柄生命周期 | 单次加载、加载完释放（不常驻） | 跟 doc resolver 一致（`AddressableResolverHelper.cs:54-57`）：parse 完拿到 `IEnumerable<PoEntry>` 后就 release，不需要保留 TextAsset 引用。区别于 icon resolver 的常驻句柄（icon 的 Sprite 还引用 atlas，PO 解析后是值类型不挂依赖） |
+| LAR-D9 | 加载失败语义 | `Addressables.LoadAssetsAsync` 异常 → fire-and-forget 路径里 try/catch + `Debug.LogError`（参考 `HotReload.ReloadAsyncLogged` 模式）；`SetAsync` 路径让异常 throw 到 caller | sync caller 没机会接异常；async caller 用 try/catch 包 |
+| LAR-D10 | 空结果语义 | label 命中 0 个 TextAsset → 不抛，TranslationStore 不写入该 locale，`UI.Tr` fallback 到 msgid | 跟 Resources 路径"目录下没有 .po"的行为对齐 |
+| LAR-D11 | `Locale` 变 partial | `public static partial class Locale` —— 把新 helper 拆到独立文件 | 镜像 `UseAddressableResolver()`(doc) 的"partial UI 接到独立 helper 文件"模式 |
+| LAR-D12 | 文件位置 | `Runtime/Application/LocaleAddressableResolverHelper.cs`，整文件 `#if PROMPTUGUI_HAS_ADDRESSABLES` 包住 | 镜像 `AddressableResolverHelper.cs` / `AddressableIconResolverHelper.cs` |
+| LAR-D13 | Editor 热重载 | **本期不动**。Editor 端 `UIAssetPostprocessor` 现在只识别 `Resources/PromptUGUI/i18n[-custom]/<locale>/*.po`，Addressables 路径下的 .po 修改不会触发 `ReloadCurrent`。补 Addressables guid → labels 反查留给后续 PR | 范围控制；要做的话需要类似 doc resolver 的 `_guidToKey` 反查表加上 labels 维度 |
+| LAR-D14 | SKILL.md 更新 | i18n 段落（line 287）追加 Addressables 路径示例 + 文件位置约定 | 参考 doc resolver 在 SKILL.md line 381 的写法 |
+
+---
+
+## 3. 完整使用示例
+
+启动期（Addressables 路径）：
+
+```csharp
+// 前置：项目装了 com.unity.addressables；
+//       Assets/Localization/zh-Hans/main.po 在 AA Group 里挂 label="zh-Hans"；
+//       Assets/Localization/en/main.po 挂 label="en"。
+//       label 命名跟 PromptUGUISettings.locales[].locale 字符串一一对应。
+
+UI.UseAddressableResolver();
+await IconResolverHelpers.UseAddressableSpriteAtlasIconResolver("IconSets");
+UI.Locale.UseAddressableResolver();
+
+UI.Locale.Set("zh-Hans");     // fire-and-forget；界面短暂回落 msgid，下载完后自动切到译文
+// 或：await UI.Locale.SetAsync("zh-Hans");  // 等加载完再继续，无闪烁
+
+await UI.LoadDocumentAsync("screens/MainMenu");
+UI.Open("MainMenu");
+```
+
+切语言：
+
+```csharp
+UI.Locale.Set("en");  // 旧 zh-Hans translation unload → 异步拉 en label → 加载完 ReSolve
+```
+
+---
+
+## 4. 公开 API 表
+
+| 状态 | 签名 | 说明 |
+|---|---|---|
+| **改签名** | `public static Func<string, Awaitable<IEnumerable<PoEntry>>> UI.PoResolver` | 旧 `Func<string, IEnumerable<PoEntry>>`。破坏性，详见 §7 |
+| 新增 | `public static void UI.Locale.UseAddressableResolver()` | 仅在 `PROMPTUGUI_HAS_ADDRESSABLES` 下可见；label = locale |
+| 不变 | `public static void UI.Locale.Set(string locale)` | 行为 sync 入口；Resources 默认路径下与今天完全等价；Addressables 路径下加载部分变 fire-and-forget |
+| 新增 | `public static Awaitable UI.Locale.SetAsync(string locale)` | 等到 .po 加载 + Translation 入库 + Variant 翻转 + Changed 触发完后才 return |
+| 不变 | `public static void UI.Locale.ReloadCurrent()` | 同 Set 的退化模型 |
+| 新增 | `public static Awaitable UI.Locale.ReloadCurrentAsync()` | 同 SetAsync |
+| 不变 | `public static event Action UI.Locale.Changed` | 加载完成后才触发（Addressables 路径） |
+
+---
+
+## 5. 落地细节
+
+### 5.1 `UI.cs` 修改要点
+
+```csharp
+// 改签名：
+public static Func<string, Awaitable<IEnumerable<I18n.PoEntry>>> PoResolver { get; set; }
+
+public static partial class Locale   // 加 partial
+{
+    public static void Set(string locale)
+    {
+        if (Current == locale) return;
+        if (Current != null)
+        {
+            VariantStore.Set(Current, false);              // 先广播一次：界面回 msgid
+            TranslationStore.Instance.UnloadLocale(Current);
+        }
+        Current = locale;
+        if (locale != null)
+        {
+            _ = LoadPoFilesAndApplyAsyncLogged(locale);   // fire-and-forget
+        }
+        else
+        {
+            VariantStore.NotifyChangedInternal();
+            Changed?.Invoke();
+        }
+    }
+
+    public static async Awaitable SetAsync(string locale)
+    {
+        if (Current == locale) return;
+        if (Current != null)
+        {
+            VariantStore.Set(Current, false);
+            TranslationStore.Instance.UnloadLocale(Current);
+        }
+        Current = locale;
+        if (locale != null)
+        {
+            await LoadPoFilesAndApplyAsync(locale);
+        }
+        else
+        {
+            VariantStore.NotifyChangedInternal();
+            Changed?.Invoke();
+        }
+    }
+
+    public static void ReloadCurrent()
+    {
+        if (Current == null) return;
+        _ = ReloadCurrentAsyncLogged();
+    }
+
+    public static async Awaitable ReloadCurrentAsync()
+    {
+        if (Current == null) return;
+        TranslationStore.Instance.UnloadLocale(Current);
+        await LoadPoFilesAndApplyAsync(Current);
+    }
+
+    // 两个 async 实现：
+    private static async Awaitable LoadPoFilesAndApplyAsync(string locale)
+    {
+        await LoadPoFilesAsync(locale);
+        if (Current != locale) return;    // raced by另一次 Set；丢弃本次结果
+        VariantStore.Set(locale, true);   // 触发 ReSolve；UI 文字最终落屏
+        Changed?.Invoke();
+    }
+
+    private static async Awaitable LoadPoFilesAndApplyAsyncLogged(string locale)
+    {
+        try { await LoadPoFilesAndApplyAsync(locale); }
+        catch (Exception e)
+        {
+            UnityEngine.Debug.LogError($"[PromptUGUI] locale load failed for '{locale}': {e}");
+        }
+    }
+
+    private static async Awaitable ReloadCurrentAsyncLogged()
+    {
+        try { await ReloadCurrentAsync(); }
+        catch (Exception e)
+        {
+            UnityEngine.Debug.LogError(
+                $"[PromptUGUI] locale reload failed for '{Current}': {e}");
+        }
+    }
+}
+
+private static async Awaitable LoadPoFilesAsync(string locale)
+{
+    if (PoResolver != null)
+    {
+        var entries = await PoResolver(locale);
+        if (Current != locale) return;    // raced；不污染 TranslationStore
+        if (entries != null)
+            TranslationStore.Instance.Load(locale, entries);
+        return;
+    }
+    LoadPoFromResourcesPath($"PromptUGUI/i18n/{locale}", locale);
+    LoadPoFromResourcesPath($"PromptUGUI/i18n-custom/{locale}", locale);
+}
+```
+
+`LoadPoFromResourcesPath` 是原 `LoadPoFromPath` 改名（语义没变，只是同步路径下的 .po 解析）。
+
+### 5.2 `LocaleAddressableResolverHelper.cs`（新文件）
+
+```csharp
+#if PROMPTUGUI_HAS_ADDRESSABLES
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using PromptUGUI.I18n;
+
+namespace PromptUGUI.Application
+{
+    public static partial class UI
+    {
+        public static partial class Locale
+        {
+            /// <summary>
+            /// 把 PoResolver 设为按 label=locale 加载所有 .po TextAsset 的 Addressables 实现。
+            /// Set("zh-Hans") → Addressables.LoadAssetsAsync&lt;TextAsset&gt;("zh-Hans", null)。
+            /// 仅在装了 com.unity.addressables 时存在（PROMPTUGUI_HAS_ADDRESSABLES 编译定义）。
+            ///
+            /// 注意 fire-and-forget 模型下 Set 返回后 UI 还看到 msgid，要等下载完才切译文；
+            /// 想避免闪烁用 await Locale.SetAsync(...)。
+            /// </summary>
+            public static void UseAddressableResolver()
+            {
+                PoResolver = LoadPoFromAddressablesAsync;
+            }
+
+            private static async Awaitable<IEnumerable<PoEntry>> LoadPoFromAddressablesAsync(
+                string locale)
+            {
+                var handle = Addressables.LoadAssetsAsync<TextAsset>(locale, null);
+                try
+                {
+                    var assets = await handle.Task;
+                    var entries = new List<PoEntry>();
+                    foreach (var ta in assets ?? Array.Empty<TextAsset>())
+                    {
+                        if (ta == null) continue;
+                        try
+                        {
+                            foreach (var e in PoParser.Parse(ta.text)) entries.Add(e);
+                        }
+                        catch (Exception ex)
+                        {
+                            Debug.LogError(
+                                $"[PromptUGUI] failed to parse .po asset '{ta.name}': {ex.Message}");
+                        }
+                    }
+                    return entries;
+                }
+                finally
+                {
+                    if (handle.IsValid()) Addressables.Release(handle);
+                }
+            }
+        }
+    }
+}
+#endif
+```
+
+### 5.3 SKILL.md 更新
+
+在 i18n 段落（line 287 起）`UI.Locale.Set("en")` 示例之后追加：
+
+````markdown
+**.po file location**
+
+By default `.po` files live in `Assets/Resources/PromptUGUI/i18n/<locale>/` or
+`/PromptUGUI/i18n-custom/<locale>/`. Files anywhere under those paths are picked
+up; subfolder names are ignored.
+
+When the project ships .po via Addressables, call `UI.Locale.UseAddressableResolver()`
+at boot. The resolver loads all TextAssets whose Addressables label matches the
+locale string (so `Locale.Set("zh-Hans")` loads everything labelled `zh-Hans`).
+Files can live anywhere. Only available when `com.unity.addressables` ≥ 1.0 is
+installed (gated by `PROMPTUGUI_HAS_ADDRESSABLES`).
+
+```csharp
+UI.Locale.UseAddressableResolver();
+UI.Locale.Set("zh-Hans");                  // sync; UI flashes msgid briefly during download
+// or:
+await UI.Locale.SetAsync("zh-Hans");       // awaits download + parse + ReSolve
+```
+````
+
+---
+
+## 6. 测试策略
+
+### 6.1 新文件 `Tests/EditMode/Addressables/LocaleAddressableResolverTests.cs`
+
+沿用 `AddressableResolverTests.cs` 的 EditMode 异步限制说明（class-level comment）。
+
+| 测试 | 断言 |
+|---|---|
+| `UseAddressableResolver_sets_po_resolver` | 调用前 `UI.PoResolver` 为 null（`ResetForTests` 已置 null）；调用后非 null |
+| `UseAddressableResolver_then_PoResolver_invocation_returns_an_awaitable` | 调用 `UI.PoResolver("zh-Hans")` 返回非 null `Awaitable<IEnumerable<PoEntry>>`；不 await（EditMode 限制） |
+
+### 6.2 新文件 `Tests/EditMode/Application/LocaleSetAsyncTests.cs`
+
+不依赖 Addressables；用 fake 异步 resolver 验证 `Set` / `SetAsync` 时序契约。
+
+| 测试 | 断言 |
+|---|---|
+| `Set_with_sync_completed_PoResolver_loads_synchronously` | fake resolver 返回 `AwaitableHelpers.Completed(entries)` → `Set("en")` 返回后 `UI.Tr` 立刻拿到译文（Resources 退化路径回归测试） |
+| `Set_with_deferred_PoResolver_does_not_load_before_Set_returns` | fake resolver 返回挂起的 `AwaitableCompletionSource` → `Set("en")` 返回后 `UI.Tr` 还看不到译文；手动 `SetResult` → 等一帧（或同步推进 player loop） → `UI.Tr` 看到译文 |
+| `SetAsync_with_deferred_PoResolver_completes_only_after_load` | `await SetAsync("en")` 在 `SetResult` 之前不返回；返回后 `UI.Tr` 立刻拿到译文 |
+| `Set_async_path_logs_error_on_resolver_throw` | fake resolver 在 await 后抛 → fire-and-forget 路径捕获并 `Debug.LogError`（用 `LogAssert.Expect`） |
+| `SetAsync_path_throws_on_resolver_throw` | `await SetAsync(...)` 抛出 resolver 的异常 |
+| `Set_triggers_two_variant_changed_events_on_locale_switch` | 第一次广播是 flip 旧 off（旧 locale 退场），第二次是 flip 新 on（加载完）；订阅 `VariantStore.Changed` 计数 |
+| `Set_rapid_consecutive_with_async_resolver_discards_stale_load` | `Set("zh")` 挂起；`Set("en")`；`SetResult` 让 zh 加载完成 → zh 译文不入 TranslationStore，zh variant 不被翻回 on；只有 en 完成时 UI 才切到 en 译文 |
+
+### 6.3 现有测试迁移
+
+| 文件 | 改动 |
+|---|---|
+| `Tests/PlayMode/E2E/I18nHotReloadTests.cs:22` | `UI.PoResolver = _ => Enumerable.Empty<PoEntry>()` → `UI.PoResolver = _ => AwaitableHelpers.Completed<IEnumerable<PoEntry>>(Array.Empty<PoEntry>())` |
+| `Tests/PlayMode/E2E/I18nFontSwapTests.cs:31` | 同上 |
+
+`AwaitableHelpers` 是 internal，PlayMode 测试通过 `InternalsVisibleTo` 已经能访问（`Runtime/AssemblyInfo.cs` 已暴露给 `PromptUGUI.Tests.PlayMode`）。
+
+### 6.4 Locale 测试 setup/teardown
+
+`LocaleAddressableResolverTests` 跟 `AddressableResolverTests` 一样在 `[SetUp]` / `[TearDown]` 调 `UI.ResetForTests()`；`ResetForTests` 已经把 `PoResolver` 置 null（`UI.cs:429`），不需要新加 cleanup 逻辑。
+
+---
+
+## 7. 迁移与破坏性影响
+
+### 7.1 `UI.PoResolver` 签名变化
+
+旧：`Func<string, IEnumerable<PoEntry>>`
+新：`Func<string, Awaitable<IEnumerable<PoEntry>>>`
+
+外部 caller 迁移：
+
+```csharp
+// 旧
+UI.PoResolver = locale => MyEntries(locale);
+
+// 新（用 Unity 6 公开的 AwaitableCompletionSource）
+UI.PoResolver = locale => {
+    var src = new AwaitableCompletionSource<IEnumerable<PoEntry>>();
+    src.SetResult(MyEntries(locale));
+    return src.Awaitable;
+};
+```
+
+仓库内部受影响：
+
+- `Tests/PlayMode/E2E/I18nHotReloadTests.cs:22`
+- `Tests/PlayMode/E2E/I18nFontSwapTests.cs:31`
+
+两处都改成用 `AwaitableHelpers.Completed<IEnumerable<PoEntry>>(Array.Empty<PoEntry>())`（详见 §6.3）。
+
+### 7.2 `Locale.Set` 行为变化
+
+Resources 默认路径：完全无感知。`AwaitableHelpers.Completed` 让首个 `await` 不让步，整条 async 链同步走完，外部观察跟今天的 sync `Set` 完全一致。
+
+Addressables 路径：`Set` 返回后 UI 短暂回落 msgid，下载完后自动 ReSolve 到译文。想避免闪烁用 `await SetAsync`。
+
+### 7.3 SKILL.md
+
+详见 §5.3，仅在 i18n 段落追加一小节，不动现有内容。
+
+### 7.4 Samples~
+
+Samples~/MainMenu 不动。本次新示例不放进 sample，避免给 sample 加 Addressables 依赖。
+
+---
+
+## 8. 非目标 / 推迟
+
+- **Editor 热重载**（LAR-D13）：Addressables 路径下保存 .po 不触发 `ReloadCurrent`。补这个要在 `UIAssetPostprocessor` 加 `guid → AA labels` 反查，类似 `AddressableResolverHelper.BuildAddressablesReverseMapping` 但多一个 labels 维度。留给后续 PR。
+- **多 label 合并加载**：`UseAddressableResolver(string[] labels)` 之类的扩展（按多 label `Or` / `And` 加载）—— 单 label 已覆盖 90% 场景，按需再扩。
+- **Locale fallback chain**：`Set("zh-Hans-CN")` 自动回落 `zh-Hans` 等 BCP-47 父语言 —— 跟 Addressables 无关，是 `LocaleHelpers` 层面的事，独立设计。
+- **Fonts 通道走 Addressables**：当前字体走 `PromptUGUISettings.fonts[].Locales[].font` 直接引用，依赖 Unity 序列化打包；如果将来要走 Addressables，新开设计。
+
+---
+
+## 9. 风险
+
+| 风险 | 影响 | 缓解 |
+|---|---|---|
+| Set fire-and-forget 路径短暂闪烁 msgid | 视觉体验：第一帧或多帧（取决于下载速度）显示英文 / 原文 | 文档明示；提供 SetAsync 给 caller 选择；推荐配合 loading 遮罩 |
+| `Addressables.LoadAssetsAsync<TextAsset>` 在 label 命中 0 个时的返回值不稳定 | 空 list 路径分支挂掉 | `assets ?? Array.Empty<TextAsset>()` 兜底（参考 icon resolver 同样的护栏） |
+| fire-and-forget 路径的异常进 `Debug.LogError`，sync caller 不知道加载失败 | 静默失败：UI 一直显示 msgid | caller 可监听 `Locale.Changed` 检测加载完成；或者用 `SetAsync` 在 try/catch 里接异常 |
+| 用户在 Addressables 里给 .po 打了拼错的 label（比如 `zh_Hans` vs `zh-Hans`） | 加载结果为空，UI 看不到译文 | Addressables 标签拼错没办法运行时检测；推荐配套一个 Editor 校验工具（非本 PR） |
+| `Locale.Set` 同步快连发（`Set("zh"); Set("en");`） | 异步加载乱序 → 后到的可能覆盖先到的，但 `Current` 已经是 `"en"`，覆盖到错 locale | `LoadPoFilesAndApplyAsync` 内部对比 `Current`，如果不一致就丢弃结果。**实施时加这个守卫** |
+| Domain reload / Play stop 时未完成的 Addressables handle 没显式 release | Addressables 内部 ref count 不清；进程退出 OS 回收 | 不缓解；与现有 doc resolver 一致 |
+
+---
+
+## 10. 实施粒度（提示）
+
+writing-plans 阶段细化，大致 5 块：
+
+1. **改 `UI.PoResolver` 签名 + 迁移 2 处 test 用例**（先红：测试编译失败 → 改实现 → 绿）
+2. **`UI.Locale.Set` / `SetAsync` / `ReloadCurrent` / `ReloadCurrentAsync` 实现**（含 fire-and-forget 守卫 §9 的 `Current` 不一致丢弃；先写 `LocaleSetAsyncTests` 红 → 实现绿）
+3. **`LocaleAddressableResolverHelper.cs` 新文件 + `LocaleAddressableResolverTests` smoke**（红 → 绿）
+4. **SKILL.md 更新**（i18n 段落加 Addressables 子段；line 585 reference 表加 `UseAddressableResolver` 一行）
+5. **lint pass + Unity MCP `refresh_unity` + `run_tests` 三个 assembly 全跑过**


### PR DESCRIPTION
## Summary

Adds `UI.Locale.UseAddressableResolver()` so `.po` translation files can ship via Addressables (label = locale string), completing the trio alongside `UI.UseAddressableResolver()` (documents) and `UseAddressableSpriteAtlasIconResolver()` (icons).

- **`UI.PoResolver` is now async-shaped**: `Func<string, Awaitable<IEnumerable<PoEntry>>>`. Resources path (default) keeps sync semantics via `AwaitableHelpers.Completed(...)`; no behavior change for existing callers.
- **`UI.Locale.Set(locale)` stays `void`** — fire-and-forget under the hood. UI briefly falls back to msgid during async download, then re-resolves to translated text automatically when the load completes. Adds **`UI.Locale.SetAsync(...)`** (+ `ReloadCurrentAsync`) for callers that need ordering (no flicker).
- **Race guard**: rapid consecutive `Set("zh"); Set("en");` discards the stale `zh` load when it eventually resolves (`if (Current != locale) return;` at two positions inside the async chain).
- **`Runtime/Application/LocaleAddressableResolverHelper.cs`**: gated by `PROMPTUGUI_HAS_ADDRESSABLES`; `Set("zh-Hans")` → `Addressables.LoadAssetsAsync<TextAsset>("zh-Hans", null)` → parse all → release.

Spec: [`docs~/superpowers/specs/2026-05-12-locale-addressable-resolver-design.md`](docs~/superpowers/specs/2026-05-12-locale-addressable-resolver-design.md)
Plan: [`docs~/superpowers/plans/2026-05-12-locale-addressable-resolver.md`](docs~/superpowers/plans/2026-05-12-locale-addressable-resolver.md)

## Breaking change

`UI.PoResolver` signature changed from `Func<string, IEnumerable<PoEntry>>` to `Func<string, Awaitable<IEnumerable<PoEntry>>>`. External callers wrap their sync result in a completed Awaitable via `AwaitableCompletionSource<T>` (Unity 6 public API). Migration documented in spec §7.1; SKILL.md updated.

## Non-goals (deferred)

- Editor `.po` hot reload via Addressables (`UIAssetPostprocessor` only watches Resources path; spec §LAR-D13).
- Multi-label resolver, locale fallback chain, fonts-via-Addressables.

## Test Plan

- [x] Lint: `dotnet format --verify-no-changes --severity warn` exit 0
- [x] EditMode: 379/379
- [x] EditorOnly: 100/100
- [x] EditMode.Addressables: 10/10 (incl. 2 new `LocaleAddressableResolverTests`)
- [x] PlayMode: 69/69
- [x] New `LocaleSetAsyncTests`: 7/7 (sync-completion regression, SetAsync await semantics, fire-and-forget error logging, race guard with `AwaitableCompletionSource` manual resumption, `ReloadCurrentAsync` reload + null no-op)
- [x] SKILL.md updated with `.po file location` subsection + reference-table rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)