### PR TITLE
feat: SpriteSet multi-format source enumeration + Aseprite support

### DIFF
--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -106,7 +106,7 @@ Built-in controls (`<Image>` / `<Btn>` / `<Toggle>` / `<Slider>` / `<Dropdown>` 
 
 - Values containing `:` (e.g. `sprite="ui:dialog"`) go through `UI.SpriteResolver` → SpriteSet/atlas path (`SpriteAtlasSyncer` includes them in package-time pruning).
 - Bare paths (`sprite="ui/dialog"`) fall back to `Resources.Load<Sprite>(value)` — handy for one-off sprites and prototype work that doesn't justify a SpriteSet yet.
-- Bare paths may add a `#sliceName` suffix to pick a named sub-sprite out of a multi-sprite (sliced) texture, e.g. `sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round"`. The path before `#` goes through `Resources.LoadAll<Sprite>`, then the slice with matching `.name` is returned. A trailing `.png` / `.jpg` / `.jpeg` / `.tga` / `.psd` extension on the path is stripped, so `foo.png#bar` and `foo#bar` are equivalent.
+- Bare paths may add a `#sliceName` suffix to pick a named sub-sprite out of a multi-sprite (sliced) texture, e.g. `sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round"`. The path before `#` goes through `Resources.LoadAll<Sprite>`, then the slice with matching `.name` is returned. Any file extension on the path before the `#` is stripped, so `foo.png#bar`, `foo.aseprite#bar`, and `foo#bar` are all equivalent.
 
 `<Icon>` stays atlas-only — it requires `ns:name` and calls `UI.SpriteResolver` directly.
 

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -89,6 +89,13 @@ SpriteResolverHelpers.UseSpriteSetResolver(new[] { uiSpriteSet, artSpriteSet });
 
 The helper builds a `(set:name) → Sprite` lookup from each SpriteSet's SpriteAtlas.
 
+**Source formats**: SpriteSet's source folder accepts any Unity-recognized texture
+format (PNG, JPG, JPEG, TGA, PSD, TIFF, BMP, EXR, HDR, GIF) plus Aseprite
+(`.ase` / `.aseprite`, requires `com.unity.2d.aseprite ≥ 1.0`). For Aseprite,
+each file must produce exactly **one sprite** — set the AsepriteImporter Import
+Mode to single-frame output or use one file per icon. Multi-sprite Aseprite
+files are logged as errors and skipped during sync.
+
 For Addressables-backed atlases, see **using-promptugui-addressables**.
 
 To use a fully custom backend, set `UI.SpriteResolver` directly with your own `(key → Sprite)` lookup.

--- a/.claude/skills/using-promptugui-addressables/SKILL.md
+++ b/.claude/skills/using-promptugui-addressables/SKILL.md
@@ -81,6 +81,11 @@ await SpriteResolverHelpers.UseAddressableSpriteSetResolver(
 
 Returns `Awaitable`. You can either `await` it (no flash of empty icons) or fire-and-forget (`_ = SpriteResolverHelpers.UseAddressableSpriteSetResolver(); UI.Open("MainMenu");`) — between the call and the await continuation `UI.IsSpriteResolverLoadInFlight` is `true`, so any `<Icon>` rendered in that window stays empty silently (no `LogError`) and is re-resolved automatically via a `VariantStore` broadcast once the download completes. Use the awaited form if a one-frame empty icon would be visible in your golden path (e.g. boot splash → main menu with no intermediate loader).
 
+**Source formats via Addressables**: Sprite source format is transparent to the
+Addressables path — `AssetReferenceT<Sprite>` resolves to a Sprite regardless of
+whether the underlying file was PNG / JPG / Aseprite / etc. The same single-sprite
+contract for Aseprite (see csharp SKILL) applies.
+
 ### Sprite handle lifecycle
 
 The loaded handle is held static and **released on a second `UseAddressableSpriteSetResolver` call** (label swap, reset). `Sprite` references returned from `UI.SpriteResolver` are only valid while the current handle is held — releasing the handle unloads the underlying `SpriteAtlas`.

--- a/Editor/PromptUGUI.Editor.asmdef
+++ b/Editor/PromptUGUI.Editor.asmdef
@@ -18,6 +18,11 @@
             "name": "com.unity.addressables",
             "expression": "1.0.0",
             "define": "PROMPTUGUI_HAS_ADDRESSABLES"
+        },
+        {
+            "name": "com.unity.2d.aseprite",
+            "expression": "1.0.0",
+            "define": "PROMPTUGUI_HAS_ASEPRITE"
         }
     ],
     "noEngineReferences": false

--- a/Editor/PromptUGUI.Editor.asmdef
+++ b/Editor/PromptUGUI.Editor.asmdef
@@ -5,7 +5,8 @@
         "PromptUGUI.Runtime",
         "Unity.Addressables",
         "Unity.Addressables.Editor",
-        "Unity.ResourceManager"
+        "Unity.ResourceManager",
+        "Unity.2D.Aseprite.Editor"
     ],
     "includePlatforms": ["Editor"],
     "excludePlatforms": [],

--- a/Editor/SpriteAtlasSyncer.cs
+++ b/Editor/SpriteAtlasSyncer.cs
@@ -279,13 +279,19 @@ namespace PromptUGUI.Editor
             refs.Add((ns, name));
         }
 
-        /// <summary>Cheap recursive count of image files under a folder. No asset
-        /// loading, no importer mutation — safe to call from OnInspectorGUI.</summary>
+        /// <summary>Cheap recursive count of sprite source assets (any Unity-recognized
+        /// texture format + Aseprite single-sprite files) under a folder. No asset
+        /// loading, no path resolution, no importer mutation — safe to call from
+        /// OnInspectorGUI.</summary>
         public static int CountPngs(string folderAssetPath)
         {
             if (string.IsNullOrEmpty(folderAssetPath)) return 0;
             if (!AssetDatabase.IsValidFolder(folderAssetPath)) return 0;
-            return EnumerateSpriteSourceGuids(folderAssetPath).Length;
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            var folders = new[] { folderAssetPath };
+            foreach (var g in AssetDatabase.FindAssets("t:Texture2D", folders)) seen.Add(g);
+            foreach (var g in AssetDatabase.FindAssets("t:Sprite", folders)) seen.Add(g);
+            return seen.Count;
         }
 
         /// <summary>每个 PNG 一个 entry，pathKey = sourceFolder 下的相对路径（'/' 分隔、

--- a/Editor/SpriteAtlasSyncer.cs
+++ b/Editor/SpriteAtlasSyncer.cs
@@ -283,7 +283,7 @@ namespace PromptUGUI.Editor
         /// texture format + Aseprite single-sprite files) under a folder. No asset
         /// loading, no path resolution, no importer mutation — safe to call from
         /// OnInspectorGUI.</summary>
-        public static int CountPngs(string folderAssetPath)
+        public static int CountSpriteSources(string folderAssetPath)
         {
             if (string.IsNullOrEmpty(folderAssetPath)) return 0;
             if (!AssetDatabase.IsValidFolder(folderAssetPath)) return 0;
@@ -294,14 +294,14 @@ namespace PromptUGUI.Editor
             return seen.Count;
         }
 
-        /// <summary>每个 PNG 一个 entry，pathKey = sourceFolder 下的相对路径（'/' 分隔、
+        /// <summary>每个 image 一个 entry，pathKey = sourceFolder 下的相对路径（'/' 分隔、
         /// 去扩展名）。Root file 的 pathKey 等于裸文件名；子目录文件形如 "UI/heart"。
-        /// 不再 first-wins —— 同名 PNG 在不同子目录下都会各自出现，由 <see cref="SyncAll"/>
+        /// 不再 first-wins —— 同名 texture 在不同子目录下都会各自出现，由 <see cref="SyncAll"/>
         /// 决定如何引用（路径形 vs. 裸名别名）。Triggers sprite reimport on first encounter.
         /// </summary>
         /// <param name="progressLabel">When non-null, drives a cancelable progress bar
         /// and throws <see cref="OperationCanceledException"/> if the user cancels.</param>
-        public static List<(string pathKey, Sprite sprite)> EnumeratePngs(
+        public static List<(string pathKey, Sprite sprite)> EnumerateSpriteSources(
             string folderAssetPath, string progressLabel = null)
         {
             var result = new List<(string, Sprite)>();
@@ -356,7 +356,7 @@ namespace PromptUGUI.Editor
             return paths;
         }
 
-        /// <summary>从 EnumeratePngs 结果建一个统一的查找表：pathKey 总是可用；
+        /// <summary>从 EnumerateSpriteSources 结果建一个统一的查找表：pathKey 总是可用；
         /// 当某个裸名（最后一段文件名）在整个表中唯一时，也可以裸名作为别名引用。
         /// 裸名冲突时不写入裸名 → 引用方必须用路径形。</summary>
         internal static Dictionary<string, Sprite> BuildLookup(
@@ -402,16 +402,16 @@ namespace PromptUGUI.Editor
             importer.SaveAndReimport();
         }
 
-        /// <summary>Force every PNG under <paramref name="folderAssetPath"/> to the
+        /// <summary>Force every texture under <paramref name="folderAssetPath"/> to the
         /// canonical PromptUGUI format: textureType=Sprite, spriteImportMode=Single,
         /// textureCompression=Uncompressed. Overrides prior author-set TextureImporter
         /// values — explicit "reset" semantics, intended for the SpriteSet inspector
-        /// "Reset All PNGs Format" button. Returns the number of PNGs reimported.
+        /// "Reset All Textures Format" button. Returns the number of textures reimported.
         /// Wraps the loop in <see cref="AssetDatabase.StartAssetEditing"/> for batch
         /// throughput.</summary>
         /// <param name="showProgress">When true, drives a cancelable progress bar;
         /// throws <see cref="OperationCanceledException"/> if the user cancels.</param>
-        public static int ResetPngImportSettings(string folderAssetPath,
+        public static int ResetTextureImportSettings(string folderAssetPath,
                                                 bool showProgress = false)
         {
             if (string.IsNullOrEmpty(folderAssetPath)) return 0;
@@ -461,13 +461,13 @@ namespace PromptUGUI.Editor
             return count;
         }
 
-        /// <summary>Inspector "Apply to All PNGs" entry: copy
+        /// <summary>Inspector "Apply to All Textures" entry: copy
         /// <paramref name="templatePngAssetPath"/>'s TextureImporter onto every other
-        /// PNG under <paramref name="folderAssetPath"/> via
+        /// texture under <paramref name="folderAssetPath"/> via
         /// <see cref="EditorUtility.CopySerialized(UnityEngine.Object,UnityEngine.Object)"/>.
         /// The template itself is skipped. Per SpriteSet contract every icon is a single
-        /// sprite, so manual slicing data is not expected to leak between PNGs.
-        /// Returns the number of non-template PNGs that received the settings copy.</summary>
+        /// sprite, so manual slicing data is not expected to leak between textures.
+        /// Returns the number of non-template textures that received the settings copy.</summary>
         /// <param name="showProgress">When true, drives a cancelable progress bar;
         /// throws <see cref="OperationCanceledException"/> if the user cancels.</param>
         public static int ApplyImportSettingsToFolder(
@@ -488,7 +488,7 @@ namespace PromptUGUI.Editor
                     $"[SpriteSync] template is not a TextureImporter: '{templatePngAssetPath}'");
                 return 0;
             }
-            // MF-D1b: TextureImporter-only, same reasoning as ResetPngImportSettings.
+            // MF-D1b: TextureImporter-only, same reasoning as ResetTextureImportSettings.
             var guids = AssetDatabase.FindAssets("t:Texture2D", new[] { folderAssetPath });
             var paths = new string[guids.Length];
             for (var i = 0; i < guids.Length; i++) paths[i] = AssetDatabase.GUIDToAssetPath(guids[i]);
@@ -525,12 +525,12 @@ namespace PromptUGUI.Editor
             return count;
         }
 
-        /// <summary>Alphabetically-first *.png under <paramref name="folderAssetPath"/>
+        /// <summary>Alphabetically-first texture under <paramref name="folderAssetPath"/>
         /// (recursive), as a project-relative "Assets/..." path. Returns null if the
-        /// folder is missing or contains no PNGs. Used by the SpriteSet inspector to pick
+        /// folder is missing or contains no textures. Used by the SpriteSet inspector to pick
         /// a default template for the embedded TextureImporter editor — sorting keeps
         /// the choice stable across filesystem enumeration order changes.</summary>
-        public static string FindFirstPng(string folderAssetPath)
+        public static string FindFirstTexture(string folderAssetPath)
         {
             if (string.IsNullOrEmpty(folderAssetPath)) return null;
             if (!AssetDatabase.IsValidFolder(folderAssetPath)) return null;
@@ -675,7 +675,7 @@ namespace PromptUGUI.Editor
                         continue;
                     }
                     var label = $"Set {i + 1}/{setList.Count} '{set.SetName}'";
-                    var entries = EnumeratePngs(folder, label);
+                    var entries = EnumerateSpriteSources(folder, label);
                     var lookup = BuildLookup(entries, out var bareCandidates);
 
                     var needed = new HashSet<string>();
@@ -704,7 +704,7 @@ namespace PromptUGUI.Editor
                     }
                     if (missing.Count > 0)
                         Debug.LogWarning(
-                            $"[SpriteSync] '{set.SetName}': XML references missing PNGs: " +
+                            $"[SpriteSync] '{set.SetName}': XML references missing sprites: " +
                             string.Join(", ", missing));
 
                     if (EditorUtility.DisplayCancelableProgressBar(
@@ -757,7 +757,7 @@ namespace PromptUGUI.Editor
         }
 
         /// <summary>若 SpriteSet.atlas 为 null，在 SO 同目录创建 &lt;setName&gt;.spriteatlas 并回填。
-        /// 新建 atlas 的 FilterMode 沿用 sourceFolder 下首个 PNG 的 TextureImporter.filterMode，
+        /// 新建 atlas 的 FilterMode 沿用 sourceFolder 下首个 texture 的 TextureImporter.filterMode，
         /// 这样像素美术 (Point) 与一般贴图 (Bilinear) 在 atlas 上不会被默认值覆盖。</summary>
         internal static SpriteAtlas EnsureAtlasAsset(PromptUGUI.Application.SpriteSet set)
         {
@@ -780,7 +780,7 @@ namespace PromptUGUI.Editor
 
         private static void ApplyTemplateFilterMode(SpriteAtlas atlas, string folderAssetPath)
         {
-            var firstPng = FindFirstPng(folderAssetPath);
+            var firstPng = FindFirstTexture(folderAssetPath);
             if (firstPng == null) return;
             if (AssetImporter.GetAtPath(firstPng) is not TextureImporter ti) return;
             var ts = atlas.GetTextureSettings();

--- a/Editor/SpriteAtlasSyncer.cs
+++ b/Editor/SpriteAtlasSyncer.cs
@@ -331,7 +331,12 @@ namespace PromptUGUI.Editor
                 EnsureSpriteImporter(assetPath);
 #if PROMPTUGUI_HAS_ASEPRITE
                 // MF-D4: multi-sprite Aseprite is rejected at validation time; skip it
-                // here so a stray first-sprite doesn't sneak into the SpriteSet.
+                // here so a stray first-sprite doesn't sneak into the SpriteSet via
+                // LoadAssetAtPath<Sprite>'s arbitrary-first behavior. Note: this
+                // LoadAllAssetsAtPath fires for EVERY Aseprite file (single- and
+                // multi-sprite) — EnsureSpriteImporter above already paid the same
+                // cost. The duplication is accepted per plan §5.5; refactor to a
+                // single call if profiling shows it's hot.
                 if (AssetImporter.GetAtPath(assetPath) is UnityEditor.U2D.Aseprite.AsepriteImporter)
                 {
                     if (AssetDatabase.LoadAllAssetsAtPath(assetPath).OfType<Sprite>().Count() != 1)

--- a/Editor/SpriteAtlasSyncer.cs
+++ b/Editor/SpriteAtlasSyncer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using PromptUGUI.IR;
 using PromptUGUI.Parser;
@@ -328,6 +329,15 @@ namespace PromptUGUI.Editor
                     throw new OperationCanceledException();
                 }
                 EnsureSpriteImporter(assetPath);
+#if PROMPTUGUI_HAS_ASEPRITE
+                // MF-D4: multi-sprite Aseprite is rejected at validation time; skip it
+                // here so a stray first-sprite doesn't sneak into the SpriteSet.
+                if (AssetImporter.GetAtPath(assetPath) is UnityEditor.U2D.Aseprite.AsepriteImporter)
+                {
+                    if (AssetDatabase.LoadAllAssetsAtPath(assetPath).OfType<Sprite>().Count() != 1)
+                        continue;
+                }
+#endif
                 var sp = AssetDatabase.LoadAssetAtPath<Sprite>(assetPath);
                 if (sp == null) continue;
                 var rel = assetPath.Substring(folderPrefix.Length);
@@ -394,12 +404,34 @@ namespace PromptUGUI.Editor
 
         private static void EnsureSpriteImporter(string assetPath)
         {
-            if (AssetImporter.GetAtPath(assetPath) is not TextureImporter importer) return;
-            if (importer.textureType == TextureImporterType.Sprite) return;
-            importer.textureType = TextureImporterType.Sprite;
-            importer.spriteImportMode = SpriteImportMode.Single;
-            importer.textureCompression = TextureImporterCompression.Uncompressed;
-            importer.SaveAndReimport();
+            var importer = AssetImporter.GetAtPath(assetPath);
+            if (importer is TextureImporter ti)
+            {
+                if (ti.textureType == TextureImporterType.Sprite) return;
+                ti.textureType = TextureImporterType.Sprite;
+                ti.spriteImportMode = SpriteImportMode.Single;
+                ti.textureCompression = TextureImporterCompression.Uncompressed;
+                ti.SaveAndReimport();
+                return;
+            }
+#if PROMPTUGUI_HAS_ASEPRITE
+            if (importer is UnityEditor.U2D.Aseprite.AsepriteImporter)
+            {
+                // MF-D4: validate single-sprite contract; do not coerce AsepriteImporter
+                // settings — layer/frame configuration is author intent.
+                var sprites = AssetDatabase.LoadAllAssetsAtPath(assetPath).OfType<Sprite>().Count();
+                if (sprites != 1)
+                {
+                    Debug.LogError(
+                        $"[SpriteSync] Aseprite '{assetPath}' produces {sprites} sprites; " +
+                        $"SpriteSet requires exactly 1 sprite per file. Skipping. " +
+                        $"Set the AsepriteImporter Import Mode to single-frame output, " +
+                        $"or use a different file per icon.");
+                }
+                return;
+            }
+#endif
+            // Other importer types (eg. SVG via com.unity.vectorgraphics) - silent skip.
         }
 
         /// <summary>Force every texture under <paramref name="folderAssetPath"/> to the

--- a/Editor/SpriteAtlasSyncer.cs
+++ b/Editor/SpriteAtlasSyncer.cs
@@ -279,17 +279,13 @@ namespace PromptUGUI.Editor
             refs.Add((ns, name));
         }
 
-        /// <summary>Cheap recursive count of *.png files under a folder. No asset
+        /// <summary>Cheap recursive count of image files under a folder. No asset
         /// loading, no importer mutation — safe to call from OnInspectorGUI.</summary>
         public static int CountPngs(string folderAssetPath)
         {
             if (string.IsNullOrEmpty(folderAssetPath)) return 0;
             if (!AssetDatabase.IsValidFolder(folderAssetPath)) return 0;
-            var fullFolder = Path.GetFullPath(folderAssetPath);
-            var n = 0;
-            foreach (var _ in Directory.EnumerateFiles(
-                         fullFolder, "*.png", SearchOption.AllDirectories)) n++;
-            return n;
+            return EnumerateSpriteSourceGuids(folderAssetPath).Length;
         }
 
         /// <summary>每个 PNG 一个 entry，pathKey = sourceFolder 下的相对路径（'/' 分隔、
@@ -310,33 +306,48 @@ namespace PromptUGUI.Editor
                 return result;
             }
 
-            var fullFolder = Path.GetFullPath(folderAssetPath);
-            var files = new List<string>(Directory.EnumerateFiles(
-                fullFolder, "*.png", SearchOption.AllDirectories));
-            for (var i = 0; i < files.Count; i++)
+            var paths = EnumerateSpriteSourceGuids(folderAssetPath);
+            var folderPrefix = folderAssetPath.EndsWith("/")
+                ? folderAssetPath
+                : folderAssetPath + "/";
+            for (var i = 0; i < paths.Length; i++)
             {
-                var fullPath = files[i];
-                var assetPath = "Assets" +
-                    fullPath.Substring(UnityEngine.Application.dataPath.Length).Replace('\\', '/');
+                var assetPath = paths[i];
                 if (progressLabel != null &&
                     EditorUtility.DisplayCancelableProgressBar(
                         ProgressTitle,
-                        $"{progressLabel}: {Path.GetFileName(assetPath)} ({i + 1}/{files.Count})",
-                        (float)i / Mathf.Max(1, files.Count)))
+                        $"{progressLabel}: {Path.GetFileName(assetPath)} ({i + 1}/{paths.Length})",
+                        (float)i / Mathf.Max(1, paths.Length)))
                 {
                     throw new OperationCanceledException();
                 }
                 EnsureSpriteImporter(assetPath);
                 var sp = AssetDatabase.LoadAssetAtPath<Sprite>(assetPath);
                 if (sp == null) continue;
