### PR TITLE
Fix rare Selectable.OnEnable crash + modal pump-latch teardown bugs

### DIFF
--- a/Runtime/Application/Modals/LoadingOverlay.cs
+++ b/Runtime/Application/Modals/LoadingOverlay.cs
@@ -23,6 +23,9 @@ namespace PromptUGUI.Application.Modals
         private static readonly List<LoadingEntry> _entries = new();
         private static readonly Queue<LoadingEntry> _pending = new();
         private static bool _materializing;
+        // 每次 CancelAllForTeardown 自增。MaterializePump 启动时快照一份；快照与当前值不符
+        // 即说明自己已被 teardown 抛弃，立刻退出、不再触碰 _materializing。
+        private static int _materializeEpoch;
 
         internal static int ActiveCount => _entries.Count;
 
@@ -62,6 +65,10 @@ namespace PromptUGUI.Application.Modals
             foreach (var e in _entries) e.Closed = true;
             _entries.Clear();
             _pending.Clear();
+            // 此刻可能还有一个 MaterializePump 挂在它的 await 上；自增 epoch 让它恢复时立刻
+            // 退出，并清掉 latch，使 teardown 之后的 Open 能正常起一个新 pump。
+            _materializeEpoch++;
+            _materializing = false;
             // overlay Screen 由 UnloadAll / ResetForTests 的 _open 循环统一关
         }
 
@@ -69,10 +76,14 @@ namespace PromptUGUI.Application.Modals
         {
             if (_materializing) return;
             _materializing = true;
+            int epoch = _materializeEpoch;
             try
             {
                 while (_pending.Count > 0)
                 {
+                    // await 期间若发生过 teardown，本 pump 已被抛弃 —— 立刻退出。
+                    if (epoch != _materializeEpoch) return;
+
                     var entry = _pending.Dequeue();
                     if (entry.Closed) continue;          // 实例化前就 Close 了
                     try
@@ -98,7 +109,11 @@ namespace PromptUGUI.Application.Modals
                     }
                 }
             }
-            finally { _materializing = false; }
+            finally
+            {
+                // 只有仍持有当前 epoch 的 pump 才清 latch —— 被抛弃的 pump 去清会误伤新 pump。
+                if (epoch == _materializeEpoch) _materializing = false;
+            }
         }
 
         private static void BindText(Screen screen, string text)

--- a/Runtime/Application/Screen.cs
+++ b/Runtime/Application/Screen.cs
@@ -68,6 +68,14 @@ namespace PromptUGUI.Application
                 typeof(Canvas),
                 typeof(UnityEngine.UI.CanvasScaler),
                 typeof(UnityEngine.UI.GraphicRaycaster));
+            // Build the whole hierarchy under an INACTIVE root: every AddComponent in
+            // the InstantiateInto recursion below then runs without firing OnEnable.
+            // OnEnable is deferred to the single SetActive(true) at the end of Open().
+            // Crucially this collapses N incremental UnityEngine.UI.Selectable.OnEnable
+            // calls (each mutates a shared static registry and is fragile when
+            // interleaved with the build) into one batched activation pass — the same
+            // path Object.Instantiate / scene-load take. Also far fewer layout rebuilds.
+            root.SetActive(false);
             var canvas = root.GetComponent<Canvas>();
             canvas.renderMode = Def.CanvasMode switch
             {
@@ -100,14 +108,28 @@ namespace PromptUGUI.Application
             var relay = root.AddComponent<RectDimensionsRelay>();
             relay.OnDimensionsChanged = () => RectTransformDimensionsChanged?.Invoke();
 
-            var result = _instantiator.InstantiateInto(root, Def);
+            // deferApply: the InstantiateInto recursion attaches every control but does
+            // NOT apply attributes yet — nodes are collected into result.ApplyOrder
+            // (DFS post-order). Attribute application is deferred until after the
+            // SetActive(true) below, because ApplyCommon → GetNativeSize measures TMP
+            // text and TMP must be Awake (the GameObject active) to measure.
+            var result = _instantiator.InstantiateInto(root, Def, deferApply: true);
             foreach (var kv in result.Controls) _byId[kv.Key] = kv.Value;
             foreach (var kv in result.NodeToControl) _nodeMap[kv.Key] = kv.Value;
             foreach (var block in Def.Variants)
             {
                 if (Variants.IsActive(block.When))
-                    ActivateAddBlock(block);
+                    ActivateAddBlock(block, result.ApplyOrder);
             }
+            // Single batched activation: fires every component's OnEnable — crucially
+            // UnityEngine.UI.Selectable.OnEnable — in one pass now that the whole tree
+            // (incl. Add blocks above) is built. See the SetActive(false) note above.
+            root.SetActive(true);
+            // Attributes applied last, on the now-Awake/active components, in the same
+            // DFS post-order the recursion would have used inline.
+            foreach (var node in result.ApplyOrder)
+                ControlAttributeApplier.Apply(node, _nodeMap[node],
+                                              _registry.Resolve(node.Tag), Variants);
             _variantSub = Variants.Changed.Subscribe(_ => ReSolve());
         }
 
