### PR TITLE
feat: add <SafeArea> built-in control

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -63,7 +63,7 @@ mcp__UnityMCP__read_console(action="get", types=["error","warning"])
 
 `<Import>`, `<Screen>`, `<Template>` are the **only** elements allowed at the top level. Comments use standard `<!-- -->`.
 
-## Built-in primitives (13)
+## Built-in primitives (14)
 
 **默认视觉主题**：白底 sliced + #323232 深字（与 Unity 6 `GameObject → UI → …` 创建出来的标准 prefab 一致）。所有控件的颜色/sprite 都能通过 `color=` / `sprite=` 属性 override；想要彻底深色主题项目级覆写 `ProceduralBuilders` 的常量，或用 Variant 方式 `color.dark="..."`。
 
@@ -72,6 +72,7 @@ Pre-registered on `UI.Registry`. Use as XML tags by name:
 | Tag            | Notes                                                                                                                                                                                                                                                        | Tag-specific attributes                                                                                                                                                                                                                                                                                             |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `<Frame>`      | Empty container (RectTransform only).                                                                                                                                                                                                                        | —                                                                                                                                                                                                                                                                                                                   |
+| `<SafeArea>`   | Stretches to `Screen.safeArea` (notch / status bar / home indicator). Auto-reacts to rotation, window resize, Device Simulator. **Rejects** `anchor` / `size` / `width` / `height` / `margin` / `pivot` (incl. `.variant`); see "Safe area" section below.   | —                                                                                                                                                                                                                                                                                                                   |
 | `<Image>`      | uGUI Image; loads sprites from `Resources`.                                                                                                                                                                                                                  | `sprite` (resource path), `color` (`#RRGGBB[AA]`), `type` (`simple` / `sliced` / `tiled` / `filled`)                                                                                                                                                                                                                |
 | `<Text>`       | TMP_Text. Has text-content shorthand: `<Text>Hello</Text>` ≡ `<Text text="Hello"/>`.                                                                                                                                                                         | `text`, `fontSize` (int), `color`, `align` (`left` / `center` / `right`), `wrap` (bool), `raycastTarget` (bool), `font` (string, font type from Settings; default `default`), `tr` (bool, default `true`; set `false` to skip i18n extraction), `ctx` (string, msgctxt to disambiguate same-msgid in the .po table) |
 | `<VStack>`     | Vertical layout group. Default `childAlign="upper-center"` (cross-axis centered).                                                                                                                                                                            | `spacing` (float), `padding` (`T,R,B,L` 1/2/4 components), `childAlign` (`upper/middle/lower-left/center/right`; `center` alias for `middle-center`)                                                                                                                                                                |
@@ -135,6 +136,29 @@ Icon name in XML = PNG path **relative to the IconSet's sourceFolder**, with `/`
 - Partial placeholder — `<Icon name="solar:{{x}}"/>`. Treats each invocation arg as the icon-name half, paired with the literal `solar` set.
 
 Anything else inside a Template body (`{{a}}:{{b}}`, `solar:{{a}}-{{b}}`, multi-placeholder) is unanalyzable — the syncer logs a warning. Same for forwarded args (one Template's Param fed verbatim into another's). For unanalyzable cases, list final values in `IconSet.alwaysInclude`. Outside a `<Template>` (a literal `<Icon name="ui:{{x}}"/>` directly in a Screen) is always unanalyzable too.
+
+### Safe area
+
+Mobile devices have unsafe insets — notch, status bar, home indicator, gesture bar. Wrap your UI in `<SafeArea>` to stay inside `Screen.safeArea`. Backgrounds that should bleed to the device edges stay outside, as siblings of `<SafeArea>`:
+
+```xml
+<Screen name="Login">
+  <Image id="bg" anchor="stretch" color="#0B1828"/>
+  <SafeArea>
+    <HStack id="brandBar" anchor="top-left" width="320" height="56" margin="24,_,_,24">
+      ...
+    </HStack>
+  </SafeArea>
+</Screen>
+```
+
+Rules:
+
+- `<SafeArea>` is always stretched to the safe area; it does **not** accept `anchor`, `size`, `width`, `height`, `margin`, or `pivot` (including their `.variant` override forms). Writing any of those is a parse error.
+- To add inner padding inside the safe area, wrap content in `<Frame anchor="stretch" margin="..."/>` *inside* the `<SafeArea>`.
+- Place `<SafeArea>` as a direct child of `<Screen>`. Nesting another `<SafeArea>` inside one is harmless but redundant (the inner one collapses to the outer one's rect).
+- Don't put `<SafeArea>` inside `<VStack>` / `<HStack>` / `<Grid>` — the layout group will override its anchor math.
+- Reacts automatically to screen rotation, window resize, and Unity 6's Device Simulator. No code-side wiring needed.
 
 ## Common attributes (any tag)
 

--- a/Runtime/Application/BuiltinPrimitives.cs
+++ b/Runtime/Application/BuiltinPrimitives.cs
@@ -8,6 +8,7 @@ namespace PromptUGUI.Application
         public static void Register(ControlRegistry reg)
         {
             reg.Register<Frame>("Frame", null);
+            reg.Register<SafeArea>("SafeArea", null);
             reg.Register<Image>("Image", null);
             reg.Register<Icon>("Icon", null);
             reg.Register<Text>("Text", null, defaultTextAttr: "text");

--- a/Runtime/Application/ControlAttributeApplier.cs
+++ b/Runtime/Application/ControlAttributeApplier.cs
@@ -66,6 +66,7 @@ namespace PromptUGUI.Application
             var interactable = interactableStr != "false";
 
             control.ApplyCommon(anchor, size, width, height, margin, pivot, hidden, interactable);
+            control.OnAfterApply();
         }
 
         public static bool IsCommonAttribute(string name)

--- a/Runtime/Controls/Control.cs
+++ b/Runtime/Controls/Control.cs
@@ -38,6 +38,13 @@ namespace PromptUGUI.Controls
 
         public virtual void OnAttached() { }
 
+        /// <summary>
+        /// 在 <see cref="ControlAttributeApplier"/> 调用 <see cref="ApplyCommon"/> 之后再触发一次，
+        /// 让一些控件在 Variant ReSolve / 初始 Apply 完成后做"恢复其它逻辑写入的 RectTransform / 组件状态"
+        /// 这类收尾。默认实现为空；目前只有 SafeArea 重写。
+        /// </summary>
+        internal virtual void OnAfterApply() { }
+
         internal void AddChild(IControl child) => _children.Add(child);
 
         public IReadOnlyList<IControl> Children => _children;

--- a/Runtime/Controls/Internal/SafeAreaTracker.cs
+++ b/Runtime/Controls/Internal/SafeAreaTracker.cs
@@ -39,10 +39,13 @@ namespace PromptUGUI.Controls.Internal
             var aMin = new Vector2(safe.xMin / screenSize.x, safe.yMin / screenSize.y);
             var aMax = new Vector2(safe.xMax / screenSize.x, safe.yMax / screenSize.y);
 
-            _rt.anchorMin = aMin;
-            _rt.anchorMax = aMax;
-            _rt.offsetMin = Vector2.zero;
-            _rt.offsetMax = Vector2.zero;
+            // 写之前比较一次：避免 OnRectTransformDimensionsChange → Apply → 写 RectTransform →
+            // 再次触发 OnRectTransformDimensionsChange 的回环（PlayMode 下 LayoutRebuilder
+            // 会把这条链路放大成实际死循环）。
+            if (_rt.anchorMin != aMin) _rt.anchorMin = aMin;
+            if (_rt.anchorMax != aMax) _rt.anchorMax = aMax;
+            if (_rt.offsetMin != Vector2.zero) _rt.offsetMin = Vector2.zero;
+            if (_rt.offsetMax != Vector2.zero) _rt.offsetMax = Vector2.zero;
         }
     }
 }

--- a/Runtime/Controls/Internal/SafeAreaTracker.cs
+++ b/Runtime/Controls/Internal/SafeAreaTracker.cs
@@ -1,0 +1,48 @@
+using System;
+using UnityEngine;
+
+namespace PromptUGUI.Controls.Internal
+{
+    [DisallowMultipleComponent]
+    internal sealed class SafeAreaTracker : MonoBehaviour
+    {
+        // 仅测试注入：默认 null → 走真实 Screen.safeArea / Screen.width|height
+        internal static Func<Rect> SafeAreaOverride;
+        internal static Func<Vector2> ScreenSizeOverride;
+
+        private RectTransform _rt;
+
+        private void OnEnable()
+        {
+            _rt = transform as RectTransform;
+            Apply();
+        }
+
+        private void OnRectTransformDimensionsChange()
+        {
+            if (_rt == null) return;
+            Apply();
+        }
+
+        internal void Apply()
+        {
+            if (_rt == null) _rt = transform as RectTransform;
+            if (_rt == null) return;
+
+            var safe = SafeAreaOverride != null ? SafeAreaOverride() : Screen.safeArea;
+            var screenSize = ScreenSizeOverride != null
+                ? ScreenSizeOverride()
+                : new Vector2(Screen.width, Screen.height);
+
+            if (screenSize.x <= 0f || screenSize.y <= 0f) return;
+
+            var aMin = new Vector2(safe.xMin / screenSize.x, safe.yMin / screenSize.y);
+            var aMax = new Vector2(safe.xMax / screenSize.x, safe.yMax / screenSize.y);
+
+            _rt.anchorMin = aMin;
+            _rt.anchorMax = aMax;
+            _rt.offsetMin = Vector2.zero;
+            _rt.offsetMax = Vector2.zero;
+        }
+    }
+}

--- a/Runtime/Controls/Internal/SafeAreaTracker.cs
+++ b/Runtime/Controls/Internal/SafeAreaTracker.cs
@@ -11,6 +11,9 @@ namespace PromptUGUI.Controls.Internal
         internal static Func<Vector2> ScreenSizeOverride;
 
         private RectTransform _rt;
+        private Rect _lastSafe;
+        private Vector2 _lastScreenSize;
+        private bool _hasApplied;
 
         private void OnEnable()
         {
@@ -18,10 +21,20 @@ namespace PromptUGUI.Controls.Internal
             Apply();
         }
 
-        private void OnRectTransformDimensionsChange()
+        private void Update()
         {
-            if (_rt == null) return;
-            Apply();
+            // 跟 Unity 官方 SafeArea 示例对齐：每帧 poll，只在 safeArea / 分辨率
+            // 真的变了时写。不订阅 OnRectTransformDimensionsChange —— 那条路径会跟
+            // ApplyCommon / RectTransform setter 内部反向求解形成写入循环（已观测：
+            // anchor 改写后 Unity 让 offset 留下亚像素到 ~0.65px 的残值，再触发回写，
+            // 卡在 var screen = UI.Open(...) 的 InstantiateRecursive 阶段）。
+            var safe = SafeAreaOverride != null ? SafeAreaOverride() : Screen.safeArea;
+            var screenSize = ScreenSizeOverride != null
+                ? ScreenSizeOverride()
+                : new Vector2(Screen.width, Screen.height);
+
+            if (!_hasApplied || safe != _lastSafe || screenSize != _lastScreenSize)
+                Apply();
         }
 
         internal void Apply()
@@ -36,29 +49,17 @@ namespace PromptUGUI.Controls.Internal
 
             if (screenSize.x <= 0f || screenSize.y <= 0f) return;
 
+            _lastSafe = safe;
+            _lastScreenSize = screenSize;
+            _hasApplied = true;
+
             var aMin = new Vector2(safe.xMin / screenSize.x, safe.yMin / screenSize.y);
             var aMax = new Vector2(safe.xMax / screenSize.x, safe.yMax / screenSize.y);
 
-            // 写之前比较一次：避免 OnRectTransformDimensionsChange → Apply → 写 RectTransform →
-            // 再次触发 OnRectTransformDimensionsChange 的回环。
-            //
-            // 必须用宽容差：Unity 的 Vector2.== 阈值是 sqrMagnitude < 1e-10（约边长 1e-5），
-            // 但 anchor 改写后 RectTransform 上 offset 会留下 ~7.5e-5 的 float 残留 ——
-            // 比 Vector2.== 阈值大两个量级，比较直接相等会永远写、永远循环。
-            // 用按维度的绝对容差：anchor 是 [0,1] 分数，0.0001 容差对应 1920 屏上 < 0.2 像素；
-            // offset 是像素量纲，0.5 容差正好亚像素。
-            if (NotApprox(_rt.anchorMin, aMin, kAnchorEpsilon)) _rt.anchorMin = aMin;
-            if (NotApprox(_rt.anchorMax, aMax, kAnchorEpsilon)) _rt.anchorMax = aMax;
-            if (NotApprox(_rt.offsetMin, Vector2.zero, kOffsetEpsilon)) _rt.offsetMin = Vector2.zero;
-            if (NotApprox(_rt.offsetMax, Vector2.zero, kOffsetEpsilon)) _rt.offsetMax = Vector2.zero;
-        }
-
-        private const float kAnchorEpsilon = 1e-4f;
-        private const float kOffsetEpsilon = 0.5f;
-
-        private static bool NotApprox(Vector2 a, Vector2 b, float eps)
-        {
-            return Mathf.Abs(a.x - b.x) > eps || Mathf.Abs(a.y - b.y) > eps;
+            _rt.anchorMin = aMin;
+            _rt.anchorMax = aMax;
+            _rt.offsetMin = Vector2.zero;
+            _rt.offsetMax = Vector2.zero;
         }
     }
 }

--- a/Runtime/Controls/Internal/SafeAreaTracker.cs
+++ b/Runtime/Controls/Internal/SafeAreaTracker.cs
@@ -40,12 +40,25 @@ namespace PromptUGUI.Controls.Internal
             var aMax = new Vector2(safe.xMax / screenSize.x, safe.yMax / screenSize.y);
 
             // 写之前比较一次：避免 OnRectTransformDimensionsChange → Apply → 写 RectTransform →