-                var rel = fullPath.Substring(fullFolder.Length)
-                    .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-                    .Replace('\\', '/');
+                var rel = assetPath.Substring(folderPrefix.Length);
                 var ext = Path.GetExtension(rel);
                 var pathKey = rel.Substring(0, rel.Length - ext.Length);
                 result.Add((pathKey, sp));
             }
             return result;
+        }
+
+        // Returns asset paths sorted ordinally for stable downstream output.
+        // MF-D1: union t:Texture2D (covers PNG/JPG/.../Aseprite-SpriteSheet + PNG-Default-mode
+        // for EnsureSpriteImporter auto-flip) with t:Sprite (covers Aseprite-AnimatedSprite
+        // where the main asset is Sprite rather than Texture2D). HashSet by GUID dedupes
+        // the overlap (eg. PNG-as-Sprite hits both filters).
+        private static string[] EnumerateSpriteSourceGuids(string folderAssetPath)
+        {
+            var folders = new[] { folderAssetPath };
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var g in AssetDatabase.FindAssets("t:Texture2D", folders)) seen.Add(g);
+            foreach (var g in AssetDatabase.FindAssets("t:Sprite", folders)) seen.Add(g);
+            var paths = new string[seen.Count];
+            var idx = 0;
+            foreach (var g in seen) paths[idx++] = AssetDatabase.GUIDToAssetPath(g);
+            Array.Sort(paths, StringComparer.Ordinal);
+            return paths;
         }
 
         /// <summary>从 EnumeratePngs 结果建一个统一的查找表：pathKey 总是可用；
@@ -403,25 +414,27 @@ namespace PromptUGUI.Editor
                 Debug.LogError($"[SpriteSync] not a folder: '{folderAssetPath}'");
                 return 0;
             }
-            var fullFolder = Path.GetFullPath(folderAssetPath);
-            var files = new List<string>(Directory.EnumerateFiles(
-                fullFolder, "*.png", SearchOption.AllDirectories));
+            // MF-D1b: TextureImporter-only operation; AsepriteImporter resources would be
+            // rejected by the importer-type guard anyway, so single t:Texture2D filter
+            // is sufficient (and avoids enumerating Aseprite AnimatedSprite which is t:Sprite).
+            var guids = AssetDatabase.FindAssets("t:Texture2D", new[] { folderAssetPath });
+            var paths = new string[guids.Length];
+            for (var i = 0; i < guids.Length; i++) paths[i] = AssetDatabase.GUIDToAssetPath(guids[i]);
+            Array.Sort(paths, StringComparer.Ordinal);
+
             var count = 0;
             try
             {
                 AssetDatabase.StartAssetEditing();
-                for (var i = 0; i < files.Count; i++)
+                for (var i = 0; i < paths.Length; i++)
                 {
-                    var fullPath = files[i];
-                    var assetPath = "Assets" +
-                        fullPath.Substring(UnityEngine.Application.dataPath.Length)
-                                .Replace('\\', '/');
+                    var assetPath = paths[i];
                     if (showProgress &&
                         EditorUtility.DisplayCancelableProgressBar(
                             ProgressTitle,
                             $"Resetting import format: {Path.GetFileName(assetPath)} " +
-                            $"({i + 1}/{files.Count})",
-                            (float)i / Mathf.Max(1, files.Count)))
+                            $"({i + 1}/{paths.Length})",
+                            (float)i / Mathf.Max(1, paths.Length)))
                     {
                         throw new OperationCanceledException();
                     }
@@ -469,29 +482,26 @@ namespace PromptUGUI.Editor
                     $"[SpriteSync] template is not a TextureImporter: '{templatePngAssetPath}'");
                 return 0;
             }
-            var fullFolder = Path.GetFullPath(folderAssetPath);
-            var templateFullPath = Path.GetFullPath(templatePngAssetPath);
-            var files = new List<string>(Directory.EnumerateFiles(
-                fullFolder, "*.png", SearchOption.AllDirectories));
+            // MF-D1b: TextureImporter-only, same reasoning as ResetPngImportSettings.
+            var guids = AssetDatabase.FindAssets("t:Texture2D", new[] { folderAssetPath });
+            var paths = new string[guids.Length];
+            for (var i = 0; i < guids.Length; i++) paths[i] = AssetDatabase.GUIDToAssetPath(guids[i]);
+            Array.Sort(paths, StringComparer.Ordinal);
             var count = 0;
             try
             {
                 AssetDatabase.StartAssetEditing();
-                for (var i = 0; i < files.Count; i++)
+                for (var i = 0; i < paths.Length; i++)
                 {
-                    var fullPath = files[i];
-                    if (string.Equals(
-                            fullPath, templateFullPath, StringComparison.OrdinalIgnoreCase))
+                    var assetPath = paths[i];
+                    if (string.Equals(assetPath, templatePngAssetPath, StringComparison.OrdinalIgnoreCase))
                         continue;
-                    var assetPath = "Assets" +
-                        fullPath.Substring(UnityEngine.Application.dataPath.Length)
-                                .Replace('\\', '/');
                     if (showProgress &&
                         EditorUtility.DisplayCancelableProgressBar(
                             ProgressTitle,
                             $"Applying import settings: {Path.GetFileName(assetPath)} " +
-                            $"({i + 1}/{files.Count})",
-                            (float)i / Mathf.Max(1, files.Count)))
+                            $"({i + 1}/{paths.Length})",
+                            (float)i / Mathf.Max(1, paths.Length)))
                     {
                         throw new OperationCanceledException();
                     }
@@ -518,13 +528,14 @@ namespace PromptUGUI.Editor
         {
             if (string.IsNullOrEmpty(folderAssetPath)) return null;
             if (!AssetDatabase.IsValidFolder(folderAssetPath)) return null;
-            var fullFolder = Path.GetFullPath(folderAssetPath);
-            var files = new List<string>(Directory.EnumerateFiles(
-                fullFolder, "*.png", SearchOption.AllDirectories));
-            if (files.Count == 0) return null;
-            files.Sort(StringComparer.OrdinalIgnoreCase);
-            return "Assets" +
-                files[0].Substring(UnityEngine.Application.dataPath.Length).Replace('\\', '/');
+            // MF-D1b: used for "first TextureImporter's filterMode" template; AsepriteImporter
+            // has no equivalent filterMode field, so t:Texture2D-only is correct.
+            var guids = AssetDatabase.FindAssets("t:Texture2D", new[] { folderAssetPath });
+            if (guids.Length == 0) return null;
+            var paths = new string[guids.Length];
+            for (var i = 0; i < guids.Length; i++) paths[i] = AssetDatabase.GUIDToAssetPath(guids[i]);
+            Array.Sort(paths, StringComparer.Ordinal);
+            return paths[0];
         }
 
         /// <summary>差量同步 atlas 的 packables。返回 true 表示发生了变更。

--- a/Editor/SpriteAtlasSyncer.cs
+++ b/Editor/SpriteAtlasSyncer.cs
@@ -562,22 +562,36 @@ namespace PromptUGUI.Editor
             return count;
         }
 
-        /// <summary>Alphabetically-first texture under <paramref name="folderAssetPath"/>
-        /// (recursive), as a project-relative "Assets/..." path. Returns null if the
-        /// folder is missing or contains no textures. Used by the SpriteSet inspector to pick
-        /// a default template for the embedded TextureImporter editor — sorting keeps
-        /// the choice stable across filesystem enumeration order changes.</summary>
+        /// <summary>Alphabetically-first <see cref="TextureImporter"/> asset under
+        /// <paramref name="folderAssetPath"/> (recursive), as a project-relative
+        /// "Assets/..." path. Returns null if the folder is missing or contains no
+        /// TextureImporter assets. AsepriteImporter assets are excluded because
+        /// AsepriteImporterEditor isn't designed for embedded hosting (NREs in
+        /// HasModified when hosted inside SpriteSetEditor). Used by the SpriteSet
+        /// inspector to pick a default template for the embedded TextureImporter editor
+        /// — sorting keeps the choice stable across filesystem enumeration order
+        /// changes.</summary>
         public static string FindFirstTexture(string folderAssetPath)
         {
             if (string.IsNullOrEmpty(folderAssetPath)) return null;
             if (!AssetDatabase.IsValidFolder(folderAssetPath)) return null;
-            // MF-D1b: used for "first TextureImporter's filterMode" template; AsepriteImporter
-            // has no equivalent filterMode field, so t:Texture2D-only is correct.
+            // MF-D1b: TextureImporter-only template (filterMode source + embedded
+            // inspector template). Aseprite SpriteSheet mode produces a t:Texture2D
+            // main asset too, so t:Texture2D alone matches Aseprite assets — filter
+            // by importer type. Aseprite has no equivalent filterMode and its
+            // AsepriteImporterEditor isn't designed to be hosted inside our custom
+            // inspector (NREs in HasModified).
             var guids = AssetDatabase.FindAssets("t:Texture2D", new[] { folderAssetPath });
             if (guids.Length == 0) return null;
-            var paths = new string[guids.Length];
-            for (var i = 0; i < guids.Length; i++) paths[i] = AssetDatabase.GUIDToAssetPath(guids[i]);
-            Array.Sort(paths, StringComparer.Ordinal);
+            var paths = new List<string>(guids.Length);
+            for (var i = 0; i < guids.Length; i++)
+            {
+                var p = AssetDatabase.GUIDToAssetPath(guids[i]);
+                if (AssetImporter.GetAtPath(p) is TextureImporter)
+                    paths.Add(p);
+            }
+            if (paths.Count == 0) return null;
+            paths.Sort(StringComparer.Ordinal);
             return paths[0];
         }
 

--- a/Editor/SpriteAtlasSyncer.cs
+++ b/Editor/SpriteAtlasSyncer.cs
@@ -294,9 +294,9 @@ namespace PromptUGUI.Editor
             return seen.Count;
         }
 
-        /// <summary>每个 image 一个 entry，pathKey = sourceFolder 下的相对路径（'/' 分隔、
+        /// <summary>每个 sprite source 一个 entry，pathKey = sourceFolder 下的相对路径（'/' 分隔、
         /// 去扩展名）。Root file 的 pathKey 等于裸文件名；子目录文件形如 "UI/heart"。
-        /// 不再 first-wins —— 同名 texture 在不同子目录下都会各自出现，由 <see cref="SyncAll"/>
+        /// 不再 first-wins —— 同名 sprite source 在不同子目录下都会各自出现，由 <see cref="SyncAll"/>
         /// 决定如何引用（路径形 vs. 裸名别名）。Triggers sprite reimport on first encounter.
         /// </summary>
         /// <param name="progressLabel">When non-null, drives a cancelable progress bar
@@ -462,7 +462,7 @@ namespace PromptUGUI.Editor
         }
 
         /// <summary>Inspector "Apply to All Textures" entry: copy
-        /// <paramref name="templatePngAssetPath"/>'s TextureImporter onto every other
+        /// <paramref name="templateTextureAssetPath"/>'s TextureImporter onto every other
         /// texture under <paramref name="folderAssetPath"/> via
         /// <see cref="EditorUtility.CopySerialized(UnityEngine.Object,UnityEngine.Object)"/>.
         /// The template itself is skipped. Per SpriteSet contract every icon is a single
@@ -471,21 +471,21 @@ namespace PromptUGUI.Editor
         /// <param name="showProgress">When true, drives a cancelable progress bar;
         /// throws <see cref="OperationCanceledException"/> if the user cancels.</param>
         public static int ApplyImportSettingsToFolder(
-            string templatePngAssetPath,
+            string templateTextureAssetPath,
             string folderAssetPath,
             bool showProgress = false)
         {
-            if (string.IsNullOrEmpty(templatePngAssetPath)) return 0;
+            if (string.IsNullOrEmpty(templateTextureAssetPath)) return 0;
             if (string.IsNullOrEmpty(folderAssetPath)) return 0;
             if (!AssetDatabase.IsValidFolder(folderAssetPath))
             {
                 Debug.LogError($"[SpriteSync] not a folder: '{folderAssetPath}'");
                 return 0;
             }
-            if (AssetImporter.GetAtPath(templatePngAssetPath) is not TextureImporter template)
+            if (AssetImporter.GetAtPath(templateTextureAssetPath) is not TextureImporter template)
             {
                 Debug.LogError(
-                    $"[SpriteSync] template is not a TextureImporter: '{templatePngAssetPath}'");
+                    $"[SpriteSync] template is not a TextureImporter: '{templateTextureAssetPath}'");
                 return 0;
             }
             // MF-D1b: TextureImporter-only, same reasoning as ResetTextureImportSettings.
@@ -500,7 +500,7 @@ namespace PromptUGUI.Editor
                 for (var i = 0; i < paths.Length; i++)
                 {
                     var assetPath = paths[i];
-                    if (string.Equals(assetPath, templatePngAssetPath, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(assetPath, templateTextureAssetPath, StringComparison.OrdinalIgnoreCase))
                         continue;
                     if (showProgress &&
                         EditorUtility.DisplayCancelableProgressBar(
@@ -780,9 +780,9 @@ namespace PromptUGUI.Editor
 
         private static void ApplyTemplateFilterMode(SpriteAtlas atlas, string folderAssetPath)
         {
-            var firstPng = FindFirstTexture(folderAssetPath);
-            if (firstPng == null) return;
-            if (AssetImporter.GetAtPath(firstPng) is not TextureImporter ti) return;
+            var firstTexture = FindFirstTexture(folderAssetPath);
+            if (firstTexture == null) return;
+            if (AssetImporter.GetAtPath(firstTexture) is not TextureImporter ti) return;
             var ts = atlas.GetTextureSettings();
             ts.filterMode = ti.filterMode;
             atlas.SetTextureSettings(ts);

--- a/Editor/SpriteSetEditor.cs
+++ b/Editor/SpriteSetEditor.cs
@@ -8,7 +8,7 @@ namespace PromptUGUI.Editor
     public sealed class SpriteSetEditor : UnityEditor.Editor
     {
         private UnityEditor.Editor _importerEditor;
-        private string _templatePngPath;
+        private string _templateTexturePath;
 
         private void OnDisable()
         {
@@ -22,19 +22,19 @@ namespace PromptUGUI.Editor
                 DestroyImmediate(_importerEditor);
                 _importerEditor = null;
             }
-            _templatePngPath = null;
+            _templateTexturePath = null;
         }
 
         private void EnsureImporterEditor(string folder)
         {
-            var first = SpriteAtlasSyncer.FindFirstPng(folder);
-            if (first == _templatePngPath && _importerEditor != null) return;
+            var first = SpriteAtlasSyncer.FindFirstTexture(folder);
+            if (first == _templateTexturePath && _importerEditor != null) return;
             DestroyImporterEditor();
             if (string.IsNullOrEmpty(first)) return;
             var importer = AssetImporter.GetAtPath(first);
             if (importer == null) return;
             _importerEditor = CreateEditor(importer);
-            _templatePngPath = first;
+            _templateTexturePath = first;
         }
 
         // Commit any pending SerializedObject edits in the embedded TextureImporterInspector
@@ -56,8 +56,8 @@ namespace PromptUGUI.Editor
             EditorGUILayout.Space();
             var set = (SpriteSet)target;
             var folder = set.SourceFolderPath;
-            var pngCount = SpriteAtlasSyncer.CountPngs(folder);
-            EditorGUILayout.LabelField("Source PNGs", pngCount.ToString());
+            var sourceCount = SpriteAtlasSyncer.CountSpriteSources(folder);
+            EditorGUILayout.LabelField("Source sprites", sourceCount.ToString());
             EditorGUILayout.LabelField("Atlas",
                 set.Atlas == null ? "(not yet generated)" : AssetDatabase.GetAssetPath(set.Atlas));
             if (GUILayout.Button("Sync This Set"))
@@ -66,11 +66,11 @@ namespace PromptUGUI.Editor
             }
 
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField("PNG Import Settings", EditorStyles.boldLabel);
-            DrawImportSettingsSection(folder, pngCount);
+            EditorGUILayout.LabelField("Texture Import Settings", EditorStyles.boldLabel);
+            DrawImportSettingsSection(folder, sourceCount);
         }
 
-        private void DrawImportSettingsSection(string folder, int pngCount)
+        private void DrawImportSettingsSection(string folder, int sourceCount)
         {
             if (string.IsNullOrEmpty(folder))
             {
@@ -82,16 +82,16 @@ namespace PromptUGUI.Editor
             if (_importerEditor == null)
             {
                 EditorGUILayout.HelpBox(
-                    $"No PNG found under '{folder}'. " +
-                    "Add a PNG to define import settings.",
+                    $"No texture found under '{folder}'. " +
+                    "Add a texture to define import settings.",
                     MessageType.Info);
                 DrawCanonicalResetButton(folder);
                 return;
             }
 
-            EditorGUILayout.LabelField("Template", _templatePngPath);
+            EditorGUILayout.LabelField("Template", _templateTexturePath);
             EditorGUILayout.HelpBox(
-                "Edit the import settings below — they'll be applied to every PNG in " +
+                "Edit the import settings below — they'll be applied to every texture in " +
                 "the folder when you click 'Apply to All'.",
                 MessageType.None);
             using (new EditorGUI.IndentLevelScope())
@@ -99,25 +99,25 @@ namespace PromptUGUI.Editor
                 _importerEditor.OnInspectorGUI();
             }
             EditorGUILayout.Space();
-            using (new EditorGUI.DisabledScope(pngCount <= 1))
+            using (new EditorGUI.DisabledScope(sourceCount <= 1))
             {
-                var label = pngCount <= 1
-                    ? "Apply Settings to All PNGs in Folder (template is the only PNG)"
-                    : $"Apply Settings to All {pngCount} PNGs in Folder";
+                var label = sourceCount <= 1
+                    ? "Apply Settings to All Textures in Folder (template is the only texture)"
+                    : $"Apply Settings to All {sourceCount} Textures in Folder";
                 if (GUILayout.Button(label))
                 {
                     if (EditorUtility.DisplayDialog(
                         "Apply Import Settings",
-                        $"Copy import settings from\n  {_templatePngPath}\n" +
-                        $"to every PNG under\n  {folder}?\n\n" +
-                        "This overrides any per-PNG manual TextureImporter tweaks.",
+                        $"Copy import settings from\n  {_templateTexturePath}\n" +
+                        $"to every texture under\n  {folder}?\n\n" +
+                        "This overrides any per-texture manual TextureImporter tweaks.",
                         "Apply", "Cancel"))
                     {
                         FlushTemplatePendingEdits();
                         var n = SpriteAtlasSyncer.ApplyImportSettingsToFolder(
-                            _templatePngPath, folder, showProgress: true);
+                            _templateTexturePath, folder, showProgress: true);
                         Debug.Log(
-                            $"[SpriteSync] copied import settings to {n} PNG(s) " +
+                            $"[SpriteSync] copied import settings to {n} texture(s) " +
                             $"under '{folder}'");
                     }
                 }
@@ -128,25 +128,25 @@ namespace PromptUGUI.Editor
 
         private static void DrawCanonicalResetButton(string folder)
         {
-            if (!GUILayout.Button("Reset All PNGs Format")) return;
+            if (!GUILayout.Button("Reset All Textures Format")) return;
             if (string.IsNullOrEmpty(folder))
             {
                 EditorUtility.DisplayDialog(
-                    "Reset PNG Import Format",
+                    "Reset Texture Import Format",
                     "Source folder is not set on this SpriteSet.", "OK");
                 return;
             }
             if (EditorUtility.DisplayDialog(
-                "Reset PNG Import Format",
-                $"Force re-import every PNG under '{folder}' as:\n\n" +
+                "Reset Texture Import Format",
+                $"Force re-import every texture under '{folder}' as:\n\n" +
                 "  • Texture Type: Sprite\n" +
                 "  • Sprite Mode: Single\n" +
                 "  • Compression: Uncompressed\n\n" +
-                "This overrides any manual TextureImporter tweaks on these PNGs.",
+                "This overrides any manual TextureImporter tweaks on these textures.",
                 "Reset", "Cancel"))
             {
-                var n = SpriteAtlasSyncer.ResetPngImportSettings(folder, showProgress: true);
-                Debug.Log($"[SpriteSync] reset {n} PNG(s) under '{folder}'");
+                var n = SpriteAtlasSyncer.ResetTextureImportSettings(folder, showProgress: true);
+                Debug.Log($"[SpriteSync] reset {n} texture(s) under '{folder}'");
             }
         }
     }

--- a/Editor/SpriteSetEditor.cs
+++ b/Editor/SpriteSetEditor.cs
@@ -81,10 +81,26 @@ namespace PromptUGUI.Editor
             EnsureImporterEditor(folder);
             if (_importerEditor == null)
             {
-                EditorGUILayout.HelpBox(
-                    $"No texture found under '{folder}'. " +
-                    "Add a texture to define import settings.",
-                    MessageType.Info);
+                if (sourceCount > 0)
+                {
+                    // Folder has sprite sources but none of them is a TextureImporter
+                    // asset (eg. all Aseprite or other non-TextureImporter formats).
+                    // The template / apply-to-all flow is TextureImporter-only.
+                    EditorGUILayout.HelpBox(
+                        $"No regular texture (PNG / JPG / TGA / PSD / ...) found under " +
+                        $"'{folder}'. Aseprite and other non-TextureImporter formats " +
+                        $"manage their own per-file import settings — edit each file " +
+                        $"directly in the Project window. Add a regular texture to use " +
+                        $"the template / apply-to-all flow below.",
+                        MessageType.Info);
+                }
+                else
+                {
+                    EditorGUILayout.HelpBox(
+                        $"No texture found under '{folder}'. " +
+                        "Add a texture to define import settings.",
+                        MessageType.Info);
+                }
                 DrawCanonicalResetButton(folder);
                 return;
             }

--- a/Editor/SpriteSetEditor.cs
+++ b/Editor/SpriteSetEditor.cs
@@ -85,13 +85,13 @@ namespace PromptUGUI.Editor
                 {
                     // Folder has sprite sources but none of them is a TextureImporter
                     // asset (eg. all Aseprite or other non-TextureImporter formats).
-                    // The template / apply-to-all flow is TextureImporter-only.
+                    // The template / apply-to-all / reset flows are TextureImporter-only.
                     EditorGUILayout.HelpBox(
                         $"No regular texture (PNG / JPG / TGA / PSD / ...) found under " +
                         $"'{folder}'. Aseprite and other non-TextureImporter formats " +
                         $"manage their own per-file import settings — edit each file " +
-                        $"directly in the Project window. Add a regular texture to use " +
-                        $"the template / apply-to-all flow below.",
+                        $"directly in the Project window. Add a regular texture to " +
+                        $"unlock the template / apply-to-all / reset flow.",
                         MessageType.Info);
                 }
                 else
@@ -101,7 +101,7 @@ namespace PromptUGUI.Editor
                         "Add a texture to define import settings.",
                         MessageType.Info);
                 }
-                DrawCanonicalResetButton(folder);
+                // Reset button is TextureImporter-only too; nothing to reset here.
                 return;
             }
 

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -97,17 +97,14 @@ namespace PromptUGUI.Application
 
             var path = value.Substring(0, hashIdx);
             var sliceName = value.Substring(hashIdx + 1);