@@ -222,7 +244,9 @@ namespace PromptUGUI.Application
             ApplyCanvasScaler(RootGameObject.GetComponent<UnityEngine.UI.CanvasScaler>());
         }
 
-        private void ActivateAddBlock(VariantBlock block)
+        // deferApplyTo 非 null（Screen.Open 首次构建）：Add 子树属性 Apply 延迟收进该列表，
+        // 由 Open 在 SetActive(true) 之后统一执行；null（ReSolve 运行时激活，树已 active）：就地 Apply。
+        private void ActivateAddBlock(VariantBlock block, List<ElementNode> deferApplyTo = null)
         {
             if (_addInstances.TryGetValue(block, out var existing))
             {
@@ -245,7 +269,7 @@ namespace PromptUGUI.Application
             var prevNodes = new HashSet<ElementNode>(_nodeMap.Keys);
 
             var inst = new AddInstance();
-            inst.Roots.AddRange(_instantiator.ApplyAddBlock(block, pseudoResult));
+            inst.Roots.AddRange(_instantiator.ApplyAddBlock(block, pseudoResult, deferApplyTo));
 
             foreach (var k in _byId.Keys)
                 if (!prevIds.Contains(k)) inst.AddedIds.Add(k);

--- a/Runtime/Application/ScreenInstantiator.cs
+++ b/Runtime/Application/ScreenInstantiator.cs
@@ -13,6 +13,8 @@ namespace PromptUGUI.Application
         public GameObject Root;
         public Dictionary<string, IControl> Controls;
         public Dictionary<ElementNode, Control> NodeToControl;
+        // DFS 后序排列的待 Apply 节点，仅在 InstantiateInto(deferApply:true) 时填充。
+        public List<ElementNode> ApplyOrder;
     }
 
     public sealed class ScreenInstantiator
@@ -61,24 +63,33 @@ namespace PromptUGUI.Application
             return rootControl;
         }
 
-        public InstantiationResult InstantiateInto(GameObject root, ScreenDef def)
+        /// <param name="deferApply">
+        /// true：递归里不就地 Apply 属性，而是把节点按 DFS 后序收进
+        /// <see cref="InstantiationResult.ApplyOrder"/>，由调用方在 SetActive(true) 之后统一
+        /// Apply —— 这样 ApplyCommon / GetNativeSize 的 TMP 文本测量发生在组件 Awake 之后。
+        /// </param>
+        public InstantiationResult InstantiateInto(GameObject root, ScreenDef def,
+                                                   bool deferApply = false)
         {
             var result = new InstantiationResult
             {
                 Root = root,
                 Controls = new Dictionary<string, IControl>(),
                 NodeToControl = new Dictionary<ElementNode, Control>(),
+                ApplyOrder = new List<ElementNode>(),
             };
 
             foreach (var childNode in def.Root.Children)
                 InstantiateRecursive(childNode, result.Root.transform,
                                      parentIsLayoutGroup: false,
-                                     result.Controls, result.NodeToControl);
+                                     result.Controls, result.NodeToControl,
+                                     applyOrder: deferApply ? result.ApplyOrder : null);
 
             return result;
         }
 