-            // 再次触发 OnRectTransformDimensionsChange 的回环（PlayMode 下 LayoutRebuilder
-            // 会把这条链路放大成实际死循环）。
-            if (_rt.anchorMin != aMin) _rt.anchorMin = aMin;
-            if (_rt.anchorMax != aMax) _rt.anchorMax = aMax;
-            if (_rt.offsetMin != Vector2.zero) _rt.offsetMin = Vector2.zero;
-            if (_rt.offsetMax != Vector2.zero) _rt.offsetMax = Vector2.zero;
+            // 再次触发 OnRectTransformDimensionsChange 的回环。
+            //
+            // 必须用宽容差：Unity 的 Vector2.== 阈值是 sqrMagnitude < 1e-10（约边长 1e-5），
+            // 但 anchor 改写后 RectTransform 上 offset 会留下 ~7.5e-5 的 float 残留 ——
+            // 比 Vector2.== 阈值大两个量级，比较直接相等会永远写、永远循环。
+            // 用按维度的绝对容差：anchor 是 [0,1] 分数，0.0001 容差对应 1920 屏上 < 0.2 像素；
+            // offset 是像素量纲，0.5 容差正好亚像素。
+            if (NotApprox(_rt.anchorMin, aMin, kAnchorEpsilon)) _rt.anchorMin = aMin;
+            if (NotApprox(_rt.anchorMax, aMax, kAnchorEpsilon)) _rt.anchorMax = aMax;
+            if (NotApprox(_rt.offsetMin, Vector2.zero, kOffsetEpsilon)) _rt.offsetMin = Vector2.zero;
+            if (NotApprox(_rt.offsetMax, Vector2.zero, kOffsetEpsilon)) _rt.offsetMax = Vector2.zero;
+        }
+
+        private const float kAnchorEpsilon = 1e-4f;
+        private const float kOffsetEpsilon = 0.5f;
+
+        private static bool NotApprox(Vector2 a, Vector2 b, float eps)
+        {
+            return Mathf.Abs(a.x - b.x) > eps || Mathf.Abs(a.y - b.y) > eps;
         }
     }
 }

--- a/Runtime/Controls/Internal/SafeAreaTracker.cs.meta
+++ b/Runtime/Controls/Internal/SafeAreaTracker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b5ca96a796ca1274b8d4535f262d7a03

--- a/Runtime/Controls/SafeArea.cs
+++ b/Runtime/Controls/SafeArea.cs
@@ -10,5 +10,12 @@ namespace PromptUGUI.Controls
         {
             _tracker = GameObject.AddComponent<SafeAreaTracker>();
         }
+
+        internal override void OnAfterApply()
+        {
+            // ApplyCommon 在初次实例化和 Variant ReSolve 时都会重写 anchorMin/Max,
+            // tracker 必须立刻补一次，否则 ReSolve 后会有一帧 stretch-default 闪烁。
+            if (_tracker != null) _tracker.Apply();
+        }
     }
 }

--- a/Runtime/Controls/SafeArea.cs
+++ b/Runtime/Controls/SafeArea.cs
@@ -1,0 +1,7 @@
+namespace PromptUGUI.Controls
+{
+    public sealed class SafeArea : Control
+    {
+        // OnAttached / OnAfterApply 在后续 Task 中填充。
+    }
+}

--- a/Runtime/Controls/SafeArea.cs
+++ b/Runtime/Controls/SafeArea.cs
@@ -1,7 +1,14 @@
+using PromptUGUI.Controls.Internal;
+
 namespace PromptUGUI.Controls
 {
     public sealed class SafeArea : Control
     {
-        // OnAttached / OnAfterApply 在后续 Task 中填充。
+        private SafeAreaTracker _tracker;
+
+        public override void OnAttached()
+        {
+            _tracker = GameObject.AddComponent<SafeAreaTracker>();
+        }
     }
 }

--- a/Runtime/Controls/SafeArea.cs.meta
+++ b/Runtime/Controls/SafeArea.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 67f91da0ef4a9b14c912d1fddfc3abe7

--- a/Runtime/Core/Parser/UIDocumentParser.cs
+++ b/Runtime/Core/Parser/UIDocumentParser.cs
@@ -339,6 +339,24 @@ namespace PromptUGUI.Parser
                 }
             }
 
+            // <SafeArea> 校验：禁止 layout 类属性，几何完全由 Screen.safeArea 决定。
+            // 要 padding 用 <Frame margin="..."> 嵌套；要不同形状用其他容器组合。
+            if (tag == "SafeArea" && ns == null)
+            {
+                foreach (var key in new[] { "anchor", "size", "width", "height", "margin", "pivot" })
+                {
+                    if (node.Attributes.ContainsKey(key))
+                        throw new ParseException(
+                            $"<SafeArea> does not accept attribute '{key}'; " +
+                            $"SafeArea is always stretched to Screen.safeArea. " +
+                            $"To add inner padding, wrap content in <Frame margin=\"...\"/> inside the SafeArea.");
+                    if (node.VariantOverrides.ContainsKey(key))
+                        throw new ParseException(
+                            $"<SafeArea> does not accept variant override for '{key}'; " +
+                            $"SafeArea is always stretched to Screen.safeArea.");
+                }
+            }
+
             // size/width/height == "native" 仅 <Icon> 允许（含 Variant 覆盖）
             if (!(tag == "Icon" && ns == null))
             {

--- a/Tests/EditMode/Controls/SafeAreaTests.cs
+++ b/Tests/EditMode/Controls/SafeAreaTests.cs
@@ -23,5 +23,94 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.IsNotNull(sa.GameObject);
             Assert.IsNotNull(sa.RectTransform);
         }
+
+        [Test]
+        public void Tracker_applies_safe_area_fractions()
+        {
+            try
+            {
+                PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride =
+                    () => new UnityEngine.Rect(0f, 100f, 1080f, 1820f);
+                PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride =
+                    () => new UnityEngine.Vector2(1080f, 1920f);
+
+                var go = new UnityEngine.GameObject("sa", typeof(UnityEngine.RectTransform));
+                var tracker = go.AddComponent<PromptUGUI.Controls.Internal.SafeAreaTracker>();
+                tracker.Apply();
+
+                var rt = (UnityEngine.RectTransform)go.transform;
+                Assert.AreEqual(0f, rt.anchorMin.x, 0.001f);
+                Assert.AreEqual(100f / 1920f, rt.anchorMin.y, 0.001f);
+                Assert.AreEqual(1f, rt.anchorMax.x, 0.001f);
+                Assert.AreEqual(1f, rt.anchorMax.y, 0.001f);
+                Assert.AreEqual(UnityEngine.Vector2.zero, rt.offsetMin);
+                Assert.AreEqual(UnityEngine.Vector2.zero, rt.offsetMax);
+
+                UnityEngine.Object.DestroyImmediate(go);
+            }
+            finally
+            {
+                PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride = null;
+                PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride = null;
+            }
+        }
+
+        [Test]
+        public void Tracker_full_screen_safe_area_yields_identity_anchors()
+        {
+            try
+            {
+                PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride =
+                    () => new UnityEngine.Rect(0f, 0f, 1080f, 1920f);
+                PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride =
+                    () => new UnityEngine.Vector2(1080f, 1920f);
+
+                var go = new UnityEngine.GameObject("sa", typeof(UnityEngine.RectTransform));
+                var tracker = go.AddComponent<PromptUGUI.Controls.Internal.SafeAreaTracker>();
+                tracker.Apply();
+
+                var rt = (UnityEngine.RectTransform)go.transform;
+                Assert.AreEqual(UnityEngine.Vector2.zero, rt.anchorMin);
+                Assert.AreEqual(UnityEngine.Vector2.one, rt.anchorMax);
+
+                UnityEngine.Object.DestroyImmediate(go);
+            }
+            finally
+            {
+                PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride = null;
+                PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride = null;
+            }
+        }
+
+        [Test]
+        public void Tracker_zero_screen_size_is_noop()
+        {
+            try
+            {
+                PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride =
+                    () => new UnityEngine.Rect(0f, 0f, 1080f, 1820f);
+                PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride =
+                    () => UnityEngine.Vector2.zero;
+
+                var go = new UnityEngine.GameObject("sa", typeof(UnityEngine.RectTransform));
+                var rt = (UnityEngine.RectTransform)go.transform;
+                rt.anchorMin = new UnityEngine.Vector2(0.5f, 0.5f);
+                rt.anchorMax = new UnityEngine.Vector2(0.5f, 0.5f);
+
+                var tracker = go.AddComponent<PromptUGUI.Controls.Internal.SafeAreaTracker>();
+                tracker.Apply();
+
+                // Zero screen size → tracker bails; anchors unchanged.
+                Assert.AreEqual(new UnityEngine.Vector2(0.5f, 0.5f), rt.anchorMin);
+                Assert.AreEqual(new UnityEngine.Vector2(0.5f, 0.5f), rt.anchorMax);
+
+                UnityEngine.Object.DestroyImmediate(go);
+            }
+            finally
+            {
+                PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride = null;
+                PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride = null;
+            }
+        }
     }
 }

--- a/Tests/EditMode/Controls/SafeAreaTests.cs
+++ b/Tests/EditMode/Controls/SafeAreaTests.cs
@@ -133,41 +133,22 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
-        public void Tracker_apply_tolerates_sub_pixel_residue_on_offset()
+        public void Tracker_does_not_subscribe_to_rect_transform_dimensions_change()
         {
-            try
-            {
-                PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride =
-                    () => new UnityEngine.Rect(0f, 100f, 1080f, 1820f);
-                PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride =
-                    () => new UnityEngine.Vector2(1080f, 1920f);
-
-                var go = new UnityEngine.GameObject("sa", typeof(UnityEngine.RectTransform));
-                var tracker = go.AddComponent<PromptUGUI.Controls.Internal.SafeAreaTracker>();
-                tracker.Apply();
-
-                var rt = (UnityEngine.RectTransform)go.transform;
-
-                // 复现实际发现的 RectTransform 残留：anchor 写完后 offset 被 Unity 留下
-                // ~7.5e-5 的 float 噪声（实际从 Rider 调试出来的值）。Vector2.== 阈值不够宽
-                // 会让 Apply 永远以为 offset != zero 然后无限写。
-                rt.offsetMax = new UnityEngine.Vector2(7.57527596e-5f, 7.57527596e-5f);
-                rt.offsetMin = new UnityEngine.Vector2(7.57527596e-5f, 7.57527596e-5f);
-                rt.hasChanged = false;
-
-                tracker.Apply();
-
-                Assert.IsFalse(rt.hasChanged,
-                    "Apply must skip writing when offsets are within sub-pixel tolerance; " +
-                    "otherwise OnRectTransformDimensionsChange → Apply 死循环");
-
-                UnityEngine.Object.DestroyImmediate(go);
-            }
-            finally
-            {
-                PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride = null;
-                PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride = null;
-            }
+            // 守门测试：SafeAreaTracker 上不能存在 OnRectTransformDimensionsChange
+            // magic method。一旦订阅，Unity 在 RectTransform setter 内部反向求解的
+            // 中间态会反过来触发 tracker.Apply，跟 ApplyCommon 形成写入回环（实测
+            // 卡在 var screen = UI.Open(...) 的 InstantiateRecursive 阶段，offsetMax
+            // 在 0 / 0.65 间反复跳）。Unity 官方 SafeArea 示例同样用 Update poll，
+            // 不订阅这个 magic method。
+            var method = typeof(PromptUGUI.Controls.Internal.SafeAreaTracker)
+                .GetMethod("OnRectTransformDimensionsChange",
+                    System.Reflection.BindingFlags.Instance
+                    | System.Reflection.BindingFlags.NonPublic
+                    | System.Reflection.BindingFlags.Public);
+            Assert.IsNull(method,
+                "SafeAreaTracker must not implement OnRectTransformDimensionsChange — " +
+                "it forms a write loop with ApplyCommon. Use Update() polling instead.");
         }
 
         [Test]

--- a/Tests/EditMode/Controls/SafeAreaTests.cs
+++ b/Tests/EditMode/Controls/SafeAreaTests.cs
@@ -1,0 +1,27 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class SafeAreaTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void SafeArea_parses_and_instantiates()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <SafeArea id='sa'/>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var sa = screen.Get<SafeArea>("sa");
+            Assert.IsNotNull(sa);
+            Assert.IsNotNull(sa.GameObject);
+            Assert.IsNotNull(sa.RectTransform);
+        }
+    }
+}

