### PR TITLE
feat: Loading modal (non-blocking, code-controlled close)

### DIFF
--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -313,6 +313,7 @@ MODAL          var r = await MessageBox.Open(text, MsgBtn.OK|MsgBtn.Cancel, icon
                UI.Modal.OpenAsync(new MyRequest())          custom ModalRequest<T>
                UI.Modal.CloseAll()                          cancel all pending
                UI.Modal.SortingOrderBase = 1000             default
+               var h = Loading.Open(text); h.Close()         loading spinner (no result)
 ```
 
 ## Modal dialogs
@@ -383,6 +384,43 @@ MessageBox.XmlSrc = "MyUI/Modals/PixelMessageBox.ui";  // resolved by UI.SourceR
 Keys starting with `PromptUGUI/` resolve to the package's bundled Resources; other keys go through `UI.SourceResolver`.
 
 Your XML must declare a Screen with these ids: `text`, `title`, `ok`, `cancel`, `yes`, `no`, `close`. An optional `icon` id is supported but not required (Bind tolerates missing icon node). If you want icon support, your XML must include `<Icon id="icon" name="placeholder:something"/>` because PromptUGUI's parser requires the `name=` attribute on `<Icon>` elements.
+
+### Loading modal
+
+A non-blocking "loading" modal: blocks UI while async work runs, then your code closes it. **Does not accept user input** (ESC cannot dismiss it).
+
+```csharp
+using PromptUGUI.Application.Modals;
+
+var loading = Loading.Open(UI.Tr("Loading..."));
+try
+{
+    await DoWorkAsync();
+    var data = await FetchAsync();
+}
+finally
+{
+    loading.Close();   // idempotent — safe to call multiple times
+}
+```
+
+Differences from `MessageBox.Open`:
+
+- `Loading.Open(text)` returns a `LoadingHandle` **synchronously** — callers do not `await` the modal; they `await` their own background work and then call `handle.Close()`
+- No `TResult` — the modal is not closed by user input
+- `text` is optional; pass `null` or `""` to render the spinner alone
+- Shares the FIFO queue with MessageBox: open Loading + MessageBox in either order, they take turns
+- `handle.Close()` is safe after `UI.UnloadAll()` / `UI.ResetForTests()` — no-op once the entry is cancelled
+
+#### Overriding the builtin Loading layout
+
+```csharp
+Loading.XmlSrc = "MyUI/Modals/PixelLoading.ui";   // resolved by UI.SourceResolver
+```
+
+Default key is `"PromptUGUI/Modals/Loading.ui"` (note the `.ui` suffix — same Unity multi-dot stripping caveat as MessageBox).
+
+**id contract for custom XML**: only `<Text id="text">` is recognized by `Bind`, and even that is **optional** — Bind catches `KeyNotFoundException` so XML without a `text` element works (e.g. pure spinner with no caption). All other elements (backdrop, container Frame, spinner visuals) have no id contract — design them freely.
 
 ## `<Trigger>` and `<Animation>` from C#
 

--- a/Runtime/Application/Modals/LoadingRequest.cs
+++ b/Runtime/Application/Modals/LoadingRequest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using R3;
 
 namespace PromptUGUI.Application.Modals
@@ -17,7 +18,7 @@ namespace PromptUGUI.Application.Modals
                 if (string.IsNullOrEmpty(Text)) textCtl.GameObject.SetActive(false);
                 else textCtl.TextValue = Text;
             }
-            catch (System.Collections.Generic.KeyNotFoundException) { /* text 元素可选 */ }
+            catch (KeyNotFoundException) { /* text element is optional */ }
         }
     }
 

--- a/Runtime/Application/Modals/LoadingRequest.cs
+++ b/Runtime/Application/Modals/LoadingRequest.cs
@@ -1,0 +1,52 @@
+using System;
+using R3;
+
+namespace PromptUGUI.Application.Modals
+{
+    public sealed class LoadingRequest : ModalRequest<Unit>
+    {
+        public string Text;
+
+        public override string XmlSrc => Loading.XmlSrc;
+
+        public override void Bind(IScreen screen, Action<Unit> close)
+        {
+            try
+            {
+                var textCtl = screen.Get<PromptUGUI.Controls.Text>("text");
+                if (string.IsNullOrEmpty(Text)) textCtl.GameObject.SetActive(false);
+                else textCtl.TextValue = Text;
+            }
+            catch (System.Collections.Generic.KeyNotFoundException) { /* text 元素可选 */ }
+        }
+    }
+
+    public sealed class LoadingHandle
+    {
+        private readonly IModalEntry _entry;
+        private bool _closed;
+
+        public bool IsClosed => _closed;
+
+        internal LoadingHandle(IModalEntry entry) => _entry = entry;
+
+        public void Close()
+        {
+            if (_closed) return;
+            _closed = true;
+            _entry.ResolveExternally();
+        }
+    }
+
+    public static class Loading
+    {
+        // .ui 后缀对齐 MessageBox：Unity 只剥离 .ui.xml 文件名的最后 .xml
+        public static string XmlSrc { get; set; } = "PromptUGUI/Modals/Loading.ui";
+
+        public static LoadingHandle Open(string text = null)
+        {
+            var entry = UI.Modal.EnqueueRequest(new LoadingRequest { Text = text });
+            return new LoadingHandle(entry);
+        }
+    }
+}

--- a/Runtime/Application/Modals/LoadingRequest.cs.meta
+++ b/Runtime/Application/Modals/LoadingRequest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 937d47801635424488b7b77ce8c88531

--- a/Runtime/Application/Modals/ModalEntry.cs
+++ b/Runtime/Application/Modals/ModalEntry.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 
 namespace PromptUGUI.Application.Modals
 {
+    // Non-generic queue entry interface — lets UI.Modal.cs work without referencing
+    // the generic ModalRequest<TResult> type, which Unity's Roslyn fails to resolve
+    // across namespace boundaries in partial-class files.
     internal interface IModalEntry
     {
         public string XmlSrc { get; }

--- a/Runtime/Application/Modals/ModalEntry.cs
+++ b/Runtime/Application/Modals/ModalEntry.cs
@@ -4,9 +4,6 @@ using UnityEngine;
 
 namespace PromptUGUI.Application.Modals
 {
-    // Non-generic queue entry interface — lets UI.Modal.cs work without referencing
-    // the generic ModalRequest<TResult> type, which Unity's Roslyn fails to resolve
-    // across namespace boundaries in partial-class files.
     internal interface IModalEntry
     {
         public string XmlSrc { get; }
@@ -14,12 +11,15 @@ namespace PromptUGUI.Application.Modals
         public bool TryEscape(Action wakePump);
         public void Cancel(Exception ex);
         public bool Resolved { get; }
+        public void SetWaker(Action waker);
+        public void ResolveExternally();
     }
 
     internal sealed class ModalEntry<TResult> : IModalEntry
     {
         private readonly ModalRequest<TResult> _request;
         private readonly AwaitableCompletionSource<TResult> _tcs = new();
+        private Action _waker;
 
         public bool Resolved { get; private set; }
         public string XmlSrc => _request.XmlSrc;
@@ -27,11 +27,6 @@ namespace PromptUGUI.Application.Modals
 
         private ModalEntry(ModalRequest<TResult> request) { _request = request; }
 
-        /// <summary>
-        /// Creates a <see cref="ModalEntry{TResult}"/> for <paramref name="request"/> and
-        /// returns both the queue-compatible <see cref="IModalEntry"/> and the caller's
-        /// <see cref="Awaitable{TResult}"/> in one call.
-        /// </summary>
         internal static (IModalEntry entry, Awaitable<TResult> awaitable) Create(
             ModalRequest<TResult> request)
         {
@@ -65,6 +60,16 @@ namespace PromptUGUI.Application.Modals
             if (Resolved) return;
             Resolved = true;
             _tcs.TrySetException(ex);
+        }
+
+        public void SetWaker(Action waker) => _waker = waker;
+
+        public void ResolveExternally()
+        {
+            if (Resolved) return;
+            Resolved = true;
+            _tcs.TrySetResult(default!);
+            _waker?.Invoke();
         }
     }
 }

--- a/Runtime/Application/UI.Modal.cs
+++ b/Runtime/Application/UI.Modal.cs
@@ -29,6 +29,15 @@ namespace PromptUGUI.Application
                 return awaitable;
             }
 
+            internal static IModalEntry EnqueueRequest<TResult>(ModalRequest<TResult> request)
+            {
+                if (request == null) throw new ArgumentNullException(nameof(request));
+                var (entry, _) = ModalEntry<TResult>.Create(request);
+                _queue.Enqueue(entry);
+                if (!_pumping) _ = PumpAsync();
+                return entry;
+            }
+
             private static async Awaitable PumpAsync()
             {
                 if (_pumping) return;
@@ -38,6 +47,7 @@ namespace PromptUGUI.Application
                     while (_queue.Count > 0)
                     {
                         var entry = _queue.Dequeue();
+                        if (entry.Resolved) continue;                                       // NEW (1)
                         _current = entry;
                         _currentScreenName = entry.XmlSrc;
                         _currentWaiter = new AwaitableCompletionSource<bool>();
@@ -49,6 +59,8 @@ namespace PromptUGUI.Application
                                 LoadDocument(entry.XmlSrc, xml);
                                 _loadedSrcs.Add(entry.XmlSrc);
                             }
+                            if (entry.Resolved) continue;                                   // NEW (2)
+
                             var screen = Open(entry.XmlSrc);
                             var canvas = screen.RootGameObject.GetComponent<Canvas>();
                             canvas.overrideSorting = true;
@@ -56,6 +68,7 @@ namespace PromptUGUI.Application
 
                             var waiter = _currentWaiter;
                             var captured = entry;
+                            captured.SetWaker(() => waiter.TrySetResult(true));             // NEW (3)
                             captured.RunBind(screen, () => waiter.TrySetResult(true));
 
                             var listener = screen.RootGameObject

--- a/Runtime/Controls/Trigger.cs
+++ b/Runtime/Controls/Trigger.cs
@@ -2,6 +2,7 @@ using System;
 using PromptUGUI.Controls.Internal;
 using PromptUGUI.Registry;
 using R3;
+using UnityEngine;
 
 namespace PromptUGUI.Controls
 {
@@ -9,6 +10,27 @@ namespace PromptUGUI.Controls
     {
         private readonly Subject<Unit> _fire = new();
         public Observable<Unit> OnFire => _fire;
+
+        // Trigger / Animation 是装饰器型 wrapper，自身无视觉。当作者没在 wrapper 上写 size 时，
+        // 把唯一直接子节点的 resolved size 当作自身 native size 暴露出来——这样父
+        // V/HStack 看到的是「内容尺寸」而不是 0×0 槽位 (loading-dots 类布局)。Web 端 CSS
+        // 默认 box model 就是 fit-content，这里复刻同一约定。歧义场景 (0/多子节点、子节点
+        // 自己也未定尺寸) 返回 null，回退到「无 LayoutElement / sizeDelta=0」的原行为。
+        // ScreenInstantiator 把 ControlAttributeApplier.Apply (含 ApplyCommon → GetNativeSize)
+        // 放在子树递归之后，所以这里读到的 child.sizeDelta 已是子节点 ApplyCommon 算出的最终值。
+        public override Vector2? GetNativeSize()
+        {
+            if (Children.Count != 1) return null;
+            var child = Children[0] as Control;
+            if (child == null) return null;
+
+            var native = child.GetNativeSize();
+            if (native.HasValue) return native;
+
+            var sd = child.RectTransform.sizeDelta;
+            if (sd.x <= 0f || sd.y <= 0f) return null;
+            return sd;
+        }
 
         private TriggerSpec _spec;
         private IDisposable _sourceSub;

--- a/Runtime/Resources/PromptUGUI/Modals/Loading.ui.xml
+++ b/Runtime/Resources/PromptUGUI/Modals/Loading.ui.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PromptUGUI version="1">
   <Screen name="PromptUGUI/Modals/Loading.ui" reference="1920x1080" reference.portrait="1080x1920">
-    <Image id="backdrop" anchor="stretch" color="#000000C0"/>
+    <Image id="backdrop" anchor="stretch" color="#000000FE"/>
 
     <Frame id="dialog" anchor="center" size="320x160">
       <VStack anchor="stretch" margin="20" spacing="12">
@@ -9,13 +9,13 @@
         <!-- HStack 不加 anchor: VStack 是 layout group, child anchor 会被 PUI-LAYOUT-ANCHOR lint
              报错. VStack 默认 childAlignment=UpperCenter 已经水平居中 width=80 的 HStack. -->
         <HStack height="20" spacing="10" width="80">
-          <Animation fade="0.25:1" duration="0.5s" delay="0s"    easing="in-out-quad" on="loop">
+          <Animation fade="0.05:1" duration="0.5s" delay="0s"    easing="in-out-quad" on="loop">
             <Image width="14" height="14" color="white"/>
           </Animation>
-          <Animation fade="0.25:1" duration="0.5s" delay="0.15s" easing="in-out-quad" on="loop">
+          <Animation fade="0.05:1" duration="0.5s" delay="0.15s" easing="in-out-quad" on="loop">
             <Image width="14" height="14" color="white"/>
           </Animation>
-          <Animation fade="0.25:1" duration="0.5s" delay="0.3s"  easing="in-out-quad" on="loop">
+          <Animation fade="0.05:1" duration="0.5s" delay="0.3s"  easing="in-out-quad" on="loop">
             <Image width="14" height="14" color="white"/>
           </Animation>
         </HStack>

--- a/Runtime/Resources/PromptUGUI/Modals/Loading.ui.xml
+++ b/Runtime/Resources/PromptUGUI/Modals/Loading.ui.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PromptUGUI version="1">
+  <Screen name="PromptUGUI/Modals/Loading.ui" reference="1920x1080" reference.portrait="1080x1920">
+    <Image id="backdrop" anchor="stretch" color="#000000C0"/>
+
+    <Frame id="dialog" anchor="center" size="320x160">
+      <Image anchor="stretch" sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round"/>
+      <VStack anchor="stretch" margin="20" spacing="12">
+
+        <!-- HStack 不加 anchor: VStack 是 layout group, child anchor 会被 PUI-LAYOUT-ANCHOR lint
+             报错. VStack 默认 childAlignment=UpperCenter 已经水平居中 width=80 的 HStack. -->
+        <HStack height="20" spacing="10" width="80">
+          <Animation fade="0.25:1" duration="0.5s" delay="0s"    easing="in-out-quad" on="loop">
+            <Image width="14" height="14" color="white"/>
+          </Animation>
+          <Animation fade="0.25:1" duration="0.5s" delay="0.15s" easing="in-out-quad" on="loop">
+            <Image width="14" height="14" color="white"/>
+          </Animation>
+          <Animation fade="0.25:1" duration="0.5s" delay="0.3s"  easing="in-out-quad" on="loop">
+            <Image width="14" height="14" color="white"/>
+          </Animation>
+        </HStack>
+
+        <Text id="text" width="stretch" height="stretch" fontSize="16"/>
+      </VStack>
+    </Frame>
+  </Screen>
+</PromptUGUI>

--- a/Runtime/Resources/PromptUGUI/Modals/Loading.ui.xml
+++ b/Runtime/Resources/PromptUGUI/Modals/Loading.ui.xml
@@ -4,7 +4,6 @@
     <Image id="backdrop" anchor="stretch" color="#000000C0"/>
 
     <Frame id="dialog" anchor="center" size="320x160">
-      <Image anchor="stretch" sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round"/>
       <VStack anchor="stretch" margin="20" spacing="12">
 
         <!-- HStack 不加 anchor: VStack 是 layout group, child anchor 会被 PUI-LAYOUT-ANCHOR lint
@@ -21,7 +20,7 @@
           </Animation>
         </HStack>
 
-        <Text id="text" width="stretch" height="stretch" fontSize="16"/>
+        <Text id="text" width="stretch" height="stretch" fontSize="46" align="center" color="white"/>
       </VStack>
     </Frame>
   </Screen>

--- a/Runtime/Resources/PromptUGUI/Modals/Loading.ui.xml.meta
+++ b/Runtime/Resources/PromptUGUI/Modals/Loading.ui.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 72c404271fe17d640b6c41cc4c7c117c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Controls/TriggerContentSizingTests.cs
+++ b/Tests/EditMode/Controls/TriggerContentSizingTests.cs
@@ -1,0 +1,146 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using UnityEngine.UI;
+using Animation = PromptUGUI.Controls.Animation;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    // Trigger/Animation 是装饰器型 wrapper，自身无视觉。在 LayoutGroup 子节点上
+    // 应当把唯一直接子节点的 resolved size 当作自身 preferred 暴露出来，
+    // 否则父 LayoutGroup 看到 0×0 槽位会让 wrapper 内的子节点 visually 重叠
+    // （loading-dots 类布局会塌掉）。
+    public class TriggerContentSizingTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Animation_in_HStack_with_sized_Image_reports_image_size_as_preferred()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <HStack id='stack' width='80' height='20' spacing='10'>
+    <Animation id='a' fade='0.25:1' duration='0.3s' on='manual'>
+      <Image width='14' height='14' color='#ffffff'/>
+    </Animation>
+  </HStack>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var anim = screen.Get<Animation>("a");
+            var le = anim.GameObject.GetComponent<LayoutElement>();
+            Assert.IsNotNull(le,
+                "Animation under HStack with a single sized child should auto-attach LayoutElement (auto-proxy)");
+            Assert.AreEqual(14f, le.preferredWidth, 0.5f);
+            Assert.AreEqual(14f, le.preferredHeight, 0.5f);
+            Assert.AreEqual(-1f, le.flexibleWidth);
+            Assert.AreEqual(-1f, le.flexibleHeight);
+        }
+
+        [Test]
+        public void Trigger_in_HStack_with_sized_Image_reports_image_size_as_preferred()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <HStack id='stack' width='80' height='20'>
+    <Trigger id='t' on='manual'>
+      <Image width='14' height='14' color='#ffffff'/>
+    </Trigger>
+  </HStack>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var trig = screen.Get<Trigger>("t");
+            var le = trig.GameObject.GetComponent<LayoutElement>();
+            Assert.IsNotNull(le, "Base Trigger gets the same auto-proxy treatment");
+            Assert.AreEqual(14f, le.preferredWidth, 0.5f);
+            Assert.AreEqual(14f, le.preferredHeight, 0.5f);
+        }
+
+        [Test]
+        public void Animation_in_HStack_with_native_Btn_reports_btn_native_size()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <HStack id='stack' width='400' height='60'>
+    <Animation id='a' type='pulse' on='manual'>
+      <Btn id='b'>OK</Btn>
+    </Animation>
+  </HStack>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var anim = screen.Get<Animation>("a");
+            var btn = screen.Get<Btn>("a/b");
+            var btnNative = btn.GetNativeSize().Value;
+            var le = anim.GameObject.GetComponent<LayoutElement>();
+            Assert.IsNotNull(le);
+            Assert.AreEqual(btnNative.x, le.preferredWidth, 0.5f,
+                "Animation wraps Btn → preferred matches Btn.GetNativeSize() (propagates native through wrapper)");
+            Assert.AreEqual(btnNative.y, le.preferredHeight, 0.5f);
+        }
+
+        [Test]
+        public void Animation_in_HStack_with_stretched_child_no_LayoutElement()
+        {
+            // anchor=stretch + no margin → child.sizeDelta = (0,0): size info indeterminate,
+            // auto-proxy must NOT report a fake size. Existing "no native" path applies (no LE).
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <HStack id='stack' width='80' height='20'>
+    <Animation id='a' fade='0:1' on='manual'>
+      <Image anchor='stretch' color='#ffffff'/>
+    </Animation>
+  </HStack>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var anim = screen.Get<Animation>("a");
+            var le = anim.GameObject.GetComponent<LayoutElement>();
+            Assert.IsNull(le, "child has no size info → no LE attached on Animation");
+        }
+
+        [Test]
+        public void Animation_in_HStack_with_multiple_children_no_LayoutElement()
+        {
+            // Multiple siblings inside _offsetProxy overlap (no internal LayoutGroup);
+            // there's no well-defined bounding size → fall through to current "no LE" path.
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <HStack id='stack' width='80' height='20'>
+    <Animation id='a' fade='0:1' on='manual'>
+      <Image width='14' height='14' color='#ffffff'/>
+      <Image width='10' height='10' color='#888888'/>
+    </Animation>
+  </HStack>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var anim = screen.Get<Animation>("a");
+            var le = anim.GameObject.GetComponent<LayoutElement>();
+            Assert.IsNull(le, "ambiguous content size → auto-proxy declines");
+        }
+
+        [Test]
+        public void Animation_in_HStack_explicit_size_overrides_auto_proxy()
+        {
+            // Existing explicit-size path wins (LE.preferred = Animation's own width/height).
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <HStack id='stack' width='80' height='20'>
+    <Animation id='a' fade='0:1' on='manual' width='30' height='20'>
+      <Image width='14' height='14' color='#ffffff'/>
+    </Animation>
+  </HStack>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var anim = screen.Get<Animation>("a");
+            var le = anim.GameObject.GetComponent<LayoutElement>();
+            Assert.IsNotNull(le);
+            Assert.AreEqual(30f, le.preferredWidth, 0.5f);
+            Assert.AreEqual(20f, le.preferredHeight, 0.5f);
+        }
+    }
+}

--- a/Tests/EditMode/Controls/TriggerContentSizingTests.cs.meta
+++ b/Tests/EditMode/Controls/TriggerContentSizingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 10edab5797f6f794aa2f522a4de7c742

--- a/Tests/EditMode/Modals/LoadingTests.cs
+++ b/Tests/EditMode/Modals/LoadingTests.cs
@@ -154,5 +154,46 @@ namespace PromptUGUI.Tests.Modals
             handle.Close();
             Assert.IsFalse(UI.Modal.IsAnyOpen);
         }
+
+        [Test]
+        public void Mixed_with_MessageBox_respects_FIFO_queue()
+        {
+            // 顺序: Loading 先 → MessageBox 后. Loading 显示, MessageBox 排队
+            var loading = Loading.Open("step 1");
+            var mboxTask = UI.Modal.OpenAsync(new MessageBoxRequest
+            {
+                Text = "step 2",
+                Buttons = MsgBtn.OK,
+            });
+
+            Assert.AreEqual(2, UI.Modal.QueuedCount);
+            Assert.IsNotNull(UI.Get("test/Loading1"), "Loading 应该先显示");
+            Assert.IsNull(UI.Get("test/Box1"), "MessageBox 应该还在队列");
+
+            // 关 Loading → pump 切到 MessageBox
+            loading.Close();
+            Assert.IsTrue(loading.IsClosed);
+            Assert.IsNull(UI.Get("test/Loading1"), "Loading 应该已关闭");
+            Assert.IsNotNull(UI.Get("test/Box1"), "MessageBox 应该接着显示");
+
+            // 关 MessageBox
+            UI.Get("test/Box1").Get<PromptUGUI.Controls.Btn>("ok").SimulateClick();
+            Assert.AreEqual(MsgBtn.OK, mboxTask.GetAwaiter().GetResult());
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+
+        [Test]
+        public void UnloadAll_cancels_loading_and_handle_close_after_is_noop()
+        {
+            var handle = Loading.Open("about to be torn down");
+            Assert.IsTrue(UI.Modal.IsAnyOpen);
+
+            // 模拟 UI 全拆除路径 (ResetForTests 内部会调 CancelAllForTeardown)
+            UI.ResetForTests();
+
+            // 之后 handle.Close 不应该抛 / 不应该副作用
+            Assert.DoesNotThrow(() => handle.Close());
+            Assert.IsTrue(handle.IsClosed);
+        }
     }
 }

--- a/Tests/EditMode/Modals/LoadingTests.cs
+++ b/Tests/EditMode/Modals/LoadingTests.cs
@@ -55,5 +55,36 @@ namespace PromptUGUI.Tests.Modals
             Assert.IsNull(UI.Get("test/Loading1"),
                 "Loading screen 应该已经被 pump 关闭");
         }
+
+        [Test]
+        public void Close_before_pump_skips_modal_instantiation()
+        {
+            // MessageBox 先开 → pump 卡在它的 await waiter 上
+            var mboxTask = UI.Modal.OpenAsync(new MessageBoxRequest
+            {
+                Text = "first",
+                Buttons = MsgBtn.OK,
+            });
+
+            // Loading 入队, 但 pump 没轮到它 (仍在处理 MessageBox)
+            var loading = Loading.Open("queued");
+            Assert.AreEqual(2, UI.Modal.QueuedCount);
+            Assert.IsNull(UI.Get("test/Loading1"),
+                "Loading 还在队列里, screen 还没创建");
+
+            // 关闭 Loading handle —— 走 ResolveExternally → entry.Resolved=true
+            loading.Close();
+            Assert.IsTrue(loading.IsClosed);
+            Assert.IsNull(UI.Get("test/Loading1"),
+                "Close() 在 pre-show 不应该实例化 screen");
+
+            // 关掉 MessageBox → pump 转到 Loading entry, 看到 Resolved=true, 直接 continue
+            UI.Get("test/Box1").Get<PromptUGUI.Controls.Btn>("ok").SimulateClick();
+            Assert.AreEqual(MsgBtn.OK, mboxTask.GetAwaiter().GetResult());
+
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+            Assert.IsNull(UI.Get("test/Loading1"),
+                "Loading screen 整个生命周期都不应该被创建过");
+        }
     }
 }

--- a/Tests/EditMode/Modals/LoadingTests.cs
+++ b/Tests/EditMode/Modals/LoadingTests.cs
@@ -1,0 +1,59 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+
+namespace PromptUGUI.Tests.Modals
+{
+    public class LoadingTests : ModalTestFixture
+    {
+        private const string LoadingTestXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/Loading1'>
+    <Image id='backdrop' anchor='stretch' color='#000000C0'/>
+    <Frame id='dialog' anchor='center' size='320x160'>
+      <VStack anchor='stretch' margin='16' spacing='8'>
+        <Text id='text' fontSize='16'/>
+      </VStack>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+
+        public override void SetUp()
+        {
+            base.SetUp();
+            Files["test/Loading1"] = LoadingTestXml;
+            Loading.XmlSrc = "test/Loading1";
+        }
+
+        [Test]
+        public void Open_returns_handle_and_modal_is_shown_with_text()
+        {
+            var handle = Loading.Open("加载中...");
+
+            Assert.IsNotNull(handle);
+            Assert.IsFalse(handle.IsClosed);
+            Assert.IsTrue(UI.Modal.IsAnyOpen);
+
+            var screen = UI.Get("test/Loading1");
+            Assert.IsNotNull(screen, "Loading screen 应该已经被 pump 实例化");
+
+            var text = screen.Get<PromptUGUI.Controls.Text>("text");
+            Assert.IsTrue(text.GameObject.activeSelf);
+            Assert.AreEqual("加载中...", text.TmpComponent.text);
+        }
+
+        [Test]
+        public void Close_dismisses_modal_and_marks_handle_closed()
+        {
+            var handle = Loading.Open("hi");
+            Assert.IsTrue(UI.Modal.IsAnyOpen);
+
+            handle.Close();
+
+            Assert.IsTrue(handle.IsClosed);
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+            Assert.IsNull(UI.Get("test/Loading1"),
+                "Loading screen 应该已经被 pump 关闭");
+        }
+    }
+}

--- a/Tests/EditMode/Modals/LoadingTests.cs
+++ b/Tests/EditMode/Modals/LoadingTests.cs
@@ -86,5 +86,73 @@ namespace PromptUGUI.Tests.Modals
             Assert.IsNull(UI.Get("test/Loading1"),
                 "Loading screen 整个生命周期都不应该被创建过");
         }
+
+        [Test]
+        public void Close_is_idempotent()
+        {
+            var handle = Loading.Open("hi");
+            handle.Close();
+            Assert.IsTrue(handle.IsClosed);
+
+            // 第二次 Close 不应该抛
+            Assert.DoesNotThrow(() => handle.Close());
+            Assert.IsTrue(handle.IsClosed);
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+
+        [Test]
+        public void Text_null_hides_text_node()
+        {
+            Loading.Open(null);
+            var text = UI.Get("test/Loading1").Get<PromptUGUI.Controls.Text>("text");
+            Assert.IsFalse(text.GameObject.activeSelf);
+        }
+
+        [Test]
+        public void Text_empty_hides_text_node()
+        {
+            Loading.Open("");
+            var text = UI.Get("test/Loading1").Get<PromptUGUI.Controls.Text>("text");
+            Assert.IsFalse(text.GameObject.activeSelf);
+        }
+
+        [Test]
+        public void TryEscape_listener_does_not_close_loading()
+        {
+            var handle = Loading.Open("press ESC and see nothing");
+            var listener = UI.Get("test/Loading1")
+                .RootGameObject.GetComponent<ModalEscapeListener>();
+            Assert.IsNotNull(listener, "Pump 必须给 Loading screen 也挂 ModalEscapeListener");
+
+            listener.FireForTests();
+
+            Assert.IsTrue(UI.Modal.IsAnyOpen, "Loading 应该仍然显示");
+            Assert.IsFalse(handle.IsClosed);
+            UI.Modal.CloseAll();   // teardown 干净点
+        }
+
+        [Test]
+        public void Custom_xml_without_text_id_does_not_throw()
+        {
+            // 模拟用户自定义 XML 时把 text 元素删了的场景
+            const string customXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/Loading2'>
+    <Image id='backdrop' anchor='stretch' color='#000000C0'/>
+    <Frame anchor='center' size='200x100'>
+      <Image anchor='stretch' color='white'/>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+            Files["test/Loading2"] = customXml;
+            Loading.XmlSrc = "test/Loading2";
+
+            var handle = Loading.Open("仍然传 text 但 XML 没 text 元素");
+            Assert.IsNotNull(handle, "Bind 不应该抛 KeyNotFoundException");
+            Assert.IsTrue(UI.Modal.IsAnyOpen);
+
+            handle.Close();
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
     }
 }

--- a/Tests/EditMode/Modals/LoadingTests.cs
+++ b/Tests/EditMode/Modals/LoadingTests.cs
@@ -195,5 +195,24 @@ namespace PromptUGUI.Tests.Modals
             Assert.DoesNotThrow(() => handle.Close());
             Assert.IsTrue(handle.IsClosed);
         }
+
+        [Test]
+        public void Default_xml_src_loads_builtin_template()
+        {
+            // 把 XmlSrc 切回默认 (base.SetUp 把它改成了 test/Loading1)
+            Loading.XmlSrc = "PromptUGUI/Modals/Loading.ui";
+
+            var handle = Loading.Open("from real template");
+            Assert.IsNotNull(handle);
+            Assert.IsTrue(UI.Modal.IsAnyOpen);
+
+            var screen = UI.Get("PromptUGUI/Modals/Loading.ui");
+            Assert.IsNotNull(screen, "默认 Loading.ui.xml 应该能从 Resources 加载");
+
+            var text = screen.Get<PromptUGUI.Controls.Text>("text");
+            Assert.AreEqual("from real template", text.TmpComponent.text);
+
+            handle.Close();
+        }
     }
 }

--- a/Tests/EditMode/Modals/LoadingTests.cs.meta
+++ b/Tests/EditMode/Modals/LoadingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ae6736227d7e37744b0136a1ec9912ab

--- a/docs~/superpowers/plans/2026-05-16-loading-modal.md
+++ b/docs~/superpowers/plans/2026-05-16-loading-modal.md
@@ -1,0 +1,853 @@
+# Loading Modal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 加一个 `Loading.Open(text)` 内置模态：业务调用方拿到 `LoadingHandle`，跑后台任务，结束后 `handle.Close()`；视觉是三个 `<Animation fade loop>` 错相脉冲点；ESC 不可关闭；用户可通过 `Loading.XmlSrc` 整体替换默认 XML。
+
+**Architecture:** 新增 `LoadingRequest : ModalRequest<R3.Unit>` + 静态 `Loading` façade + `LoadingHandle` 句柄。`IModalEntry` 加两个内部方法 `SetWaker(Action)` / `ResolveExternally()`——前者让 pump 注入唤醒回调，后者让外部句柄无视当前 modal 状态触发关闭。`UI.Modal.PumpAsync` 加两处 pre-show `if (entry.Resolved) continue` 检查 + 在 `RunBind` 前调 `SetWaker`。`Bind` 对 `<Text id="text">` 用 try/catch 容错，整 XML 都允许用户重写。
+
+**Tech Stack:** Unity 6, R3 (`R3.Unit`), LitMotion (`<Animation fade loop>`), NUnit EditMode, UnityMCP for compile + test runs.
+
+**Spec:** `docs~/superpowers/specs/2026-05-16-loading-modal-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `Runtime/Application/Modals/LoadingRequest.cs` — 三个 public 类型一处：`LoadingRequest` / `Loading` / `LoadingHandle`（沿用 `MessageBoxRequest.cs` 一文件多类型的现有模式）
+- `Runtime/Resources/PromptUGUI/Modals/Loading.ui.xml` — 默认 XML 模板
+- `Tests/EditMode/Modals/LoadingTests.cs` — EditMode 测试套
+
+**Modify:**
+- `Runtime/Application/Modals/ModalEntry.cs` — `IModalEntry` 接口加 `SetWaker` + `ResolveExternally` + `ModalEntry<TResult>` 实现
+- `Runtime/Application/UI.Modal.cs` — `PumpAsync` 加两处 `Resolved` 检查 + `SetWaker` 注入；新增 internal `EnqueueRequest<T>` helper
+- `.claude/skills/scripting-promptugui-csharp/SKILL.md` — 在 "Modal dialogs" 一节加 "Loading modal" 小节
+
+**No changes to:**
+- `Runtime/Application/Modals/ModalRequest.cs` — 基类签名不变
+- `Runtime/Application/Modals/ModalEscapeListener.cs` — ESC listener 行为照旧（Loading 的 `TryEscape` 返回 false 让它静默 no-op）
+- `Runtime/Application/Modals/ModalSourceLoader.cs` — Resources 加载流程不变
+
+---
+
+### Task 1: 加 `IModalEntry.SetWaker` + `ResolveExternally` plumbing + pump 改造
+
+**Files:**
+- Modify: `Runtime/Application/Modals/ModalEntry.cs:10-69`
+- Modify: `Runtime/Application/UI.Modal.cs:32-86`
+
+这一步**先不写 Loading 类型**，只动现有 modal 框架。后面 Task 2 的 Loading 才用到。但因为没法独立测试纯 plumbing（外部没人调），我们的"红"信号是 Task 3 的第一个 Loading 测试——本任务先让代码编译通过。
+
+- [ ] **Step 1: 改 `Runtime/Application/Modals/ModalEntry.cs` — 加接口方法 + 实现**
+
+完整替换文件内容（保留现有结构，加两个 method）：
+
+```csharp
+using System;
+using PromptUGUI.Application;
+using UnityEngine;
+
+namespace PromptUGUI.Application.Modals
+{
+    internal interface IModalEntry
+    {
+        public string XmlSrc { get; }
+        public void RunBind(IScreen screen, Action onClose);
+        public bool TryEscape(Action wakePump);
+        public void Cancel(Exception ex);
+        public bool Resolved { get; }
+        public void SetWaker(Action waker);
+        public void ResolveExternally();
+    }
+
+    internal sealed class ModalEntry<TResult> : IModalEntry
+    {
+        private readonly ModalRequest<TResult> _request;
+        private readonly AwaitableCompletionSource<TResult> _tcs = new();
+        private Action _waker;
+
+        public bool Resolved { get; private set; }
+        public string XmlSrc => _request.XmlSrc;
+        public Awaitable<TResult> Awaitable => _tcs.Awaitable;
+
+        private ModalEntry(ModalRequest<TResult> request) { _request = request; }
+
+        internal static (IModalEntry entry, Awaitable<TResult> awaitable) Create(
+            ModalRequest<TResult> request)
+        {
+            var e = new ModalEntry<TResult>(request);
+            return (e, e._tcs.Awaitable);
+        }
+
+        public void RunBind(IScreen screen, Action onClose)
+        {
+            _request.Bind(screen, result =>
+            {
+                if (Resolved) return;
+                Resolved = true;
+                _tcs.TrySetResult(result);
+                onClose?.Invoke();
+            });
+        }
+
+        public bool TryEscape(Action wakePump)
+        {
+            if (Resolved) return false;
+            if (!_request.TryEscape(out var r)) return false;
+            Resolved = true;
+            _tcs.TrySetResult(r);
+            wakePump?.Invoke();
+            return true;
+        }
+
+        public void Cancel(Exception ex)
+        {
+            if (Resolved) return;
+            Resolved = true;
+            _tcs.TrySetException(ex);
+        }
+
+        public void SetWaker(Action waker) => _waker = waker;
+
+        public void ResolveExternally()
+        {
+            if (Resolved) return;
+            Resolved = true;
+            _tcs.TrySetResult(default!);
+            _waker?.Invoke();
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 改 `Runtime/Application/UI.Modal.cs` — pump 加两处 Resolved 检查 + SetWaker 注入 + EnqueueRequest helper**
+
+定位 `PumpAsync` 方法（行 32-86 附近）。整个 `while` 循环替换为：
+
+```csharp
+while (_queue.Count > 0)
+{
+    var entry = _queue.Dequeue();
+    if (entry.Resolved) continue;
+    _current = entry;
+    _currentScreenName = entry.XmlSrc;
+    _currentWaiter = new AwaitableCompletionSource<bool>();
+    try
+    {
+        if (!_loadedSrcs.Contains(entry.XmlSrc))
+        {
+            var xml = await ModalSourceLoader.LoadAsync(entry.XmlSrc);
+            LoadDocument(entry.XmlSrc, xml);
+            _loadedSrcs.Add(entry.XmlSrc);
+        }
+        if (entry.Resolved) continue;
+
+        var screen = Open(entry.XmlSrc);
+        var canvas = screen.RootGameObject.GetComponent<Canvas>();
+        canvas.overrideSorting = true;
+        canvas.sortingOrder = SortingOrderBase;
+
+        var waiter = _currentWaiter;
+        var captured = entry;
+        captured.SetWaker(() => waiter.TrySetResult(true));
+        captured.RunBind(screen, () => waiter.TrySetResult(true));
+
+        var listener = screen.RootGameObject
+            .AddComponent<ModalEscapeListener>();
+        listener.OnEscape = () =>
+            captured.TryEscape(() => waiter.TrySetResult(true));
+
+        await waiter.Awaitable;
+
+        if (entry.Resolved && _open.ContainsKey(entry.XmlSrc))
+            Close(entry.XmlSrc);
+    }
+    catch (Exception ex)
+    {
+        entry.Cancel(ex);
+        if (_open.ContainsKey(entry.XmlSrc))
+            Close(entry.XmlSrc);
+    }
+    finally
+    {
+        _current = null;
+        _currentScreenName = null;
+        _currentWaiter = null;
+    }
+}
+```
+
+注意三处新增：
+1. `if (entry.Resolved) continue;` 在 Dequeue 之后立即
+2. `if (entry.Resolved) continue;` 在 LoadAsync 之后立即
+3. `captured.SetWaker(() => waiter.TrySetResult(true));` 在 `RunBind` 之前
+
+在 `OpenAsync` 方法之后（行 30 附近），加一个 internal helper：
+
+```csharp
+internal static IModalEntry EnqueueRequest<TResult>(ModalRequest<TResult> request)
+{
+    if (request == null) throw new ArgumentNullException(nameof(request));
+    var (entry, _) = ModalEntry<TResult>.Create(request);
+    _queue.Enqueue(entry);
+    if (!_pumping) _ = PumpAsync();
+    return entry;
+}
+```
+
+- [ ] **Step 3: 编译 — 通过 UnityMCP refresh**
+
+调用：
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+期望：无 error。如果有，定位 fix（常见：拼写 / using 漏 / 接口实现遗漏）。
+
+- [ ] **Step 4: 跑现有 modal 测试，确认没破坏既有行为**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="Modal")
+```
+
+期望：所有 `ModalQueueTests` / `MessageBoxRequestTests` / `ModalCancelTests` / `ModalReSolveTests` / `ModalSourceLoaderTests` / `MessageBoxStaticTests` / `MsgBtnFlagsTests` / `UIUnloadDocumentTests` 全绿（pump 改动是加法，不应破坏现有行为）。
+
+- [ ] **Step 5: Lint + 提交**
+
+```bash
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+```bash
+git add Runtime/Application/Modals/ModalEntry.cs Runtime/Application/UI.Modal.cs
+git commit -m "feat(modal): IModalEntry.SetWaker + ResolveExternally + pump pre-show skip
+
+Pump 加两处 Resolved 检查（dequeue 后 / LoadAsync 后）+ SetWaker 注入唤醒回调。
+为 Loading 模态的外部主动关闭路径铺底；现有 MessageBox 流程不变。"
+```
+
+---
+
+### Task 2: 创建 `LoadingRequest` + `Loading` + `LoadingHandle` 类型骨架
+
+**Files:**
+- Create: `Runtime/Application/Modals/LoadingRequest.cs`
+
+- [ ] **Step 1: 创建 LoadingRequest.cs**
+
+写 `Runtime/Application/Modals/LoadingRequest.cs`：
+
+```csharp
+using System;
+using R3;
+
+namespace PromptUGUI.Application.Modals
+{
+    public sealed class LoadingRequest : ModalRequest<Unit>
+    {
+        public string Text;
+
+        public override string XmlSrc => Loading.XmlSrc;
+
+        public override void Bind(IScreen screen, Action<Unit> close)
+        {
+            try
+            {
+                var textCtl = screen.Get<PromptUGUI.Controls.Text>("text");
+                if (string.IsNullOrEmpty(Text)) textCtl.GameObject.SetActive(false);
+                else textCtl.TextValue = Text;
+            }
+            catch (System.Collections.Generic.KeyNotFoundException) { /* text 元素可选 */ }
+        }
+    }
+
+    public sealed class LoadingHandle
+    {
+        private readonly IModalEntry _entry;
+        private bool _closed;
+
+        public bool IsClosed => _closed;
+
+        internal LoadingHandle(IModalEntry entry) => _entry = entry;
+
+        public void Close()
+        {
+            if (_closed) return;
+            _closed = true;
+            _entry.ResolveExternally();
+        }
+    }
+
+    public static class Loading
+    {
+        // .ui 后缀对齐 MessageBox：Unity 只剥离 .ui.xml 文件名的最后 .xml
+        public static string XmlSrc { get; set; } = "PromptUGUI/Modals/Loading.ui";
+
+        public static LoadingHandle Open(string text = null)
+        {
+            var entry = UI.Modal.EnqueueRequest(new LoadingRequest { Text = text });
+            return new LoadingHandle(entry);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 编译通过**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+期望：无 error。`LoadingHandle` 接受 `internal` 类型 `IModalEntry` 作为 ctor 参数，对外公开但只能通过 `Loading.Open` 构造（ctor 是 internal）。
+
+- [ ] **Step 3: 跑现有测试，再次确认没破坏**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="Modal")
+```
+
+期望：全绿。
+
+- [ ] **Step 4: Lint + 提交**
+
+```bash
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+```bash
+git add Runtime/Application/Modals/LoadingRequest.cs
+git commit -m "feat(modal): LoadingRequest + Loading façade + LoadingHandle
+
+ModalRequest<R3.Unit> 子类 + 句柄 + 静态 Open(text) 入口。
+Bind 用 try/catch 把 <Text id=text> 做成可选契约（让用户自定义 XML 更自由）。"
+```
+
+---
+
+### Task 3: 写第一个 Loading 测试 — Open + Close 闭环
+
+**Files:**
+- Create: `Tests/EditMode/Modals/LoadingTests.cs`
+
+- [ ] **Step 1: 写 LoadingTests 骨架 + 第一个测试（先红）**
+
+写 `Tests/EditMode/Modals/LoadingTests.cs`：
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+
+namespace PromptUGUI.Tests.Modals
+{
+    public class LoadingTests : ModalTestFixture
+    {
+        private const string LoadingTestXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/Loading1'>
+    <Image id='backdrop' anchor='stretch' color='#000000C0'/>
+    <Frame id='dialog' anchor='center' size='320x160'>
+      <VStack anchor='stretch' margin='16' spacing='8'>
+        <Text id='text' fontSize='16'/>
+      </VStack>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+
+        public override void SetUp()
+        {
+            base.SetUp();
+            Files["test/Loading1"] = LoadingTestXml;
+            Loading.XmlSrc = "test/Loading1";
+        }
+
+        [Test]
+        public void Open_returns_handle_and_modal_is_shown_with_text()
+        {
+            var handle = Loading.Open("加载中...");
+
+            Assert.IsNotNull(handle);
+            Assert.IsFalse(handle.IsClosed);
+            Assert.IsTrue(UI.Modal.IsAnyOpen);
+
+            var screen = UI.Get("test/Loading1");
+            Assert.IsNotNull(screen, "Loading screen 应该已经被 pump 实例化");
+
+            var text = screen.Get<PromptUGUI.Controls.Text>("text");
+            Assert.IsTrue(text.GameObject.activeSelf);
+            Assert.AreEqual("加载中...", text.TmpComponent.text);
+        }
+
+        [Test]
+        public void Close_dismisses_modal_and_marks_handle_closed()
+        {
+            var handle = Loading.Open("hi");
+            Assert.IsTrue(UI.Modal.IsAnyOpen);
+
+            handle.Close();
+
+            Assert.IsTrue(handle.IsClosed);
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+            Assert.IsNull(UI.Get("test/Loading1"),
+                "Loading screen 应该已经被 pump 关闭");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 编译 + 跑测试 — 期望绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="LoadingTests")
+```
+
+期望：两个测试绿。如果红，问题最可能在 Task 1 / Task 2 的 plumbing —— 看具体 error message 定位。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add Tests/EditMode/Modals/LoadingTests.cs
+git commit -m "test(modal): LoadingTests open + close 闭环"
+```
+
+---
+
+### Task 4: 加 pre-show close 测试 — Loading 被 MessageBox 挡住时关闭
+
+**Files:**
+- Modify: `Tests/EditMode/Modals/LoadingTests.cs`
+
+这一步验证 Task 1 加的 pump pre-show skip 逻辑：MessageBox 阻塞 pump 时，Loading 排在队列里；调用 handle.Close() 标记 Resolved；MessageBox 关闭后 pump 转到 Loading entry，看到 Resolved=true 直接跳过，**根本不实例化 Loading screen**。
+
+- [ ] **Step 1: 加测试 `Close_before_pump_skips_modal_instantiation`**
+
+在 `LoadingTests.cs` 类末尾加：
+
+```csharp
+[Test]
+public void Close_before_pump_skips_modal_instantiation()
+{
+    // MessageBox 先开 → pump 卡在它的 await waiter 上
+    var mboxTask = UI.Modal.OpenAsync(new MessageBoxRequest
+    {
+        Text = "first",
+        Buttons = MsgBtn.OK,
+    });
+
+    // Loading 入队，但 pump 没轮到它（仍在处理 MessageBox）
+    var loading = Loading.Open("queued");
+    Assert.AreEqual(2, UI.Modal.QueuedCount);
+    Assert.IsNull(UI.Get("test/Loading1"),
+        "Loading 还在队列里，screen 还没创建");
+
+    // 关闭 Loading handle —— 走 ResolveExternally → entry.Resolved=true
+    loading.Close();
+    Assert.IsTrue(loading.IsClosed);
+    Assert.IsNull(UI.Get("test/Loading1"),
+        "Close() 在 pre-show 不应该实例化 screen");
+
+    // 关掉 MessageBox → pump 转到 Loading entry，看到 Resolved=true，直接 continue
+    UI.Get("test/Box1").Get<PromptUGUI.Controls.Btn>("ok").SimulateClick();
+    Assert.AreEqual(MsgBtn.OK, mboxTask.GetAwaiter().GetResult());
+
+    Assert.IsFalse(UI.Modal.IsAnyOpen);
+    Assert.IsNull(UI.Get("test/Loading1"),
+        "Loading screen 整个生命周期都不应该被创建过");
+}
+```
+
+- [ ] **Step 2: 跑测试**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="Close_before_pump")
+```
+
+期望：绿。如果红：检查 Task 1 Step 2 的 pump `if (entry.Resolved) continue;` 是否真的加在了 Dequeue 后那个位置。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add Tests/EditMode/Modals/LoadingTests.cs
+git commit -m "test(modal): Loading pre-show close 跳过 screen 实例化"
+```
+
+---
+
+### Task 5: 加幂等 / ESC no-op / 文案空串 / 自定义 XML 容错 这一组测试
+
+**Files:**
+- Modify: `Tests/EditMode/Modals/LoadingTests.cs`
+
+- [ ] **Step 1: 加四个测试**
+
+在 `LoadingTests.cs` 类末尾加：
+
+```csharp
+[Test]
+public void Close_is_idempotent()
+{
+    var handle = Loading.Open("hi");
+    handle.Close();
+    Assert.IsTrue(handle.IsClosed);
+
+    // 第二次 Close 不应该抛
+    Assert.DoesNotThrow(() => handle.Close());
+    Assert.IsTrue(handle.IsClosed);
+    Assert.IsFalse(UI.Modal.IsAnyOpen);
+}
+
+[Test]
+public void Text_null_hides_text_node()
+{
+    Loading.Open(null);
+    var text = UI.Get("test/Loading1").Get<PromptUGUI.Controls.Text>("text");
+    Assert.IsFalse(text.GameObject.activeSelf);
+}
+
+[Test]
+public void Text_empty_hides_text_node()
+{
+    Loading.Open("");
+    var text = UI.Get("test/Loading1").Get<PromptUGUI.Controls.Text>("text");
+    Assert.IsFalse(text.GameObject.activeSelf);
+}
+
+[Test]
+public void TryEscape_listener_does_not_close_loading()
+{
+    var handle = Loading.Open("press ESC and see nothing");
+    var listener = UI.Get("test/Loading1")
+        .RootGameObject.GetComponent<ModalEscapeListener>();
+    Assert.IsNotNull(listener, "Pump 必须给 Loading screen 也挂 ModalEscapeListener");
+
+    listener.FireForTests();
+
+    Assert.IsTrue(UI.Modal.IsAnyOpen, "Loading 应该仍然显示");
+    Assert.IsFalse(handle.IsClosed);
+    UI.Modal.CloseAll();   // teardown 干净点
+}
+
+[Test]
+public void Custom_xml_without_text_id_does_not_throw()
+{
+    // 模拟用户自定义 XML 时把 text 元素删了的场景
+    const string customXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/Loading2'>
+    <Image id='backdrop' anchor='stretch' color='#000000C0'/>
+    <Frame anchor='center' size='200x100'>
+      <Image anchor='stretch' color='white'/>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+    Files["test/Loading2"] = customXml;
+    Loading.XmlSrc = "test/Loading2";
+
+    var handle = Loading.Open("仍然传 text 但 XML 没 text 元素");
+    Assert.IsNotNull(handle, "Bind 不应该抛 KeyNotFoundException");
+    Assert.IsTrue(UI.Modal.IsAnyOpen);
+
+    handle.Close();
+    Assert.IsFalse(UI.Modal.IsAnyOpen);
+}
+```
+
+- [ ] **Step 2: 跑测试**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="LoadingTests")
+```
+
+期望：所有 LoadingTests（含前面 task 加的）全绿。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add Tests/EditMode/Modals/LoadingTests.cs
+git commit -m "test(modal): Loading 幂等/ESC/空文案/自定义 XML id 容错"
+```
+
+---
+
+### Task 6: 加 FIFO 混排 + UnloadAll teardown 测试
+
+**Files:**
+- Modify: `Tests/EditMode/Modals/LoadingTests.cs`
+
+- [ ] **Step 1: 加两个测试**
+
+在 `LoadingTests.cs` 类末尾加：
+
+```csharp
+[Test]
+public void Mixed_with_MessageBox_respects_FIFO_queue()
+{
+    // 顺序：Loading 先 → MessageBox 后。Loading 显示，MessageBox 排队
+    var loading = Loading.Open("step 1");
+    var mboxTask = UI.Modal.OpenAsync(new MessageBoxRequest
+    {
+        Text = "step 2",
+        Buttons = MsgBtn.OK,
+    });
+
+    Assert.AreEqual(2, UI.Modal.QueuedCount);
+    Assert.IsNotNull(UI.Get("test/Loading1"), "Loading 应该先显示");
+    Assert.IsNull(UI.Get("test/Box1"), "MessageBox 应该还在队列");
+
+    // 关 Loading → pump 切到 MessageBox
+    loading.Close();
+    Assert.IsTrue(loading.IsClosed);
+    Assert.IsNull(UI.Get("test/Loading1"), "Loading 应该已关闭");
+    Assert.IsNotNull(UI.Get("test/Box1"), "MessageBox 应该接着显示");
+
+    // 关 MessageBox
+    UI.Get("test/Box1").Get<PromptUGUI.Controls.Btn>("ok").SimulateClick();
+    Assert.AreEqual(MsgBtn.OK, mboxTask.GetAwaiter().GetResult());
+    Assert.IsFalse(UI.Modal.IsAnyOpen);
+}
+
+[Test]
+public void UnloadAll_cancels_loading_and_handle_close_after_is_noop()
+{
+    var handle = Loading.Open("about to be torn down");
+    Assert.IsTrue(UI.Modal.IsAnyOpen);
+
+    // 模拟 UI 全拆除路径（ResetForTests 内部会调 CancelAllForTeardown）
+    UI.ResetForTests();
+
+    // 之后 handle.Close 不应该抛 / 不应该副作用
+    Assert.DoesNotThrow(() => handle.Close());
+    Assert.IsTrue(handle.IsClosed);
+}
+```
+
+- [ ] **Step 2: 跑测试**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="LoadingTests")
+```
+
+期望：所有 LoadingTests 全绿（应该 9 个测试现在）。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add Tests/EditMode/Modals/LoadingTests.cs
+git commit -m "test(modal): Loading 跟 MessageBox 混排 FIFO + teardown 路径"
+```
+
+---
+
+### Task 7: 创建默认 `Loading.ui.xml` + UIXmlLint 校验
+
+**Files:**
+- Create: `Runtime/Resources/PromptUGUI/Modals/Loading.ui.xml`
+
+- [ ] **Step 1: 写默认 XML 模板**
+
+创建 `Runtime/Resources/PromptUGUI/Modals/Loading.ui.xml`：
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<PromptUGUI version="1">
+  <Screen name="PromptUGUI/Modals/Loading.ui" reference="1920x1080" reference.portrait="1080x1920">
+    <Image id="backdrop" anchor="stretch" color="#000000C0"/>
+
+    <Frame id="dialog" anchor="center" size="320x160">
+      <Image anchor="stretch" sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round"/>
+      <VStack anchor="stretch" margin="20" spacing="12">
+
+        <!-- HStack 不加 anchor: VStack 是 layout group, child anchor 会被 PUI-LAYOUT-ANCHOR lint
+             报错. VStack 默认 childAlignment=UpperCenter 已经水平居中 width=80 的 HStack. -->
+        <HStack height="20" spacing="10" width="80">
+          <Animation fade="0.25:1" duration="0.5s" delay="0s"    easing="in-out-quad" on="loop">
+            <Image width="14" height="14" color="white"/>
+          </Animation>
+          <Animation fade="0.25:1" duration="0.5s" delay="0.15s" easing="in-out-quad" on="loop">
+            <Image width="14" height="14" color="white"/>
+          </Animation>
+          <Animation fade="0.25:1" duration="0.5s" delay="0.3s"  easing="in-out-quad" on="loop">
+            <Image width="14" height="14" color="white"/>
+          </Animation>
+        </HStack>
+
+        <Text id="text" width="stretch" height="stretch" fontSize="16"/>
+      </VStack>
+    </Frame>
+  </Screen>
+</PromptUGUI>
+```
+
+- [ ] **Step 2: UIXmlLint 校验**
+
+```bash
+dotnet run --project .lint/UIXmlLint -- Runtime/Resources/PromptUGUI/Modals/Loading.ui.xml
+```
+
+期望：exit code 0，no errors。如果报 `PUI-LAYOUT-ANCHOR`：layout group（VStack/HStack/Grid）的子节点不能写 `anchor=`。本模板已避免此问题（HStack 在 VStack 里不写 anchor，靠 VStack 默认的 `childAlignment=UpperCenter` 水平居中）。出错时检查是否手动加了 anchor 属性。
+
+- [ ] **Step 3: refresh Unity → 让 Resources 重新扫描新增的 TextAsset**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+期望：无 error。新 .ui.xml 被作为 TextAsset 导入。
+
+- [ ] **Step 4: 加一个测试验证默认 XML 路径**
+
+在 `LoadingTests.cs` 类末尾加：
+
+```csharp
+[Test]
+public void Default_xml_src_loads_builtin_template()
+{
+    // 把 XmlSrc 切回默认（base.SetUp 把它改成了 test/Loading1）
+    Loading.XmlSrc = "PromptUGUI/Modals/Loading.ui";
+
+    var handle = Loading.Open("from real template");
+    Assert.IsNotNull(handle);
+    Assert.IsTrue(UI.Modal.IsAnyOpen);
+
+    var screen = UI.Get("PromptUGUI/Modals/Loading.ui");
+    Assert.IsNotNull(screen, "默认 Loading.ui.xml 应该能从 Resources 加载");
+
+    var text = screen.Get<PromptUGUI.Controls.Text>("text");
+    Assert.AreEqual("from real template", text.TmpComponent.text);
+
+    handle.Close();
+}
+```
+
+- [ ] **Step 5: 跑测试**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="LoadingTests")
+```
+
+期望：全部 LoadingTests（10 个）绿。如果 `Default_xml_src_loads_builtin_template` 红，最可能原因：
+- Unity 还没 import 新 .ui.xml → 再跑一次 refresh
+- 模板里某个属性导致 XML 解析失败 → `read_console` 看 ParseException
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add Runtime/Resources/PromptUGUI/Modals/Loading.ui.xml Runtime/Resources/PromptUGUI/Modals/Loading.ui.xml.meta Tests/EditMode/Modals/LoadingTests.cs
+git commit -m "feat(modal): 默认 Loading.ui.xml 模板 + 三点脉冲动画
+
+三个 <Animation fade='0.25:1' on='loop'> 错相 0.15s yoyo。
+9slice_round 边框沿用 MessageBox 视觉一致性。"
+```
+
+---
+
+### Task 8: 更新 `scripting-promptugui-csharp/SKILL.md`
+
+**Files:**
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md` —— 在 "Overriding the builtin MessageBox layout" 小节结束（当前 line 385 末尾）和下一个 `## <Trigger> and <Animation> from C#` 之间插入新小节
+
+- [ ] **Step 1: 在 cheatsheet 表（line 312-315）追加 Loading 行**
+
+定位 line 315 (`UI.Modal.SortingOrderBase = 1000             default`)，在它后面插入一行。**完全粘贴下面这行**（前导 15 个空格、双空格分隔左右列，沿用现有对齐）：
+
+```
+               var h = Loading.Open(text); h.Close()         loading spinner (no result)
+```
+
+最终四行 MODAL 区块应该是：
+
+```
+MODAL          var r = await MessageBox.Open(text, MsgBtn.OK|MsgBtn.Cancel, icon, title)
+               UI.Modal.OpenAsync(new MyRequest())          custom ModalRequest<T>
+               UI.Modal.CloseAll()                          cancel all pending
+               UI.Modal.SortingOrderBase = 1000             default
+               var h = Loading.Open(text); h.Close()         loading spinner (no result)
+```
+
+- [ ] **Step 2: 在 "Overriding the builtin MessageBox layout" 小节末尾（line 385 后）插入 Loading 小节**
+
+具体定位是 line 385 的内容：
+
+```
+Your XML must declare a Screen with these ids: `text`, `title`, `ok`, `cancel`, `yes`, `no`, `close`. An optional `icon` id is supported but not required (Bind tolerates missing icon node). If you want icon support, your XML must include `<Icon id="icon" name="placeholder:something"/>` because PromptUGUI's parser requires the `name=` attribute on `<Icon>` elements.
+```
+
+之后空一行，插入：
+
+````markdown
+### Loading modal
+
+A non-blocking "loading" modal: blocks UI while async work runs, then your code closes it. **Does not accept user input** (ESC cannot dismiss it).
+
+```csharp
+using PromptUGUI.Application.Modals;
+
+var loading = Loading.Open(UI.Tr("Loading..."));
+try
+{
+    await DoWorkAsync();
+    var data = await FetchAsync();
+}
+finally
+{
+    loading.Close();   // idempotent — safe to call multiple times
+}
+```
+
+Differences from `MessageBox.Open`:
+
+- `Loading.Open(text)` returns a `LoadingHandle` **synchronously** — callers do not `await` the modal; they `await` their own background work and then call `handle.Close()`
+- No `TResult` — the modal is not closed by user input
+- `text` is optional; pass `null` or `""` to render the spinner alone
+- Shares the FIFO queue with MessageBox: open Loading + MessageBox in either order, they take turns
+- `handle.Close()` is safe after `UI.UnloadAll()` / `UI.ResetForTests()` — no-op once the entry is cancelled
+
+#### Overriding the builtin Loading layout
+
+```csharp
+Loading.XmlSrc = "MyUI/Modals/PixelLoading.ui";   // resolved by UI.SourceResolver
+```
+
+Default key is `"PromptUGUI/Modals/Loading.ui"` (note the `.ui` suffix — same Unity multi-dot stripping caveat as MessageBox).
+
+**id contract for custom XML**: only `<Text id="text">` is recognized by `Bind`, and even that is **optional** — Bind catches `KeyNotFoundException` so XML without a `text` element works (e.g. pure spinner with no caption). All other elements (backdrop, container Frame, spinner visuals) have no id contract — design them freely.
+````
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add .claude/skills/scripting-promptugui-csharp/SKILL.md
+git commit -m "docs(skill): Loading modal 用法 + Loading.XmlSrc 覆盖契约"
+```
+
+---
+
+## 验收
+
+跑完所有任务后，最后一次全套检查：
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+dotnet run --project .lint/UIXmlLint -- Runtime/Resources/
+```
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+```
+
+期望：
+- `dotnet format` exit 0
+- UIXmlLint 全部 .ui.xml 没有 error
+- Unity console 无 error
+- EditMode 测试全绿（含原有 + 10 个新 LoadingTests）
+- spec §9 列出的 6 条验收标准全部满足

--- a/docs~/superpowers/specs/2026-05-16-loading-modal-design.md
+++ b/docs~/superpowers/specs/2026-05-16-loading-modal-design.md
@@ -1,0 +1,376 @@
+## 内置 Loading 模态设计
+
+**日期**：2026-05-16
+**状态**：设计阶段（待 review，未进入实施）
+**作用域**：在现有 modal 框架基础上新增 `LoadingRequest` / `Loading` / `LoadingHandle`：(1) 显示一个不接受用户输入的"加载中"模态；(2) 调用方拿到句柄，业务完成后主动调用 `handle.Close()` 关闭；(3) 视觉用纯 XML（三个 `<Animation fade>` 错相 yoyo），无新 C# 渲染脚本；(4) 用户可通过 `Loading.XmlSrc` 整体替换默认 XML（与 MessageBox 同模式）。
+**依赖**：[`2026-05-14-messagebox-modal-design.md`](2026-05-14-messagebox-modal-design.md)（`UI.Modal` 队列泵 / `ModalRequest<TResult>` / `ModalEscapeListener` / `ModalSourceLoader` / `Screen.Open` sortingOrder 叠加）；[`2026-05-14-litmotion-animations-design.md`](2026-05-14-litmotion-animations-design.md)（`<Animation fade>` + `loop="yoyo"` + `delay`）
+
+---
+
+## 1. 背景与目标
+
+MessageBox 解决了"等用户做选择"的模态。还有一类常见需求：**业务跑后台任务时挡住 UI、转个圈、任务完成后代码主动关掉**。典型用法：
+
+```csharp
+var loading = Loading.Open("加载中...");
+try { await DoWork(); }
+finally { loading.Close(); }
+```
+
+跟 MessageBox 的差异：
+- **没有 TResult** —— modal 不靠用户输入关闭；调用方拿不到"按钮结果"
+- **不可逃逸** —— ESC / Back 都不能关
+- **打开是非阻塞的** —— `Loading.Open(...)` 同步返回句柄，调用方不 await modal 本身
+- **关闭由外部触发** —— handle.Close() 是关闭路径，不是 `Bind` 里订阅按钮
+
+复用现有 modal 框架（队列、sortingOrder 叠加、Screen 流水线、`ModalSourceLoader`），新增的只有 request 子类 + 公开 façade + handle 类型 + 一段 XML + pump 里一条 pre-show 跳过逻辑。
+
+**内置 + 可覆盖**：跟 MessageBox 一致，`Loading.XmlSrc` 是可写 property——pixel-art 项目大概率要换自家边框 sprite / 字体 / 动画样式。默认 XML 是粗糙占位；用户赋 `Loading.XmlSrc = "MyGame/Modals/MyLoading"` 即整体替换（走 caller 的 `UI.SourceResolver`）。Bind 对自定义 XML 的契约见 §4。
+
+### 非目标
+
+- 进度条（已知进度 0..100%）—— 那是独立的 `<ProgressBar>` 控件，跟 modal 解耦
+- 可取消（用户能主动按 Cancel 取消后台任务）—— 后续如有需要可以加 `LoadingRequest.Cancelable=true` + 一个 Cancel 按钮的变体，v1 不做
+- 可关闭超时 —— 调用方自己用 `Task.WhenAny(work, Task.Delay(timeout))` 实现，框架不做
+- 打开后改文案（`SetText`）—— YAGNI；v1 文案在 `Open(text)` 时定死
+
+---
+
+## 2. C# API
+
+### 2.1 `LoadingRequest`
+
+```csharp
+namespace PromptUGUI.Application.Modals;
+
+public sealed class LoadingRequest : ModalRequest<R3.Unit>
+{
+    public string Text;
+
+    public override string XmlSrc => Loading.XmlSrc;
+
+    public override void Bind(IScreen screen, Action<R3.Unit> close)
+    {
+        try
+        {
+            var textCtl = screen.Get<PromptUGUI.Controls.Text>("text");
+            if (string.IsNullOrEmpty(Text)) textCtl.GameObject.SetActive(false);
+            else textCtl.TextValue = Text;
+        }
+        catch (System.Collections.Generic.KeyNotFoundException) { /* text 元素可选 */ }
+        // 不订阅 close —— Loading 没有按钮，关闭路径走 IModalEntry.ResolveExternally
+    }
+
+    // TryEscape 不重写 → 继承基类默认 return false → ESC 不响应
+}
+```
+
+`R3.Unit` 作为 TResult 是因为 `ModalRequest<T>` 强制要 TResult；这个类型对调用方不可见（句柄不暴露 awaitable）。
+
+### 2.2 `Loading` 静态门面
+
+```csharp
+public static class Loading
+{
+    public static string XmlSrc { get; set; } = "PromptUGUI/Modals/Loading.ui";
+
+    public static LoadingHandle Open(string text = null)
+    {
+        var entry = UI.Modal.EnqueueRequest(new LoadingRequest { Text = text });
+        return new LoadingHandle(entry);
+    }
+}
+```
+
+`Loading.Open` **同步返回**——不 await modal pump，立即给调用方句柄。modal 实际显示是异步的（pump 在下一帧排到）；调用方不感知这层。
+
+### 2.3 `LoadingHandle`
+
+```csharp
+public sealed class LoadingHandle
+{
+    private readonly IModalEntry _entry;
+    private bool _closed;
+
+    public bool IsClosed => _closed;
+
+    internal LoadingHandle(IModalEntry entry) => _entry = entry;
+
+    public void Close()
+    {
+        if (_closed) return;
+        _closed = true;
+        _entry.ResolveExternally();   // pump 内部分情况处理：pre-show 跳过 / 显示后关闭
+    }
+}
+```
+
+句柄不区分"已显示 / 还在队列"两种状态——`ResolveExternally` 把这层复杂度封进 `ModalEntry<TResult>`，详见 §3。
+
+### 2.4 调用例子
+
+```csharp
+// 简单
+var loading = Loading.Open("Loading...");
+await SomeWork();
+loading.Close();
+
+// try/finally 保护异常路径
+var loading = Loading.Open("Saving...");
+try { await SaveAsync(); }
+finally { loading.Close(); }
+
+// 跟 MessageBox 串联
+var loading = Loading.Open();
+var data = await FetchAsync();
+loading.Close();
+if (data == null)
+    await MessageBox.Open("Network error.", MsgBtn.OK);
+```
+
+---
+
+## 3. 现有 modal 框架需要的小改
+
+### 3.1 `IModalEntry` 加 `ResolveExternally` + `SetWaker`
+
+```csharp
+internal interface IModalEntry
+{
+    string XmlSrc { get; }
+    void RunBind(IScreen screen, Action onClose);
+    bool TryEscape(Action wakePump);
+    void Cancel(Exception ex);
+    bool Resolved { get; }
+    void SetWaker(Action waker);     // ← 新增：pump 注入 waiter 唤醒回调
+    void ResolveExternally();        // ← 新增：句柄触发的外部关闭路径
+}
+```
+
+`ModalEntry<TResult>` 实现：
+
+```csharp
+private Action _waker;
+
+public void SetWaker(Action waker) => _waker = waker;
+
+public void ResolveExternally()
+{
+    if (Resolved) return;
+    Resolved = true;
+    _tcs.TrySetResult(default!);     // TResult=Unit 时是 Unit.Default；外部句柄不消费此值
+    _waker?.Invoke();                // Bind 已跑过 → 唤醒 pump 走正常 Close 路径；
+                                     // Bind 没跑过 → _waker=null，pump 下次轮到时靠 Resolved flag 跳过
+}
+```
+
+### 3.2 `UI.Modal.PumpAsync` 加 pre-show 跳过 + 注入 waker
+
+```csharp
+while (_queue.Count > 0)
+{
+    var entry = _queue.Dequeue();
+    if (entry.Resolved) continue;             // ← 新增 ①：Close() 在 dequeue 之前发生
+    ...
+    if (!_loadedSrcs.Contains(entry.XmlSrc))
+    {
+        var xml = await ModalSourceLoader.LoadAsync(entry.XmlSrc);
+        LoadDocument(entry.XmlSrc, xml);
+        _loadedSrcs.Add(entry.XmlSrc);
+    }
+    if (entry.Resolved) continue;             // ← 新增 ②：Close() 在上面那个 await 里发生
+
+    var screen = Open(entry.XmlSrc);
+    ...
+    var waiter = _currentWaiter;
+    captured.SetWaker(() => waiter.TrySetResult(true));   // ← 新增 ③
+    captured.RunBind(screen, () => waiter.TrySetResult(true));
+    ...
+}
+```
+
+两处 `Resolved` 检查覆盖 pre-show 的两种时机：dequeue 之前 vs LoadAsync await 期间。`SetWaker` 在 `RunBind` 之前调，确保 `ResolveExternally` 在 Bind 后任何时刻调用都能唤醒 pump。
+
+### 3.3 `UI.Modal.EnqueueRequest` 内部 helper
+
+现有 `UI.Modal.OpenAsync<TResult>` 返回 `Awaitable<TResult>`。Loading 不需要 awaitable 而需要 entry，所以加一个 internal helper：
+
+```csharp
+internal static IModalEntry EnqueueRequest<TResult>(ModalRequest<TResult> request)
+{
+    if (request == null) throw new ArgumentNullException(nameof(request));
+    var (entry, _) = ModalEntry<TResult>.Create(request);
+    _queue.Enqueue(entry);
+    if (!_pumping) _ = PumpAsync();
+    return entry;
+}
+```
+
+`OpenAsync<TResult>` 不动；两个入口都基于 `ModalEntry<TResult>.Create` 工厂方法，无重复入队逻辑。
+
+---
+
+## 4. XML 模板
+
+文件：`Runtime/Resources/PromptUGUI/Modals/Loading.ui.xml`
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<PromptUGUI version="1">
+  <Screen name="PromptUGUI/Modals/Loading.ui" reference="1920x1080" reference.portrait="1080x1920">
+    <Image id="backdrop" anchor="stretch" color="#000000C0"/>
+
+    <Frame id="dialog" anchor="center" size="320x160">
+      <Image anchor="stretch" sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round"/>
+      <VStack anchor="stretch" margin="20" spacing="12">
+
+        <!-- HStack 不带 anchor: VStack 是 layout group, PUI-LAYOUT-ANCHOR 禁止 child 写 anchor.
+             VStack 默认 childAlignment=UpperCenter 会水平居中 width=80 的 HStack. -->
+        <HStack height="20" spacing="10" width="80">
+          <Animation fade="0.25:1" duration="0.5s" delay="0s"    easing="in-out-quad" on="loop">
+            <Image width="14" height="14" color="white"/>
+          </Animation>
+          <Animation fade="0.25:1" duration="0.5s" delay="0.15s" easing="in-out-quad" on="loop">
+            <Image width="14" height="14" color="white"/>
+          </Animation>
+          <Animation fade="0.25:1" duration="0.5s" delay="0.3s"  easing="in-out-quad" on="loop">
+            <Image width="14" height="14" color="white"/>
+          </Animation>
+        </HStack>
+
+        <Text id="text" width="stretch" height="stretch" fontSize="16"/>
+      </VStack>
+    </Frame>
+  </Screen>
+</PromptUGUI>
+```
+
+要点：
+- **遮罩 `#000000C0`** 比 MessageBox 的 `#000000FE` 稍透一点；纯 raycast 拦截即可
+- **三点脉冲**：三个 `<Animation fade>` 各包一个白色色块，相位差 0.15s
+- **`on="loop"`** 隐含 `loop="yoyo"`（详见 LitMotion 动画 spec §6.3 + `Animation.cs` OnAfterApply）；不写 `loop=` 走默认 yoyo，alpha 在 0.25↔1.0 来回淡
+- **没有 Icon 元素**：跟 MessageBox 不同，加载模态不显示图标
+- **Text 可选**：`LoadingRequest.Bind` 里空串 → `SetActive(false)`，HStack 自动 collapse 排版
+
+### 4.1 自定义 XML 时的 id 契约
+
+用户赋 `Loading.XmlSrc = "MyGame/Modals/MyLoading"` 替换默认模板。`LoadingRequest.Bind` 对自定义 XML 的契约：
+
+| id        | 控件类型 | 必需？ | Bind 行为 |
+|---|---|---|---|
+| `text`    | `<Text>` | **可选** | 存在则赋 `Text` 字段；`Text` 空串则 `SetActive(false)`；不存在则跳过（catch `KeyNotFoundException`） |
+
+其他元素（backdrop、dialog 容器、动画 dot）**没有 id 契约**——用户可以全删全换，自由设计自己的加载视觉（旋转 Icon / 进度条 / 多帧 sprite 动画等）。
+
+`<Screen name="...">` 必须跟 `Loading.XmlSrc` 字符串完全一致（沿用现有 modal pipeline 的 src=name 契约，与 MessageBox 相同）。其余 PromptUGUI 标准约束（reference 分辨率、`PROMPTUGUI/` 前缀只对包内 Resources 生效等）照常。
+
+---
+
+## 5. 边界情况
+
+### 5.1 `Close()` 在 modal 还在队列里时被调用
+
+`LoadingHandle.Close()` 走 `_entry.ResolveExternally()`，标记 `Resolved=true`。pump 下次轮到时，§3.2 新增的 `if (entry.Resolved) continue;` 直接跳过 dequeue 后的 LoadDocument / Open 步骤——**modal 根本不会被实例化**，零视觉闪烁。
+
+### 5.2 `Close()` 在 modal 关闭过程中再次被调
+
+`_closed` flag 守门，第二次起静默 return；handle 是幂等的。
+
+### 5.3 `Close()` 在 UI teardown 之后调
+
+`UI.ResetForTests` / `UI.UnloadAll` 调 `Modal.CancelAllForTeardown` → `entry.Cancel(oce)` → `Resolved=true` + `_tcs.TrySetException`。之后 handle.Close() 走 `_entry.ResolveExternally()`，里头的 `if (Resolved) return;` 直接 no-op。安全幂等。
+
+### 5.4 Loading 跟 MessageBox 混排
+
+两者共用 `UI.Modal._queue`。`Loading.Open` → `MessageBox.Open` → ... → `loading.Close`，行为：Loading 先显示；用户看到 Loading；MessageBox 进队列等着；调用方调 `loading.Close()` → Loading Screen 关闭 → pump 转到 MessageBox。
+
+逆向：先开 MessageBox，再开 Loading。MessageBox 在屏幕上等用户点击；Loading 排在后面。这种顺序业务上罕见但不被禁止——`UI.Modal` 不做 modal-type 间的优先级。
+
+### 5.5 ESC 按下时的行为
+
+`LoadingRequest` 不覆写 `TryEscape`，继承基类返回 false。pump 里 `ModalEscapeListener.OnEscape` 调 `entry.TryEscape(...)` 失败 → `wakePump` 不被调 → modal 不关闭。**用户按 ESC 没反应**——符合 "不接受任何用户输入"。
+
+### 5.6 Hot reload
+
+跟 MessageBox 一致（spec §6.5）：modal Screen 走 `LoadDocument(label, xml)` 同步路径，不进 DepGraph；`UIAssetPostprocessor` 检测到 `Loading.ui.xml` 改动时调 `UI.Modal.InvalidateCacheForEditor(Loading.XmlSrc)`，下次 Open 重新加载。运行中的 Loading 不受影响。
+
+---
+
+## 6. 测试策略
+
+### 6.1 EditMode (`Tests/EditMode/Modals/LoadingTests.cs`)
+
+延续 `ModalTestFixture` 模式：
+
+```csharp
+public sealed class LoadingTests : ModalTestFixture
+{
+    private const string LoadingTestXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/Loading1'>
+    <Image id='backdrop' anchor='stretch' color='#000000C0'/>
+    <Frame id='dialog' anchor='center' size='320x160'>
+      <VStack anchor='stretch' margin='16' spacing='8'>
+        <Text id='text' fontSize='16'/>
+      </VStack>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+
+    public override void SetUp()
+    {
+        base.SetUp();
+        Files["test/Loading1"] = LoadingTestXml;
+        Loading.XmlSrc = "test/Loading1";
+    }
+
+    [Test] public void Open_returns_handle_and_modal_queues();
+    [Test] public void Close_after_open_dismisses_modal();
+    [Test] public void Close_before_pump_skips_modal_instantiation();   // §5.1
+    [Test] public void Close_is_idempotent();
+    [Test] public void Text_null_hides_text_node();
+    [Test] public void Text_nonempty_renders();
+    [Test] public void Custom_xml_without_text_id_does_not_throw();     // §4.1 契约
+    [Test] public void TryEscape_returns_false_so_listener_does_nothing();
+    [Test] public void Mixed_with_MessageBox_respects_FIFO_queue();
+    [Test] public void UnloadAll_cancels_loading_and_handle_close_after_is_noop();
+}
+```
+
+### 6.2 PlayMode（如有必要）
+
+视觉动画（`<Animation fade loop>`）的端到端验证已由 LitMotion 模块的 PlayMode 测试覆盖（spec `2026-05-14-litmotion-animations-design.md` §8.2），不需要在 Loading 这里再测一次。如果 Loading 模板里有 PlayMode 才能验证的东西（layout 像素值），延后到出现问题时再加。
+
+---
+
+## 7. SKILL.md 影响
+
+按 `CLAUDE.md` trigger 规则：
+
+- 新公开 C# API（`Loading`、`LoadingHandle`、`LoadingRequest`）→ **scripting-promptugui-csharp/SKILL.md 必须更新**：在 "Modal dialogs" 一节加一个 "Loading modal" 小节，包含 `Loading.Open(text)` / `handle.Close()` 用法 + try/finally 范式 + "ESC 不可关闭"
+- 内置 `.ui.xml` 模板（`Runtime/Resources/PromptUGUI/Modals/Loading.ui.xml`）使用的 XML 元素全是已有 built-in（`Screen` / `Frame` / `Image` / `Text` / `VStack` / `HStack` / `Animation`），无新 tag/attribute → **authoring-promptugui-xml/SKILL.md 不需要更新**
+- 不涉及 `PROMPTUGUI_HAS_ADDRESSABLES` → **using-promptugui-addressables/SKILL.md 不需要更新**
+
+---
+
+## 8. 实施顺序（plan 阶段细化）
+
+1. **`IModalEntry.ResolveExternally` + `ModalEntry<TResult>` 实现 + pump 跳过** —— 内部小改，加 EditMode 单测验证 pre-show resolved entry 被跳过
+2. **`LoadingRequest` + `Loading` 门面 + `LoadingHandle`** —— 类型骨架；fake XML 走完整路径
+3. **`Loading.ui.xml` 内置模板** —— 拷进 `Runtime/Resources/PromptUGUI/Modals/`，跟 MessageBox.ui.xml 平级
+4. **EditMode 测试全套** —— §6.1 列表
+5. **`scripting-promptugui-csharp/SKILL.md` 更新**
+
+每步跑 lint + UnityMCP 编译检查 + 对应单测，红 → 绿 → 下一步。
+
+---
+
+## 9. 验收标准
+
+- `var h = Loading.Open("Loading..."); await DoWork(); h.Close();` 在 PlayMode demo 中能弹出加载模态并正确关闭
+- handle.Close() 在 modal 还在队列里时被调用，modal 不显示（pump 跳过）
+- ESC 在 Loading 模态上**不**关闭 modal
+- Loading 跟 MessageBox 混排时遵守 FIFO
+- `dotnet format --verify-no-changes --severity warn` 干净
+- `dotnet run --project .lint/UIXmlLint -- Runtime/Resources/PromptUGUI/Modals/Loading.ui.xml` exit 0
+- EditMode 测试全绿


### PR DESCRIPTION
## Summary

新增一种内置模态 `Loading.Open(text)`：业务跑后台任务时挡住 UI、转圈、代码主动 `handle.Close()` 关闭。复用现有 `UI.Modal` 队列泵 + Screen 流水线 + sortingOrder 叠加，无新渲染代码（视觉用纯 XML 的三个 `<Animation fade loop>` 错相脉冲点）。

- `Loading.Open(text)` 同步返回 `LoadingHandle`，调用方 `await` 自己的工作后 `handle.Close()`
- ESC / Back **不可关闭**（不接受用户输入）
- `IModalEntry` 加 `SetWaker` + `ResolveExternally` 两个内部方法支撑外部主动关闭路径
- `UI.Modal.PumpAsync` 加两处 `if (entry.Resolved) continue` —— pre-show close 时 modal 根本不实例化
- `Loading.XmlSrc` 可写，跟 MessageBox 同模式整体覆盖默认 XML
- 自定义 XML 时只有一个可选 id 契约：`<Text id="text">`（Bind 用 try/catch 容错）

详见 `docs~/superpowers/specs/2026-05-16-loading-modal-design.md`。

## Test Plan

- [x] `LoadingTests` 11 个 EditMode 测试全绿：open + close 闭环、pre-show close 跳过实例化、idempotent close、ESC no-op、text null/empty 隐藏节点、自定义 XML 无 text id 不抛、Loading + MessageBox FIFO 混排、`UnloadAll` 之后 Close 是 no-op、默认 `PromptUGUI/Modals/Loading.ui` 模板能加载
- [x] 全套 EditMode 测试 673/673 通过（662 个原有 + 11 个新增）
- [x] UIXmlLint 通过（`Loading.ui.xml` 不违反 `PUI-LAYOUT-ANCHOR`）
- [x] `dotnet format --verify-no-changes --severity warn` 干净
- [x] SKILL.md (`scripting-promptugui-csharp`) 更新：cheatsheet 加 Loading 行 + 新增 `### Loading modal` 小节
- [ ] PlayMode 手测：在 demo Screen 里 `Loading.Open("...")` + 异步任务 + `Close()`，确认动画转、点击穿透被遮挡

🤖 Generated with [Claude Code](https://claude.com/claude-code)