-        internal List<GameObject> ApplyAddBlock(VariantBlock block, InstantiationResult result)
+        internal List<GameObject> ApplyAddBlock(VariantBlock block, InstantiationResult result,
+                                                List<ElementNode> applyOrder = null)
         {
             var roots = new List<GameObject>();
             foreach (var add in block.Adds)
@@ -90,7 +101,8 @@ namespace PromptUGUI.Application
                 int prevCount = parent.childCount;
                 foreach (var child in add.Children)
                     InstantiateRecursive(child, parent, parentIsLayoutGroup,
-                                         result.Controls, result.NodeToControl);
+                                         result.Controls, result.NodeToControl,
+                                         applyOrder: applyOrder);
                 int addedN = parent.childCount - prevCount;
 
                 // 计算目标基准索引（at='end' 时等于 prevCount，保持新增项原位在末尾）
@@ -161,7 +173,8 @@ namespace PromptUGUI.Application
                                            bool parentIsLayoutGroup,
                                            Dictionary<string, IControl> controls,
                                            Dictionary<ElementNode, Control> nodeMap,
-                                           Control parentControl = null)
+                                           Control parentControl = null,
+                                           List<ElementNode> applyOrder = null)
         {
             if (parentIsLayoutGroup)
             {
@@ -221,11 +234,16 @@ namespace PromptUGUI.Application
             var selfIsLayoutGroup = node.Tag is "VStack" or "HStack" or "Grid";
             foreach (var c in node.Children)
                 InstantiateRecursive(c, control.ChildHostTransform, selfIsLayoutGroup, childScope, nodeMap,
-                                     parentControl: control);
+                                     parentControl: control, applyOrder: applyOrder);
 
             // Apply 放在子树递归之后：OnAfterApply（如 Trigger.SubscribeClick）可以安全访问
             // 已完全实例化的子节点（通过 ScopedIds / GetComponentsInChildren 等）。
-            ControlAttributeApplier.Apply(node, control, entry, _variants);
+            // applyOrder != null：延迟 Apply —— 调用方会先 SetActive(true) 让组件 Awake，
+            // 再按这里收集的 DFS 后序统一 Apply（GetNativeSize 的 TMP 测量需要 Awake）。
+            if (applyOrder != null)
+                applyOrder.Add(node);
+            else
+                ControlAttributeApplier.Apply(node, control, entry, _variants);
         }
 
         private static void BindFields(Control control, GameObject prefabRoot)

--- a/Runtime/Application/UI.Modal.cs
+++ b/Runtime/Application/UI.Modal.cs
@@ -26,6 +26,10 @@ namespace PromptUGUI.Application
             private static readonly Queue<IModalEntry> _pending = new();  // 待实例化
             private static bool _materializing;
             private static IModalEntry _inFlight;
+            // 每次 teardown（CancelAllForTeardown / CloseAll）自增。MaterializePump 启动时
+            // 快照一份；快照与当前值不符即说明自己已被 teardown 抛弃，必须立刻退出、不再触碰
+            // 任何共享状态，把所有权让给 teardown 之后新起的 pump。
+            private static int _materializeEpoch;
 
             public static int SortingOrderBase { get; set; } = 1000;
 
@@ -64,10 +68,15 @@ namespace PromptUGUI.Application
             {
                 if (_materializing) return;
                 _materializing = true;
+                int epoch = _materializeEpoch;
                 try
                 {
                     while (_pending.Count > 0)
                     {
+                        // await 期间若发生过 teardown，本 pump 已被抛弃 —— 立刻退出：
+                        // 既不消费新 entry，也不在下面的 finally 里清共享状态。
+                        if (epoch != _materializeEpoch) return;
+
                         var entry = _pending.Dequeue();
                         if (entry.Resolved) continue;       // CloseAll 在实例化前取消
                         _inFlight = entry;
@@ -104,14 +113,20 @@ namespace PromptUGUI.Application
                         }
                         finally
                         {
-                            _inFlight = null;
+                            // epoch 不符 = 已被 teardown 抛弃，_inFlight 现归新 pump，别动。
+                            if (epoch == _materializeEpoch) _inFlight = null;
                         }
                     }
                 }
                 finally
                 {
-                    _materializing = false;
-                    PromoteWaiting();
+                    // 只有仍持有当前 epoch 的 pump 才负责清 latch —— 被抛弃的 pump 去清会
+                    // 误伤 teardown 之后新起 pump 的状态。
+                    if (epoch == _materializeEpoch)
+                    {
+                        _materializing = false;
+                        PromoteWaiting();
+                    }
                 }
             }
 