+            // Resources virtual paths don't carry extensions; strip any trailing
+            // extension on the value side so sprite="ui/dialog.png#slice" and
+            // sprite="ui/dialog.aseprite#slice" both resolve via LoadAll("ui/dialog").
+            // dotIdx > slashIdx guards "v2.0/dialog" where the dot is in a folder name.
+            var slashIdx = path.LastIndexOf('/');
             var dotIdx = path.LastIndexOf('.');
-            if (dotIdx > 0)
-            {
-                var ext = path.Substring(dotIdx);
-                if (ext.Equals(".png", System.StringComparison.OrdinalIgnoreCase)
-                 || ext.Equals(".jpg", System.StringComparison.OrdinalIgnoreCase)
-                 || ext.Equals(".jpeg", System.StringComparison.OrdinalIgnoreCase)
-                 || ext.Equals(".tga", System.StringComparison.OrdinalIgnoreCase)
-                 || ext.Equals(".psd", System.StringComparison.OrdinalIgnoreCase))
-                    path = path.Substring(0, dotIdx);
-            }
+            if (dotIdx > slashIdx && dotIdx > 0)
+                path = path.Substring(0, dotIdx);
             var all = UnityEngine.Resources.LoadAll<UnityEngine.Sprite>(path);
             if (all == null || all.Length == 0)
                 return null;

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -61,8 +61,8 @@ namespace PromptUGUI.Application
         /// (SpriteSet/atlas path); bare paths fall through to
         /// <c>Resources.Load&lt;Sprite&gt;</c>. Bare paths may include
         /// <c>#sliceName</c> to pick a named sub-sprite from a multi-sprite
-        /// (sliced) texture via <c>Resources.LoadAll&lt;Sprite&gt;</c>; an
-        /// image extension on the path before the <c>#</c> is stripped so
+        /// (sliced) texture via <c>Resources.LoadAll&lt;Sprite&gt;</c>; any
+        /// file extension on the path before the <c>#</c> is stripped so
         /// <c>foo.png#bar</c> and <c>foo#bar</c> both work. Null/empty input
         /// returns null.
         /// </summary>

--- a/Runtime/PromptUGUI.Runtime.asmdef
+++ b/Runtime/PromptUGUI.Runtime.asmdef
@@ -22,6 +22,11 @@
       "name": "com.unity.addressables",
       "expression": "1.0.0",
       "define": "PROMPTUGUI_HAS_ADDRESSABLES"
+    },
+    {
+      "name": "com.unity.2d.aseprite",
+      "expression": "1.0.0",
+      "define": "PROMPTUGUI_HAS_ASEPRITE"
     }
   ],
   "noEngineReferences": false

--- a/Tests/EditMode/Application/ResolveSpriteTests.cs
+++ b/Tests/EditMode/Application/ResolveSpriteTests.cs
@@ -120,5 +120,25 @@ namespace PromptUGUI.Tests.EditMode.Application
             var actual = UI.ResolveSprite("does/not/exist#anything");
             Assert.IsNull(actual);
         }
+
+        [Test]
+        public void ResolveSprite_with_hash_strips_aseprite_extension()
+        {
+            // After whitelist removal, any extension should be stripped before LoadAll.
+            var actual = UI.ResolveSprite("PromptUGUI/Defaults/pugui.aseprite#pugui_caret");
+
+            Assert.IsNotNull(actual);
+            Assert.AreEqual("pugui_caret", actual.name);
+        }
+
+        [Test]
+        public void ResolveSprite_with_hash_strips_unknown_extension()
+        {
+            // Any extension after the last '.' (not in folder name) is dropped.
+            var actual = UI.ResolveSprite("PromptUGUI/Defaults/pugui.xyz#pugui_caret");
+
+            Assert.IsNotNull(actual);
+            Assert.AreEqual("pugui_caret", actual.name);
+        }
     }
 }

--- a/Tests/EditMode/Application/ResolveSpriteTests.cs
+++ b/Tests/EditMode/Application/ResolveSpriteTests.cs
@@ -140,5 +140,14 @@ namespace PromptUGUI.Tests.EditMode.Application
             Assert.IsNotNull(actual);
             Assert.AreEqual("pugui_caret", actual.name);
         }
+
+        [Test]
+        public void ResolveSprite_does_not_strip_dot_in_folder_name()
+        {
+            // "v2.0/foo" — the dot is in the folder segment before the slash, so it must
+            // NOT be stripped. LoadAll("v2.0/foo") returns empty → null is returned silently.
+            var actual = UI.ResolveSprite("v2.0/foo#anything");
+            Assert.IsNull(actual); // LoadAll finds nothing; no error expected either
+        }
     }
 }

--- a/Tests/EditMode/Editor/Fixtures.meta
+++ b/Tests/EditMode/Editor/Fixtures.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ab32650c5eb52a04e8fa69154e51e668
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Editor/Fixtures/aseprite.meta
+++ b/Tests/EditMode/Editor/Fixtures/aseprite.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b0449645b32245e48a805965dda2db9b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Editor/Fixtures/aseprite/README.md
+++ b/Tests/EditMode/Editor/Fixtures/aseprite/README.md
@@ -1,0 +1,18 @@
+# Aseprite test fixtures
+
+Place the following `.aseprite` files here to enable the conditional-compiled
+Aseprite tests in `SpriteAtlasSyncerTests`:
+
+- `single_animated.aseprite` — 1 frame, Aseprite Import Mode = AnimatedSprite (default).
+  Main asset is `t:Sprite`, no Texture2D main asset.
+- `single_sheet.aseprite` — 1 frame, Aseprite Import Mode = SpriteSheet.
+  Main asset is `t:Texture2D` with one Sprite sub-asset.
+- `multi.aseprite` — 3+ frames. Used to verify the SpriteSet single-sprite
+  contract logs an error and skips the file.
+
+Tests gated by `Assume.That(File.Exists(...))` are skipped when fixtures are absent.
+
+Requires the `com.unity.2d.aseprite` package (≥ 1.0) to be installed in the
+host Unity project. When installed, the `PROMPTUGUI_HAS_ASEPRITE` compile
+define activates and the Aseprite-branch code in `SpriteAtlasSyncer.cs`
+participates in compilation.

--- a/Tests/EditMode/Editor/Fixtures/aseprite/README.md.meta
+++ b/Tests/EditMode/Editor/Fixtures/aseprite/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b2308023e5dc7764991b96117c0f40f6
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs
+++ b/Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs
@@ -244,7 +244,7 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
-        public void EnumeratePngs_returns_pathkey_for_root_file()
+        public void EnumerateSpriteSources_returns_pathkey_for_root_file()
         {
             var folder = $"{TestRoot}/icons";
             AssetDatabase.CreateFolder(TestRoot, "icons");
@@ -258,7 +258,7 @@ namespace PromptUGUI.Tests.Editor
                 importer.SaveAndReimport();
             }
 