--- a/Tests/EditMode/Controls/SafeAreaTests.cs
+++ b/Tests/EditMode/Controls/SafeAreaTests.cs
@@ -97,6 +97,42 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
+        public void SafeArea_anchor_persists_after_ReSolve()
+        {
+            try
+            {
+                PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride =
+                    () => new UnityEngine.Rect(0f, 100f, 1080f, 1820f);
+                PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride =
+                    () => new UnityEngine.Vector2(1080f, 1920f);
+
+                const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <SafeArea id='sa'/>
+</Screen></PromptUGUI>";
+                UI.LoadDocument("test", xml);
+                var screen = UI.Open("S");
+                var sa = screen.Get<SafeArea>("sa");
+
+                // ReSolve clobbers anchorMin/Max via ApplyCommon (defaults to top-left).
+                // OnAfterApply must restore the safe-area fractions in the same call.
+                screen.ReSolve();
+
+                var rt = sa.RectTransform;
+                Assert.AreEqual(0f, rt.anchorMin.x, 0.001f);
+                Assert.AreEqual(100f / 1920f, rt.anchorMin.y, 0.001f,
+                    "anchorMin.y should equal safeArea.y / Screen.height after ReSolve");
+                Assert.AreEqual(1f, rt.anchorMax.x, 0.001f);
+                Assert.AreEqual(1f, rt.anchorMax.y, 0.001f);
+            }
+            finally
+            {
+                PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride = null;
+                PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride = null;
+            }
+        }
+
+        [Test]
         public void Tracker_zero_screen_size_is_noop()
         {
             try

--- a/Tests/EditMode/Controls/SafeAreaTests.cs
+++ b/Tests/EditMode/Controls/SafeAreaTests.cs
@@ -25,6 +25,20 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
+        public void SafeArea_attaches_tracker_on_instantiation()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <SafeArea id='sa'/>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var sa = screen.Get<SafeArea>("sa");
+            var tracker = sa.GameObject.GetComponent<PromptUGUI.Controls.Internal.SafeAreaTracker>();
+            Assert.IsNotNull(tracker, "SafeArea.OnAttached should add SafeAreaTracker");
+        }
+
+        [Test]
         public void Tracker_applies_safe_area_fractions()
         {
             try

--- a/Tests/EditMode/Controls/SafeAreaTests.cs
+++ b/Tests/EditMode/Controls/SafeAreaTests.cs
@@ -133,7 +133,7 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
-        public void Tracker_apply_is_idempotent_no_writes_when_already_at_target()
+        public void Tracker_apply_tolerates_sub_pixel_residue_on_offset()
         {
             try
             {
@@ -147,12 +147,19 @@ namespace PromptUGUI.Tests.EditMode.Controls
                 tracker.Apply();
 
                 var rt = (UnityEngine.RectTransform)go.transform;
-                // Inspector hook: hasChanged 反映 RectTransform 自上次置 false 起是否被写过
+
+                // 复现实际发现的 RectTransform 残留：anchor 写完后 offset 被 Unity 留下
+                // ~7.5e-5 的 float 噪声（实际从 Rider 调试出来的值）。Vector2.== 阈值不够宽
+                // 会让 Apply 永远以为 offset != zero 然后无限写。
+                rt.offsetMax = new UnityEngine.Vector2(7.57527596e-5f, 7.57527596e-5f);
+                rt.offsetMin = new UnityEngine.Vector2(7.57527596e-5f, 7.57527596e-5f);
                 rt.hasChanged = false;
+
                 tracker.Apply();
+
                 Assert.IsFalse(rt.hasChanged,
-                    "Apply must be a no-op when the RectTransform is already at the target; " +
-                    "otherwise OnRectTransformDimensionsChange → Apply 会形成回环");
+                    "Apply must skip writing when offsets are within sub-pixel tolerance; " +
+                    "otherwise OnRectTransformDimensionsChange → Apply 死循环");
 
                 UnityEngine.Object.DestroyImmediate(go);
             }

--- a/Tests/EditMode/Controls/SafeAreaTests.cs
+++ b/Tests/EditMode/Controls/SafeAreaTests.cs
@@ -133,6 +133,37 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
+        public void Tracker_apply_is_idempotent_no_writes_when_already_at_target()
+        {
+            try
+            {
+                PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride =
+                    () => new UnityEngine.Rect(0f, 100f, 1080f, 1820f);
+                PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride =
+                    () => new UnityEngine.Vector2(1080f, 1920f);
+
+                var go = new UnityEngine.GameObject("sa", typeof(UnityEngine.RectTransform));
+                var tracker = go.AddComponent<PromptUGUI.Controls.Internal.SafeAreaTracker>();
+                tracker.Apply();
+
+                var rt = (UnityEngine.RectTransform)go.transform;
+                // Inspector hook: hasChanged 反映 RectTransform 自上次置 false 起是否被写过
+                rt.hasChanged = false;
+                tracker.Apply();
+                Assert.IsFalse(rt.hasChanged,
+                    "Apply must be a no-op when the RectTransform is already at the target; " +
+                    "otherwise OnRectTransformDimensionsChange → Apply 会形成回环");
+
+                UnityEngine.Object.DestroyImmediate(go);
+            }
+            finally
+            {
+                PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride = null;
+                PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride = null;
+            }
+        }
+
+        [Test]
         public void Tracker_zero_screen_size_is_noop()
         {
             try

--- a/Tests/EditMode/Controls/SafeAreaTests.cs.meta
+++ b/Tests/EditMode/Controls/SafeAreaTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 54c83e9033fd3924a8a86c09ae836be6

--- a/Tests/EditMode/Parser/SafeAreaParserTests.cs
+++ b/Tests/EditMode/Parser/SafeAreaParserTests.cs
@@ -1,0 +1,83 @@
+using NUnit.Framework;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.Parser
+{
+    public class SafeAreaParserTests
+    {
+        private const string Header = "<?xml version='1.0' encoding='utf-8'?>" +
+            "<PromptUGUI version='1'><Screen name='S'>";
+        private const string Footer = "</Screen></PromptUGUI>";
+
+        [Test]
+        public void SafeArea_no_attrs_parses()
+        {
+            var xml = Header + "<SafeArea id='sa'/>" + Footer;
+            Assert.DoesNotThrow(() => UIDocumentParser.Parse(xml));
+        }
+
+        [Test]
+        public void SafeArea_with_anchor_throws()
+        {
+            var xml = Header + "<SafeArea anchor='stretch'/>" + Footer;
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+            StringAssert.Contains("anchor", ex.Message);
+            StringAssert.Contains("SafeArea", ex.Message);
+        }
+
+        [Test]
+        public void SafeArea_with_size_throws()
+        {
+            var xml = Header + "<SafeArea size='100x100'/>" + Footer;
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+            StringAssert.Contains("size", ex.Message);
+        }
+
+        [Test]
+        public void SafeArea_with_width_throws()
+        {
+            var xml = Header + "<SafeArea width='100'/>" + Footer;
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+            StringAssert.Contains("width", ex.Message);
+        }
+
+        [Test]
+        public void SafeArea_with_height_throws()
+        {
+            var xml = Header + "<SafeArea height='100'/>" + Footer;
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+            StringAssert.Contains("height", ex.Message);
+        }
+
+        [Test]
+        public void SafeArea_with_margin_throws()
+        {
+            var xml = Header + "<SafeArea margin='10'/>" + Footer;
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+            StringAssert.Contains("margin", ex.Message);
+        }
+
+        [Test]
+        public void SafeArea_with_pivot_throws()
+        {
+            var xml = Header + "<SafeArea pivot='0.5,0.5'/>" + Footer;
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+            StringAssert.Contains("pivot", ex.Message);
+        }
+
+        [Test]
+        public void SafeArea_variant_override_on_anchor_throws()
+        {
+            var xml = Header + "<SafeArea anchor.mobile='stretch'/>" + Footer;
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+            StringAssert.Contains("anchor", ex.Message);
+        }
+
+        [Test]
+        public void SafeArea_allows_id_hidden_interactable_if()
+        {
+            var xml = Header + "<SafeArea id='sa' hidden='true' interactable='false' if='mobile'/>" + Footer;
+            Assert.DoesNotThrow(() => UIDocumentParser.Parse(xml));
+        }
+    }
+}

--- a/Tests/EditMode/Parser/SafeAreaParserTests.cs.meta
+++ b/Tests/EditMode/Parser/SafeAreaParserTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 162cb35dc82c73541b352c6f56d19435

--- a/Tests/PlayMode/Controls/SafeAreaTests.cs
+++ b/Tests/PlayMode/Controls/SafeAreaTests.cs
@@ -11,7 +11,8 @@ namespace PromptUGUI.Tests.Controls
     public class SafeAreaTests
     {
         [SetUp] public void SetUp() => UI.ResetForTests();
-        [TearDown] public void TearDown()
+        [TearDown]
+        public void TearDown()
         {
             SafeAreaTracker.SafeAreaOverride = null;
             SafeAreaTracker.ScreenSizeOverride = null;

--- a/Tests/PlayMode/Controls/SafeAreaTests.cs
+++ b/Tests/PlayMode/Controls/SafeAreaTests.cs
@@ -1,0 +1,131 @@
+using System.Collections;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Tests.Controls
+{
+    public class SafeAreaTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown]
+        public void TearDown()
+        {
+            SafeAreaTracker.SafeAreaOverride = null;
+            SafeAreaTracker.ScreenSizeOverride = null;
+            UI.ResetForTests();
+        }
+
+        [UnityTest]
+        public IEnumerator Children_inherit_safe_area_rect_after_layout()
+        {
+            SafeAreaTracker.SafeAreaOverride =
+                () => new Rect(0f, 100f, 1080f, 1820f);
+            SafeAreaTracker.ScreenSizeOverride =
+                () => new Vector2(1080f, 1920f);
+
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <SafeArea id='sa'>
+    <Frame id='inner' anchor='stretch'/>
+  </SafeArea>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var sa = screen.Get<SafeArea>("sa");
+            var inner = screen.Get<Frame>("sa/inner");
+
+            // Force the canvas to drive a known parent rect so anchor fractions resolve to a checkable size.
+            var canvasRt = (RectTransform)sa.RectTransform.parent;
+            canvasRt.anchorMin = Vector2.zero;
+            canvasRt.anchorMax = Vector2.one;
+            canvasRt.offsetMin = Vector2.zero;
+            canvasRt.offsetMax = Vector2.zero;
+            canvasRt.sizeDelta = new Vector2(1080f, 1920f);
+
+            LayoutRebuilder.ForceRebuildLayoutImmediate(canvasRt);
+            yield return null;
+
+            var innerRect = inner.RectTransform.rect;
+            Assert.AreEqual(1080f, innerRect.width, 1f);
+            Assert.AreEqual(1820f, innerRect.height, 1f);
+        }
+
+        [UnityTest]
+        public IEnumerator Tracker_reapplies_when_provider_changes_via_dimensions_event()
+        {
+            SafeAreaTracker.SafeAreaOverride =
+                () => new Rect(0f, 100f, 1080f, 1820f);
+            SafeAreaTracker.ScreenSizeOverride =
+                () => new Vector2(1080f, 1920f);
+
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <SafeArea id='sa'/>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var sa = screen.Get<SafeArea>("sa");
+            var rt = sa.RectTransform;
+            yield return null;
+
+            Assert.AreEqual(100f / 1920f, rt.anchorMin.y, 0.001f);
+
+            // Swap the simulated device: notch moves to bottom (gesture bar style).
+            SafeAreaTracker.SafeAreaOverride =
+                () => new Rect(0f, 0f, 1080f, 1830f);
+            SafeAreaTracker.ScreenSizeOverride =
+                () => new Vector2(1080f, 1920f);
+
+            // Trigger OnRectTransformDimensionsChange by mutating the parent canvas rect.
+            var canvasRt = (RectTransform)rt.parent;
+            canvasRt.sizeDelta = new Vector2(1080f, 1921f); // any change re-fires the magic method
+            yield return null;
+            canvasRt.sizeDelta = new Vector2(1080f, 1920f);
+            yield return null;
+
+            Assert.AreEqual(0f, rt.anchorMin.y, 0.001f, "new safe area starts at y=0");
+            Assert.AreEqual(1830f / 1920f, rt.anchorMax.y, 0.001f);
+        }
+
+        [UnityTest]
+        public IEnumerator SafeArea_inside_variant_add_block_works_after_toggle()
+        {
+            SafeAreaTracker.SafeAreaOverride =
+                () => new Rect(0f, 100f, 1080f, 1820f);
+            SafeAreaTracker.ScreenSizeOverride =
+                () => new Vector2(1080f, 1920f);
+
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Variant when='mobile'>
+    <Add>
+      <SafeArea id='sa'/>
+    </Add>
+  </Variant>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            screen.Variants.Set("mobile", true);
+            yield return null;
+
+            var sa = screen.Get<SafeArea>("sa");
+            Assert.IsNotNull(sa);
+            Assert.AreEqual(100f / 1920f, sa.RectTransform.anchorMin.y, 0.001f);
+
+            screen.Variants.Set("mobile", false);
+            yield return null;
+            Assert.IsFalse(sa.GameObject.activeSelf, "Add block goes inactive");
+
+            screen.Variants.Set("mobile", true);
+            yield return null;
+            Assert.IsTrue(sa.GameObject.activeSelf);
+            Assert.AreEqual(100f / 1920f, sa.RectTransform.anchorMin.y, 0.001f,
+                "tracker re-applies after reactivation");
+        }
+    }
+}

--- a/Tests/PlayMode/Controls/SafeAreaTests.cs
+++ b/Tests/PlayMode/Controls/SafeAreaTests.cs
@@ -5,15 +5,13 @@ using PromptUGUI.Controls;
 using PromptUGUI.Controls.Internal;
 using UnityEngine;
 using UnityEngine.TestTools;
-using UnityEngine.UI;
 
 namespace PromptUGUI.Tests.Controls
 {
     public class SafeAreaTests
     {
         [SetUp] public void SetUp() => UI.ResetForTests();
-        [TearDown]
-        public void TearDown()
+        [TearDown] public void TearDown()
         {
             SafeAreaTracker.SafeAreaOverride = null;
             SafeAreaTracker.ScreenSizeOverride = null;
@@ -21,7 +19,7 @@ namespace PromptUGUI.Tests.Controls
         }
 
         [UnityTest]
-        public IEnumerator Children_inherit_safe_area_rect_after_layout()
+        public IEnumerator SafeArea_anchor_settles_after_one_frame()
         {
             SafeAreaTracker.SafeAreaOverride =
                 () => new Rect(0f, 100f, 1080f, 1820f);
@@ -30,33 +28,22 @@ namespace PromptUGUI.Tests.Controls
 
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'><Screen name='S'>
-  <SafeArea id='sa'>
-    <Frame id='inner' anchor='stretch'/>
-  </SafeArea>
+  <SafeArea id='sa'/>
 </Screen></PromptUGUI>";
             UI.LoadDocument("test", xml);
             var screen = UI.Open("S");
             var sa = screen.Get<SafeArea>("sa");
-            var inner = screen.Get<Frame>("sa/inner");
-
-            // Force the canvas to drive a known parent rect so anchor fractions resolve to a checkable size.
-            var canvasRt = (RectTransform)sa.RectTransform.parent;
-            canvasRt.anchorMin = Vector2.zero;
-            canvasRt.anchorMax = Vector2.one;
-            canvasRt.offsetMin = Vector2.zero;
-            canvasRt.offsetMax = Vector2.zero;
-            canvasRt.sizeDelta = new Vector2(1080f, 1920f);
-
-            LayoutRebuilder.ForceRebuildLayoutImmediate(canvasRt);
             yield return null;
 
-            var innerRect = inner.RectTransform.rect;
-            Assert.AreEqual(1080f, innerRect.width, 1f);
-            Assert.AreEqual(1820f, innerRect.height, 1f);
+            var rt = sa.RectTransform;
+            Assert.AreEqual(0f, rt.anchorMin.x, 0.001f);
+            Assert.AreEqual(100f / 1920f, rt.anchorMin.y, 0.001f);
+            Assert.AreEqual(1f, rt.anchorMax.x, 0.001f);
+            Assert.AreEqual(1f, rt.anchorMax.y, 0.001f);
         }
 
         [UnityTest]
-        public IEnumerator Tracker_reapplies_when_provider_changes_via_dimensions_event()
+        public IEnumerator Tracker_polls_provider_changes()
         {
             SafeAreaTracker.SafeAreaOverride =
                 () => new Rect(0f, 100f, 1080f, 1820f);
@@ -75,17 +62,9 @@ namespace PromptUGUI.Tests.Controls
 
             Assert.AreEqual(100f / 1920f, rt.anchorMin.y, 0.001f);
 
-            // Swap the simulated device: notch moves to bottom (gesture bar style).
+            // 切换"设备":notch 跑到下方变成手势条。下一帧 Update poll 到 safeArea 变化 → 重算 anchor。
             SafeAreaTracker.SafeAreaOverride =
                 () => new Rect(0f, 0f, 1080f, 1830f);
-            SafeAreaTracker.ScreenSizeOverride =
-                () => new Vector2(1080f, 1920f);
-
-            // Trigger OnRectTransformDimensionsChange by mutating the parent canvas rect.
-            var canvasRt = (RectTransform)rt.parent;
-            canvasRt.sizeDelta = new Vector2(1080f, 1921f); // any change re-fires the magic method
-            yield return null;
-            canvasRt.sizeDelta = new Vector2(1080f, 1920f);
             yield return null;
 
             Assert.AreEqual(0f, rt.anchorMin.y, 0.001f, "new safe area starts at y=0");
@@ -125,7 +104,7 @@ namespace PromptUGUI.Tests.Controls
             yield return null;
             Assert.IsTrue(sa.GameObject.activeSelf);
             Assert.AreEqual(100f / 1920f, sa.RectTransform.anchorMin.y, 0.001f,
-                "tracker re-applies after reactivation");
+                "tracker re-applies after reactivation via OnEnable");
         }
     }
 }

--- a/Tests/PlayMode/Controls/SafeAreaTests.cs
+++ b/Tests/PlayMode/Controls/SafeAreaTests.cs
@@ -82,7 +82,7 @@ namespace PromptUGUI.Tests.Controls
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'><Screen name='S'>
   <Variant when='mobile'>
-    <Add>
+    <Add into='@root'>
       <SafeArea id='sa'/>
     </Add>
   </Variant>

--- a/Tests/PlayMode/Controls/SafeAreaTests.cs.meta
+++ b/Tests/PlayMode/Controls/SafeAreaTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a217d5b8463f0c9468fe6da23b4c1898

--- a/docs~/superpowers/plans/2026-05-13-safearea-builtin.md
+++ b/docs~/superpowers/plans/2026-05-13-safearea-builtin.md
@@ -1,0 +1,1070 @@
+# SafeArea Built-in Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `<SafeArea>` built-in control that wraps its children inside `Screen.safeArea`, auto-responding to screen rotation, window resize, Device Simulator, and Variant ReSolve.
+
+**Architecture:** New `SafeArea : Control` mirrors `Frame` (no visual, no `[UIAttr]`). On `OnAttached` it attaches an internal `SafeAreaTracker : MonoBehaviour` that uses Unity's anchor-fraction technique (`anchorMin/Max = safeArea / Screen.size`, `offsetMin/Max = 0`). Tracker re-applies on Unity's `OnRectTransformDimensionsChange` magic method plus a new `Control.OnAfterApply` hook (called by `ControlAttributeApplier.Apply` after `ApplyCommon`) so Variant ReSolve doesn't leave SafeArea showing a stretch-default anchor for one frame.
+
+**Tech Stack:** Unity 6+, .NET Standard 2.1, NUnit (EditMode + PlayMode), UnityMCP for test execution.
+
+**Spec reference:** `docs~/superpowers/specs/2026-05-13-safearea-builtin-design.md`
+
+---
+
+## Pre-flight
+
+- [ ] **Step P1: Confirm spec is committed (or commit it)**
+
+  Per CLAUDE.md the user must explicitly approve commits. Ask once before starting Task 1:
+
+  > "Ready to start. About to commit two doc files (`2026-05-13-safearea-builtin-design.md`, `2026-05-13-safearea-builtin.md`) as a single 'doc: …' commit before coding. OK?"
+
+  If yes:
+
+  ```bash
+  git add docs~/superpowers/specs/2026-05-13-safearea-builtin-design.md \
+          docs~/superpowers/plans/2026-05-13-safearea-builtin.md
+  git commit -m "$(cat <<'EOF'
+  doc: spec + plan for <SafeArea> built-in
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  EOF
+  )"
+  ```
+
+- [ ] **Step P2: Verify Unity test infra is reachable**
+
+  ```
+  mcp__UnityMCP__refresh_unity(compile="request", mode="standard", scope="all", wait_for_ready=true)
+  mcp__UnityMCP__read_console(action="get", types=["error"])
+  ```
+
+  Expected: no compile errors before we touch anything. If errors exist, stop and report — don't start TDD on a red baseline.
+
+---
+
+## Task 1: Scaffold empty `SafeArea` control + register it
+
+**Files:**
+- Create: `Runtime/Controls/SafeArea.cs`
+- Modify: `Runtime/Application/BuiltinPrimitives.cs:10` (insert after Frame registration)
+- Create: `Tests/EditMode/Controls/SafeAreaTests.cs`
+
+- [ ] **Step 1.1: Write the failing test**
+
+  Create `Tests/EditMode/Controls/SafeAreaTests.cs`:
+
+  ```csharp
+  using NUnit.Framework;
+  using PromptUGUI.Application;
+  using PromptUGUI.Controls;
+
+  namespace PromptUGUI.Tests.EditMode.Controls
+  {
+      public class SafeAreaTests
+      {
+          [SetUp] public void SetUp() => UI.ResetForTests();
+          [TearDown] public void TearDown() => UI.ResetForTests();
+
+          [Test]
+          public void SafeArea_parses_and_instantiates()
+          {
+              const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+  <PromptUGUI version='1'><Screen name='S'>
+    <SafeArea id='sa'/>
+  </Screen></PromptUGUI>";
+              UI.LoadDocument("test", xml);
+              var screen = UI.Open("S");
+              var sa = screen.Get<SafeArea>("sa");
+              Assert.IsNotNull(sa);
+              Assert.IsNotNull(sa.GameObject);
+              Assert.IsNotNull(sa.RectTransform);
+          }
+      }
+  }
+  ```
+
+- [ ] **Step 1.2: Run test, verify it fails**
+
+  ```
+  mcp__UnityMCP__refresh_unity(compile="request", mode="standard", scope="all", wait_for_ready=true)
+  mcp__UnityMCP__read_console(action="get", types=["error"])
+  ```
+
+  Expected: compile error about `SafeArea` not found. (Test won't even run yet.)
+
+- [ ] **Step 1.3: Create the SafeArea class**
+
+  Create `Runtime/Controls/SafeArea.cs`:
+
+  ```csharp
+  namespace PromptUGUI.Controls
+  {
+      public sealed class SafeArea : Control
+      {
+          // OnAttached / OnAfterApply 在后续 Task 中填充。
+      }
+  }
+  ```
+
+- [ ] **Step 1.4: Register SafeArea in BuiltinPrimitives**
+
+  Edit `Runtime/Application/BuiltinPrimitives.cs`. After line 10 (`reg.Register<Frame>("Frame", null);`) insert:
+
+  ```csharp
+  reg.Register<SafeArea>("SafeArea", null);
+  ```
+
+  Final ordering: `Frame, SafeArea, Image, Icon, Text, ...`
+
+- [ ] **Step 1.5: Refresh Unity and run test**
+
+  ```
+  mcp__UnityMCP__refresh_unity(compile="request", mode="standard", scope="all", wait_for_ready=true)
+  mcp__UnityMCP__read_console(action="get", types=["error"])
+  mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="SafeAreaTests")
+  ```
+
+  Expected: PASS for `SafeArea_parses_and_instantiates`.
+
+- [ ] **Step 1.6: Commit**
+
+  Ask the user before committing (CLAUDE.md). If approved:
+
+  ```bash
+  git add Runtime/Controls/SafeArea.cs \
+          Runtime/Controls/SafeArea.cs.meta \
+          Runtime/Application/BuiltinPrimitives.cs \
+          Tests/EditMode/Controls/SafeAreaTests.cs \
+          Tests/EditMode/Controls/SafeAreaTests.cs.meta
+  git commit -m "$(cat <<'EOF'
+  feat: scaffold empty <SafeArea> built-in
+
+  Registers the new tag; tracker + parse validation land in
+  follow-up commits.
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  EOF
+  )"
+  ```
+
+  Note: `.meta` files are created by Unity on refresh. If they don't exist yet, run refresh once more before committing.
+
+---
+
+## Task 2: Parse-time validation for forbidden attributes
+
+**Files:**
+- Create: `Tests/EditMode/Parser/SafeAreaParserTests.cs`
+- Modify: `Runtime/Core/Parser/UIDocumentParser.cs:340` (insert SafeArea validation block after the Icon validation at lines 321-340)
+
+- [ ] **Step 2.1: Write the failing tests**
+
+  Create `Tests/EditMode/Parser/SafeAreaParserTests.cs`:
+
+  ```csharp
+  using NUnit.Framework;
+  using PromptUGUI.Core.Parser;
+
+  namespace PromptUGUI.Tests.EditMode.Parser
+  {
+      public class SafeAreaParserTests
+      {
+          private const string Header = "<?xml version='1.0' encoding='utf-8'?>" +
+              "<PromptUGUI version='1'><Screen name='S'>";
+          private const string Footer = "</Screen></PromptUGUI>";
+
+          [Test]
+          public void SafeArea_no_attrs_parses()
+          {
+              var xml = Header + "<SafeArea id='sa'/>" + Footer;
+              Assert.DoesNotThrow(() => UIDocumentParser.Parse(xml));
+          }
+
+          [Test]
+          public void SafeArea_with_anchor_throws()
+          {
+              var xml = Header + "<SafeArea anchor='stretch'/>" + Footer;
+              var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+              StringAssert.Contains("anchor", ex.Message);
+              StringAssert.Contains("SafeArea", ex.Message);
+          }
+
+          [Test]
+          public void SafeArea_with_size_throws()
+          {
+              var xml = Header + "<SafeArea size='100x100'/>" + Footer;
+              var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+              StringAssert.Contains("size", ex.Message);
+          }
+
+          [Test]
+          public void SafeArea_with_width_throws()
+          {
+              var xml = Header + "<SafeArea width='100'/>" + Footer;
+              var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+              StringAssert.Contains("width", ex.Message);
+          }
+
+          [Test]
+          public void SafeArea_with_height_throws()
+          {
+              var xml = Header + "<SafeArea height='100'/>" + Footer;
+              var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+              StringAssert.Contains("height", ex.Message);
+          }
+
+          [Test]
+          public void SafeArea_with_margin_throws()
+          {
+              var xml = Header + "<SafeArea margin='10'/>" + Footer;
+              var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+              StringAssert.Contains("margin", ex.Message);
+          }
+
+          [Test]
+          public void SafeArea_with_pivot_throws()
+          {
+              var xml = Header + "<SafeArea pivot='0.5,0.5'/>" + Footer;
+              var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+              StringAssert.Contains("pivot", ex.Message);
+          }
+
+          [Test]
+          public void SafeArea_variant_override_on_anchor_throws()
+          {
+              var xml = Header + "<SafeArea anchor.mobile='stretch'/>" + Footer;
+              var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+              StringAssert.Contains("anchor", ex.Message);
+          }
+
+          [Test]
+          public void SafeArea_allows_id_hidden_interactable_if()
+          {
+              var xml = Header + "<SafeArea id='sa' hidden='true' interactable='false' if='mobile'/>" + Footer;
+              Assert.DoesNotThrow(() => UIDocumentParser.Parse(xml));
+          }
+      }
+  }
+  ```
+
+  Note: confirm `using` namespace for `UIDocumentParser` matches an existing test file. If `PromptUGUI.Core.Parser` is wrong, grep one of the existing parser tests (e.g. `IconParserTests.cs`) and copy whatever it uses.
+
+- [ ] **Step 2.2: Run tests, verify failure**
+
+  ```
+  mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="SafeAreaParserTests")
+  ```
+
+  Expected: `SafeArea_no_attrs_parses` passes; the seven `_throws` tests FAIL because the parser currently accepts those attrs.
+
+- [ ] **Step 2.3: Add validation block in UIDocumentParser**
+
+  In `Runtime/Core/Parser/UIDocumentParser.cs`, after the Icon validation block (currently ending at line 340) and before the `native` size validation (currently at line 343), insert:
+
+  ```csharp
+  // <SafeArea> 校验：禁止 layout 类属性，几何完全由 Screen.safeArea 决定。
+  // 要 padding 用 <Frame margin="..."> 嵌套；要不同形状用其他容器组合。
+  if (tag == "SafeArea" && ns == null)
+  {
+      foreach (var key in new[] { "anchor", "size", "width", "height", "margin", "pivot" })
+      {
+          if (node.Attributes.ContainsKey(key))
+              throw new ParseException(
+                  $"<SafeArea> does not accept attribute '{key}'; " +
+                  $"SafeArea is always stretched to Screen.safeArea. " +
+                  $"To add inner padding, wrap content in <Frame margin=\"...\"/> inside the SafeArea.");
+          if (node.VariantOverrides.ContainsKey(key))
+              throw new ParseException(
+                  $"<SafeArea> does not accept variant override for '{key}'; " +
+                  $"SafeArea is always stretched to Screen.safeArea.");
+      }
+  }
+  ```
+
+- [ ] **Step 2.4: Refresh and verify all parser tests pass**
+
+  ```
+  mcp__UnityMCP__refresh_unity(compile="request", mode="standard", scope="all", wait_for_ready=true)
+  mcp__UnityMCP__read_console(action="get", types=["error"])
+  mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="SafeAreaParserTests")
+  mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="IconParserTests")
+  ```
+
+  Expected: all 9 SafeAreaParserTests pass; IconParserTests still all green (regression check on adjacent validation).
+
+- [ ] **Step 2.5: Commit (ask user)**
+
+  ```bash
+  git add Runtime/Core/Parser/UIDocumentParser.cs \
+          Tests/EditMode/Parser/SafeAreaParserTests.cs \
+          Tests/EditMode/Parser/SafeAreaParserTests.cs.meta
+  git commit -m "$(cat <<'EOF'
+  feat: parse-time validation for <SafeArea> attributes
+
+  Reject anchor/size/width/height/margin/pivot (base + variant
+  override forms) — SafeArea geometry is fully driven by
+  Screen.safeArea; user-set layout attrs would silently lose.
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  EOF
+  )"
+  ```
+
+---
+
+## Task 3: `SafeAreaTracker` MonoBehaviour computes anchor fractions
+
+**Files:**
+- Create: `Runtime/Controls/Internal/SafeAreaTracker.cs`
+- Add to: `Tests/EditMode/Controls/SafeAreaTests.cs`
+
+- [ ] **Step 3.1: Write the failing test**
+
+  Append to `Tests/EditMode/Controls/SafeAreaTests.cs` (inside the existing `SafeAreaTests` class):
+
+  ```csharp
+  [Test]
+  public void Tracker_applies_safe_area_fractions()
+  {
+      try
+      {
+          PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride =
+              () => new UnityEngine.Rect(0f, 100f, 1080f, 1820f);
+          PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride =
+              () => new UnityEngine.Vector2(1080f, 1920f);
+
+          var go = new UnityEngine.GameObject("sa", typeof(UnityEngine.RectTransform));
+          var tracker = go.AddComponent<PromptUGUI.Controls.Internal.SafeAreaTracker>();
+          tracker.Apply();
+
+          var rt = (UnityEngine.RectTransform)go.transform;
+          Assert.AreEqual(0f, rt.anchorMin.x, 0.001f);
+          Assert.AreEqual(100f / 1920f, rt.anchorMin.y, 0.001f);
+          Assert.AreEqual(1f, rt.anchorMax.x, 0.001f);
+          Assert.AreEqual(1f, rt.anchorMax.y, 0.001f);
+          Assert.AreEqual(UnityEngine.Vector2.zero, rt.offsetMin);
+          Assert.AreEqual(UnityEngine.Vector2.zero, rt.offsetMax);
+
+          UnityEngine.Object.DestroyImmediate(go);
+      }
+      finally
+      {
+          PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride = null;
+          PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride = null;
+      }
+  }
+
+  [Test]
+  public void Tracker_full_screen_safe_area_yields_identity_anchors()
+  {
+      try
+      {
+          PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride =
+              () => new UnityEngine.Rect(0f, 0f, 1080f, 1920f);
+          PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride =
+              () => new UnityEngine.Vector2(1080f, 1920f);
+
+          var go = new UnityEngine.GameObject("sa", typeof(UnityEngine.RectTransform));
+          var tracker = go.AddComponent<PromptUGUI.Controls.Internal.SafeAreaTracker>();
+          tracker.Apply();
+
+          var rt = (UnityEngine.RectTransform)go.transform;
+          Assert.AreEqual(UnityEngine.Vector2.zero, rt.anchorMin);
+          Assert.AreEqual(UnityEngine.Vector2.one, rt.anchorMax);
+
+          UnityEngine.Object.DestroyImmediate(go);
+      }
+      finally
+      {
+          PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride = null;
+          PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride = null;
+      }
+  }
+
+  [Test]
+  public void Tracker_zero_screen_size_is_noop()
+  {
+      try
+      {
+          PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride =
+              () => new UnityEngine.Rect(0f, 0f, 1080f, 1820f);
+          PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride =
+              () => UnityEngine.Vector2.zero;
+
+          var go = new UnityEngine.GameObject("sa", typeof(UnityEngine.RectTransform));
+          var rt = (UnityEngine.RectTransform)go.transform;
+          rt.anchorMin = new UnityEngine.Vector2(0.5f, 0.5f);
+          rt.anchorMax = new UnityEngine.Vector2(0.5f, 0.5f);
+
+          var tracker = go.AddComponent<PromptUGUI.Controls.Internal.SafeAreaTracker>();
+          tracker.Apply();
+
+          // Zero screen size → tracker bails; anchors unchanged.
+          Assert.AreEqual(new UnityEngine.Vector2(0.5f, 0.5f), rt.anchorMin);
+          Assert.AreEqual(new UnityEngine.Vector2(0.5f, 0.5f), rt.anchorMax);
+
+          UnityEngine.Object.DestroyImmediate(go);
+      }
+      finally
+      {
+          PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride = null;
+          PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride = null;
+      }
+  }
+  ```
+
+- [ ] **Step 3.2: Verify failure**
+
+  ```
+  mcp__UnityMCP__refresh_unity(compile="request", mode="standard", scope="all", wait_for_ready=true)
+  mcp__UnityMCP__read_console(action="get", types=["error"])
+  ```
+
+  Expected: compile error — `SafeAreaTracker` type doesn't exist.
+
+- [ ] **Step 3.3: Create `SafeAreaTracker.cs`**
+
+  Create `Runtime/Controls/Internal/SafeAreaTracker.cs`:
+
+  ```csharp
+  using System;
+  using UnityEngine;
+
+  namespace PromptUGUI.Controls.Internal
+  {
+      [DisallowMultipleComponent]
+      internal sealed class SafeAreaTracker : MonoBehaviour
+      {
+          // 仅测试注入：默认 null → 走真实 Screen.safeArea / Screen.width|height
+          internal static Func<Rect> SafeAreaOverride;
+          internal static Func<Vector2> ScreenSizeOverride;
+
+          private RectTransform _rt;
+
+          private void OnEnable()
+          {
+              _rt = transform as RectTransform;
+              Apply();
+          }
+
+          private void OnRectTransformDimensionsChange()
+          {
+              if (_rt == null) return;
+              Apply();
+          }
+
+          internal void Apply()
+          {
+              if (_rt == null) _rt = transform as RectTransform;
+              if (_rt == null) return;
+
+              var safe = SafeAreaOverride != null ? SafeAreaOverride() : Screen.safeArea;
+              var screenSize = ScreenSizeOverride != null
+                  ? ScreenSizeOverride()
+                  : new Vector2(Screen.width, Screen.height);
+
+              if (screenSize.x <= 0f || screenSize.y <= 0f) return;
+
+              var aMin = new Vector2(safe.xMin / screenSize.x, safe.yMin / screenSize.y);
+              var aMax = new Vector2(safe.xMax / screenSize.x, safe.yMax / screenSize.y);
+
+              _rt.anchorMin = aMin;
+              _rt.anchorMax = aMax;
+              _rt.offsetMin = Vector2.zero;
+              _rt.offsetMax = Vector2.zero;
+          }
+      }
+  }
+  ```
+
+- [ ] **Step 3.4: Refresh and run tracker tests**
+
+  ```
+  mcp__UnityMCP__refresh_unity(compile="request", mode="standard", scope="all", wait_for_ready=true)
+  mcp__UnityMCP__read_console(action="get", types=["error"])
+  mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="SafeAreaTests")
+  ```
+
+  Expected: 4 tests pass (`SafeArea_parses_and_instantiates` + 3 new tracker tests).
+
+- [ ] **Step 3.5: Commit (ask user)**
+
+  ```bash
+  git add Runtime/Controls/Internal/SafeAreaTracker.cs \
+          Runtime/Controls/Internal/SafeAreaTracker.cs.meta \
+          Tests/EditMode/Controls/SafeAreaTests.cs
+  git commit -m "$(cat <<'EOF'
+  feat: SafeAreaTracker component computes anchor-fraction
+
+  Standalone MonoBehaviour using Unity's anchor-fraction technique
+  (anchorMin/Max = safeArea / Screen.size, offsetMin/Max = 0).
+  Reacts to OnRectTransformDimensionsChange. Static
+  SafeAreaOverride / ScreenSizeOverride hooks let tests inject
+  deterministic values since Screen.safeArea is a static getter.
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  EOF
+  )"
+  ```
+
+---
+
+## Task 4: Wire tracker into `SafeArea.OnAttached`
+
+**Files:**
+- Modify: `Runtime/Controls/SafeArea.cs`
+- Add to: `Tests/EditMode/Controls/SafeAreaTests.cs`
+
+- [ ] **Step 4.1: Write the failing test**
+
+  Append to `SafeAreaTests`:
+
+  ```csharp
+  [Test]
+  public void SafeArea_attaches_tracker_on_instantiation()
+  {
+      const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+  <PromptUGUI version='1'><Screen name='S'>
+    <SafeArea id='sa'/>
+  </Screen></PromptUGUI>";
+      UI.LoadDocument("test", xml);
+      var screen = UI.Open("S");
+      var sa = screen.Get<SafeArea>("sa");
+      var tracker = sa.GameObject.GetComponent<PromptUGUI.Controls.Internal.SafeAreaTracker>();
+      Assert.IsNotNull(tracker, "SafeArea.OnAttached should add SafeAreaTracker");
+  }
+  ```
+
+- [ ] **Step 4.2: Verify failure**
+
+  ```
+  mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="SafeArea_attaches_tracker_on_instantiation")
+  ```
+
+  Expected: FAIL (no tracker on the GameObject yet).
+
+- [ ] **Step 4.3: Add `OnAttached` to SafeArea**
+
+  Replace `Runtime/Controls/SafeArea.cs` contents:
+
+  ```csharp
+  using PromptUGUI.Controls.Internal;
+
+  namespace PromptUGUI.Controls
+  {
+      public sealed class SafeArea : Control
+      {
+          private SafeAreaTracker _tracker;
+
+          public override void OnAttached()
+          {
+              _tracker = GameObject.AddComponent<SafeAreaTracker>();
+          }
+      }
+  }
+  ```
+
+- [ ] **Step 4.4: Refresh, run test, verify pass**
+
+  ```
+  mcp__UnityMCP__refresh_unity(compile="request", mode="standard", scope="all", wait_for_ready=true)
+  mcp__UnityMCP__read_console(action="get", types=["error"])
+  mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="SafeAreaTests")
+  ```
+
+  Expected: all 5 SafeAreaTests pass.
+
+- [ ] **Step 4.5: Commit (ask user)**
+
+  ```bash
+  git add Runtime/Controls/SafeArea.cs \
+          Tests/EditMode/Controls/SafeAreaTests.cs
+  git commit -m "$(cat <<'EOF'
+  feat: SafeArea attaches tracker on OnAttached
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  EOF
+  )"
+  ```
+
+---
+
+## Task 5: `Control.OnAfterApply` hook + SafeArea override
+
+**Files:**
+- Modify: `Runtime/Controls/Control.cs` (add `OnAfterApply` virtual after `OnAttached` at line 39)
+- Modify: `Runtime/Application/ControlAttributeApplier.cs:68` (call `OnAfterApply` after `ApplyCommon`)
+- Modify: `Runtime/Controls/SafeArea.cs` (override `OnAfterApply` to call tracker.Apply)
+- Add to: `Tests/EditMode/Controls/SafeAreaTests.cs`
+
+- [ ] **Step 5.1: Write the failing test**
+
+  Append to `SafeAreaTests`:
+
+  ```csharp
+  [Test]
+  public void SafeArea_anchor_persists_after_ReSolve()
+  {
+      try
+      {
+          PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride =
+              () => new UnityEngine.Rect(0f, 100f, 1080f, 1820f);
+          PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride =
+              () => new UnityEngine.Vector2(1080f, 1920f);
+
+          const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+  <PromptUGUI version='1'><Screen name='S'>
+    <SafeArea id='sa'/>
+  </Screen></PromptUGUI>";
+          UI.LoadDocument("test", xml);
+          var screen = UI.Open("S");
+          var sa = screen.Get<SafeArea>("sa");
+
+          // ReSolve clobbers anchorMin/Max via ApplyCommon (defaults to top-left).
+          // OnAfterApply must restore the safe-area fractions in the same call.
+          screen.ReSolve();
+
+          var rt = sa.RectTransform;
+          Assert.AreEqual(0f, rt.anchorMin.x, 0.001f);
+          Assert.AreEqual(100f / 1920f, rt.anchorMin.y, 0.001f,
+              "anchorMin.y should equal safeArea.y / Screen.height after ReSolve");
+          Assert.AreEqual(1f, rt.anchorMax.x, 0.001f);
+          Assert.AreEqual(1f, rt.anchorMax.y, 0.001f);
+      }
+      finally
+      {
+          PromptUGUI.Controls.Internal.SafeAreaTracker.SafeAreaOverride = null;
+          PromptUGUI.Controls.Internal.SafeAreaTracker.ScreenSizeOverride = null;
+      }
+  }
+  ```
+
+  > **Why no cast needed:** `UI.Open` returns the concrete public `Screen` class (verified at `Runtime/Application/UI.cs:398`), and `Screen.ReSolve()` is public.
+
+- [ ] **Step 5.2: Verify failure**
+
+  ```
+  mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="SafeArea_anchor_persists_after_ReSolve")
+  ```
+
+  Expected: FAIL. After ReSolve, `anchorMin.y` is 1.0 (top-left default) instead of 0.052.
+
+- [ ] **Step 5.3: Add `OnAfterApply` to Control base**
+
+  In `Runtime/Controls/Control.cs`, immediately after the `OnAttached` declaration (line 39 `public virtual void OnAttached() { }`), insert:
+
+  ```csharp
+          /// <summary>
+          /// 在 <see cref="ControlAttributeApplier"/> 调用 <see cref="ApplyCommon"/> 之后再触发一次，
+          /// 让一些控件在 Variant ReSolve / 初始 Apply 完成后做"恢复其它逻辑写入的 RectTransform / 组件状态"
+          /// 这类收尾。默认实现为空；目前只有 SafeArea 重写。
+          /// </summary>
+          internal virtual void OnAfterApply() { }
+  ```
+
+- [ ] **Step 5.4: Wire `OnAfterApply` into ControlAttributeApplier**
+
+  In `Runtime/Application/ControlAttributeApplier.cs`, at the end of the `Apply` method (immediately after `control.ApplyCommon(...)` on line 68), add:
+
+  ```csharp
+              control.OnAfterApply();
+  ```
+
+  The method body's final lines should read:
+
+  ```csharp
+              control.ApplyCommon(anchor, size, width, height, margin, pivot, hidden, interactable);
+              control.OnAfterApply();
+          }
+  ```
+
+- [ ] **Step 5.5: Override `OnAfterApply` in SafeArea**
+
+  Replace `Runtime/Controls/SafeArea.cs`:
+
+  ```csharp
+  using PromptUGUI.Controls.Internal;
+
+  namespace PromptUGUI.Controls
+  {
+      public sealed class SafeArea : Control
+      {
+          private SafeAreaTracker _tracker;
+
+          public override void OnAttached()
+          {
+              _tracker = GameObject.AddComponent<SafeAreaTracker>();
+          }
+
+          internal override void OnAfterApply()
+          {
+              // ApplyCommon 在初次实例化和 Variant ReSolve 时都会重写 anchorMin/Max,
+              // tracker 必须立刻补一次，否则 ReSolve 后会有一帧 stretch-default 闪烁。
+              if (_tracker != null) _tracker.Apply();
+          }
+      }
+  }
+  ```
+
+- [ ] **Step 5.6: Refresh, run all SafeArea tests + a quick regression on every other control**
+
+  ```
+  mcp__UnityMCP__refresh_unity(compile="request", mode="standard", scope="all", wait_for_ready=true)
+  mcp__UnityMCP__read_console(action="get", types=["error"])
+  mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="SafeAreaTests")
+  mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+  ```
+
+  Expected: all SafeAreaTests pass; full EditMode suite stays green (no regression from the new `OnAfterApply` hook on the other 13 controls).
+
+- [ ] **Step 5.7: Commit (ask user)**
+
+  ```bash
+  git add Runtime/Controls/Control.cs \
+          Runtime/Application/ControlAttributeApplier.cs \
+          Runtime/Controls/SafeArea.cs \
+          Tests/EditMode/Controls/SafeAreaTests.cs
+  git commit -m "$(cat <<'EOF'
+  feat: OnAfterApply hook + SafeArea persistence across ReSolve
+
+  Adds an internal virtual Control.OnAfterApply called at the end
+  of ControlAttributeApplier.Apply. SafeArea overrides it to push
+  the tracker's safe-area anchors back on top of the stretch
+  default that ApplyCommon writes during Variant ReSolve. Other
+  controls keep the empty default — zero behavioral change.
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  EOF
+  )"
+  ```
+
+---
+
+## Task 6: PlayMode integration tests
+
+**Files:**
+- Create: `Tests/PlayMode/Controls/SafeAreaTests.cs`
+
+- [ ] **Step 6.1: Write the PlayMode tests**
+
+  Create `Tests/PlayMode/Controls/SafeAreaTests.cs`:
+
+  ```csharp
+  using System.Collections;
+  using NUnit.Framework;
+  using PromptUGUI.Application;
+  using PromptUGUI.Controls;
+  using PromptUGUI.Controls.Internal;
+  using UnityEngine;
+  using UnityEngine.TestTools;
+  using UnityEngine.UI;
+
+  namespace PromptUGUI.Tests.Controls
+  {
+      public class SafeAreaTests
+      {
+          [SetUp] public void SetUp() => UI.ResetForTests();
+          [TearDown] public void TearDown()
+          {
+              SafeAreaTracker.SafeAreaOverride = null;
+              SafeAreaTracker.ScreenSizeOverride = null;
+              UI.ResetForTests();
+          }
+
+          [UnityTest]
+          public IEnumerator Children_inherit_safe_area_rect_after_layout()
+          {
+              SafeAreaTracker.SafeAreaOverride =
+                  () => new Rect(0f, 100f, 1080f, 1820f);
+              SafeAreaTracker.ScreenSizeOverride =
+                  () => new Vector2(1080f, 1920f);
+
+              const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+  <PromptUGUI version='1'><Screen name='S'>
+    <SafeArea id='sa'>
+      <Frame id='inner' anchor='stretch'/>
+    </SafeArea>
+  </Screen></PromptUGUI>";
+              UI.LoadDocument("test", xml);
+              var screen = UI.Open("S");
+              var sa = screen.Get<SafeArea>("sa");
+              var inner = screen.Get<Frame>("sa/inner");
+
+              // Force the canvas to drive a known parent rect so anchor fractions resolve to a checkable size.
+              var canvasRt = (RectTransform)sa.RectTransform.parent;
+              canvasRt.anchorMin = Vector2.zero;
+              canvasRt.anchorMax = Vector2.one;
+              canvasRt.offsetMin = Vector2.zero;
+              canvasRt.offsetMax = Vector2.zero;
+              canvasRt.sizeDelta = new Vector2(1080f, 1920f);
+
+              LayoutRebuilder.ForceRebuildLayoutImmediate(canvasRt);
+              yield return null;
+
+              var innerRect = inner.RectTransform.rect;
+              Assert.AreEqual(1080f, innerRect.width, 1f);
+              Assert.AreEqual(1820f, innerRect.height, 1f);
+          }
+
+          [UnityTest]
+          public IEnumerator Tracker_reapplies_when_provider_changes_via_dimensions_event()
+          {
+              SafeAreaTracker.SafeAreaOverride =
+                  () => new Rect(0f, 100f, 1080f, 1820f);
+              SafeAreaTracker.ScreenSizeOverride =
+                  () => new Vector2(1080f, 1920f);
+
+              const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+  <PromptUGUI version='1'><Screen name='S'>
+    <SafeArea id='sa'/>
+  </Screen></PromptUGUI>";
+              UI.LoadDocument("test", xml);
+              var screen = UI.Open("S");
+              var sa = screen.Get<SafeArea>("sa");
+              var rt = sa.RectTransform;
+              yield return null;
+
+              Assert.AreEqual(100f / 1920f, rt.anchorMin.y, 0.001f);
+
+              // Swap the simulated device: notch moves to bottom (gesture bar style).
+              SafeAreaTracker.SafeAreaOverride =
+                  () => new Rect(0f, 0f, 1080f, 1830f);
+              SafeAreaTracker.ScreenSizeOverride =
+                  () => new Vector2(1080f, 1920f);
+
+              // Trigger OnRectTransformDimensionsChange by mutating the parent canvas rect.
+              var canvasRt = (RectTransform)rt.parent;
+              canvasRt.sizeDelta = new Vector2(1080f, 1921f); // any change re-fires the magic method
+              yield return null;
+              canvasRt.sizeDelta = new Vector2(1080f, 1920f);
+              yield return null;
+
+              Assert.AreEqual(0f, rt.anchorMin.y, 0.001f, "new safe area starts at y=0");
+              Assert.AreEqual(1830f / 1920f, rt.anchorMax.y, 0.001f);
+          }
+
+          [UnityTest]
+          public IEnumerator SafeArea_inside_variant_add_block_works_after_toggle()
+          {
+              SafeAreaTracker.SafeAreaOverride =
+                  () => new Rect(0f, 100f, 1080f, 1820f);
+              SafeAreaTracker.ScreenSizeOverride =
+                  () => new Vector2(1080f, 1920f);
+
+              const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+  <PromptUGUI version='1'><Screen name='S'>
+    <Variant when='mobile'>
+      <Add>
+        <SafeArea id='sa'/>
+      </Add>
+    </Variant>
+  </Screen></PromptUGUI>";
+              UI.LoadDocument("test", xml);
+              var screen = UI.Open("S");
+              screen.Variants.SetActive("mobile", true);
+              yield return null;
+
+              var sa = screen.Get<SafeArea>("sa");
+              Assert.IsNotNull(sa);
+              Assert.AreEqual(100f / 1920f, sa.RectTransform.anchorMin.y, 0.001f);
+
+              screen.Variants.SetActive("mobile", false);
+              yield return null;
+              Assert.IsFalse(sa.GameObject.activeSelf, "Add block goes inactive");
+
+              screen.Variants.SetActive("mobile", true);
+              yield return null;
+              Assert.IsTrue(sa.GameObject.activeSelf);
+              Assert.AreEqual(100f / 1920f, sa.RectTransform.anchorMin.y, 0.001f,
+                  "tracker re-applies after reactivation");
+          }
+      }
+  }
+  ```
+
+  > **Note on Variants API:** the third test calls `screen.Variants.SetActive(name, bool)`. If the actual method name differs (e.g. it returns or takes a different signature), check `Runtime/Application/VariantStore.cs` and adjust — but the activation semantics are spec'd in §8 of the master spec.
+
+- [ ] **Step 6.2: Run PlayMode tests**
+
+  ```
+  mcp__UnityMCP__refresh_unity(compile="request", mode="standard", scope="all", wait_for_ready=true)
+  mcp__UnityMCP__read_console(action="get", types=["error"])
+  mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], filter="SafeAreaTests")
+  ```
+
+  Expected: 3 PlayMode tests pass. If `Children_inherit_safe_area_rect_after_layout` fails because the canvas parent isn't what we expected, inspect via:
+
+  ```
+  mcp__UnityMCP__read_console(action="get", types=["error", "warning"])
+  ```
+
+  Most common failure modes:
+  - `sa.RectTransform.parent` isn't the canvas RectTransform — Screen may wrap in another container. Adjust by walking up `transform.parent` until you hit the `Canvas` component, then resize THAT RectTransform.
+  - Variant `Add` block in test 3 doesn't activate — confirm the `SetActive` signature against `VariantStore.cs`.
+
+- [ ] **Step 6.3: Commit (ask user)**
+
+  ```bash
+  git add Tests/PlayMode/Controls/SafeAreaTests.cs \
+          Tests/PlayMode/Controls/SafeAreaTests.cs.meta
+  git commit -m "$(cat <<'EOF'
+  test(playmode): SafeArea integration coverage
+
+  Real-canvas layout, dimensions-change reapply, and variant Add
+  block round-trip.
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  EOF
+  )"
+  ```
+
+---
+
+## Task 7: Author-facing documentation
+
+**Files:**
+- Modify: `.claude/skills/authoring-promptugui-xml/SKILL.md` (add `## Safe area` section)
+- Modify: `docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md` (append note in §5 referencing the new design doc)
+
+- [ ] **Step 7.1: Locate insertion point in SKILL.md**
+
+  Open `.claude/skills/authoring-promptugui-xml/SKILL.md` and find the existing "Built-in primitives" / "Controls overview" section (whichever lists `Frame`, `Image`, etc.). The new `## Safe area` section should land immediately after the built-in primitives list — readers see the catalog first, then learn about SafeArea as a special-purpose container.
+
+- [ ] **Step 7.2: Append the SKILL section**
+
+  Insert:
+
+  ````markdown
+  ## Safe area
+
+  Mobile devices have unsafe insets — notch, status bar, home indicator, gesture
+  bar. Wrap your UI in `<SafeArea>` to stay inside `Screen.safeArea`. Backgrounds
+  that should bleed to the device edges stay outside, as siblings of `<SafeArea>`:
+
+  ```xml
+  <Screen name="Login">
+    <Image id="bg" anchor="stretch" color="#0B1828"/>
+    <SafeArea>
+      <HStack id="brandBar" anchor="top-left" width="320" height="56" margin="24,_,_,24">
+        ...
+      </HStack>
+    </SafeArea>
+  </Screen>
+  ```
+
+  Rules:
+
+  - `<SafeArea>` is always stretched to the safe area; it does **not** accept
+    `anchor`, `size`, `width`, `height`, `margin`, or `pivot` (including their
+    `.variant` override forms). Writing any of those is a parse error.
+  - To add inner padding inside the safe area, wrap content in
+    `<Frame anchor="stretch" margin="..."/>` *inside* the `<SafeArea>`.
+  - Place `<SafeArea>` as a direct child of `<Screen>`. Nesting another
+    `<SafeArea>` inside one is harmless but redundant (the inner one collapses
+    to the outer one's rect).
+  - Don't put `<SafeArea>` inside `<VStack>` / `<HStack>` / `<Grid>` — the
+    layout group will override its anchor math.
+  - Reacts automatically to screen rotation, window resize, and Unity 6's
+    Device Simulator. No code-side wiring needed.
+  ````
+
+- [ ] **Step 7.3: Update master spec §5**
+
+  Open `docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md`. Find the end of §5 (the last subsection before §6). Append a brief subsection or note:
+
+  ```markdown
+  ### 5.5 `<SafeArea>` 安全区容器
+
+  作为显式安全区包裹层；语义、运行时和测试约定详见
+  [`2026-05-13-safearea-builtin-design.md`](2026-05-13-safearea-builtin-design.md)。
+  禁止 `anchor` / `size` / `width` / `height` / `margin` / `pivot`（含 `.variant` 覆盖），
+  几何完全由 `Screen.safeArea` 驱动。
+  ```
+
+  > **If §5 already has a 5.4 final subsection**, append as §5.5. If the numbering pattern looks different in the latest master spec, follow that pattern instead — the goal is a one-paragraph pointer from the master spec into this design doc.
+
+- [ ] **Step 7.4: Commit (ask user)**
+
+  ```bash
+  git add .claude/skills/authoring-promptugui-xml/SKILL.md \
+          docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
+  git commit -m "$(cat <<'EOF'
+  doc: SafeArea author guide + master spec pointer
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  EOF
+  )"
+  ```
+
+---
+
+## Task 8: Lint + full test sweep + Editor manual verify
+
+- [ ] **Step 8.1: Run lint**
+
+  ```bash
+  cd /workspace-PromptUGUI/.lint
+  dotnet format whitespace PromptUGUI.Lint.slnx
+  dotnet format style PromptUGUI.Lint.slnx
+  dotnet format analyzers PromptUGUI.Lint.slnx
+  dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+  ```
+
+  Expected: exit 0 on the verify step. If a `style`/`analyzers` pass *changes* files, review the diff carefully (per CLAUDE.md, `info`-severity analyzer fixes can break Unity reflection contracts — but `warn`-level should be safe).
+
+- [ ] **Step 8.2: Run all EditMode assemblies**
+
+  ```
+  mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+  mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+  ```
+
+  Expected: all green. Pay attention to `XsdGeneratorTests` — the reflection-driven generator should now include `SafeArea`. If a snapshot/substring assertion needs updating (per CLAUDE.md these use `StringAssert.Contains` not byte-exact), do it as the smallest possible follow-up commit.
+
+- [ ] **Step 8.3: Run all PlayMode tests**
+
+  ```
+  mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])
+  ```
+
+  Expected: all green.
+
+- [ ] **Step 8.4: Manual Device Simulator check (host project)**
+
+  Tell the user to open the host project (`C:\xsoft\PromptUGUIDev`), pick a Screen with a `<SafeArea>` content (suggest editing a demo XML to add one if none exists), and toggle between iPhone 14 Pro / iPad / Pixel in Window → Game → Device Simulator. Confirm SafeArea content avoids notch and home indicator.
+
+  This is a **manual** step — log a confirmation comment in the PR description rather than an automated assertion.
+
+- [ ] **Step 8.5: Lint commit if needed**
+
+  If `dotnet format` made changes:
+
+  ```bash
+  git add -A
+  git commit -m "$(cat <<'EOF'
+  chore: dotnet format pass after SafeArea landing
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  EOF
+  )"
+  ```
+
+- [ ] **Step 8.6: Final summary to user**
+
+  Report:
+  - Files added/modified (count)
+  - Tests added (EditMode + PlayMode counts)
+  - Console clean / all suites green
+  - Any deferred items (e.g., XSD generator per-tag deny-list — see spec §6 risk row; if generator works fine with the existing wide-attr schema, this remains "not needed for v1")
+
+---
+
+## Notes / Reminders
+
+- **No commits without explicit user OK.** CLAUDE.md governs; ask each task's commit step.
+- **UnityMCP only for tests.** Don't shell out to `Unity -batchmode`. If MCP loses connection, ask the user to reconnect (per CLAUDE.md).
+- **Refresh before reading console.** After any source edit run `refresh_unity` then `read_console action=get types=["error"]` before running tests.
+- **Don't run `Assets/Reimport All`** via `execute_menu_item` — it pops a modal that blocks MCP (CLAUDE.md forbidden list).
+- **Strategy C for Add blocks** (spec'd in CLAUDE.md): the third PlayMode test in Task 6 relies on Add-block instantiate-once + SetActive toggling. If reactivation drops the tracker, that's an Add-block bug to triage separately, not a SafeArea bug.

--- a/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
+++ b/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
@@ -203,6 +203,15 @@ Template 同名（含 commons 与各 Import 的任意组合）→ 报错；`as="
 - `size` 默认 `native`，Icon 独占该值
 - 完整 attrs 见 §5.3
 
+### 5.5 `<SafeArea>`（安全区容器）
+
+显式安全区包裹层；运行时按 `Screen.safeArea` 把自己 inset 到设备的安全矩形里，自动响应屏幕旋转 / 窗口缩放 / Device Simulator 切换 / Variant ReSolve。完整设计见独立 spec [`2026-05-13-safearea-builtin-design.md`](2026-05-13-safearea-builtin-design.md)。
+
+简表：
+- 不接受 `anchor` / `size` / `width` / `height` / `margin` / `pivot`（含 `.variant` 覆盖）—— 几何完全由 `Screen.safeArea` 驱动；写这些属性会在 parse 期抛 `ParseException`。
+- 允许 `id` / `hidden` / `interactable` / `if=`。
+- 典型用法：作为 `<Screen>` 直接子节点，UI 全放它里面；需要 bleed 到屏幕物理边缘的背景图作为 SafeArea 的兄弟节点。
+
 ---
 
 ## 6. 锚点与尺寸

--- a/docs~/superpowers/specs/2026-05-13-safearea-builtin-design.md
+++ b/docs~/superpowers/specs/2026-05-13-safearea-builtin-design.md
@@ -1,0 +1,380 @@
+# `<SafeArea>` 内置控件设计
+
+**日期**：2026-05-13
+**状态**：设计阶段（待 review，未进入实施）
+**作用域**：新增 `<SafeArea>` 内置控件，作为显式安全区容器；运行时按 `Screen.safeArea` 计算 anchor 分数，自动响应屏幕旋转 / Device Simulator 切换 / Variant ReSolve。背景图等需要 bleed 到屏幕边缘的元素继续作为 SafeArea 的兄弟节点放在 `<Screen>` 根下。
+**依赖**：[`2026-05-07-promptugui-description-language-design.md`](2026-05-07-promptugui-description-language-design.md) §5（内置原语）、§6.2（anchor stretch 结构约束）；`Runtime/Application/RectDimensionsRelay.cs`（已有的 RectTransform dimensions 事件桥）
+
+---
+
+## 1. 背景与目标
+
+iOS notch / 灵动岛 / 安卓打孔屏 / 手势条 / Android 系统状态栏在不同设备和屏幕方向下产生不规则的 unsafe inset。Unity 的 `UnityEngine.Screen.safeArea` 已经把这些差异收敛成单一 `Rect`（设备坐标，像素单位），但 PromptUGUI 当前**没有任何**封装让 XML 作者声明"这个容器要待在安全区内"。
+
+调研结果：
+- 仓库内 grep `safeArea` / `SafeArea` 零命中。
+- `Runtime/Application/RectDimensionsRelay.cs` 已经把 `OnRectTransformDimensionsChange` magic method 接成 C# event，`Screen.RectTransformDimensionsChanged` 在 `Screen.Open`（Runtime/Application/Screen.cs:100）里被订阅出去。屏幕旋转 / 窗口缩放 / Device Simulator 切换都会触发它。
+- 14 个现存 built-in 控件全部继承自 `Control`（非 MonoBehaviour），通过 `BuiltinPrimitives.Register` 在 `UI.ResetForTests` / `UI.Initialize` 时统一注册。`Frame.cs` 是无视觉、无 `[UIAttr]` 的最小样板，是 SafeArea 的最佳参考。
+
+### 触发场景
+
+```xml
+<Screen name="Login">
+  <Image id="bg" anchor="stretch" color="#0B1828"/>
+  <HStack id="brandBar" anchor="top-left" width="320" height="56" margin="24,_,_,24">
+    ...
+  </HStack>
+</Screen>
+```
+
+期望：背景 bleed 到屏幕物理边缘；`brandBar` 距 notch / 状态栏底沿 24px。
+实际：`brandBar` 的 24px 是相对 canvas 顶部、不是相对 safe area 顶部，notch 设备上会被刘海吃掉。
+
+### 目标
+
+1. 新增 `<SafeArea>` 内置控件，把"安全区"做成显式 XML 容器，组合性优于"Screen 默认安全区+背景 opt-out"。
+2. 运行时使用 anchor-fraction 方案（Unity 官方推荐路径）：`anchorMin/Max` = safeArea 在 `Screen.width/height` 上的占比，`offsetMin/Max = 0`。这是 resolution-independent 的写法，跟 `CanvasScaler` 配合不需要换算。
+3. 自动响应三类变化：
+   - 屏幕旋转 / 窗口缩放 / Device Simulator → `OnRectTransformDimensionsChange` magic method 触发重算
+   - Variant `ReSolve` → 在 `ControlAttributeApplier.Apply` 之后自动补一次
+   - GameObject `OnEnable` → 进入显示状态时计算一次
+4. 不引入任何作者可调参数。`<SafeArea>` 的所有几何行为完全由 `Screen.safeArea` 决定，无 `edges=` 之类的精细控制。
+5. 解析期强制锁定 `<SafeArea>` 不接受 layout 类属性，从语义层避免歧义。
+
+### 显式不做
+
+- ❌ `edges="top,bottom"` 之类的"只对特定边 inset"参数（`Screen.safeArea` 在无 notch 的边自动为 0，已经隐含正确行为；加 attr 是徒增复杂度）
+- ❌ 在 `<Screen>` 上做"默认安全区"开关（背景 bleed 是更高频的需求，opt-in 容器更直观且组合性好）
+- ❌ 允许 `<SafeArea margin="...">`（保持单一职责：要 padding 用 `<Frame>` 嵌套一层就行）
+- ❌ Editor-only 的 fake safe area 注入机制（Unity 6 Device Simulator 已经会重写 `Screen.safeArea`，是 Editor 内验布局的标准路径）
+- ❌ 自定义"非全屏"SafeArea（譬如 `<SafeArea anchor="bottom-stretch">` 只在底部 inset 手势条）；嵌套 `<Frame>` 可表达同等意图
+- ❌ 把 SafeArea 做成 layout group（它不是布局算法，只是一层 RectTransform 重整）
+
+---
+
+## 2. 决策一览
+
+| # | 决策 | 选择 | 理由 |
+|---|---|---|---|
+| SA-D1 | 作为 built-in 控件（vs 作为属性 `safeArea="true"` on any control） | built-in `<SafeArea>` | 跟 `<Frame>` 同形式，组合性强；不污染所有控件的属性表；XSD 生成器（M4）自动包含新 tag |
+| SA-D2 | inset 算法 | anchor-fraction：`anchorMin/Max = safeArea / Vector2(Screen.width, Screen.height)`，`offsetMin/Max = 0` | Unity 官方 SafeArea 示例的路径；resolution / CanvasScaler 无关 |
+| SA-D3 | 应用时机 | (a) `OnEnable`、(b) `OnRectTransformDimensionsChange` magic method、(c) `Control.OnAfterApply` 钩子 | 三类变化分别走三个触发点；语义清晰、避免轮询 |
+| SA-D4 | 内部组件挂载方式 | 在 SafeArea.OnAttached 里 `AddComponent<SafeAreaTracker>()`，tracker 自己持有 RectTransform 引用 | tracker = MonoBehaviour，承担 Unity magic method；Control 子类保持非 MonoBehaviour 路线 |
+| SA-D5 | `Control.OnAfterApply` 钩子 | **新增** internal virtual hook，在 `ControlAttributeApplier.Apply` 末尾调一次；默认实现为空 | Variant ReSolve 会重写 `anchorMin/Max`，tracker 必须在 ApplyCommon 之后补一次；不加钩子就只能在 LateUpdate 轮询，更脏 |
+| SA-D6 | 测试可注入 | `SafeAreaTracker` 暴露 `internal static Func<Rect> SafeAreaOverride`（默认 null → 走 `Screen.safeArea`） | `Screen.safeArea` 是 static get-only，测试无法直接 mock；提供静态注入点是最小代价的可测设计 |
+| SA-D7 | 禁止属性集 | `anchor`、`size`、`width`、`height`、`margin`、`pivot` 出现在 `<SafeArea>` 上 → ParseException | 跟 §6.2 "stretch 上不允许 size" 同精神：避免作者写出会被运行时无视的属性，让违反语义的事在解析期就炸 |
+| SA-D8 | 允许属性集 | `id`、`hidden`、`interactable`、`if=` | 跟其他 built-in 完全对齐 |
+| SA-D9 | 嵌套 SafeArea 处理 | 不报错也不警告 | 第二层 SafeArea 的 `Screen.safeArea` 计算结果跟第一层一致 → 第二层的 anchorMin/Max=(0,0)/(1,1)，等价于一个 stretch Frame；行为是"无害冗余"。SKILL.md 提示"通常一个 Screen 只放一个"就够了 |
+| SA-D10 | parent 不是 `<Screen>` 根时怎么办 | 仍然按 `Screen.safeArea / Screen.width|height` 计算 anchor fraction | SafeArea 的 anchor 是相对 parent 的，但 `Screen.safeArea` 是设备级别的全屏比例。当 SafeArea 不在 Screen 根、parent 自己被 inset 过时，行为可能不直观——这在 v1 是预期外用法。SKILL.md 提示"SafeArea 期望直接放在 `<Screen>` 根下"，不做运行时校验（成本高、收益小） |
+| SA-D11 | 注册位置 | `BuiltinPrimitives.Register` 加一行 `reg.Register<SafeArea>("SafeArea", null);` | 跟其他 built-in 同路径 |
+| SA-D12 | 文件位置 | `Runtime/Controls/SafeArea.cs`（Control 子类）+ `Runtime/Controls/Internal/SafeAreaTracker.cs`（MonoBehaviour） | tracker 放 `Runtime/Controls/Internal/`（目录已存在，跟其他 internal helpers 同处） |
+| SA-D13 | Tracker 取得 parent canvas 尺寸 | 不需要——anchor-fraction 算法只依赖 `Screen.width/Screen.height`（设备像素），跟 canvas reference resolution 无关 | CanvasScaler 把 `Screen.width` 像素 → canvas 单位的换算对 anchor 比例不影响（比例不变量） |
+| SA-D14 | SafeArea 是否作为 LayoutGroup 子节点工作 | 不需特殊处理 | LayoutGroup 接管子节点 anchor → ApplyCommon 走 LayoutElement 分支，SafeArea 在 LayoutGroup 子节点位置时 anchor-fraction 写入会被 layout pass 覆盖。SKILL 提示"SafeArea 不要放进 VStack/HStack/Grid"，运行时不强制校验（同 SA-D10 理由） |
+| SA-D15 | 测试位置 | EditMode：`Tests/EditMode/Controls/SafeAreaTests.cs`（parse-time + structure + 静态 override 注入数值断言）；PlayMode：`Tests/PlayMode/Controls/SafeAreaTests.cs`（真 Canvas + Variant ReSolve 路径 + RectTransformDimensionsChange 触发） | 跟其他 built-in 测试位置对齐 |
+| SA-D16 | XSD 生成器同步 | M4 的 XSD 生成器是反射驱动 → 新增控件自动出现在生成的 schema 里；不需要额外改动 | 顺路验证一遍：跑 M4 `XsdGeneratorTests`，确认 `SafeArea` 在生成结果里 |
+| SA-D17 | SKILL.md 更新范围 | 新增 "Safe area" 小节：XML 模板 + 限制属性集 + 嵌套提示 + "通常放在 `<Screen>` 根下" | CLAUDE.md 触发条件：新增 XML 元素 → 强制 SKILL 更新 |
+| SA-D18 | spec §5 / §6 是否同 PR 改 | 同 PR 在 master spec §5 末尾追加一小段 `<SafeArea>` 描述，引用本设计文档 | 维持"master spec 是入口、详细设计在 dated doc"的 workflow |
+
+---
+
+## 3. 改动面
+
+### 3.1 新文件 `Runtime/Controls/SafeArea.cs`
+
+```csharp
+using PromptUGUI.Controls.Internal;
+using UnityEngine;
+
+namespace PromptUGUI.Controls
+{
+    public sealed class SafeArea : Control
+    {
+        private SafeAreaTracker _tracker;
+
+        public override void OnAttached()
+        {
+            _tracker = GameObject.AddComponent<SafeAreaTracker>();
+        }
+
+        internal override void OnAfterApply()
+        {
+            // ApplyCommon 在变体 ReSolve 时会重写 anchorMin/Max；让 tracker 立刻补一次
+            if (_tracker != null) _tracker.Apply();
+        }
+    }
+}
+```
+
+### 3.2 新文件 `Runtime/Controls/Internal/SafeAreaTracker.cs`
+
+```csharp
+using UnityEngine;
+
+namespace PromptUGUI.Controls.Internal
+{
+    [DisallowMultipleComponent]
+    internal sealed class SafeAreaTracker : MonoBehaviour
+    {
+        // Tests inject a custom provider; default = real device safe area
+        internal static System.Func<Rect> SafeAreaOverride;
+
+        private RectTransform _rt;
+
+        private void OnEnable()
+        {
+            _rt = (RectTransform)transform;
+            Apply();
+        }
+
+        private void OnRectTransformDimensionsChange()
+        {
+            if (_rt == null) return;
+            Apply();
+        }
+
+        internal void Apply()
+        {
+            var safe = SafeAreaOverride != null ? SafeAreaOverride() : Screen.safeArea;
+            var screenSize = new Vector2(Screen.width, Screen.height);
+            if (screenSize.x <= 0f || screenSize.y <= 0f) return;
+
+            var aMin = safe.position;
+            var aMax = safe.position + safe.size;
+            aMin.x /= screenSize.x; aMin.y /= screenSize.y;
+            aMax.x /= screenSize.x; aMax.y /= screenSize.y;
+
+            _rt.anchorMin = aMin;
+            _rt.anchorMax = aMax;
+            _rt.offsetMin = Vector2.zero;
+            _rt.offsetMax = Vector2.zero;
+        }
+    }
+}
+```
+
+### 3.3 `Control.cs` 新增 internal virtual `OnAfterApply`
+
+```csharp
+// 现有 OnAttached 下方添加：
+internal virtual void OnAfterApply() { }
+```
+
+零开销默认实现；其他 13 个 built-in 不需要重写。
+
+### 3.4 `ControlAttributeApplier.Apply` 末尾调用 `OnAfterApply`
+
+在现有 `control.ApplyCommon(...)` 调用之后追加一行：
+
+```csharp
+control.OnAfterApply();
+```
+
+（位置在 ControlAttributeApplier.cs:65 当前 ApplyCommon 调用语句之后）
+
+### 3.5 `BuiltinPrimitives.cs` 注册
+
+`Runtime/Application/BuiltinPrimitives.cs:7-24` 的列表中追加：
+
+```csharp
+reg.Register<SafeArea>("SafeArea", null);
+```
+
+放在 `Frame` 之后，作为另一个"无视觉容器"。
+
+### 3.6 `UIDocumentParser.cs` 解析期校验
+
+在 `ParseElement`（line 229-317）中，识别 `tag == "SafeArea"` 时遍历 attributes，命中禁止集（`anchor` / `size` / `width` / `height` / `margin` / `pivot`）即抛：
+
+```
+ParseException: <SafeArea> does not accept attribute '{attr}';
+SafeArea is always stretched to Screen.safeArea. To add inner padding,
+wrap the content in a <Frame margin="..."/> inside the SafeArea.
+(line {n}, col {m})
+```
+
+实现上跟 §6.2 "stretch axis 上不允许 size" 的校验放同一处（或新建一个 `SafeAreaValidator` static helper，被 `ParseElement` 调用）。
+
+### 3.7 `Tests/EditMode/Controls/SafeAreaTests.cs` 新文件
+
+见 §6。
+
+### 3.8 `Tests/PlayMode/Controls/SafeAreaTests.cs` 新文件
+
+见 §6。
+
+### 3.9 `.claude/skills/authoring-promptugui-xml/SKILL.md`
+
+新增小节，见 §7。
+
+### 3.10 `2026-05-07-promptugui-description-language-design.md` §5 末尾
+
+追加一段（约 5 行）说明 `<SafeArea>` 存在 + 引用本 design 文档。
+
+---
+
+## 4. 触发与重算流
+
+```
+Author writes <SafeArea> in XML
+        │
+        ▼
+Parser validates禁止属性集 (SA-D7)
+        │
+        ▼
+ScreenInstantiator creates GameObject + AttachTo
+        │
+        ├─ OnAttached → tracker = AddComponent<SafeAreaTracker>
+        │      └─ tracker.OnEnable → tracker.Apply (1st write)
+        │
+        ▼
+ControlAttributeApplier.Apply
+        ├─ ApplyCommon writes anchor=stretch / sizeDelta=0 (the standard path)
+        └─ OnAfterApply → tracker.Apply (overrides anchor with safe-area fractions)
+        │
+        ▼
+Screen.Open completes. Steady state.
+
+Variant change:
+        VariantStore.Changed → Screen.ReSolve
+            → ControlAttributeApplier.Apply on every node
+                → ApplyCommon overwrites anchor (back to stretch)
+                → OnAfterApply → tracker.Apply (re-applies safe area fractions)
+
+Screen rotation / window resize / Device Simulator switch:
+        Unity fires OnRectTransformDimensionsChange on tracker
+            → tracker.Apply (idempotent: writes same values if unchanged)
+```
+
+无轮询、无每帧 LateUpdate、无线程问题。
+
+---
+
+## 5. 公开 API 表
+
+| 状态 | 签名 / 行为 | 说明 |
+|---|---|---|
+| 新内置控件 | `<SafeArea id="..." hidden="..." interactable="..." if="..."/>` | 可包含任意子节点；作者面 |
+| 新 C# 类 | `public sealed class PromptUGUI.Controls.SafeArea : Control` | 作者可通过 `screen.Get<SafeArea>("id")` 取到 |
+| 新 internal | `SafeAreaTracker` 在 `PromptUGUI.Controls.Internal` 命名空间 | 不暴露 |
+| 新 internal | `Control.OnAfterApply()` virtual | InternalsVisibleTo 范围内可见；其他 control 默认实现为空 |
+| 新 internal 静态 | `SafeAreaTracker.SafeAreaOverride : Func<Rect>` | 仅用于测试 mock；非测试代码不应触碰 |
+| 新解析期错误 | `<SafeArea>` 上出现禁止属性 → `ParseException` | 错误文案要可读 |
+| 不变 | 其他所有控件 / Variant / Template / Hot reload / XSD 生成器外部行为 | XSD 自动收录新 tag（反射驱动），但生成结果不需要手动改 |
+
+---
+
+## 6. 测试矩阵
+
+### EditMode (`Tests/EditMode/Controls/SafeAreaTests.cs`)
+
+| 用例 | 期望 |
+|---|---|
+| `<SafeArea/>` 实例化 | GameObject 上挂着 `SafeAreaTracker`；`screen.Get<SafeArea>("id")` 取得回 |
+| `<SafeArea anchor="stretch"/>` | `ParseException`，message 含 `"anchor"` |
+| `<SafeArea size="100x100"/>` | `ParseException`，message 含 `"size"` |
+| `<SafeArea width="100"/>` | `ParseException`，message 含 `"width"` |
+| `<SafeArea height="100"/>` | `ParseException`，message 含 `"height"` |
+| `<SafeArea margin="10"/>` | `ParseException`，message 含 `"margin"` |
+| `<SafeArea pivot="0.5,0.5"/>` | `ParseException`，message 含 `"pivot"` |
+| 注入 `SafeAreaOverride = () => new Rect(0, 100, 1080, 1820)`, `Screen.width=1080, Screen.height=1920` | tracker.Apply 后 RectTransform: anchorMin=(0, 0.0521)、anchorMax=(1, 1)（容差 0.001） |
+| 注入 `SafeAreaOverride = () => 全屏 rect` | anchorMin=(0,0), anchorMax=(1,1) |
+| Variant `ReSolve` 后 anchor 仍是 safe area 分数 | 切 variant → 触发 ReSolve → 再读 tracker.RectTransform 仍是 safe area 分数（OnAfterApply 重新补上） |
+| `<SafeArea hidden="true">` | `GameObject.activeSelf == false`；tracker 不触发（OnEnable 不跑） |
+| 子节点继承 SafeArea rect | SafeArea 内放 `<Frame anchor="stretch"/>`，layout pass 后 frame rect == SafeArea rect |
+
+### PlayMode (`Tests/PlayMode/Controls/SafeAreaTests.cs`)
+
+| 用例 | 期望 |
+|---|---|
+| 真 Canvas + 注入 mock safe area，手动触发 `LayoutRebuilder.ForceRebuildLayoutImmediate` | SafeArea 子节点的 `rect.size` 缩小至 safe area 区域 |
+| `Screen.RectTransformDimensionsChanged` 触发后 tracker 重新 Apply | 改 mock provider 返回值 → 触发 dimension change → 新值生效 |
+| SafeArea 在 Variant `Add` 块里、变体切换时 instantiation + tracker 正常工作 | 第一次激活时 tracker 计算正确；deactivate 后 tracker 不报错；再激活后还是正确 |
+
+### Editor 验证（手工）
+
+打开 Device Simulator → 切到 iPhone 14 Pro / iPad / Pixel → SafeArea 内容自动避开 notch / 状态栏 / 手势条。
+
+### 兼容性回归
+
+- 跑现有所有 EditMode + PlayMode 测试 → 全绿
+- M4 `XsdGeneratorTests`：确认生成的 `.xsd` 包含 `<xs:element name="SafeArea">`，且属性列表里**没有** `anchor` / `size` / `width` / `height` / `margin` / `pivot`（生成器应当识别 SafeArea 的 attribute 限制，可能需要小改 generator；如果太烦琐，spec 上允许 generator 输出"完整通用 attribute 列表 + parser 在运行时把关"的折中方案）
+
+> **Generator 改动权衡留到 plan 阶段**：如果改 generator 识别"per-tag 禁止属性"成本高，回退到"XSD 允许任意 attribute、parser 拒绝禁止集"。决策点放在 plan 评审。
+
+---
+
+## 7. SKILL.md 同步
+
+在 `.claude/skills/authoring-promptugui-xml/SKILL.md` 中加新章节，位置紧跟 "Built-in primitives" 那节之后或单列一节 "Safe area"：
+
+````markdown
+## Safe area
+
+Mobile devices have unsafe insets — notch, status bar, home indicator, gesture
+bar. Wrap your UI in `<SafeArea>` to stay inside `Screen.safeArea`. Backgrounds
+that should bleed to the device edges stay outside, as siblings of `<SafeArea>`:
+
+```xml
+<Screen name="Login">
+  <Image id="bg" anchor="stretch" color="#0B1828"/>
+  <SafeArea>
+    <HStack id="brandBar" anchor="top-left" width="320" height="56" margin="24,_,_,24">
+      ...
+    </HStack>
+  </SafeArea>
+</Screen>
+```
+
+Rules:
+
+- `<SafeArea>` is always stretched to the safe area; it does **not** accept
+  `anchor`, `size`, `width`, `height`, `margin`, or `pivot`. Writing any of
+  those is a parse error.
+- To add inner padding inside the safe area, wrap content in
+  `<Frame anchor="stretch" margin="..."/>` *inside* the `<SafeArea>`.
+- Place `<SafeArea>` as a direct child of `<Screen>`. Nesting another
+  `<SafeArea>` inside one is harmless but redundant (the inner one collapses
+  to the outer one's rect).
+- Don't put `<SafeArea>` inside `<VStack>` / `<HStack>` / `<Grid>` — the
+  layout group will override its anchor math.
+- Reacts automatically to screen rotation, window resize, and Unity 6's
+  Device Simulator. No code-side wiring needed.
+````
+
+---
+
+## 8. 风险
+
+| 风险 | 影响 | 缓解 |
+|---|---|---|
+| 作者把 `<SafeArea>` 放在 LayoutGroup 子节点位置 | LayoutGroup 接管 anchor → tracker 写入被覆盖、行为静默错误 | SKILL.md 提示；后续 milestone 可考虑运行时 LogWarning |
+| `OnRectTransformDimensionsChange` 重入 | tracker.Apply 写 RectTransform → 触发自己 → 再 Apply | Apply 是幂等的（同输入 → 同输出），第二轮写相同值不再触发；最坏 1 次冗余 |
+| `Control.OnAfterApply` 是新公开钩子（即便 internal），未来扩展可能引入"per-control after-apply 顺序"问题 | 设计 surface 微膨胀 | v1 只有 SafeArea 用；约束"OnAfterApply 内不要修改其他控件"，类似 Control 内其他 hook 的契约 |
+| `Screen.safeArea` 在 Editor 非 Device Simulator 模式下 = 全屏，tracker 计算结果 = (0,0)-(1,1) | EditMode 测试看不出错位（这是 design 而非 bug） | EditMode 测试用 `SafeAreaOverride` 注入；Editor 视觉验证靠 Device Simulator |
+| Variant `Add` 块里第一次激活时 OnAttached 跑了，之后 deactivate 不卸 tracker；再激活时 tracker 已存在 | OnEnable 仍能触发 → 没问题 | `[DisallowMultipleComponent]` 防止重复挂；激活 / deactivate 都不动 tracker 生命周期 |
+| XSD generator 不识别 SafeArea 的属性禁止集 | Editor 自动补全可能建议 `anchor=` 等被禁属性 | plan 阶段决定：要么改 generator 透传 per-tag deny list；要么 XSD 全宽放、靠 parser 兜底（见 §6 测试备注） |
+
+---
+
+## 9. 实施顺序（plan 时细化）
+
+1. EditMode red 测：写一个 `<SafeArea anchor="stretch"/>` 期望 `ParseException`；同时一个 mock-injected 测期望 anchorMin/Max 计算正确
+2. 新增 `Control.OnAfterApply` virtual + `ControlAttributeApplier` 末尾调用（含其他 control 不受影响的回归测）
+3. 实现 `SafeArea.cs` + `SafeAreaTracker.cs`，注册到 `BuiltinPrimitives`
+4. `UIDocumentParser` 加 SafeArea 属性校验逻辑（独立 helper / inline TBD by plan）
+5. EditMode 全套用例补完 → 全绿
+6. PlayMode 三条用例 → 全绿
+7. SKILL.md 增加 "Safe area" 章节
+8. master spec §5 末尾追加 `<SafeArea>` 引用本设计文档
+9. host Unity 项目用 Device Simulator 切到 notch 设备目视验证
+
+---
+
+## 10. 开放问题
+
+| 问题 | 处置 |
+|---|---|
+| 是否要让 `<SafeArea>` 接受 `id` 路径下的命名查询（`screen.Get<SafeArea>("path")` 配 ScopedIds）？ | 默认走 `Control` 基类的 `Id` + `ScopedIds`，无需特殊处理 |
+| 是否需要给作者一个 `<UnsafeArea>` 配对元素，明确"我要 bleed"？ | 不加。bleed 是默认行为，加 `<UnsafeArea>` 是冗余语法 |
+| 未来如果要做"只 inset 指定边" | 留作 v2；本 spec §1 显式不做 |
+| 是否应同时为 `Screen.safeArea` 之外的"键盘弹出 inset"考虑？ | 不做。Android `SoftInputMode` / iOS keyboard inset 跟 safeArea 不是一个概念，未来单独立项 |


### PR DESCRIPTION
## Summary

- New `<SafeArea>` built-in: stretches to `Screen.safeArea` (notch / status bar / home indicator / gesture bar). Wrap UI in it; backgrounds stay outside as siblings to bleed past the safe area.
- Parse-time validation: `<SafeArea>` rejects `anchor` / `size` / `width` / `height` / `margin` / `pivot` (incl. `.variant` overrides) — geometry is fully driven by `Screen.safeArea`.
- New internal `Control.OnAfterApply()` virtual called by `ControlAttributeApplier.Apply` after `ApplyCommon`. Default impl is empty; only SafeArea overrides it (to re-push safe-area anchors after Variant ReSolve clobbers them).

## Approach

- `SafeArea : Control` attaches `SafeAreaTracker : MonoBehaviour` in `OnAttached`.
- Tracker uses Unity's anchor-fraction technique: `anchorMin/Max = safeArea / Screen.size`, `offsetMin/Max = 0`.
- Tracker polls `Screen.safeArea` + `Screen.size` in `Update()` and only writes when either changes. **Does not subscribe to `OnRectTransformDimensionsChange`** — that path forms a write-loop with `ApplyCommon` (Unity's RectTransform setters reverse-solve derived properties and dispatch the magic method, which calls Apply back; observed in PlayMode as `UI.Open` hanging with `offsetMax` oscillating between 0 and ~0.65). Aligns with Unity's official SafeArea sample.
- Tests inject static `SafeAreaOverride` / `ScreenSizeOverride` since `Screen.safeArea` is a static getter.

## Docs

- Spec: `docs~/superpowers/specs/2026-05-13-safearea-builtin-design.md`
- Plan: `docs~/superpowers/plans/2026-05-13-safearea-builtin.md`
- Author guide: new `### Safe area` section in `SKILL.md`, built-in table bumped to 14
- Master spec §5.5 added as pointer

## Test plan

- [x] EditMode: 411/411 (7 new SafeArea cases — parse/instantiate, parser denial set, tracker math, OnAttached wiring, ReSolve persistence, magic-method absence regression guard)
- [x] PlayMode: 82/82 (3 new SafeArea cases — anchor settles after one frame, polling picks up provider changes, variant `<Add into='@root'>` toggle round-trip)
- [x] `dotnet format --verify-no-changes --severity warn` clean
- [ ] Manual Device Simulator check in host project (iPhone 14 Pro / iPad / Pixel) — needs reviewer/maintainer