@@ -158,6 +173,16 @@ namespace PromptUGUI.Application
                 }
             }
 
+            // teardown 收尾：此刻可能还有一个 MaterializePump 挂在它唯一的 await 上。自增
+            // epoch 让那个 pump 恢复时立刻退出；清掉 latch / _inFlight，使 teardown 之后的
+            // QueueForMaterialize 能正常起一个新 pump。调用方须已清空 _pending / _waiting / _stack。
+            private static void AbandonInFlightPump()
+            {
+                _materializeEpoch++;
+                _materializing = false;
+                _inFlight = null;
+            }
+
             public static void CloseAll()
             {
                 var oce = new OperationCanceledException("Modal cancelled (CloseAll)");
@@ -170,6 +195,7 @@ namespace PromptUGUI.Application
                 _inFlight?.Cancel(oce);
                 while (_pending.Count > 0) _pending.Dequeue().Cancel(oce);
                 while (_waiting.Count > 0) _waiting.Dequeue().Cancel(oce);
+                AbandonInFlightPump();
             }
 
             // UI.UnloadAll / UI.ResetForTests 调用:取消所有 await,但不关 Screen
@@ -182,6 +208,7 @@ namespace PromptUGUI.Application
                 _inFlight?.Cancel(oce);
                 while (_pending.Count > 0) _pending.Dequeue().Cancel(oce);
                 while (_waiting.Count > 0) _waiting.Dequeue().Cancel(oce);
+                AbandonInFlightPump();
             }
 
 #if UNITY_EDITOR

--- a/Tests/EditMode/Modals/ModalTeardownTests.cs
+++ b/Tests/EditMode/Modals/ModalTeardownTests.cs
@@ -106,5 +106,37 @@ namespace PromptUGUI.Tests.Modals
             // slow is intentionally left uncompleted: the orphaned pump stays parked
             // and (by the epoch guard) no-ops if it ever resumes.
         }
+
+        [Test]
+        public void Loading_teardown_while_pump_suspended_lets_later_overlays_open()
+        {
+            // Twin of the modal-pump test: LoadingOverlay has its own MaterializePump
+            // and its own _materializing latch. "test/slow" never completes, so the
+            // overlay pump parks at its await with the latch set.
+            var slow = new UnityEngine.AwaitableCompletionSource<string>();
+            UI.SourceResolver = src =>
+                src == "test/slow"
+                    ? slow.Awaitable
+                    : AwaitableHelpers.Completed(Files.TryGetValue(src, out var v) ? v : null);
+
+            // Overlay A — pump starts, then suspends awaiting the never-completing load.
+            Loading.XmlSrc = "test/slow";
+            Loading.Open("A");
+
+            // Teardown while the pump is parked mid-await.
+            LoadingOverlay.CancelAllForTeardown();
+
+            // Overlay B — loads synchronously, opened after the teardown. It must still
+            // materialize: CancelAllForTeardown has to release LoadingOverlay's latch.
+            Loading.XmlSrc = "test/Loading1";
+            Loading.Open("B");
+            var materialized = 0;
+            foreach (var _ in LoadingOverlay.ActiveScreens) materialized++;
+            Assert.AreEqual(1, materialized,
+                "an overlay opened after CancelAllForTeardown must still materialize");
+
+            // slow is intentionally left uncompleted — the orphaned pump no-ops via
+            // the epoch guard if it ever resumes.
+        }
     }
 }

--- a/Tests/EditMode/Modals/ModalTeardownTests.cs
+++ b/Tests/EditMode/Modals/ModalTeardownTests.cs
@@ -65,5 +65,46 @@ namespace PromptUGUI.Tests.Modals
             loading.Close();
             Assert.AreEqual(0, LoadingOverlay.ActiveCount);
         }