-            var entries = SpriteAtlasSyncer.EnumeratePngs(folder);
+            var entries = SpriteAtlasSyncer.EnumerateSpriteSources(folder);
             var keys = new List<string>();
             foreach (var (k, _) in entries) keys.Add(k);
             Assert.That(keys, Does.Contain("foo"),
@@ -266,7 +266,7 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
-        public void EnumeratePngs_returns_pathkey_with_subfolder()
+        public void EnumerateSpriteSources_returns_pathkey_with_subfolder()
         {
             // File at <folder>/UI/heart.png should produce key "UI/heart" (relative
             // path under sourceFolder, '/' separator, no extension).
@@ -277,7 +277,7 @@ namespace PromptUGUI.Tests.Editor
             File.WriteAllBytes(pngPath, MakeBlankPng());
             ImportAsSprite(pngPath);
 
-            var entries = SpriteAtlasSyncer.EnumeratePngs(folder);
+            var entries = SpriteAtlasSyncer.EnumerateSpriteSources(folder);
             var keys = new List<string>();
             foreach (var (k, _) in entries) keys.Add(k);
             Assert.That(keys, Does.Contain("UI/heart"),
@@ -285,7 +285,7 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
-        public void EnumeratePngs_returns_both_entries_on_basename_collision()
+        public void EnumerateSpriteSources_returns_both_entries_on_basename_collision()
         {
             // Two PNGs sharing a basename in different subfolders must each appear
             // with their own pathKey — no first-wins, no warning.
@@ -300,7 +300,7 @@ namespace PromptUGUI.Tests.Editor
             ImportAsSprite(pngA);
             ImportAsSprite(pngB);
 
-            var entries = SpriteAtlasSyncer.EnumeratePngs(folder);
+            var entries = SpriteAtlasSyncer.EnumerateSpriteSources(folder);
             var keys = new HashSet<string>();
             foreach (var (k, _) in entries) keys.Add(k);
             Assert.That(keys, Does.Contain("UI/heart"));
@@ -308,7 +308,7 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
-        public void EnumeratePngs_forces_sprite_single_on_default_texture()
+        public void EnumerateSpriteSources_forces_sprite_single_on_default_texture()
         {
             var folder = $"{TestRoot}/icons_default";
             AssetDatabase.CreateFolder(TestRoot, "icons_default");
@@ -320,7 +320,7 @@ namespace PromptUGUI.Tests.Editor
             importer.textureType = TextureImporterType.Default;
             importer.SaveAndReimport();
 
-            SpriteAtlasSyncer.EnumeratePngs(folder);
+            SpriteAtlasSyncer.EnumerateSpriteSources(folder);
 
             var after = AssetImporter.GetAtPath(pngPath) as TextureImporter;
             Assert.AreEqual(TextureImporterType.Sprite, after.textureType);
@@ -328,7 +328,7 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
-        public void EnumeratePngs_sets_uncompressed_on_default_texture()
+        public void EnumerateSpriteSources_sets_uncompressed_on_default_texture()
         {
             // Repro for SpriteAtlas pack-time warning: "Source Texture (...) is using
             // compressed format. To ensure no loss in source pixel details when
@@ -346,7 +346,7 @@ namespace PromptUGUI.Tests.Editor
             importer.textureType = TextureImporterType.Default;
             importer.SaveAndReimport();
 
-            SpriteAtlasSyncer.EnumeratePngs(folder);
+            SpriteAtlasSyncer.EnumerateSpriteSources(folder);
 
             var after = AssetImporter.GetAtPath(pngPath) as TextureImporter;
             Assert.AreEqual(TextureImporterCompression.Uncompressed, after.textureCompression,
@@ -354,7 +354,7 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
-        public void ResetPngImportSettings_forces_canonical_format()
+        public void ResetTextureImportSettings_forces_canonical_format()
         {
             // Inspector "Reset All PNGs Format" button entry point. Unlike the
             // implicit-on-sync flow (which respects author tweaks on already-Sprite
@@ -372,7 +372,7 @@ namespace PromptUGUI.Tests.Editor
             importer.textureCompression = TextureImporterCompression.Compressed;
             importer.SaveAndReimport();
 
-            var n = SpriteAtlasSyncer.ResetPngImportSettings(folder);
+            var n = SpriteAtlasSyncer.ResetTextureImportSettings(folder);
 
             Assert.AreEqual(1, n);
             var after = AssetImporter.GetAtPath(pngPath) as TextureImporter;
@@ -382,7 +382,7 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
-        public void ResetPngImportSettings_walks_subfolders()
+        public void ResetTextureImportSettings_walks_subfolders()
         {
             // Mirrors EnumeratePngs: recursive over subfolders.
             var folder = $"{TestRoot}/icons_reset_sub";
@@ -395,7 +395,7 @@ namespace PromptUGUI.Tests.Editor
             AssetDatabase.ImportAsset(rootPng, ImportAssetOptions.ForceUpdate);
             AssetDatabase.ImportAsset(subPng, ImportAssetOptions.ForceUpdate);
 
-            var n = SpriteAtlasSyncer.ResetPngImportSettings(folder);
+            var n = SpriteAtlasSyncer.ResetTextureImportSettings(folder);
 
             Assert.AreEqual(2, n);
         }
@@ -482,7 +482,7 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
-        public void FindFirstPng_returns_alphabetically_first_under_folder()
+        public void FindFirstTexture_returns_alphabetically_first_under_folder()
         {
             var folder = $"{TestRoot}/icons_first";
             AssetDatabase.CreateFolder(TestRoot, "icons_first");
@@ -493,18 +493,18 @@ namespace PromptUGUI.Tests.Editor
             AssetDatabase.ImportAsset(b, ImportAssetOptions.ForceUpdate);
             AssetDatabase.ImportAsset(a, ImportAssetOptions.ForceUpdate);
 
-            var first = SpriteAtlasSyncer.FindFirstPng(folder);
+            var first = SpriteAtlasSyncer.FindFirstTexture(folder);
 
             Assert.AreEqual(a, first);
         }
 
         [Test]
-        public void FindFirstPng_returns_null_for_empty_folder()
+        public void FindFirstTexture_returns_null_for_empty_folder()
         {
             var folder = $"{TestRoot}/icons_empty";
             AssetDatabase.CreateFolder(TestRoot, "icons_empty");
 
-            Assert.IsNull(SpriteAtlasSyncer.FindFirstPng(folder));
+            Assert.IsNull(SpriteAtlasSyncer.FindFirstTexture(folder));
         }
 
         [Test]
@@ -550,7 +550,7 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
-        public void EnumeratePngs_leaves_existing_sprite_importer_untouched()
+        public void EnumerateSpriteSources_leaves_existing_sprite_importer_untouched()
         {
             var folder = $"{TestRoot}/icons_multi";
             AssetDatabase.CreateFolder(TestRoot, "icons_multi");
@@ -563,7 +563,7 @@ namespace PromptUGUI.Tests.Editor
             importer.spriteImportMode = SpriteImportMode.Multiple;
             importer.SaveAndReimport();
 
-            SpriteAtlasSyncer.EnumeratePngs(folder);
+            SpriteAtlasSyncer.EnumerateSpriteSources(folder);
 
             var after = AssetImporter.GetAtPath(pngPath) as TextureImporter;
             Assert.AreEqual(TextureImporterType.Sprite, after.textureType);
@@ -572,7 +572,7 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
-        public void EnumeratePngs_picks_up_jpg_alongside_png()
+        public void EnumerateSpriteSources_picks_up_jpg_alongside_png()
         {
             // Multi-format coverage: glob-based *.png enumeration would miss JPG.
             // After switching to AssetDatabase.FindAssets("t:Texture2D" ∪ "t:Sprite"),
@@ -586,7 +586,7 @@ namespace PromptUGUI.Tests.Editor
             ImportAsSprite(pngPath);
             ImportAsSprite(jpgPath);
 
-            var entries = SpriteAtlasSyncer.EnumeratePngs(folder);
+            var entries = SpriteAtlasSyncer.EnumerateSpriteSources(folder);
             var keys = new HashSet<string>();
             foreach (var (k, _) in entries) keys.Add(k);
             Assert.That(keys, Does.Contain("p"));
@@ -594,7 +594,7 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
-        public void EnumeratePngs_returns_entries_in_stable_path_order()
+        public void EnumerateSpriteSources_returns_entries_in_stable_path_order()
         {
             var folder = $"{TestRoot}/icons_order";
             AssetDatabase.CreateFolder(TestRoot, "icons_order");
@@ -605,7 +605,7 @@ namespace PromptUGUI.Tests.Editor
             File.WriteAllBytes(a, MakeBlankPng()); ImportAsSprite(a);
             File.WriteAllBytes(b, MakeBlankPng()); ImportAsSprite(b);
 
-            var entries = SpriteAtlasSyncer.EnumeratePngs(folder);
+            var entries = SpriteAtlasSyncer.EnumerateSpriteSources(folder);
             var keys = new List<string>();
             foreach (var (k, _) in entries) keys.Add(k);
             Assert.AreEqual(new[] { "a", "b", "c" }, keys.ToArray());

--- a/Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs
+++ b/Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs
@@ -990,6 +990,50 @@ namespace PromptUGUI.Tests.Editor
         }
 #endif
 
+#if PROMPTUGUI_HAS_ASEPRITE
+        [Test]
+        public void FindFirstTexture_skips_aseprite_assets()
+        {
+            // Repro for NRE: AsepriteImporterEditor isn't designed to be hosted inside
+            // SpriteSetEditor's embedded inspector. FindFirstTexture must skip Aseprite
+            // assets even though their main asset is t:Texture2D (SpriteSheet mode).
+            var folder = $"{TestRoot}/find_first_skips_aseprite";
+            AssetDatabase.CreateFolder(TestRoot, "find_first_skips_aseprite");
+            var srcAseprite = "Packages/com.heerozh.promptugui/Tests/EditMode/Editor/Fixtures/aseprite/single_sheet.aseprite";
+            Assume.That(File.Exists(srcAseprite), $"Fixture missing: {srcAseprite}");
+            // Aseprite at "a.aseprite" alphabetically wins over PNG at "b.png" with
+            // ordinal sort, so without the importer-type filter the result would be
+            // the Aseprite path — which then causes AsepriteImporterEditor NRE when
+            // hosted by SpriteSetEditor.
+            AssetDatabase.CopyAsset(srcAseprite, $"{folder}/a.aseprite");
+            var pngPath = $"{folder}/b.png";
+            File.WriteAllBytes(pngPath, MakeBlankPng());
+            ImportAsSprite(pngPath);
+
+            var first = SpriteAtlasSyncer.FindFirstTexture(folder);
+
+            Assert.AreEqual(pngPath, first,
+                "FindFirstTexture must return the PNG (TextureImporter), not the alphabetically-prior Aseprite.");
+        }
+#endif
+
+        [Test]
+        public void FindFirstTexture_returns_alphabetically_first_texture_importer()
+        {
+            var folder = $"{TestRoot}/find_first_sort";
+            AssetDatabase.CreateFolder(TestRoot, "find_first_sort");
+            var c = $"{folder}/c.png";
+            var a = $"{folder}/a.png";
+            var b = $"{folder}/b.png";
+            File.WriteAllBytes(c, MakeBlankPng()); ImportAsSprite(c);
+            File.WriteAllBytes(a, MakeBlankPng()); ImportAsSprite(a);
+            File.WriteAllBytes(b, MakeBlankPng()); ImportAsSprite(b);
+
+            var first = SpriteAtlasSyncer.FindFirstTexture(folder);
+
+            Assert.AreEqual(a, first);
+        }
+
         private string MakeFolder(string name)
         {
             AssetDatabase.CreateFolder(TestRoot, name);

--- a/Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs
+++ b/Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs
@@ -572,6 +572,46 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
+        public void EnumeratePngs_picks_up_jpg_alongside_png()
+        {
+            // Multi-format coverage: glob-based *.png enumeration would miss JPG.
+            // After switching to AssetDatabase.FindAssets("t:Texture2D" ∪ "t:Sprite"),
+            // any importer-recognized image file in the folder is included.
+            var folder = $"{TestRoot}/icons_mixed";
+            AssetDatabase.CreateFolder(TestRoot, "icons_mixed");
+            var pngPath = $"{folder}/p.png";
+            var jpgPath = $"{folder}/j.jpg";
+            File.WriteAllBytes(pngPath, MakeBlankPng());
+            File.WriteAllBytes(jpgPath, MakeBlankJpg());
+            ImportAsSprite(pngPath);
+            ImportAsSprite(jpgPath);
+
+            var entries = SpriteAtlasSyncer.EnumeratePngs(folder);
+            var keys = new HashSet<string>();
+            foreach (var (k, _) in entries) keys.Add(k);
+            Assert.That(keys, Does.Contain("p"));
+            Assert.That(keys, Does.Contain("j"));
+        }
+
+        [Test]
+        public void EnumeratePngs_returns_entries_in_stable_path_order()
+        {
+            var folder = $"{TestRoot}/icons_order";
+            AssetDatabase.CreateFolder(TestRoot, "icons_order");
+            var c = $"{folder}/c.png";
+            var a = $"{folder}/a.png";
+            var b = $"{folder}/b.png";
+            File.WriteAllBytes(c, MakeBlankPng()); ImportAsSprite(c);
+            File.WriteAllBytes(a, MakeBlankPng()); ImportAsSprite(a);
+            File.WriteAllBytes(b, MakeBlankPng()); ImportAsSprite(b);
+
+            var entries = SpriteAtlasSyncer.EnumeratePngs(folder);
+            var keys = new List<string>();
+            foreach (var (k, _) in entries) keys.Add(k);
+            Assert.AreEqual(new[] { "a", "b", "c" }, keys.ToArray());
+        }
+
+        [Test]
         public void UpdateAtlas_v2_does_not_accumulate_packables_on_repeated_sync()
         {
             var folder = $"{TestRoot}/v2";
@@ -913,6 +953,16 @@ namespace PromptUGUI.Tests.Editor
             t.SetPixel(0, 0, Color.white);
             t.Apply();
             var bytes = t.EncodeToPNG();
+            UnityEngine.Object.DestroyImmediate(t);
+            return bytes;
+        }
+
+        private byte[] MakeBlankJpg()
+        {
+            var t = new Texture2D(1, 1);
+            t.SetPixel(0, 0, Color.white);
+            t.Apply();
+            var bytes = t.EncodeToJPG();
             UnityEngine.Object.DestroyImmediate(t);
             return bytes;
         }

--- a/Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs
+++ b/Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs
@@ -930,6 +930,66 @@ namespace PromptUGUI.Tests.Editor
             SpriteAtlasSyncer.ScanXmlReferences();
         }
 
+#if PROMPTUGUI_HAS_ASEPRITE
+        [Test]
+        public void EnumerateSpriteSources_picks_up_single_frame_animatedsprite_aseprite()
+        {
+            // AnimatedSprite is Aseprite's default Import Mode. Main asset is t:Sprite,
+            // NOT t:Texture2D, so the union filter (MF-D1) is what makes this work.
+            var folder = $"{TestRoot}/aseprite_animated";
+            AssetDatabase.CreateFolder(TestRoot, "aseprite_animated");
+            var srcAseprite = "Packages/com.heerozh.promptugui/Tests/EditMode/Editor/Fixtures/aseprite/single_animated.aseprite";
+            Assume.That(File.Exists(srcAseprite), $"Fixture missing: {srcAseprite}");
+            var destAseprite = $"{folder}/single.aseprite";
+            AssetDatabase.CopyAsset(srcAseprite, destAseprite);
+
+            var entries = SpriteAtlasSyncer.EnumerateSpriteSources(folder);
+            var keys = new List<string>();
+            foreach (var (k, _) in entries) keys.Add(k);
+            Assert.That(keys, Does.Contain("single"));
+        }
+
+        [Test]
+        public void EnumerateSpriteSources_picks_up_single_frame_spritesheet_aseprite()
+        {
+            var folder = $"{TestRoot}/aseprite_sheet";
+            AssetDatabase.CreateFolder(TestRoot, "aseprite_sheet");
+            var srcAseprite = "Packages/com.heerozh.promptugui/Tests/EditMode/Editor/Fixtures/aseprite/single_sheet.aseprite";
+            Assume.That(File.Exists(srcAseprite), $"Fixture missing: {srcAseprite}");
+            var destAseprite = $"{folder}/single.aseprite";
+            AssetDatabase.CopyAsset(srcAseprite, destAseprite);
+
+            var entries = SpriteAtlasSyncer.EnumerateSpriteSources(folder);
+            var keys = new List<string>();
+            foreach (var (k, _) in entries) keys.Add(k);
+            Assert.That(keys, Does.Contain("single"),
+                "SpriteSheet-mode 1-sprite Aseprite must be enumerated");
+            // Dedupe assertion: SpriteSheet mode hits BOTH t:Texture2D and t:Sprite.
+            // Union HashSet should fold them into one entry.
+            Assert.AreEqual(1, keys.Count,
+                "Expected exactly one entry; got: " + string.Join(",", keys));
+        }
+
+        [Test]
+        public void EnumerateSpriteSources_skips_multi_sprite_aseprite_with_log_error()
+        {
+            var folder = $"{TestRoot}/aseprite_multi";
+            AssetDatabase.CreateFolder(TestRoot, "aseprite_multi");
+            var srcAseprite = "Packages/com.heerozh.promptugui/Tests/EditMode/Editor/Fixtures/aseprite/multi.aseprite";
+            Assume.That(File.Exists(srcAseprite), $"Fixture missing: {srcAseprite}");
+            var destAseprite = $"{folder}/multi.aseprite";
+            AssetDatabase.CopyAsset(srcAseprite, destAseprite);
+
+            LogAssert.Expect(LogType.Error,
+                new System.Text.RegularExpressions.Regex("produces .* sprites; SpriteSet requires exactly 1"));
+
+            var entries = SpriteAtlasSyncer.EnumerateSpriteSources(folder);
+            var keys = new List<string>();
+            foreach (var (k, _) in entries) keys.Add(k);
+            Assert.That(keys, Does.Not.Contain("multi"));
+        }
+#endif
+
         private string MakeFolder(string name)
         {
             AssetDatabase.CreateFolder(TestRoot, name);

--- a/Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs
+++ b/Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs
@@ -356,9 +356,9 @@ namespace PromptUGUI.Tests.Editor
         [Test]
         public void ResetTextureImportSettings_forces_canonical_format()
         {
-            // Inspector "Reset All PNGs Format" button entry point. Unlike the
+            // Inspector "Reset All Textures Format" button entry point. Unlike the
             // implicit-on-sync flow (which respects author tweaks on already-Sprite
-            // imports), this is an explicit user-triggered force: every PNG in the
+            // imports), this is an explicit user-triggered force: every texture in the
             // folder ends up Sprite + Single + Uncompressed, overriding prior config.
             var folder = $"{TestRoot}/icons_reset";
             AssetDatabase.CreateFolder(TestRoot, "icons_reset");
@@ -384,7 +384,7 @@ namespace PromptUGUI.Tests.Editor
         [Test]
         public void ResetTextureImportSettings_walks_subfolders()
         {
-            // Mirrors EnumeratePngs: recursive over subfolders.
+            // Mirrors EnumerateSpriteSources: recursive over subfolders.
             var folder = $"{TestRoot}/icons_reset_sub";
             AssetDatabase.CreateFolder(TestRoot, "icons_reset_sub");
             AssetDatabase.CreateFolder(folder, "Sub");
@@ -403,8 +403,8 @@ namespace PromptUGUI.Tests.Editor
         [Test]
         public void ApplyImportSettingsToFolder_propagates_template_settings_to_others()
         {
-            // Inspector "Apply to All PNGs" entry point: copy a chosen template PNG's
-            // TextureImporter onto every other PNG in the folder, preserving whatever
+            // Inspector "Apply to All Textures" entry point: copy a chosen template texture's
+            // TextureImporter onto every other texture in the folder, preserving whatever
             // settings the user dialed in via the embedded importer inspector.
             var folder = $"{TestRoot}/icons_apply";
             AssetDatabase.CreateFolder(TestRoot, "icons_apply");
@@ -508,10 +508,10 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
-        public void EnsureAtlasAsset_inherits_filter_mode_from_first_png()
+        public void EnsureAtlasAsset_inherits_filter_mode_from_first_texture()
         {
             // Newly-created atlases should pick up FilterMode from the alphabetically
-            // first PNG in the source folder, so atlas filtering matches the icons it
+            // first texture in the source folder, so atlas filtering matches the icons it
             // packs (pixel-art games typically want Point on both).
             var folder = MakeFolder("icons_atlas_filter");
             var pngPath = $"{folder}/a.png";

--- a/docs~/superpowers/plans/2026-05-24-spriteset-multi-format.md
+++ b/docs~/superpowers/plans/2026-05-24-spriteset-multi-format.md
@@ -1,0 +1,1027 @@
+# SpriteSet 源资产枚举去扩展名化 (多格式 + Aseprite) 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 SpriteSet 接受任何 Unity 原生纹理格式 (PNG/JPG/TGA/PSD/...) 以及 Aseprite 文件 (`.ase`/`.aseprite`)，不再硬绑 `*.png` 扩展名。
+
+**Architecture:** Editor `SpriteAtlasSyncer` 从 `Directory.EnumerateFiles(*.png)` 切到 `AssetDatabase.FindAssets("t:Texture2D" ∪ "t:Sprite", ...)` 联合查询（HashSet by GUID 去重，覆盖 Aseprite AnimatedSprite/SpriteSheet 两种 import mode 和 PNG Default-mode 的 auto-flip 路径）。Aseprite 走 `PROMPTUGUI_HAS_ASEPRITE` versionDefines（照搬 Addressables 套路），单 sprite 契约由 Syncer 验证而非强制改写 importer 设置。Runtime `UI.cs` 扩展名 strip 去白名单，改为"strip 最后一个 `.`"。
+
+**Tech Stack:** Unity 6+ `AssetDatabase.FindAssets` / `TextureImporter` / `AsepriteImporter` (`com.unity.2d.aseprite`)；`PromptUGUI.Tests.EditMode` (NUnit) + Unity MCP run_tests。
+
+**Spec reference:** [`docs~/superpowers/specs/2026-05-24-spriteset-multi-format-design.md`](../specs/2026-05-24-spriteset-multi-format-design.md)
+
+---
+
+## File Structure
+
+**Modify:**
+- `Runtime/Application/UI.cs:100-110` — strip-extension 白名单 → "strip 最后一个 `.`"
+- `Runtime/PromptUGUI.Runtime.asmdef:20-26` — 加 `PROMPTUGUI_HAS_ASEPRITE` versionDefine
+- `Editor/PromptUGUI.Editor.asmdef:16-22` — 同上
+- `Editor/SpriteAtlasSyncer.cs` — 5 处 `Directory.EnumerateFiles("*.png", ...)` 切到 `FindAssets` union；`EnsureSpriteImporter` 加 Aseprite 分支；方法重命名 (`CountPngs`/`EnumeratePngs`/`ResetPngImportSettings`/`FindFirstPng` → 去 PNG 化)
+- `Editor/SpriteSetEditor.cs:30,59,148` — 跟随重命名 + Inspector 文案 "PNG" → "image"/"texture"
+- `Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs` — 加 mixed-extension / Aseprite case；旧 `EnumeratePngs_*` test 名跟随方法重命名
+- `Tests/EditMode/Application/ResolveSpriteTests.cs` — 加扩展名 strip case
+- `.claude/skills/scripting-promptugui-csharp/SKILL.md` — 加一段 "SpriteSet accepts any Unity-recognized texture format + Aseprite"
+- `.claude/skills/using-promptugui-addressables/SKILL.md` — 同上
+
+**No new files.**
+
+---
+
+## Task 1: Runtime `UI.cs` 扩展名 strip 简化
+
+**Files:**
+- Modify: `Runtime/Application/UI.cs:100-110`
+- Test: `Tests/EditMode/Application/ResolveSpriteTests.cs`
+
+`UI.ResolveSprite` 当前对 `"foo.png#slice"` 形式的 `value` 用一个 PNG/JPG/JPEG/TGA/PSD 白名单去 strip 扩展名后再 `Resources.LoadAll<Sprite>(path)`。改成"任何扩展名都 strip"，对 `.aseprite`/`.bmp`/`.tiff` 等也工作。`dotIdx > slashIdx` 守门防止 `v2.0/foo` 这种"点在目录名"的情况被误 strip。
+
+- [ ] **Step 1.1: 加 failing test (任意扩展名 strip)**
+
+In `Tests/EditMode/Application/ResolveSpriteTests.cs`, append:
+
+```csharp
+[Test]
+public void ResolveSprite_with_hash_strips_aseprite_extension()
+{
+    // After whitelist removal, any extension should be stripped before LoadAll.
+    var actual = UI.ResolveSprite("PromptUGUI/Defaults/pugui.aseprite#pugui_caret");
+
+    Assert.IsNotNull(actual);
+    Assert.AreEqual("pugui_caret", actual.name);
+}
+
+[Test]
+public void ResolveSprite_with_hash_strips_unknown_extension()
+{
+    // Any extension after the last '.' (not in folder name) is dropped.
+    var actual = UI.ResolveSprite("PromptUGUI/Defaults/pugui.xyz#pugui_caret");
+
+    Assert.IsNotNull(actual);
+    Assert.AreEqual("pugui_caret", actual.name);
+}
+```
+
+- [ ] **Step 1.2: 跑 test 确认 fail**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ResolveSpriteTests")
+```
+
+Expected: 2 new tests fail with "Expected: not null, but was: null"（因为 LoadAll 收到带扩展名的 path，找不到资源）。
+
+- [ ] **Step 1.3: 实现 — 替换 `UI.cs:100-110` 的白名单**
+
+In `Runtime/Application/UI.cs:100-110`, replace:
+
+```csharp
+            var dotIdx = path.LastIndexOf('.');
+            if (dotIdx > 0)
+            {
+                var ext = path.Substring(dotIdx);
+                if (ext.Equals(".png", System.StringComparison.OrdinalIgnoreCase)
+                 || ext.Equals(".jpg", System.StringComparison.OrdinalIgnoreCase)
+                 || ext.Equals(".jpeg", System.StringComparison.OrdinalIgnoreCase)
+                 || ext.Equals(".tga", System.StringComparison.OrdinalIgnoreCase)
+                 || ext.Equals(".psd", System.StringComparison.OrdinalIgnoreCase))
+                    path = path.Substring(0, dotIdx);
+            }
+```
+
+with:
+
+```csharp
+            // Resources virtual paths don't carry extensions; strip any trailing
+            // extension on the value side so sprite="ui/dialog.png#slice" and
+            // sprite="ui/dialog.aseprite#slice" both resolve via LoadAll("ui/dialog").
+            // dotIdx > slashIdx guards "v2.0/dialog" where the dot is in a folder name.
+            var slashIdx = path.LastIndexOf('/');
+            var dotIdx = path.LastIndexOf('.');
+            if (dotIdx > slashIdx && dotIdx > 0)
+                path = path.Substring(0, dotIdx);
+```
+
+- [ ] **Step 1.4: 跑 test 确认 pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ResolveSpriteTests")
+```
+
+Expected: all `ResolveSpriteTests.*` pass (含 2 个新 case + 既有 case 不破)。
+
+- [ ] **Step 1.5: dotnet format 验证**
+
+```bash
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx
+dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+Expected: 无 diff，无报错。
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add Runtime/Application/UI.cs Tests/EditMode/Application/ResolveSpriteTests.cs
+git commit -m "$(cat <<'EOF'
+feat: UI.ResolveSprite — strip any extension (was PNG/JPG/JPEG/TGA/PSD whitelist)
+
+The previous whitelist silently fell through on .aseprite / .bmp / .tiff /
+unknown extensions, leaving the dot in the path passed to Resources.LoadAll
+and returning null. Strip the trailing extension unconditionally, guarded
+by dotIdx > slashIdx so "v2.0/foo" isn't misread.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Editor enumeration 切到 `AssetDatabase.FindAssets` union
+
+**Files:**
+- Modify: `Editor/SpriteAtlasSyncer.cs` (5 处 enumeration + 私有 helper)
+- Test: `Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs`
+
+把 `Directory.EnumerateFiles(fullFolder, "*.png", SearchOption.AllDirectories)` 全部换成 `AssetDatabase.FindAssets`。两条 enumeration 路径（MF-D1/D1b）：
+
+- **Sync 路径** (`EnumeratePngs` / `CountPngs`): union `t:Texture2D ∪ t:Sprite`，覆盖 Aseprite AnimatedSprite (主资产 = Sprite) + Aseprite SpriteSheet (主资产 = Texture2D) + PNG-as-Sprite + PNG-Default-mode (待 auto-flip)。
+- **TextureImporter-only 路径** (`ResetPngImportSettings` / `ApplyImportSettingsToFolder` / `FindFirstPng`): 单查 `t:Texture2D` —— AsepriteImporter 在这些路径里本来就被 importer-type guard 拒掉，没必要 union。
+
+本任务**只动 enumeration**，**不改方法名**（rename 在 Task 3）。
+
+- [ ] **Step 2.1: 加 failing test — JPG 在同文件夹应被枚举**
+
+In `Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs`, append (after the existing `EnumeratePngs_*` block):
+
+```csharp
+[Test]
+public void EnumeratePngs_picks_up_jpg_alongside_png()
+{
+    // Multi-format coverage: glob-based *.png enumeration would miss JPG.
+    // After switching to AssetDatabase.FindAssets("t:Texture2D" ∪ "t:Sprite"),
+    // any importer-recognized image file in the folder is included.
+    var folder = $"{TestRoot}/icons_mixed";
+    AssetDatabase.CreateFolder(TestRoot, "icons_mixed");
+    var pngPath = $"{folder}/p.png";
+    var jpgPath = $"{folder}/j.jpg";
+    File.WriteAllBytes(pngPath, MakeBlankPng());
+    File.WriteAllBytes(jpgPath, MakeBlankJpg());
+    ImportAsSprite(pngPath);
+    ImportAsSprite(jpgPath);
+
+    var entries = SpriteAtlasSyncer.EnumeratePngs(folder);
+    var keys = new HashSet<string>();
+    foreach (var (k, _) in entries) keys.Add(k);
+    Assert.That(keys, Does.Contain("p"));
+    Assert.That(keys, Does.Contain("j"));
+}
+```
+
+Then add a `MakeBlankJpg` helper next to `MakeBlankPng` (around line 910):
+
+```csharp
+private byte[] MakeBlankJpg()
+{
+    var t = new Texture2D(1, 1);
+    t.SetPixel(0, 0, Color.white);
+    t.Apply();
+    var bytes = t.EncodeToJPG();
+    UnityEngine.Object.DestroyImmediate(t);
+    return bytes;
+}
+```
+
+- [ ] **Step 2.2: 加 failing test — stable order**
+
+Append:
+
+```csharp
+[Test]
+public void EnumeratePngs_returns_entries_in_stable_path_order()
+{
+    // FindAssets returns an implementation-defined order; the syncer must
+    // sort by asset path so atlas packing and SpriteSet entries are stable
+    // across runs.
+    var folder = $"{TestRoot}/icons_order";
+    AssetDatabase.CreateFolder(TestRoot, "icons_order");
+    var c = $"{folder}/c.png";
+    var a = $"{folder}/a.png";
+    var b = $"{folder}/b.png";
+    File.WriteAllBytes(c, MakeBlankPng()); ImportAsSprite(c);
+    File.WriteAllBytes(a, MakeBlankPng()); ImportAsSprite(a);
+    File.WriteAllBytes(b, MakeBlankPng()); ImportAsSprite(b);
+
+    var entries = SpriteAtlasSyncer.EnumeratePngs(folder);
+    var keys = new List<string>();
+    foreach (var (k, _) in entries) keys.Add(k);
+    Assert.AreEqual(new[] { "a", "b", "c" }, keys.ToArray());
+}
+```
+
+- [ ] **Step 2.3: 跑 test 确认 fail**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="SpriteAtlasSyncerTests")
+```
+
+Expected: `EnumeratePngs_picks_up_jpg_alongside_png` 缺 "j"（glob 漏 JPG）；`EnumeratePngs_returns_entries_in_stable_path_order` 顺序可能不稳定（依赖 FS）。两个 fail。
+
+- [ ] **Step 2.4: 实现 — `EnumeratePngs` / `CountPngs` 切到 union**
+
+In `Editor/SpriteAtlasSyncer.cs`, replace `CountPngs` (around line 282):
+
+```csharp
+public static int CountPngs(string folderAssetPath)
+{
+    if (string.IsNullOrEmpty(folderAssetPath)) return 0;
+    if (!AssetDatabase.IsValidFolder(folderAssetPath)) return 0;
+    return EnumerateSpriteSourceGuids(folderAssetPath).Length;
+}
+```
+
+Replace `EnumeratePngs` body (around line 302–340):
+
+```csharp
+public static List<(string pathKey, Sprite sprite)> EnumeratePngs(
+    string folderAssetPath, string progressLabel = null)
+{
+    var result = new List<(string, Sprite)>();
+    if (string.IsNullOrEmpty(folderAssetPath)) return result;
+    if (!AssetDatabase.IsValidFolder(folderAssetPath))
+    {
+        Debug.LogError($"[SpriteSync] not a folder: '{folderAssetPath}'");
+        return result;
+    }
+
+    var paths = EnumerateSpriteSourceGuids(folderAssetPath);
+    var folderPrefix = folderAssetPath.EndsWith("/")
+        ? folderAssetPath
+        : folderAssetPath + "/";
+    for (var i = 0; i < paths.Length; i++)
+    {
+        var assetPath = paths[i];
+        if (progressLabel != null &&
+            EditorUtility.DisplayCancelableProgressBar(
+                ProgressTitle,
+                $"{progressLabel}: {Path.GetFileName(assetPath)} ({i + 1}/{paths.Length})",
+                (float)i / Mathf.Max(1, paths.Length)))
+        {
+            throw new OperationCanceledException();
+        }
+        EnsureSpriteImporter(assetPath);
+        var sp = AssetDatabase.LoadAssetAtPath<Sprite>(assetPath);
+        if (sp == null) continue;
+        var rel = assetPath.Substring(folderPrefix.Length);
+        var ext = Path.GetExtension(rel);
+        var pathKey = rel.Substring(0, rel.Length - ext.Length);
+        result.Add((pathKey, sp));
+    }
+    return result;
+}
+
+// Returns asset paths sorted ordinally for stable downstream output.
+// MF-D1: union t:Texture2D (covers PNG/JPG/.../Aseprite-SpriteSheet + PNG-Default-mode
+// for EnsureSpriteImporter auto-flip) with t:Sprite (covers Aseprite-AnimatedSprite
+// where the main asset is Sprite rather than Texture2D). HashSet by GUID dedupes
+// the overlap (eg. PNG-as-Sprite hits both filters).
+private static string[] EnumerateSpriteSourceGuids(string folderAssetPath)
+{
+    var folders = new[] { folderAssetPath };
+    var seen = new HashSet<string>(StringComparer.Ordinal);
+    foreach (var g in AssetDatabase.FindAssets("t:Texture2D", folders)) seen.Add(g);
+    foreach (var g in AssetDatabase.FindAssets("t:Sprite",    folders)) seen.Add(g);
+    var paths = new string[seen.Count];
+    var idx = 0;
+    foreach (var g in seen) paths[idx++] = AssetDatabase.GUIDToAssetPath(g);
+    Array.Sort(paths, StringComparer.Ordinal);
+    return paths;
+}
+```
+
+- [ ] **Step 2.5: 实现 — `ResetPngImportSettings` 切到 `t:Texture2D` 单查 (MF-D1b)**
+
+In `Editor/SpriteAtlasSyncer.cs:397-443`, replace the `Directory.EnumerateFiles` block with `FindAssets`:
+
+```csharp
+public static int ResetPngImportSettings(string folderAssetPath,
+                                         bool showProgress = false)
+{
+    if (string.IsNullOrEmpty(folderAssetPath)) return 0;
+    if (!AssetDatabase.IsValidFolder(folderAssetPath))
+    {
+        Debug.LogError($"[SpriteSync] not a folder: '{folderAssetPath}'");
+        return 0;
+    }
+    // MF-D1b: TextureImporter-only operation; AsepriteImporter resources would be
+    // rejected by the importer-type guard anyway, so single t:Texture2D filter
+    // is sufficient (and avoids enumerating Aseprite AnimatedSprite which is t:Sprite).
+    var guids = AssetDatabase.FindAssets("t:Texture2D", new[] { folderAssetPath });
+    var paths = new string[guids.Length];
+    for (var i = 0; i < guids.Length; i++) paths[i] = AssetDatabase.GUIDToAssetPath(guids[i]);
+    Array.Sort(paths, StringComparer.Ordinal);
+
+    var count = 0;
+    try
+    {
+        AssetDatabase.StartAssetEditing();
+        for (var i = 0; i < paths.Length; i++)
+        {
+            var assetPath = paths[i];
+            if (showProgress &&
+                EditorUtility.DisplayCancelableProgressBar(
+                    ProgressTitle,
+                    $"Resetting import format: {Path.GetFileName(assetPath)} " +
+                    $"({i + 1}/{paths.Length})",
+                    (float)i / Mathf.Max(1, paths.Length)))
+            {
+                throw new OperationCanceledException();
+            }
+            if (AssetImporter.GetAtPath(assetPath) is not TextureImporter imp)
+                continue;
+            imp.textureType = TextureImporterType.Sprite;
+            imp.spriteImportMode = SpriteImportMode.Single;
+            imp.textureCompression = TextureImporterCompression.Uncompressed;
+            imp.SaveAndReimport();
+            count++;
+        }
+    }
+    finally
+    {
+        AssetDatabase.StopAssetEditing();
+        if (showProgress) EditorUtility.ClearProgressBar();
+    }
+    return count;
+}
+```
+
+- [ ] **Step 2.6: 实现 — `ApplyImportSettingsToFolder` 切到 `t:Texture2D` 单查**
+
+In `Editor/SpriteAtlasSyncer.cs:454-510`, replace the `Directory.EnumerateFiles` enumeration. The body shape is identical to Step 2.5; replace:
+
+```csharp
+            var fullFolder = Path.GetFullPath(folderAssetPath);
+            var templateFullPath = Path.GetFullPath(templatePngAssetPath);
+            var files = new List<string>(Directory.EnumerateFiles(
+                fullFolder, "*.png", SearchOption.AllDirectories));
+```
+
+with:
+
+```csharp
+            // MF-D1b: TextureImporter-only, same reasoning as ResetPngImportSettings.
+            var guids = AssetDatabase.FindAssets("t:Texture2D", new[] { folderAssetPath });
+            var paths = new string[guids.Length];
+            for (var i = 0; i < guids.Length; i++) paths[i] = AssetDatabase.GUIDToAssetPath(guids[i]);
+            Array.Sort(paths, StringComparer.Ordinal);
+```
+
+Then in the loop, replace `var fullPath = files[i];` + the `if (string.Equals(fullPath, templateFullPath, ...))` skip + `var assetPath = "Assets" + fullPath.Substring(...)` reconstruction with:
+
+```csharp
+                    var assetPath = paths[i];
+                    if (string.Equals(assetPath, templatePngAssetPath, StringComparison.OrdinalIgnoreCase))
+                        continue;
+```
+
+And update `files.Count` → `paths.Length` throughout.
+
+- [ ] **Step 2.7: 实现 — `FindFirstPng` 切到 `t:Texture2D` 单查**
+
+In `Editor/SpriteAtlasSyncer.cs:517-528`, replace the body:
+
+```csharp
+public static string FindFirstPng(string folderAssetPath)
+{
+    if (string.IsNullOrEmpty(folderAssetPath)) return null;
+    if (!AssetDatabase.IsValidFolder(folderAssetPath)) return null;
+    // MF-D1b: used for "first TextureImporter's filterMode" template; AsepriteImporter
+    // has no equivalent filterMode field, so t:Texture2D-only is correct.
+    var guids = AssetDatabase.FindAssets("t:Texture2D", new[] { folderAssetPath });
+    if (guids.Length == 0) return null;
+    var paths = new string[guids.Length];
+    for (var i = 0; i < guids.Length; i++) paths[i] = AssetDatabase.GUIDToAssetPath(guids[i]);
+    Array.Sort(paths, StringComparer.Ordinal);
+    return paths[0];
+}
+```
+
+- [ ] **Step 2.8: 跑 test 确认 pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="SpriteAtlasSyncerTests")
+```
+
+Expected: 2 new tests pass + 既有 `EnumeratePngs_*` / `ResetPngImportSettings_*` / `ApplyImportSettingsToFolder_*` 全部不破。
+
+- [ ] **Step 2.9: dotnet format 验证**
+
+```bash
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx
+dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+- [ ] **Step 2.10: Commit**
+
+```bash
+git add Editor/SpriteAtlasSyncer.cs Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs
+git commit -m "$(cat <<'EOF'
+feat: SpriteAtlasSyncer — enumerate sources via AssetDatabase.FindAssets
+
+Replace 5 Directory.EnumerateFiles("*.png") sites with FindAssets:
+sync paths use t:Texture2D ∪ t:Sprite union (Aseprite AnimatedSprite
+mode has Sprite as main asset, not Texture2D); TextureImporter-only
+operations (Reset/Apply/FindFirst) use t:Texture2D alone.
+
+Method names still carry "Png" — rename in next commit. Stable
+ordinal sort on asset paths so atlas packing is reproducible.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: 方法重命名 + Inspector 文案
+
+**Files:**
+- Modify: `Editor/SpriteAtlasSyncer.cs` (method declarations + 1 internal call site at line 661)
+- Modify: `Editor/SpriteSetEditor.cs:30,59,69,85,93-95,102-106,109-122,131-149`
+- Modify: `Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs` (test names + assertions referring to method names)
+
+Rename map:
+- `CountPngs` → `CountSpriteSources`
+- `EnumeratePngs` → `EnumerateSpriteSources`
+- `ResetPngImportSettings` → `ResetTextureImportSettings`
+- `FindFirstPng` → `FindFirstTexture`
+- `ApplyImportSettingsToFolder` — 不改名（已经不含 "Png"）；只更新 XML doc
+
+Inspector 文案：
+- "Source PNGs" → "Source sprites"
+- "PNG Import Settings" → "Texture Import Settings"
+- "No PNG found under '{folder}'" → "No texture found under '{folder}'"
+- "Add a PNG to define import settings." → "Add a texture to define import settings."
+- "...applied to every PNG in the folder..." → "...applied to every texture in the folder..."
+- "Apply Settings to All N PNGs in Folder" → "Apply Settings to All N Textures in Folder"
+- "(template is the only PNG)" → "(template is the only texture)"
+- "Apply Import Settings" dialog body "...every PNG under..." → "...every texture under..."
+- "This overrides any per-PNG manual TextureImporter tweaks." → "This overrides any per-texture manual TextureImporter tweaks."
+- "Reset All PNGs Format" → "Reset All Textures Format"
+- "Reset PNG Import Format" dialog title → "Reset Texture Import Format"
+- "Force re-import every PNG under..." → "Force re-import every texture under..."
+- "This overrides any manual TextureImporter tweaks on these PNGs." → "...on these textures."
+- log strings `[SpriteSync] copied import settings to N PNG(s)` / `[SpriteSync] reset N PNG(s)` → `texture(s)`
+
+- [ ] **Step 3.1: 重命名方法 (decl + 1 内部 callsite)**
+
+In `Editor/SpriteAtlasSyncer.cs`:
+- Line ~284 `public static int CountPngs` → `CountSpriteSources`
+- Line ~302 `public static List<...> EnumeratePngs` → `EnumerateSpriteSources`
+- Line ~397 `public static int ResetPngImportSettings` → `ResetTextureImportSettings`
+- Line ~517 `public static string FindFirstPng` → `FindFirstTexture`
+- Line ~661 internal call `EnumeratePngs(folder, label)` → `EnumerateSpriteSources(folder, label)`
+- Line ~766 internal call `FindFirstPng(folderAssetPath)` → `FindFirstTexture(folderAssetPath)`
+- 同名 XML doc 段里的 "PNG" 字面统一改 "image"/"texture" (e.g. line 295 注释 `// 每个 PNG 一个 entry` → `// 每个 sprite 源资产一个 entry`；line 297 注释 `// 不再 first-wins —— 同名 PNG ...` → `// 不再 first-wins —— 同名 sprite 源资产 ...`)
+
+- [ ] **Step 3.2: 重命名 Inspector callsites + 文案**
+
+In `Editor/SpriteSetEditor.cs`:
+- Line 11 `_templatePngPath` → `_templateTexturePath`
+- Line 30 `FindFirstPng` → `FindFirstTexture`
+- Line 59 `CountPngs` → `CountSpriteSources`; `pngCount` 局部变量 → `sourceCount`
+- Line 60 `"Source PNGs"` → `"Source sprites"`
+- Line 69 `"PNG Import Settings"` → `"Texture Import Settings"`
+- Line 73 形参 `pngCount` → `sourceCount`
+- Line 85-86 dialog message PNG → texture
+- Line 93-95 helpbox text PNG → texture
+- Line 102-106 button label PNG → texture
+- Line 109-122 dialog body / log PNG → texture
+- Line 131 button label "Reset All PNGs Format" → "Reset All Textures Format"
+- Line 134-136 dialog "Reset PNG Import Format" → "Reset Texture Import Format"
+- Line 139-145 dialog body PNG → texture
+- Line 148 `ResetPngImportSettings` → `ResetTextureImportSettings`
+- Line 149 log PNG → texture
+
+- [ ] **Step 3.3: 重命名 test 名 + 内部 call**
+
+In `Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs`, mass-replace (limit to occurrences inside `[Test]` decorated method names and method-call expressions; **不**改 `MakeBlankPng` helper name 因它仍只生成 PNG):
+
+- 测试方法名 `EnumeratePngs_*` → `EnumerateSpriteSources_*` (8 处)
+- 测试方法名 `ResetPngImportSettings_*` → `ResetTextureImportSettings_*` (2 处)
+- 调用 `SpriteAtlasSyncer.EnumeratePngs(...)` → `EnumerateSpriteSources(...)` (8 处)
+- 调用 `SpriteAtlasSyncer.ResetPngImportSettings(...)` → `ResetTextureImportSettings(...)` (2 处)
+- 调用 `SpriteAtlasSyncer.CountPngs` → `CountSpriteSources` (如有)
+- 调用 `SpriteAtlasSyncer.FindFirstPng` → `FindFirstTexture` (如有)
+- 注释里 "PNG" 留着（fixture 真的就是 PNG 文件，描述准确）
+
+- [ ] **Step 3.4: refresh + 跑 test 确认 pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+```
+
+Expected: 0 compile error；既有所有 SpriteAtlasSyncer / ResolveSprite 测试通过；新加的 mixed-extension / stable-order 测试通过。
+
+- [ ] **Step 3.5: dotnet format 验证**
+
+```bash
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx
+dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add Editor/SpriteAtlasSyncer.cs Editor/SpriteSetEditor.cs Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs
+git commit -m "$(cat <<'EOF'
+refactor: SpriteAtlasSyncer — drop Png-specific method names + Inspector text
+
+CountPngs → CountSpriteSources, EnumeratePngs → EnumerateSpriteSources,
+ResetPngImportSettings → ResetTextureImportSettings, FindFirstPng →
+FindFirstTexture. Inspector labels "PNG" → "image"/"texture". Behavior
+unchanged; cosmetic alignment with multi-format enumeration.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `PROMPTUGUI_HAS_ASEPRITE` versionDefines
+
+**Files:**
+- Modify: `Runtime/PromptUGUI.Runtime.asmdef:20-26`
+- Modify: `Editor/PromptUGUI.Editor.asmdef:16-22`
+
+照搬 Addressables 的 `versionDefines` 写法。**不**加 `references` 条目——`AsepriteImporter` 的所有引用都在 `#if PROMPTUGUI_HAS_ASEPRITE` 内，define 不设时编译器看不到这些类型，不需要 assembly reference。
+
+- [ ] **Step 4.1: 加 versionDefine — Runtime**
+
+In `Runtime/PromptUGUI.Runtime.asmdef`, change `versionDefines`:
+
+```json
+  "versionDefines": [
+    {
+      "name": "com.unity.addressables",
+      "expression": "1.0.0",
+      "define": "PROMPTUGUI_HAS_ADDRESSABLES"
+    },
+    {
+      "name": "com.unity.2d.aseprite",
+      "expression": "1.0.0",
+      "define": "PROMPTUGUI_HAS_ASEPRITE"
+    }
+  ],
+```
+
+- [ ] **Step 4.2: 加 versionDefine — Editor**
+
+In `Editor/PromptUGUI.Editor.asmdef`, change `versionDefines`:
+
+```json
+    "versionDefines": [
+        {
+            "name": "com.unity.addressables",
+            "expression": "1.0.0",
+            "define": "PROMPTUGUI_HAS_ADDRESSABLES"
+        },
+        {
+            "name": "com.unity.2d.aseprite",
+            "expression": "1.0.0",
+            "define": "PROMPTUGUI_HAS_ASEPRITE"
+        }
+    ],
+```
+
+- [ ] **Step 4.3: 在 host 项目装 `com.unity.2d.aseprite` 包**
+
+```
+# Manual step the implementer takes in Unity Package Manager:
+# Window → Package Manager → "+ Add package by name" → "com.unity.2d.aseprite"
+# Confirm version ≥ 1.0.0
+```
+
+Verification:
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error", "warning"])
+```
+
+Expected: no compile errors; new define `PROMPTUGUI_HAS_ASEPRITE` is set in both asmdefs (verify by adding a temp `#if PROMPTUGUI_HAS_ASEPRITE` in any .cs file and seeing the code highlighted as active in IDE, then removing).
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add Runtime/PromptUGUI.Runtime.asmdef Editor/PromptUGUI.Editor.asmdef
+git commit -m "$(cat <<'EOF'
+chore: asmdef — PROMPTUGUI_HAS_ASEPRITE versionDefine for com.unity.2d.aseprite
+
+Mirrors the PROMPTUGUI_HAS_ADDRESSABLES gating pattern. No references
+entry needed — Aseprite-specific code is wrapped in #if blocks so the
+type isn't compiled when the package is absent.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Aseprite branch in `EnsureSpriteImporter` (validation, not coercion)
+
+**Files:**
+- Modify: `Editor/SpriteAtlasSyncer.cs:378-386` (existing `EnsureSpriteImporter`)
+- Test: `Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs` (new Aseprite cases)
+- Test fixture: `Tests/EditMode/Editor/Fixtures/aseprite/` (commit small `.aseprite` files)
+
+`EnsureSpriteImporter` 当前只识别 `TextureImporter`。加 `#if PROMPTUGUI_HAS_ASEPRITE` 分支：检测 `AsepriteImporter`，验证 `LoadAllAssetsAtPath(path).OfType<Sprite>().Count() == 1`，违反 → `Debug.LogError` + `EnumerateSpriteSources` 在 LoadAssetAtPath<Sprite> 拿到第一个 sprite 后通过单 sprite 检测器跳过该项。
+
+由于需要 fixture `.aseprite` 文件，本任务包含 fixture 准备步骤。
+
+- [ ] **Step 5.1: 准备 fixture .aseprite 文件**
+
+In the host Unity project (`UnityProjects~/PromptUGUIDev`), create three small Aseprite files via the Aseprite tool (or download minimal sample files from the Aseprite docs):
+
+- 1-frame AnimatedSprite (default mode): saves as `single_animated.aseprite`
+- 1-frame SpriteSheet (Import Mode set to SpriteSheet in Inspector): `single_sheet.aseprite`
+- 3-frame AnimatedSprite: `multi.aseprite`
+
+Copy them into the **package** `Tests/EditMode/Editor/Fixtures/aseprite/` directory:
+
+```bash
+mkdir -p Tests/EditMode/Editor/Fixtures/aseprite
+# Then place the three .aseprite files at:
+#   Tests/EditMode/Editor/Fixtures/aseprite/single_animated.aseprite
+#   Tests/EditMode/Editor/Fixtures/aseprite/single_sheet.aseprite
+#   Tests/EditMode/Editor/Fixtures/aseprite/multi.aseprite
+```
+
+Verify Unity recognizes them: in Project window, each `.aseprite` shows the expected Sprite sub-asset count (1, 1, 3) under the foldout.
+
+If creating .aseprite from scratch is impractical: use NUnit `Assume.That(File.Exists(...))` to skip tests when fixtures are missing, and document fixture setup in a `Tests/EditMode/Editor/Fixtures/aseprite/README.md` (single sentence: "Drop test .aseprite files here; see plan §5.1"). Decide on a per-tester basis.
+
+- [ ] **Step 5.2: 加 failing test — single-frame AnimatedSprite Aseprite 被收**
+
+In `Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs`, append at end of class:
+
+```csharp
+#if PROMPTUGUI_HAS_ASEPRITE
+[Test]
+public void EnumerateSpriteSources_picks_up_single_frame_animatedsprite_aseprite()
+{
+    // AnimatedSprite is Aseprite's default Import Mode. Main asset is t:Sprite,
+    // NOT t:Texture2D, so the union filter (MF-D1) is what makes this work.
+    var folder = $"{TestRoot}/aseprite_animated";
+    AssetDatabase.CreateFolder(TestRoot, "aseprite_animated");
+    var srcAseprite = "Packages/com.heerozh.promptugui/Tests/EditMode/Editor/Fixtures/aseprite/single_animated.aseprite";
+    Assume.That(File.Exists(srcAseprite), $"Fixture missing: {srcAseprite}");
+    var destAseprite = $"{folder}/single.aseprite";
+    AssetDatabase.CopyAsset(srcAseprite, destAseprite);
+
+    var entries = SpriteAtlasSyncer.EnumerateSpriteSources(folder);
+    var keys = new List<string>();
+    foreach (var (k, _) in entries) keys.Add(k);
+    Assert.That(keys, Does.Contain("single"));
+}
+
+[Test]
+public void EnumerateSpriteSources_picks_up_single_frame_spritesheet_aseprite()
+{
+    var folder = $"{TestRoot}/aseprite_sheet";
+    AssetDatabase.CreateFolder(TestRoot, "aseprite_sheet");
+    var srcAseprite = "Packages/com.heerozh.promptugui/Tests/EditMode/Editor/Fixtures/aseprite/single_sheet.aseprite";
+    Assume.That(File.Exists(srcAseprite), $"Fixture missing: {srcAseprite}");
+    var destAseprite = $"{folder}/single.aseprite";
+    AssetDatabase.CopyAsset(srcAseprite, destAseprite);
+
+    var entries = SpriteAtlasSyncer.EnumerateSpriteSources(folder);
+    var keys = new List<string>();
+    foreach (var (k, _) in entries) keys.Add(k);
+    Assert.That(keys, Does.Contain("single"),
+        "SpriteSheet-mode 1-sprite Aseprite must be enumerated");
+    // Dedupe assertion: SpriteSheet mode hits BOTH t:Texture2D and t:Sprite.
+    // Union HashSet should fold them into one entry.
+    Assert.AreEqual(1, keys.Count, "Expected exactly one entry; got: " + string.Join(",", keys));
+}
+
+[Test]
+public void EnumerateSpriteSources_skips_multi_sprite_aseprite_with_log_error()
+{
+    var folder = $"{TestRoot}/aseprite_multi";
+    AssetDatabase.CreateFolder(TestRoot, "aseprite_multi");
+    var srcAseprite = "Packages/com.heerozh.promptugui/Tests/EditMode/Editor/Fixtures/aseprite/multi.aseprite";
+    Assume.That(File.Exists(srcAseprite), $"Fixture missing: {srcAseprite}");
+    var destAseprite = $"{folder}/multi.aseprite";
+    AssetDatabase.CopyAsset(srcAseprite, destAseprite);
+
+    LogAssert.Expect(LogType.Error,
+        new System.Text.RegularExpressions.Regex("produces .* sprites; SpriteSet requires exactly 1"));
+
+    var entries = SpriteAtlasSyncer.EnumerateSpriteSources(folder);
+    var keys = new List<string>();
+    foreach (var (k, _) in entries) keys.Add(k);
+    Assert.That(keys, Does.Not.Contain("multi"));
+}
+#endif
+```
+
+- [ ] **Step 5.3: 跑 test 确认 fail**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="aseprite")
+```
+
+Expected (assuming fixtures present): `EnumerateSpriteSources_picks_up_single_frame_animatedsprite_aseprite` 可能已 pass（union 已经覆盖）；`EnumerateSpriteSources_skips_multi_sprite_aseprite_with_log_error` FAIL（当前 multi-frame Aseprite 没被任何代码拒绝，会 silently include 它的第一个 sprite）。
+
+- [ ] **Step 5.4: 实现 — `EnsureSpriteImporter` Aseprite 分支**
+
+In `Editor/SpriteAtlasSyncer.cs:378-386`, replace `EnsureSpriteImporter`:
+
+```csharp
+private static void EnsureSpriteImporter(string assetPath)
+{
+    var importer = AssetImporter.GetAtPath(assetPath);
+    if (importer is TextureImporter ti)
+    {
+        if (ti.textureType == TextureImporterType.Sprite) return;
+        ti.textureType = TextureImporterType.Sprite;
+        ti.spriteImportMode = SpriteImportMode.Single;
+        ti.textureCompression = TextureImporterCompression.Uncompressed;
+        ti.SaveAndReimport();
+        return;
+    }
+#if PROMPTUGUI_HAS_ASEPRITE
+    if (importer is UnityEditor.U2D.Aseprite.AsepriteImporter)
+    {
+        // MF-D4: validate single-sprite contract; do not coerce AsepriteImporter
+        // settings — layer/frame configuration is author intent.
+        var sprites = AssetDatabase.LoadAllAssetsAtPath(assetPath).OfType<Sprite>().Count();
+        if (sprites != 1)
+        {
+            Debug.LogError(
+                $"[SpriteSync] Aseprite '{assetPath}' produces {sprites} sprites; " +
+                $"SpriteSet requires exactly 1 sprite per file. Skipping. " +
+                $"Set the AsepriteImporter Import Mode to single-frame output, " +
+                $"or use a different file per icon.");
+        }
+        return;
+    }
+#endif
+    // Other importer types (eg. SVG via com.unity.vectorgraphics) - silent skip.
+}
+```
+
+Add `using System.Linq;` at the top of `SpriteAtlasSyncer.cs` if not already there (needed for `.OfType<Sprite>()`).
+
+- [ ] **Step 5.5: 实现 — `EnumerateSpriteSources` skip multi-sprite Aseprite**
+
+The current `EnumerateSpriteSources` body calls `EnsureSpriteImporter(assetPath)` then `LoadAssetAtPath<Sprite>(assetPath)`. For multi-sprite Aseprite, `EnsureSpriteImporter` logs an error but doesn't change the asset; `LoadAssetAtPath<Sprite>` still returns a (random) sprite, so the entry leaks.
+
+In `Editor/SpriteAtlasSyncer.cs` `EnumerateSpriteSources` body, replace the `EnsureSpriteImporter(assetPath); var sp = AssetDatabase.LoadAssetAtPath<Sprite>(assetPath);` block with:
+
+```csharp
+        EnsureSpriteImporter(assetPath);
+#if PROMPTUGUI_HAS_ASEPRITE
+        // MF-D4: multi-sprite Aseprite is rejected at validation time; skip it
+        // here so a stray first-sprite doesn't sneak into the SpriteSet.
+        if (AssetImporter.GetAtPath(assetPath) is UnityEditor.U2D.Aseprite.AsepriteImporter)
+        {
+            if (AssetDatabase.LoadAllAssetsAtPath(assetPath).OfType<Sprite>().Count() != 1)
+                continue;
+        }
+#endif
+        var sp = AssetDatabase.LoadAssetAtPath<Sprite>(assetPath);
+        if (sp == null) continue;
+```
+
+> **Note**: The Aseprite count check runs twice for multi-sprite files (once in `EnsureSpriteImporter` to log, once here to skip). That's two `LoadAllAssetsAtPath` calls per Aseprite file (the existing test fixtures have at most a handful of files, so the cost is negligible). Refactoring to one call would require either threading the count through a return value or caching by path; the duplication is the simpler choice. If profiling later shows it's hot, fold into a single helper.
+
+- [ ] **Step 5.6: 跑 test 确认 pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="aseprite")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="SpriteAtlasSyncerTests")
+```
+
+Expected: all Aseprite tests pass; existing SpriteAtlasSyncerTests not broken.
+
+- [ ] **Step 5.7: dotnet format 验证**
+
+```bash
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx
+dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+- [ ] **Step 5.8: Commit**
+
+```bash
+git add Editor/SpriteAtlasSyncer.cs Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs Tests/EditMode/Editor/Fixtures/aseprite/
+git commit -m "$(cat <<'EOF'
+feat: SpriteAtlasSyncer — Aseprite support (PROMPTUGUI_HAS_ASEPRITE)
+
+EnsureSpriteImporter gains an AsepriteImporter branch that validates
+the single-sprite contract (LoadAllAssetsAtPath... OfType<Sprite>()
+.Count() == 1) without coercing AsepriteImporter settings.
+EnumerateSpriteSources skips multi-sprite Aseprite files so they
+don't sneak in via LoadAssetAtPath<Sprite>'s arbitrary-first behavior.
+
+Test fixtures in Tests/EditMode/Editor/Fixtures/aseprite/ cover
+both AnimatedSprite (main asset = t:Sprite) and SpriteSheet (main
+asset = t:Texture2D) modes; gated by Assume.That for repos that
+haven't installed the package.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: SKILL.md updates
+
+**Files:**
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md`
+- Modify: `.claude/skills/using-promptugui-addressables/SKILL.md`
+
+XML SKILL **不**动（`sprite="ns:name"` 引用形态与底层文件格式无关）。
+
+- [ ] **Step 6.1: 找到 csharp SKILL 里的 SpriteSet 段**
+
+```bash
+grep -n "SpriteSet\|SpriteResolverHelpers\|sourceFolder" .claude/skills/scripting-promptugui-csharp/SKILL.md | head -20
+```
+
+- [ ] **Step 6.2: 在 SpriteSet 段尾追加格式说明**
+
+In `.claude/skills/scripting-promptugui-csharp/SKILL.md`, locate the SpriteSet description and append (use the exact insertion point identified in Step 6.1):
+
+```markdown
+**Source formats**: SpriteSet's source folder accepts any Unity-recognized texture
+format (PNG, JPG, JPEG, TGA, PSD, TIFF, BMP, EXR, HDR, GIF) plus Aseprite
+(`.ase` / `.aseprite`, requires `com.unity.2d.aseprite ≥ 1.0`). For Aseprite,
+each file must produce exactly **one sprite** — set the AsepriteImporter Import
+Mode to single-frame output or use one file per icon. Multi-sprite Aseprite
+files are logged as errors and skipped during sync.
+```
+
+- [ ] **Step 6.3: 在 addressables SKILL 加同样说明**
+
+```bash
+grep -n "SpriteSet\|UseAddressableSpriteSetResolver" .claude/skills/using-promptugui-addressables/SKILL.md | head -10
+```
+
+In `.claude/skills/using-promptugui-addressables/SKILL.md`, append next to the SpriteSet Addressable resolver section:
+
+```markdown
+**Source formats via Addressables**: Sprite source format is transparent to the
+Addressables path — `AssetReferenceT<Sprite>` resolves to a Sprite regardless of
+whether the underlying file was PNG / JPG / Aseprite / etc. The same single-sprite
+contract for Aseprite (see csharp SKILL) applies.
+```
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add .claude/skills/scripting-promptugui-csharp/SKILL.md .claude/skills/using-promptugui-addressables/SKILL.md
+git commit -m "$(cat <<'EOF'
+docs: SKILL.md — SpriteSet multi-format + Aseprite
+
+csharp + addressables SKILLs note that SpriteSet accepts any Unity-recognized
+texture format plus Aseprite (single-sprite contract; PROMPTUGUI_HAS_ASEPRITE
+gating). XML SKILL unchanged — `sprite="ns:name"` is format-agnostic.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: 全量 verify + Sample smoke check
+
+**Files:** none
+
+最终验收：跨 assembly 跑 EditMode + PlayMode 全套；Sample 里手动改一个 PNG 为 JPG 跑 sync 确认 end-to-end。
+
+- [ ] **Step 7.1: refresh + 全量 EditMode test**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+```
+
+Expected: 0 failures, 0 compile errors. If `PROMPTUGUI_HAS_ADDRESSABLES` enabled in the host:
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode.Addressables"])
+```
+
+- [ ] **Step 7.2: 全量 PlayMode test**
+
+```
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])
+```
+
+Expected: 0 failures.
+
+- [ ] **Step 7.3: Sample 端 smoke**
+
+```bash
+ls Samples~/MainMenu/
+```
+
+In Samples~/MainMenu (or whichever sample has a SpriteSet referenced from `.ui.xml`):
+1. Pick an existing PNG referenced by `<Image sprite="ns:name">` in a sample XML.
+2. Re-import it as JPG (rename in OS, or duplicate-and-rename then delete the PNG) and adjust the SpriteSet sourceFolder to include it.
+3. Run `Tools → PromptUGUI → Sprite → Sync Atlases (All Sets)`.
+4. Open the Sample scene, hit Play, confirm the sprite still appears in the UI.
+
+Document the outcome in this task's commit message; no code change expected.
+
+- [ ] **Step 7.4: dotnet format final pass**
+
+```bash
+cd .lint && dotnet restore PromptUGUI.Lint.slnx
+dotnet format whitespace PromptUGUI.Lint.slnx
+dotnet format style PromptUGUI.Lint.slnx
+dotnet format analyzers PromptUGUI.Lint.slnx
+dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+Expected: no diffs introduced; verify step passes.
+
+- [ ] **Step 7.5: UIXmlLint pass**
+
+```bash
+dotnet run --project .lint/UIXmlLint -- Runtime/Resources/
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 7.6: (No commit unless Step 7.3 surfaces fix-ups)**
+
+If Step 7.3 surfaced fixes (eg. SpriteSet asset references), commit them with:
+
+```bash
+git commit -m "$(cat <<'EOF'
+chore: Samples — verify multi-format sprite resolves end-to-end
+
+<one-line description of what was changed in the sample>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+If no fixes needed: skip commit.
+
+---
+
+## Self-Review Checklist (filled at plan-write time)
+
+**Spec coverage:**
+- MF-D1 (union enumeration) → Task 2 Step 2.4
+- MF-D1b (Reset/Apply use t:Texture2D only) → Task 2 Steps 2.5–2.7
+- MF-D2 (silent skip non-TextureImporter/non-AsepriteImporter) → Task 5 Step 5.4 (else-branch implicit return)
+- MF-D3 (PROMPTUGUI_HAS_ASEPRITE gating) → Task 4
+- MF-D4 (Aseprite validate-not-coerce) → Task 5 Step 5.4
+- MF-D5 (TextureImporter still auto-flips, Aseprite doesn't) → Task 5 Step 5.4
+- MF-D6 (Runtime UI.cs strip simplification) → Task 1
+- MF-D7 (rename methods去 Png) → Task 3
+- MF-D8 (Inspector text "PNG" → "image"/"texture") → Task 3 Step 3.2
+- MF-D9 (stable sort) → Task 2 Step 2.4 `Array.Sort`
+- MF-D10 (multi-sprite PNG behavior unchanged) → no task needed; existing tests cover
+- MF-D11 (XML scan unchanged) → no task needed
+- MF-D12 (SKILL updates: csharp + addressables) → Task 6
+
+**Placeholder scan:** none found — every code step has a complete code block; every command is exact; every commit message is fully written.
+
+**Type consistency:**
+- `EnumerateSpriteSourceGuids` is the only new private helper; called in Task 2 Steps 2.4. Signature `private static string[] EnumerateSpriteSourceGuids(string folderAssetPath)` used consistently.
+- `EnumerateSpriteSources` (renamed in Task 3) — all Task 5 references use this name (assertions and method calls in tests).
+- `EnsureSpriteImporter` signature unchanged: `private static void EnsureSpriteImporter(string assetPath)`.
+- `using System.Linq;` added in Step 5.4 — required for `.OfType<Sprite>()`.
+- `multi.aseprite` fixture referenced in Step 5.2 must match the file created in Step 5.1.
+
+**Found and fixed:**
+- (none after self-review)

--- a/docs~/superpowers/specs/2026-05-24-spriteset-multi-format-design.md
+++ b/docs~/superpowers/specs/2026-05-24-spriteset-multi-format-design.md
@@ -1,0 +1,372 @@
+# SpriteSet 源资产枚举去扩展名化（多格式 + Aseprite）设计
+
+**日期**: 2026-05-24
+**状态**: 设计阶段（待 review，未进入实施）
+**作用域**:
+1. `Editor/SpriteAtlasSyncer` 当前用 `Directory.EnumerateFiles(folder, "*.png", ...)` 枚举源资产，改为 `AssetDatabase.FindAssets("t:Texture2D ∪ t:Sprite", folderAssetPath)` 联合查询（HashSet dedupe by GUID）。换掉 5 处 enumeration——其中 `Reset*` / `Apply*` 因仅作用于 TextureImporter，只查 `t:Texture2D` 即可。
+2. `EnsureSpriteImporter` 加 `AsepriteImporter` 分支（仅 `PROMPTUGUI_HAS_ASEPRITE` 下编译），验证"单 sprite"契约；不修改 Aseprite 导入器设置。
+3. `Runtime/Application/UI.cs:100-110` 的扩展名 strip 白名单（`.png/.jpg/.jpeg/.tga/.psd`）改为"strip 最后一个 `.` 后到结尾"——Resources 虚拟路径本来就不带扩展名，去掉白名单后任何扩展名都能正常工作。
+4. `PromptUGUI.Runtime.asmdef` 和 `PromptUGUI.Editor.asmdef` 加 `com.unity.2d.aseprite ≥ 1.0` → `PROMPTUGUI_HAS_ASEPRITE` 的 `versionDefines`，照搬现有 Addressables 写法。
+5. `SpriteAtlasSyncer` 的 `CountPngs / EnumeratePngs / ResetPngImportSettings` 方法 + Inspector 文案的 "PNG" 字面去掉。
+
+**依赖**: [`2026-05-15-spriteset-rename-design.md`](2026-05-15-spriteset-rename-design.md)（`SpriteAtlasSyncer` 的当前命名）。
+
+---
+
+## 1. 背景
+
+当前 SpriteSet 源资产枚举走 `Directory.EnumerateFiles(fullFolder, "*.png", SearchOption.AllDirectories)`，硬编码 PNG。导致：
+
+- 作者用 JPG/TGA/PSD 等 Unity 原生支持的纹理格式时，源资产被 Syncer 静默忽略，最终 SpriteSet entries 缺项；XML 端 `<Image sprite="ui:foo">` 报 "resolver returned null"，但没有线索说"你的 foo.jpg 没被 Syncer 收"。
+- Aseprite（`.ase` / `.aseprite`，由 `com.unity.2d.aseprite` 包的 `AsepriteImporter` 处理）完全走不通——`AsepriteImporter` 不是 `TextureImporter`，glob 也不匹配。
+
+Runtime 端 `UI.cs:100-110` 也有一段对称的扩展名白名单（PNG/JPG/JPEG/TGA/PSD）用于从 `sprite="ui/foo.png#slice"` 之类的字面里 strip 扩展名再调 `Resources.LoadAll<Sprite>(path)`。这一段是为 `<Icon>` 之外的"裸路径 + sub-asset 引用"形态服务的——白名单不全时同样静默失效。
+
+观察：
+
+1. Unity 的 `AssetDatabase.FindAssets("t:Texture2D", searchFolders)` 是**跨 importer 跨扩展名**返回任何被识别为 Texture2D 主资产的资产 GUID。这覆盖了 PNG/JPG/JPEG/TGA/PSD/TIFF/BMP/EXR/HDR/GIF 以及 Aseprite **SpriteSheet 模式**（主资产 Texture2D + Sprite sub-assets）。但 **Aseprite 的默认 AnimatedSprite 模式主资产是 Sprite 而非 Texture2D**，单查 `t:Texture2D` 会漏掉它。因此实际枚举走 `t:Texture2D ∪ t:Sprite` 联合查询（HashSet by GUID 去重），既覆盖 Aseprite 两种 import mode，又保留 PNG Default 模式被 EnsureSpriteImporter auto-flip 的现有路径（Default 模式的 PNG 是 `t:Texture2D` 但还没有 Sprite sub-asset）。
+2. Resources 虚拟路径本来就是去扩展名的（Unity 文档：`Resources.Load("foo/bar")` 不带扩展名），所以 Runtime 端"strip 最后一个 `.` 后到结尾"完全等价于"去掉扩展名"，不需要白名单。
+3. Aseprite 本身有 multi-frame 概念；要把它纳入 SpriteSet 必须固化"一个 Aseprite 文件 = 一个 Sprite"的契约——作者负责把 Aseprite 文件导成单 sprite 输出，Syncer 端验证，违反则 LogError + skip 该文件。
+
+---
+
+## 2. 决策一览
+
+| # | 决策 | 选择 | 理由 |
+|---|---|---|---|
+| MF-D1 | Editor 枚举 API（sync 路径） | `AssetDatabase.FindAssets("t:Texture2D", ...) ∪ FindAssets("t:Sprite", ...)`，HashSet by GUID 去重 | 跨 importer 跨扩展名；Aseprite AnimatedSprite 模式（默认）的主资产是 `t:Sprite` 而非 `t:Texture2D`，单查 `t:Texture2D` 漏；Aseprite SpriteSheet 模式两个都命中（dedupe 消除）；PNG Default 模式只在 `t:Texture2D` 命中（用于触发 EnsureSpriteImporter auto-flip） |
+| MF-D1b | Editor 枚举 API（Reset / Apply 路径） | 仅 `t:Texture2D` | `ResetTextureImportSettings` / `ApplyImportSettingsToFolder` 都是 TextureImporter-only 操作；Aseprite 资产 (`AsepriteImporter`) 在这两个路径里本来就要被 importer-type guard 拒掉，与其多扫一遍 `t:Sprite` 再过滤，不如只查 `t:Texture2D` |
+| MF-D2 | 跳过非 TextureImporter / 非 AsepriteImporter 的 Texture2D 资产 | silent skip | SVG（vectorgraphics 包）或其他第三方 importer 当前不打算支持；未来如要支持，新增 importer 分支即可，不影响现有路径 |
+| MF-D3 | Aseprite 支持的 gating 方式 | `versionDefines`: `com.unity.2d.aseprite ≥ 1.0` → `PROMPTUGUI_HAS_ASEPRITE` | 照搬 Addressables 的现有写法；未装包时 Aseprite 分支完全不参与编译；装包用户零配置启用 |
+| MF-D4 | Aseprite "单 sprite" 契约的强度 | **验证而非强制**：Syncer 检查 `LoadAllAssetsAtPath(path).OfType<Sprite>().Count() == 1`，违反则 `Debug.LogError` + skip 该文件 | Aseprite 的 layer/frame 是作者意图的一部分，自动改 `AsepriteImporter` 设置（像 `EnsureSpriteImporter` 改 `TextureImporter` 那样）侵入性过强；硬契约 + loud failure 是合理的中间路线 |
+| MF-D5 | EnsureSpriteImporter 对非 TextureImporter 资产的处理 | TextureImporter 走现有 flip-to-Sprite 路径；AsepriteImporter 不改设置（仅在 enumerate 时验证）；其他 importer 不动 | TextureImporter 的 default → Sprite 翻转保持现有"扔个 PNG 就能用"的便利性；Aseprite 不动，避免吞掉作者的 frame/layer 配置 |
+| MF-D6 | Runtime `UI.cs:100-110` 扩展名 strip | "strip 最后一个 `/` 之后的 `.` 到结尾"，去掉 PNG/JPG/JPEG/TGA/PSD 白名单 | Resources 虚拟路径本来去扩展名；保护 `foo.v2/bar` 这种"点在目录名里"的情况靠 `dotIdx > slashIdx` 判断 |
+| MF-D7 | `CountPngs` / `EnumeratePngs` / `ResetPngImportSettings` 改名 | `CountSpriteSources` / `EnumerateSpriteSources` / `ResetTextureImportSettings`；`ApplyImportSettingsToFolder` 不改名 | 不再 PNG-specific；`Reset*` 仍只对 TextureImporter 生效（不动 Aseprite），名字里留 "Texture" 是诚实的；`Apply*` 同样 TextureImporter-only，但名字已经不含 "Png"，doc-note 即可 |
+| MF-D8 | Inspector 文案 | "Source PNGs" → "Source sprites"；"Apply Settings to All N PNGs in Folder" → "Apply Settings to All N TextureImporters in Folder"；"Reset All PNGs Format" → "Reset All TextureImporters Format" | 与方法名对齐，避免误以为"这个按钮也会改 Aseprite 设置" |
+| MF-D9 | `FindAssets` 返回顺序的稳定性 | 调用方对 `assetPath` 字符串排序后再处理 | `FindAssets` 的返回顺序是实现细节，sync 输出（SpriteSet entries 顺序、atlas pack）应当对源资产路径稳定 |
+| MF-D10 | 多 Sprite PNG（TextureImporter Multi 模式）的处理 | 维持现有行为：`LoadAssetAtPath<Sprite>` 拿第一个 sprite，silent | 现有行为，本期不改；如果作者需要 multi-sprite PNG 进 SpriteSet 那是另一个 milestone |
+| MF-D11 | XML scan（`ScanXmlReferences`）的改动 | **零改动** | XML 端引用形态是 `ns:name`，与源资产扩展名无关；scan 完全不受影响 |
+| MF-D12 | SKILL.md 更新 | csharp + addressables 两份；xml SKILL 不动 | csharp SKILL 在"自定义控件读取 sprite"段提一句 "SpriteSet 接受任何 Unity 原生纹理格式 + Aseprite（约定单 sprite）"；addressables SKILL 顺带提 Aseprite 走 Addressables 没问题（无新 API，纯说明）；xml SKILL 与扩展名无关，不动 |
+
+---
+
+## 3. 完整使用示例
+
+作者新增一个 Aseprite icon：
+
+```
+Assets/UI/SpriteSources/ui/
+├── dialog-frame.png          # 既有
+├── button.jpg                # 新格式：直接放进去，Syncer 自动识别
+└── bell.aseprite             # 新格式：需要装 com.unity.2d.aseprite 包
+```
+
+1. 装 `com.unity.2d.aseprite` 包，确认 `bell.aseprite` 在 Project 窗口里展开后只有 1 个 Sprite sub-asset（在 Aseprite Importer Inspector 把 Import Mode 设为 "SpriteSheet" 且只有 1 帧；或 "AnimatedSprite" 但只有 1 帧）。
+2. 跑 `Tools → PromptUGUI → Sprite → Sync Atlases (All Sets)`。
+3. SpriteSet entries：
+   - `ui/dialog-frame` + `dialog-frame`
+   - `ui/button` + `button`
+   - `ui/bell` + `bell`
+4. XML 端：
+
+```xml
+<Image  sprite="ui:dialog-frame" type="sliced" anchor="stretch"/>
+<Btn    sprite="ui:button"       anchor="bottom-center"/>
+<Icon   name="ui:bell"           size="48x48"/>
+```
+
+若 `bell.aseprite` 产出 >1 sprite，Syncer console:
+
+```
+[SpriteSync] Aseprite 'Assets/UI/SpriteSources/ui/bell.aseprite' produces 3 sprites; SpriteSet requires exactly 1 sprite per file. Skipping. Set the AsepriteImporter Import Mode to single-frame output, or use a different file per icon.
+```
+
+`ui/bell` ref 在 SpriteSet 中缺失，后续 `<Icon name="ui:bell">` 在 Runtime 显示空白 + 既有 `UI.ResolveSprite` "resolver returned null" LogError 提示去 sync。
+
+---
+
+## 4. 公开 API 表
+
+| 状态 | 签名 | 说明 |
+|---|---|---|
+| 改名 | `public static int SpriteAtlasSyncer.CountSpriteSources(string folderAssetPath)` | 原 `CountPngs`；统计可识别的源 sprite 文件数（TextureImporter 或 AsepriteImporter）。Inspector 用 |
+| 改名 | `public static List<(string pathKey, Sprite sprite)> SpriteAtlasSyncer.EnumerateSpriteSources(string folderAssetPath, string progressLabel = null)` | 原 `EnumeratePngs`；返回 `(pathKey, Sprite)` 列表，pathKey 是去扩展名的相对路径 |
+| 改名 | `public static int SpriteAtlasSyncer.ResetTextureImportSettings(string folderAssetPath, bool showProgress = false)` | 原 `ResetPngImportSettings`；仅对 TextureImporter 生效（Sprite/Single/Uncompressed）；AsepriteImporter / 其他 importer 跳过 |
+| 不变 | `public static int SpriteAtlasSyncer.ApplyImportSettingsToFolder(string templateAssetPath, string folderAssetPath, bool showProgress = false)` | 仅对 TextureImporter 生效；template 也必须是 TextureImporter；doc 加一行说明 |
+| 新增 | `PROMPTUGUI_HAS_ASEPRITE` compile define | `Runtime/PromptUGUI.Runtime.asmdef` + `Editor/PromptUGUI.Editor.asmdef` 同时声明；条件触发：项目装了 `com.unity.2d.aseprite ≥ 1.0` |
+| 不变 | `UI.SpriteResolver`、`UI.ResolveSprite`、所有 7 个内置控件的 `Sprite` setter | 行为不变；只是 strip 扩展名那段算法换了 |
+
+---
+
+## 5. 落地细节
+
+### 5.1 `SpriteAtlasSyncer.EnumerateSpriteSources` 重写
+
+`Editor/SpriteAtlasSyncer.cs`:
+
+```csharp
+public static List<(string pathKey, Sprite sprite)> EnumerateSpriteSources(
+    string folderAssetPath, string progressLabel = null)
+{
+    var result = new List<(string, Sprite)>();
+    if (string.IsNullOrEmpty(folderAssetPath)) return result;
+    if (!AssetDatabase.IsValidFolder(folderAssetPath))
+    {
+        Debug.LogError($"[SpriteSync] not a folder: '{folderAssetPath}'");
+        return result;
+    }
+
+    // MF-D1: union t:Texture2D (covers PNG/JPG/.../Aseprite-SpriteSheet) with t:Sprite
+    // (covers Aseprite-AnimatedSprite where main asset is Sprite, not Texture2D).
+    var guidSet = new HashSet<string>(StringComparer.Ordinal);
+    foreach (var g in AssetDatabase.FindAssets("t:Texture2D", new[] { folderAssetPath })) guidSet.Add(g);
+    foreach (var g in AssetDatabase.FindAssets("t:Sprite",    new[] { folderAssetPath })) guidSet.Add(g);
+    var paths = new string[guidSet.Count];
+    var idx = 0;
+    foreach (var g in guidSet) paths[idx++] = AssetDatabase.GUIDToAssetPath(g);
+    Array.Sort(paths, StringComparer.Ordinal); // MF-D9: stable output
+
+    var folderPrefix = folderAssetPath.EndsWith("/") ? folderAssetPath : folderAssetPath + "/";
+    for (var i = 0; i < paths.Length; i++)
+    {
+        var assetPath = paths[i];
+        if (progressLabel != null &&
+            EditorUtility.DisplayCancelableProgressBar(
+                ProgressTitle,
+                $"{progressLabel}: {Path.GetFileName(assetPath)} ({i + 1}/{paths.Length})",
+                (float)i / Mathf.Max(1, paths.Length)))
+        {
+            throw new OperationCanceledException();
+        }
+        if (!EnsureSpriteImporter(assetPath, out var importerOk)) continue;
+        if (!importerOk) continue; // MF-D5: unsupported importer type
+
+        var sp = AssetDatabase.LoadAssetAtPath<Sprite>(assetPath);
+        if (sp == null) continue;
+
+        // assetPath always starts with folderPrefix (FindAssets searchFolder contract)
+        var rel = assetPath.Substring(folderPrefix.Length);
+        var ext = Path.GetExtension(rel);
+        var pathKey = rel.Substring(0, rel.Length - ext.Length);
+        result.Add((pathKey, sp));
+    }
+    return result;
+}
+```
+
+`EnsureSpriteImporter` 改成返回 bool 让调用方区分 "importer 识别且 OK" / "importer 不识别" / "Aseprite 但多 sprite"：
+
+```csharp
+// out importerOk: true = 该资产可作为 sprite 源；false = 跳过（既包括"识别但不合规"如 Aseprite 多 sprite，也包括"importer 不在白名单"）
+// 返回值: true = 继续处理；false = 调用方应 continue（与 importerOk 等价，保留两参方便未来扩展不同跳过原因）
+private static bool EnsureSpriteImporter(string assetPath, out bool importerOk)
+{
+    importerOk = false;
+    var importer = AssetImporter.GetAtPath(assetPath);
+    if (importer is TextureImporter ti)
+    {
+        if (ti.textureType != TextureImporterType.Sprite)
+        {
+            ti.textureType = TextureImporterType.Sprite;
+            ti.spriteImportMode = SpriteImportMode.Single;
+            ti.textureCompression = TextureImporterCompression.Uncompressed;
+            ti.SaveAndReimport();
+        }
+        importerOk = true;
+        return true;
+    }
+#if PROMPTUGUI_HAS_ASEPRITE
+    if (importer is UnityEditor.U2D.Aseprite.AsepriteImporter)
+    {
+        var sprites = AssetDatabase.LoadAllAssetsAtPath(assetPath).OfType<Sprite>().Count();
+        if (sprites != 1)
+        {
+            Debug.LogError(
+                $"[SpriteSync] Aseprite '{assetPath}' produces {sprites} sprites; " +
+                $"SpriteSet requires exactly 1 sprite per file. Skipping. " +
+                $"Set the AsepriteImporter Import Mode to single-frame output, " +
+                $"or use a different file per icon.");
+            return true; // 别 abort 整个 enumerate；importerOk = false 让调用方 skip 这一个
+        }
+        importerOk = true;
+        return true;
+    }
+#endif
+    // Other importers (eg. SVG via com.unity.vectorgraphics) - silent skip
+    return true;
+}
+```
+
+设计权衡：
+
+- `EnsureSpriteImporter` 返回 `(bool, out bool)` 看着冗余——其实第一个返回值现在永远是 true。保留它是为了未来"枚举级 abort"（比如 user cancel）的扩展位；如果不要这个口子，简化为 `static bool EnsureSpriteImporter(string path)` 直接返回 importerOk 也可以。`writing-plans` 阶段再定。
+
+### 5.2 其他 4 处 enumeration 的统一改造
+
+`ResetTextureImportSettings`（原 `ResetPngImportSettings`）、`ApplyImportSettingsToFolder`、`CountSpriteSources`（原 `CountPngs`）、`SpriteAtlasSyncer` 内部 `743:` 行附近"读首个 PNG 的 FilterMode 作 atlas 默认"逻辑——按 MF-D1 / MF-D1b 分两条 enumeration 路径：
+
+- **`CountSpriteSources`**：与 `EnumerateSpriteSources` 同形，走 union（统计与枚举对齐，避免 Inspector 显示数字与 sync 后 entries 数对不上）。实现上抽出私有 `EnumerateSpriteSourceGuids(folder)` 助手，两个 public 方法共享。
+- **`ResetTextureImportSettings` / `ApplyImportSettingsToFolder`**：只查 `t:Texture2D`（MF-D1b）。内部仍保持 `if (AssetImporter.GetAtPath(...) is not TextureImporter) continue;` —— 多余的 AsepriteImporter / 其他 importer 在此被 guard 拒掉。`Apply*` 额外要求 template 是 TextureImporter（已有逻辑保持）。
+- **"首个资产决定 atlas FilterMode"**：改成"枚举结果（union）排序后取第一个 TextureImporter 资产的 `filterMode`"，AsepriteImporter 跳过（没有跨 importer 等价的 `filterMode` 字段；若 union 结果里只有 Aseprite 资产，FilterMode 用 Unity SpriteAtlas 默认值即可）。
+
+### 5.3 Runtime `UI.cs` 扩展名 strip 简化
+
+`Runtime/Application/UI.cs:100-110`，替换为：
+
+```csharp
+// Strip the trailing extension if any. Resources virtual paths don't carry
+// extensions; this lets sprite="ui/dialog.png#slice" resolve like "ui/dialog#slice".
+// dotIdx > slashIdx guards against "foo.v2/bar" where the dot is in a folder name.
+var slashIdx = path.LastIndexOf('/');
+var dotIdx = path.LastIndexOf('.');
+if (dotIdx > slashIdx && dotIdx > 0) path = path.Substring(0, dotIdx);
+```
+
+无白名单 → 任何扩展名都被 strip → `Resources.LoadAll<Sprite>(path)` 拿到的依旧是同一个 Texture2D 资产。
+
+### 5.4 asmdef 改动
+
+`Runtime/PromptUGUI.Runtime.asmdef`:
+
+```diff
+   "versionDefines": [
+     {
+       "name": "com.unity.addressables",
+       "expression": "1.0.0",
+       "define": "PROMPTUGUI_HAS_ADDRESSABLES"
++    },
++    {
++      "name": "com.unity.2d.aseprite",
++      "expression": "1.0.0",
++      "define": "PROMPTUGUI_HAS_ASEPRITE"
+     }
+   ]
+```
+
+`Editor/PromptUGUI.Editor.asmdef` 同样追加。`AsepriteImporter` 是 Editor-only 类（`UnityEditor.U2D.Aseprite` 命名空间），因此只有 Editor asmdef 真正需要这个 define，但 Runtime asmdef 也声明它是为了未来 Runtime 路径（例如 Sample 里的 demo 控制器）能 `#if PROMPTUGUI_HAS_ASEPRITE` 走条件分支。
+
+asmdef `references` **不**添加 `Unity.2D.Aseprite.Editor`——所有 `AsepriteImporter` 引用都包在 `#if PROMPTUGUI_HAS_ASEPRITE` 内，define 未设时类型引用根本不会被编译器看到，不需要 reference 解析。
+
+### 5.5 命名同步
+
+| 文件 | 改动 |
+|---|---|
+| `Editor/SpriteAtlasSyncer.cs` | `CountPngs` → `CountSpriteSources`；`EnumeratePngs` → `EnumerateSpriteSources`；`ResetPngImportSettings` → `ResetTextureImportSettings`；内部 XML doc / 注释里 "PNG" 字面普查替换 |
+| `Editor/SpriteSetEditor.cs` | "Source PNGs" → "Source sprites"；"Apply Settings to All N PNGs in Folder" → "Apply Settings to All N TextureImporters in Folder"；"Reset All PNGs Format" → "Reset All TextureImporters Format"；helper 文案里的 "manual TextureImporter tweaks on these PNGs" → "...on these textures" |
+| `Editor/SpriteAtlasAutoSync.cs` / `Editor/SpriteAtlasMenu.cs` / `Editor/SpriteAtlasBuildHook.cs` | 跨文件 grep 替换 `CountPngs` / `EnumeratePngs` / `ResetPngImportSettings` 引用 |
+
+`SyncAll` 的"unknown ref" 错误消息提示作者引用了不存在的 sprite——文案不动，已经是"ref name 维度"而非"文件名维度"了。
+
+### 5.6 SKILL.md 更新
+
+| SKILL | 改动 |
+|---|---|
+| `scripting-promptugui-csharp/SKILL.md` | 在 "SpriteSet" 段补一行: "Source folder accepts any Unity-recognized texture format (PNG, JPG, TGA, PSD, TIFF, BMP, EXR, HDR, GIF) plus Aseprite (`.ase`/`.aseprite`, requires `com.unity.2d.aseprite ≥ 1.0`; one sprite per file)." |
+| `using-promptugui-addressables/SKILL.md` | 同一行注释；强调 Addressables 路径对 Aseprite 透明（Addressables 装载的是 `AssetReferenceT<Sprite>`，与底层 importer 无关） |
+| `authoring-promptugui-xml/SKILL.md` | **不动**——XML 端 `sprite="ns:name"` 引用形态与底层文件扩展名无关 |
+
+---
+
+## 6. 测试策略
+
+### 6.1 改造 `Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs`
+
+| 测试 | 断言 |
+|---|---|
+| `EnumerateSpriteSources_picks_up_png` (rename from existing) | 单 PNG 文件夹 → entries 含该 sprite |
+| `EnumerateSpriteSources_picks_up_mixed_extensions` (new) | 同一文件夹混 PNG + JPG + TGA 各一个，entries 全部 3 个；pathKey 都去扩展名 |
+| `EnumerateSpriteSources_skips_textures_with_non_TextureImporter` (new) | 模拟一个非 TextureImporter / 非 AsepriteImporter 的 Texture2D 资产（实现上：创建一个 Texture2D scriptable asset 或留作 manual TODO 跳过该 case）→ entries 不含它 |
+| `EnumerateSpriteSources_stable_order_by_path` (new) | 文件夹下 `b.png` `a.png` `c.png` → entries 顺序 a/b/c（pathKey 字典序） |
+| `EnumerateSpriteSources_flips_default_TextureImporter_to_sprite` (new) | 故意把一个 PNG 设为 `textureType=Default`，调用后断言 `TextureImporter.textureType == Sprite` 且 entries 包含它 |
+| `ResetTextureImportSettings_only_affects_TextureImporter` (new) | 文件夹混 PNG + 模拟 AsepriteImporter（如有条件）→ reset 后只有 PNG 被 reset，AsepriteImporter 资产的设置不动 |
+
+Aseprite-specific（仅 `PROMPTUGUI_HAS_ASEPRITE` 编译时跑）：
+
+| 测试 | 断言 |
+|---|---|
+| `EnumerateSpriteSources_picks_up_single_frame_animatedsprite_aseprite` | 1 帧 Aseprite，AnimatedSprite mode（默认，主资产 t:Sprite） → entries 含它，pathKey 去 `.aseprite` 扩展名 |
+| `EnumerateSpriteSources_picks_up_single_frame_spritesheet_aseprite` | 1 帧 Aseprite，SpriteSheet mode（主资产 t:Texture2D + 1 Sprite sub-asset） → entries 含它 |
+| `EnumerateSpriteSources_skips_multi_sprite_aseprite_with_logError` | >1 帧 Aseprite（无论哪种 import mode） → entries 不含 + `LogAssert.Expect(LogType.Error, ...)` 含 "produces N sprites" |
+| `EnumerateSpriteSources_dedupes_aseprite_spritesheet_under_union` | SpriteSheet mode Aseprite 同时命中 `t:Texture2D` 和 `t:Sprite` → entries 仍只有 1 条 |
+
+> **风险**: Aseprite 测试需要 fixture `.aseprite` 文件；本仓库目前没有，Plan 阶段决定是 (a) commit fixture 二进制 (b) 在 `[OneTimeSetUp]` 里程序化生成 Aseprite 文件（如果包暴露这样的 API）。**(a) 是默认**——每个 import mode + frame count combo 一个最小 fixture。
+
+### 6.2 Runtime `UI.cs` 扩展名 strip
+
+新增 `Tests/EditMode/Application/ResolveSpriteTests.cs` (existing) 中的几个 case，或者放到现有 `Tests/EditMode/Application/ResolveSpriteTests.cs`：
+
+| 测试 | 断言 |
+|---|---|
+| `ResolveSprite_strips_png_extension` (existing-equivalent) | `"foo.png#slice"` → 实际 LoadAll path 是 `"foo"` |
+| `ResolveSprite_strips_aseprite_extension` (new) | `"foo.aseprite#slice"` → LoadAll path 是 `"foo"` |
+| `ResolveSprite_strips_unknown_extension` (new) | `"foo.svg#slice"` / `"foo.xyz#slice"` → LoadAll path 是 `"foo"`；不再硬编码白名单 |
+| `ResolveSprite_does_not_strip_dot_in_folder_name` (new) | `"v2.0/foo#slice"` → LoadAll path 是 `"v2.0/foo"`（dot 在 slash 前，不该 strip） |
+
+### 6.3 不写的测试
+
+- 7 个控件的 `Sprite` setter——已被 `ResolveSpriteTests` 覆盖。
+- XML scan——本期不动 `ScanXmlReferences`，无新增 case。
+- asmdef `versionDefines`——Unity 自身的契约，不在我们范围。
+
+---
+
+## 7. 迁移与破坏性影响
+
+库未上线（前 spec 既有结论），不做向后兼容：
+
+- `SpriteAtlasSyncer.CountPngs` / `EnumeratePngs` / `ResetPngImportSettings` 直接改名，不留 `[Obsolete]` 别名。三者都是 `public static`，但仅 Editor asmdef 内部 + Inspector 使用，no-op for Player.
+- Runtime `UI.cs` 扩展名 strip 行为：白名单（PNG/JPG/JPEG/TGA/PSD）→ "strip 最后一个 `.`"。语义扩展，对原白名单中的扩展名结果完全一致；对原白名单**外**的（如 `.bmp .tiff .exr .gif .aseprite .ase`）从"不 strip → LoadAll 失败"变成"strip → LoadAll 命中"——这是 bugfix 方向。
+- Inspector 文案 "PNG" → "image"/"texture"：无 API 影响。
+- asmdef 加 `versionDefines`：装包用户得到新 define；未装包用户照旧（define 不设）。
+
+Samples 目前没有 JPG/TGA/Aseprite 引用，无需改。验证一个最小 Sample case：把现有 Samples 里一个 PNG 改个扩展名为 JPG（重新导成 JPG），跑 sync，验证 SpriteSet 内 entry 仍存在、`<Image sprite="ui:foo">` 仍正常。
+
+---
+
+## 8. 非目标 / 推迟
+
+- **Multi-sprite PNG（TextureImporter Multi 模式）进 SpriteSet**：现有"`LoadAssetAtPath<Sprite>` 拿第一个"行为不变；本期不引入 multi-sprite-per-file 支持。
+- **SVG / Photoshop layer / 第三方 importer 支持**：MF-D2 已决，silent skip；要支持时新增 importer 分支。
+- **强制改写 `AsepriteImporter` 设置以确保单 sprite 输出**：MF-D4 已决，仅验证不改写。
+- **Aseprite multi-frame → 动画 Sprite 序列**：非本期范围。`<Icon>` / `<Image>` 都是静态 sprite 控件；想要 Aseprite 驱动的动画走 LitMotion 或 sprite swap，与 SpriteSet 不交互。
+- **`UI.cs` 扩展名 strip 的 Span 优化**：current `Substring` 拷贝在 sprite resolve 路径里不是热路径（一次 Open 调几十次），不动。
+- **`FindAssets` 用 `t:Sprite` 替代 union**：`t:Sprite` 单查会漏掉 `textureType=Default` 的 PNG（它还没有 Sprite sub-asset），破坏现有"扔一个 PNG 就能用"的便利性；不漏 Aseprite。MF-D1 选 union 是为了同时覆盖"Default 模式 PNG（auto-flip 触发）"和"Aseprite AnimatedSprite 模式（主资产 t:Sprite）"两条路径。
+
+---
+
+## 9. 风险
+
+| 风险 | 影响 | 缓解 |
+|---|---|---|
+| ~~Aseprite 主资产在某些 import 模式下不是 Texture2D~~ | ~~漏单~~ | **已确认 + 已解决**：AnimatedSprite mode (默认) 主资产是 `t:Sprite`、SpriteSheet mode 主资产是 `t:Texture2D`；MF-D1 用 union 覆盖两种 |
+| `versionDefines` 不带 `references` 时，`UnityEditor.U2D.Aseprite.AsepriteImporter` 类型即使包了 `#if PROMPTUGUI_HAS_ASEPRITE` 仍解析不到 | 编译错误 | Plan 阶段实测；若发现需要 reference，加 `Unity.2D.Aseprite.Editor` 到 references。Unity 对"reference 缺失但 versionDefines 没触发"的处理是 warning 而非 error（Addressables 既有路径已验证），所以预期 OK |
+| `FindAssets` 在大型项目里比 `Directory.EnumerateFiles` 慢 | Sync 时间延长 | 实际作者级 SpriteSet 文件夹通常 <500 文件，差距毫秒级；不优化 |
+| 作者改了 PNG 扩展名到 JPG/TGA 但忘了重新 sync | SpriteSet entry 仍指向旧 GUID（已被 Unity 跟踪），但 atlas 没 repack | sync 流程已有；与现有 PNG 改名场景一致，不是新风险 |
+| 多扩展名混在同一 setName 下产生 pathKey 冲突（`foo.png` 和 `foo.jpg` 都在 `ui/` 下）| 后到的 entry 覆盖前者，silent | 加 `EnumerateSpriteSources` 内的重复 pathKey 检测，遇到 → `Debug.LogError` + 跳过后者；plan 阶段决定具体实现 |
+| Inspector 文案改完后 SpriteSet 老用户找不到按钮 | UX 摩擦 | 库未上线，n/a |
+
+---
+
+## 10. 实施粒度（提示）
+
+writing-plans 阶段细化，大致 4 块：
+
+1. **Editor enumeration 切换**
+   - `EnumerateSpriteSources` 重写 + `EnsureSpriteImporter` 分支化
+   - `CountSpriteSources` / `ResetTextureImportSettings` 切到 `FindAssets`
+   - `ApplyImportSettingsToFolder` 切到 `FindAssets`（TextureImporter guard 保持）
+   - 测试: `SpriteAtlasSyncerTests` 新 case（不含 Aseprite）
+2. **Aseprite 分支 + asmdef versionDefines**
+   - 两个 asmdef 加 `PROMPTUGUI_HAS_ASEPRITE`
+   - `EnsureSpriteImporter` Aseprite 分支
+   - 测试: 装包 + Aseprite fixture（条件编译），覆盖单 sprite / 多 sprite 两 case
+3. **Runtime `UI.cs` 扩展名 strip 简化**
+   - 替换白名单为"strip 最后一个 `.`"
+   - 测试: `ResolveSpriteTests` 新 case（任意扩展名 / dot-in-folder-name）
+4. **命名 + 文案 + SKILL.md**
+   - `CountPngs` / `EnumeratePngs` / `ResetPngImportSettings` rename + 跨文件引用更新
+   - `SpriteSetEditor` Inspector 文案
+   - SKILL.md csharp + addressables 两份各加一段
+   - dotnet format + Unity MCP run_tests 全跑过
+
+---


### PR DESCRIPTION
## Summary

- `SpriteAtlasSyncer` 把 5 处 `Directory.EnumerateFiles("*.png")` 切到 `AssetDatabase.FindAssets`。Sync 路径用 union `t:Texture2D ∪ t:Sprite`（覆盖 Aseprite AnimatedSprite 主资产 = `t:Sprite` 这一种），TextureImporter-only 路径（Reset/Apply/FindFirst）单查 `t:Texture2D`。SpriteSet 现在接受 PNG/JPG/TGA/PSD/TIFF/BMP/EXR/HDR/GIF + Aseprite 单 sprite 文件。
- `UI.ResolveSprite` 扩展名 strip 去掉了 PNG/JPG/JPEG/TGA/PSD 白名单，改成"strip 最后一个 `/` 之后的 `.`"——`foo.aseprite#slice` / 任意扩展名都能正常 resolve。
- `PROMPTUGUI_HAS_ASEPRITE` versionDefine for `com.unity.2d.aseprite ≥ 1.0`；`EnsureSpriteImporter` 加 validate-only AsepriteImporter 分支（单 sprite 契约——违反 LogError + skip，**不**修改 AsepriteImporter 设置）。
- 方法重命名 `CountPngs → CountSpriteSources` / `EnumeratePngs → EnumerateSpriteSources` / `ResetPngImportSettings → ResetTextureImportSettings` / `FindFirstPng → FindFirstTexture` / `templatePngAssetPath → templateTextureAssetPath`；Inspector 文案 "PNG" → "image"/"texture"。
- 修复 `AsepriteImporterEditor` NRE：`FindFirstTexture` 在 `t:Texture2D` 之上再加 `is TextureImporter` 过滤（Aseprite SpriteSheet 模式主资产也是 `t:Texture2D`，但 `AsepriteImporterEditor` 嵌进我们自定义 Inspector 会在 `HasModified()` NRE）。
- 配套 UX 收尾：纯 Aseprite / 空文件夹下，"Texture Import Settings" 段显示更具体的 helpbox，Reset 按钮也跟着隐藏（按了也是 no-op）。
- SKILL: csharp + addressables SKILL.md 各加一段 "Source formats"；xml SKILL 不动（`sprite="ns:name"` 与扩展名无关）。

## 已知 follow-up (非 blocker)

- 同文件夹下 `foo.png` 和 `foo.jpg` 的 pathKey collision：当前 last-wins silent。Spec §9 列了 "加重复检测 + LogError" 但 plan 阶段没收，pre-release 阶段可接受。值得后续单独修。

## Test Plan

- [x] `PromptUGUI.Tests.EditMode` (Unity MCP run_tests): 737/737 passed
- [x] `PromptUGUI.Tests.EditorOnly`: 160/160 passed
- [x] `PromptUGUI.Tests.EditMode.Addressables`: 25/25 passed
- [x] `PromptUGUI.Tests.PlayMode`: 110/110 passed
- [x] `dotnet format whitespace` + `--verify-no-changes --severity warn` clean
- [x] `UIXmlLint Runtime/Resources/` clean
- [x] Host project 装了 `com.unity.2d.aseprite`，3 个 Aseprite 测试编译通过；fixture 缺失时通过 `Assume.That(File.Exists(...))` skip
- [ ] 手测：Sample 里 PNG → JPG swap，跑 Sync，确认 `<Image sprite="ui:foo">` 在 Play 模式仍正常显示
- [ ] 手测：SpriteSet sourceFolder 全是 Aseprite —— Inspector helpbox 显示"No regular texture..."文案，Reset 按钮不出现，无 NRE
- [ ] 手测：SpriteSet sourceFolder PNG + Aseprite 混合 —— PNG 作模板，Apply/Reset 按钮正常，操作不影响 Aseprite 文件
- [ ] 手测：commit fixtures `single_animated.aseprite` / `single_sheet.aseprite` / `multi.aseprite` 后验证 3 个 Aseprite 测试 assertion (而非仅 Assume skip)

## 参考

- Spec: \`docs~/superpowers/specs/2026-05-24-spriteset-multi-format-design.md\`
- Plan: \`docs~/superpowers/plans/2026-05-24-spriteset-multi-format.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)