+
+        [Test]
+        public void Teardown_while_pump_suspended_lets_later_modals_open()
+        {
+            // A resolver whose "test/slow" src never completes — the materialize pump
+            // parks at its await with the pump-running latch (_materializing) set.
+            var slow = new UnityEngine.AwaitableCompletionSource<string>();
+            UI.SourceResolver = src =>
+                src == "test/slow"
+                    ? slow.Awaitable
+                    : AwaitableHelpers.Completed(Files.TryGetValue(src, out var v) ? v : null);
+
+            // Modal A — pump starts, then suspends awaiting the never-completing load.
+            MessageBox.XmlSrc = "test/slow";
+            var aTask = UI.Modal.OpenAsync(
+                new MessageBoxRequest { Text = "A", Buttons = MsgBtn.OK });
+            Assert.IsFalse(UI.Modal.IsAnyOpen, "A is still loading — not on the stack yet");
+
+            // Teardown while the pump is parked mid-await.
+            UI.Modal.CancelAllForTeardown();
+            Assert.Throws<System.OperationCanceledException>(
+                () => aTask.GetAwaiter().GetResult(),
+                "teardown cancels the in-flight modal");
+
+            // Modal B — loads synchronously, opened after the teardown. It must still
+            // materialize: CancelAllForTeardown has to release the pump-running latch
+            // even when a MaterializePump was suspended mid-flight, otherwise every
+            // later modal is silently stuck in _pending.
+            MessageBox.XmlSrc = "test/Box1";
+            var bTask = UI.Modal.OpenAsync(
+                new MessageBoxRequest { Text = "B", Buttons = MsgBtn.OK });
+            Assert.IsNotNull(UI.Modal.TopScreen,
+                "a modal opened after CancelAllForTeardown must still materialize");
+
+            // B is fully functional, not merely on the stack.
+            UI.Modal.TopScreen.Get<PromptUGUI.Controls.Btn>("ok").SimulateClick();
+            Assert.AreEqual(MsgBtn.OK, bTask.GetAwaiter().GetResult());
+
+            // slow is intentionally left uncompleted: the orphaned pump stays parked
+            // and (by the epoch guard) no-ops if it ever resumes.
+        }
     }
 }

--- a/Tests/PlayMode/Lifecycle/ScreenLifecycleTests.cs
+++ b/Tests/PlayMode/Lifecycle/ScreenLifecycleTests.cs
@@ -196,6 +196,52 @@ namespace PromptUGUI.Tests.Lifecycle
             public void Dispose() => Disposed = true;
         }
 
+        // Test probe: records the GameObject's hierarchy-active state at OnAttached time.
+        private sealed class ActiveProbe : Control
+        {
+            public static bool Recorded;
+            public static bool ActiveInHierarchyAtAttach;
+            public override void OnAttached()
+            {
+                Recorded = true;
+                ActiveInHierarchyAtAttach = GameObject.activeInHierarchy;
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator Screen_Open_instantiates_tree_while_inactive_then_activates_once()
+        {
+            // Regression guard for the uGUI Selectable.OnEnable IndexOutOfRange crash:
+            // Screen.Open must build the whole tree under an INACTIVE root so that no
+            // Selectable.OnEnable fires mid-build (interleaved with AddComponent). All
+            // OnEnable callbacks must be deferred to one batch activation pass — the
+            // same path Object.Instantiate / scene-load use.
+            ActiveProbe.Recorded = false;
+            ActiveProbe.ActiveInHierarchyAtAttach = true;   // sentinel
+            _reg.Register<ActiveProbe>("ActiveProbe", null);
+
+            UI.LoadDocument("probe_doc", @"<PromptUGUI version='1'>
+                <Screen name='ProbeScreen'>
+                    <Frame id='f'>
+                        <ActiveProbe id='p'/>
+                    </Frame>
+                </Screen></PromptUGUI>");
+
+            var screen = UI.Open("ProbeScreen");
+
+            Assert.IsTrue(ActiveProbe.Recorded, "probe OnAttached must have run during Open");
+            Assert.IsFalse(ActiveProbe.ActiveInHierarchyAtAttach,
+                "controls must be instantiated while the screen tree is INACTIVE — " +
+                "every Selectable.OnEnable is then deferred to one batch SetActive(true)");
+
+            // Once Open returns, the tree is active and usable.
+            Assert.IsTrue(screen.RootGameObject.activeInHierarchy);
+            Assert.IsTrue(screen.Get("p").GameObject.activeInHierarchy);
+
+            UI.Close("ProbeScreen");
+            yield return null;
+        }
+
         [UnityTest]
         public IEnumerator AddTo_screen_disposes_on_close()
         {

--- a/Tests/PlayMode/Modals/ModalEscapePlayModeTests.cs
+++ b/Tests/PlayMode/Modals/ModalEscapePlayModeTests.cs
@@ -16,6 +16,10 @@ namespace PromptUGUI.Tests.PlayMode.Modals
         public void SetUp()
         {
             UI.ResetForTests();
+            // MessageBox.XmlSrc is a mutable static; ModalTestFixture-based EditMode
+            // tests repoint it to "test/Box1" and never restore it. Pin it back to the
+            // builtin so this fixture does not depend on cross-suite test ordering.
+            MessageBox.XmlSrc = "PromptUGUI/Modals/MessageBox.ui";
             // Resources path structure: Assets/Runtime/Resources/PromptUGUI/Modals/MessageBox.ui.xml
             // Resources.Load("PromptUGUI/Modals/MessageBox.ui") loads the above file
             UI.SourceResolver = src =>


### PR DESCRIPTION
## Background

A rare `IndexOutOfRangeException` in `UnityEngine.UI.Selectable.OnEnable` was reported when opening a modal. `Selectable` keeps a process-global mutable static registry (`s_Selectables` / `s_SelectableCount`); PromptUGUI builds UI by incrementally `AddComponent`-ing onto an already-active hierarchy, so every `Btn`/`Toggle` fires an isolated `Selectable.OnEnable` interleaved with the build — the path most exposed to uGUI's `OnEnable` accounting edge cases. Investigating it surfaced two more latent modal-teardown bugs.

## Changes (4 independent commits)

**`23237f5` — Build the screen tree inactive, activate once.**
`Screen.Open` now builds the whole hierarchy under an inactive root and activates it once at the end, so all `OnEnable` fire in a single batched pass (the path `Object.Instantiate` / scene-load take) instead of N incremental calls interleaved with the build. Attribute application is deferred until after `SetActive(true)` because `GetNativeSize` measures TMP text and TMP must be awake. Also a perf win — one layout-rebuild pass instead of many.

**`2eedfc0` — Reset `Modal._materializing` on teardown.**
`Modal.CancelAllForTeardown` / `CloseAll` drained the queues but left the `_materializing` pump latch set. If a `MaterializePump` was suspended at its `await` (async resolver, e.g. Addressables) when teardown ran, the latch stayed set and every later modal silently never materialized. A `_materializeEpoch` counter now lets a teardown abandon an in-flight pump cleanly.

**`b4d81ea` — Reset `LoadingOverlay._materializing` on teardown.**
The exact twin of the above, in `LoadingOverlay`'s own pump. Same epoch fix.

**`8d2d058` — Pin `MessageBox.XmlSrc` in `ModalEscapePlayModeTests.SetUp`.**
`MessageBox.XmlSrc` is a mutable static that `ModalTestFixture.SetUp` repoints and never restores; `ModalEscapePlayModeTests` relied on the default, making it order-dependently flaky. SetUp now pins it.

## Testing

- EditMode 694/694, PlayMode 110/110 — both green.
- 3 new regression tests (one per runtime fix).
- `dotnet format --verify-no-changes --severity warn` clean.

## Notes

- The build-inactive change moves PromptUGUI off the uGUI edge-case-prone path onto the well-tested batch-activation path. Because `Selectable`'s registry is process-global, it reduces — but cannot 100% guarantee elimination of — the crash if corruption originates in non-PromptUGUI UI.
- No SKILL.md changes: all four are internal / test-only and change no `.ui.xml` semantics or public C# API surface.
- `ScrollList`'s dynamic-item path (`InstantiateNode`) still builds incrementally active — a narrower remaining exposure, left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
