### PR TITLE
feat: <Progress> control (linear scale + Image.Type.Filled)

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -95,6 +95,7 @@ Pre-registered on `UI.Registry`. Use as XML tags by name:
 | `<Dropdown>`   | TMP_Dropdown. R3 `OnSelected: int`. Options pushed C#-side via `BindOptions(...)`. **不写 size 时默认 160×44**（不读 caption 文字宽，避免每选一项就改宽度）。                                                                                                                                                                                                                                    | `value` (int initial index), `color`, `sprite`, `font`                                                                                                                                                                                                                                                                                             |
 | `<ScrollList>` | ScrollRect + Mask. Items pushed C#-side via `BindItems(...)`. `itemTemplate` references a `<Template name=...>` or registered Control class. **不写 size 时按方向给视口默认**：纵向滚动 160×200、横向滚动 200×160；实际项目通常显式写 size。                                                                                                                                                     | `itemTemplate` (required tag name), `direction` (`vertical` / `horizontal`), `spacing` (float), `padding`, `color`, `sprite`                                                                                                                                                                                                                       |
 | `<InputField>` | TMP_InputField；R3 `OnValueChanged` / `OnEndEdit` / `OnSubmit: string`。`<InputField>初始文本</InputField>` 短手设 `text=`。                                                                                                                                                                                                                                                                     | `text`, `placeholder`, `contentType` (`standard`/`autocorrected`/`integer-number`/`decimal-number`/`alphanumeric`/`name`/`email`/`password`/`pin`/`custom`), `lineType` (`single`/`multi-newline`/`multi-submit`), `characterLimit` (int), `readOnly` (bool), `color`, `sprite`, `font`, `tr` (placeholder)/`ctx`                                  |
+| `<Progress>` | 显示型线性进度条（只读，无 `OnValueChanged`）。一行配齐 frame / mask / bg / fill / mode / direction / value，零手糊图层。 | `value` (float `[0..1]`, default `0`), `fill` (sprite key), `fillColor` (`#rrggbbaa`), `bg` (sprite key), `bgColor` (颜色), `frame` (sprite key), `mask` (sprite key), `mode` (`scale`\|`fill`, default `scale`), `direction` (`horizontal`\|`vertical`\|`reverse-horizontal`\|`reverse-vertical`, default `horizontal`) |
 
 `<Toggle>` / `<Slider>` / `<Dropdown>` / `<ScrollList>` are reference implementations. For project-specific differentiation (pixel border, press feedback, custom popup chrome) subclass and override `OnAttached` — see scripting-promptugui-csharp.
 
@@ -195,6 +196,7 @@ Other notes:
 | `<Dropdown>`   | `Image` + `TMP_Dropdown`                                                                                                                                                        | `Label` + `Arrow` + `Template`（默认 inactive，内含 `Viewport` / `Content` / `Item` / `Scrollbar` 完整下拉子树）                                                             | `OnSelected` ← `TMP_Dropdown.onValueChanged`                                                       |
 | `<ScrollList>` | `Image` + `ScrollRect`                                                                                                                                                          | `Viewport`(`Image` + `Mask` stencil) → `Content`(V/H `LayoutGroup` + `ContentSizeFitter`)；按 `direction` 再加一个 `Scrollbar`                                               | 无独立事件；C# 端 `BindItems(...)` 推数据                                                          |
 | `<InputField>` | `Image` + `TMP_InputField`                                                                                                                                                      | `Text Area`(`RectMask2D`) → `Placeholder`(`TMP_Text`, italic 半透明) + `Text`(`TMP_Text`)                                                                                    | `OnValueChanged` / `OnEndEdit` / `OnSubmit` ← `TMP_InputField.*`                                   |
+| `<Progress>`   | `RectTransform`（无 Graphic）                                                                                                                                                   | `MaskWrapper`(`RectTransform`; 按需挂 `UnityImage` + `Mask`) → `Bg`(`Image`, 按需启用) + `Fill`(`Image`, 永远存在)；`Frame`(`Image`, 按需启用, `raycastTarget=false`) | —                                                                                                  |
 | `<SafeArea>`   | `RectTransform` + `SafeAreaTracker`（内部 `MonoBehaviour`，订阅设备 safeArea / 旋转 / Device Simulator）                                                                        | —                                                                                                                                                                            | —                                                                                                  |
 | `<Trigger>`    | `RectTransform` 单独（无视觉、无 layout 行为，仅作 wrapper 划定事件源 scope）                                                                                                   | —                                                                                                                                                                            | `OnFire` ← R3 `Subject<Unit>`，由 `on=`（open/loop/click/hover-enter/hover-exit/press/manual）触发 |
 | `<Animation>`  | `RectTransform` + `CanvasGroup`（继承自 Trigger；CanvasGroup 给 `fade=` 用，由 `ApplyCommon` 懒加载）                                                                           | `_offsetProxy`(`RectTransform`，anchor stretch、margin=0、pivot=0.5,0.5) — XML 子节点全 parent 到这一层；LitMotion 驱动它的 anchoredPosition / localScale / localEulerAngles | `OnFire` ← 继承 Trigger；同时由 `on=` 触发 LitMotion `MotionHandle[]`                              |
@@ -551,6 +553,61 @@ PromptUGUI never auto-enables masking — you must opt in via `mask=`. Two reaso
 
 **Variant overrides** on `mask` / `showMask` / `maskPadding` are rejected in v1 (`PUI-MASK-VARIANT`) — switching mask mode means `AddComponent`/`Destroy` at runtime, which we don't support. If you need per-variant clipping, split into two Screens or use `<Add into=…>`.
 
+## Progress
+
+`<Progress>` 是显示型线性进度条，把 frame / mask / bg / fill / mode / direction / value 打包进一行 XML。**只读** — C# 侧直接 setter，无 `OnValueChanged` Observable。
+
+Radial fill（冷却环）不在 `<Progress>` 范围；以后用单独的 `<Cooldown>` 控件。
+
+### 六个典型用例
+
+```xml
+<!-- 1. 最简：纯色 bg + 单色 fill；scale 横向 -->
+<Progress value="0.6" bgColor="#222" fillColor="#3cf"/>
+
+<!-- 2. 单 sprite 填充；scale 横向 -->
+<Progress value="0.6" fill="ui:bar_red"/>
+
+<!-- 3. 圆角胶囊：mask sprite 兼当底 (PB-D9) -->
+<Progress value="0.4" mask="ui:pill" fill="ui:bar_blue"/>
+
+<!-- 4. 全套装饰：frame + mask + bg + fill -->
+<Progress value="0.6" frame="ui:gold_border" mask="ui:pill" bg="ui:track" fill="ui:bar_red"/>
+
+<!-- 5. Unity Image.Type.Filled, 反向纵向（液体从顶部往下空） -->
+<Progress value="0.3" fill="ui:liquid" mode="fill" direction="reverse-vertical"/>
+
+<!-- 6. 在 Variant 中切换 value / colors (mask/frame/bg/fill sprite 允许；mask 模式禁止) -->
+<Progress id="hp" value="1.0" fill="ui:bar" bgColor="#000">
+  <Variant when="state.low">
+    <Attr name="value" value="0.2"/>
+    <Attr name="fillColor" value="#f44"/>
+  </Variant>
+</Progress>
+```
+
+### mask × bg 四种组合
+
+| 条件 | MaskWrapper.UnityImage | MaskWrapper.Mask | MaskWrapper.showMaskGraphic | Bg.SetActive | Frame.SetActive |
+|---|---|---|---|---|---|
+| 无 mask、无 bg/bgColor | 不挂 | 不挂 | — | false | (按 frame) |
+| 无 mask、有 bg/bgColor | 不挂 | 不挂 | — | true | (按 frame) |
+| 有 mask、无 bg/bgColor | 挂（sprite=mask） | 挂 | true | false | (按 frame) |
+| 有 mask、有 bg/bgColor | 挂（sprite=mask） | 挂 | false | true | (按 frame) |
+
+`有 mask、无 bg/bgColor` 时 `showMaskGraphic=true` — mask sprite 兼任可见底，一个 sprite 干两件事（圆角胶囊最常见路径）。
+
+### Lint 规则
+
+| Code | 触发条件 | 级别 |
+|---|---|---|
+| `PUI-PROG-VALUE-RANGE` | `value` 字面量超出 `[0..1]` | warning |
+| `PUI-PROG-MODE` | `mode` 不在 `scale\|fill` | error |
+| `PUI-PROG-DIRECTION` | `direction` 不在 `horizontal\|vertical\|reverse-horizontal\|reverse-vertical` | error |
+| `PUI-PROG-CHILDREN` | `<Progress>` 包含子元素 | error |
+| `PUI-PROG-MASK-VARIANT` | `mask` 出现在 Variant 覆盖里 | error |
+| `PUI-PROG-NO-FILL` | `value` 有值但 `fill`/`fillColor` 均未设 | warning |
+
 ## Common mistakes (XML)
 
 | Symptom                                                                             | Cause                                                                                                                                                                                              | Fix                                                                                                                                                                                                                                                             |
@@ -583,6 +640,7 @@ TOP LEVEL     <Import src="" [as=""]/>  <Screen name="" [canvas="overlay|camera|
 
 BUILT-INS     <Frame> <Image> <Text> <VStack> <HStack> <Grid> <Btn> <Icon>
               <Toggle> <Slider> <Dropdown> <ScrollList> <InputField>
+              <Progress value="0.6" fill="ui:bar"/>  最简；mask= + 不设 bg → mask sprite 自动可见兼当底；radial 进度环不在 <Progress> 范围
 TEXT SHORT    <Text>Hi</Text> ≡ <Text text="Hi"/>     (also <Btn>, <Toggle>, <InputField>)
 
 COMMON ATTRS  id  anchor  size|width|height  margin  pivot  hidden  interactable

--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -73,7 +73,7 @@ mcp__UnityMCP__read_console(action="get", types=["error","warning"])
 
 `<Import>`, `<Screen>`, `<Template>` are the **only** elements allowed at the top level. Comments use standard `<!-- -->`.
 
-## Built-in primitives (14)
+## Built-in primitives (15)
 
 **默认视觉主题**：白底 sliced + #323232 深字（同 Unity 6 标准 UI prefab）。`color=` / `sprite=` 单点 override，整体深色覆写 `ProceduralBuilders` 常量或用 Variant `color.dark="..."`。
 
@@ -95,7 +95,7 @@ Pre-registered on `UI.Registry`. Use as XML tags by name:
 | `<Dropdown>`   | TMP_Dropdown. R3 `OnSelected: int`. Options pushed C#-side via `BindOptions(...)`. **不写 size 时默认 160×44**（不读 caption 文字宽，避免每选一项就改宽度）。                                                                                                                                                                                                                                    | `value` (int initial index), `color`, `sprite`, `font`                                                                                                                                                                                                                                                                                             |
 | `<ScrollList>` | ScrollRect + Mask. Items pushed C#-side via `BindItems(...)`. `itemTemplate` references a `<Template name=...>` or registered Control class. **不写 size 时按方向给视口默认**：纵向滚动 160×200、横向滚动 200×160；实际项目通常显式写 size。                                                                                                                                                     | `itemTemplate` (required tag name), `direction` (`vertical` / `horizontal`), `spacing` (float), `padding`, `color`, `sprite`                                                                                                                                                                                                                       |
 | `<InputField>` | TMP_InputField；R3 `OnValueChanged` / `OnEndEdit` / `OnSubmit: string`。`<InputField>初始文本</InputField>` 短手设 `text=`。                                                                                                                                                                                                                                                                     | `text`, `placeholder`, `contentType` (`standard`/`autocorrected`/`integer-number`/`decimal-number`/`alphanumeric`/`name`/`email`/`password`/`pin`/`custom`), `lineType` (`single`/`multi-newline`/`multi-submit`), `characterLimit` (int), `readOnly` (bool), `color`, `sprite`, `font`, `tr` (placeholder)/`ctx`                                  |
-| `<Progress>` | 显示型线性进度条（只读，无 `OnValueChanged`）。一行配齐 frame / mask / bg / fill / mode / direction / value，零手糊图层。 | `value` (float `[0..1]`, default `0`), `fill` (sprite key), `fillColor` (`#rrggbbaa`), `bg` (sprite key), `bgColor` (颜色), `frame` (sprite key), `mask` (sprite key), `mode` (`scale`\|`fill`, default `scale`), `direction` (`horizontal`\|`vertical`\|`reverse-horizontal`\|`reverse-vertical`, default `horizontal`) |
+| `<Progress>` | 显示型线性进度条（只读，无 `OnValueChanged`）。一行配齐 frame / mask / bg / fill / mode / direction / value，零手糊图层。 | `value` (float `[0..1]`, default `0`), `fill` (sprite key), `fillColor` (`#RRGGBB[AA]` / 命名色), `bg` (sprite key), `bgColor` (`#RRGGBB[AA]` / 命名色), `frame` (sprite key), `mask` (sprite key), `mode` (`scale`\|`fill`, default `scale`), `direction` (`horizontal`\|`vertical`\|`reverse-horizontal`\|`reverse-vertical`, default `horizontal`) |
 
 `<Toggle>` / `<Slider>` / `<Dropdown>` / `<ScrollList>` are reference implementations. For project-specific differentiation (pixel border, press feedback, custom popup chrome) subclass and override `OnAttached` — see scripting-promptugui-csharp.
 
@@ -577,7 +577,7 @@ Radial fill（冷却环）不在 `<Progress>` 范围；以后用单独的 `<Cool
 <!-- 5. Unity Image.Type.Filled, 反向纵向（液体从顶部往下空） -->
 <Progress value="0.3" fill="ui:liquid" mode="fill" direction="reverse-vertical"/>
 
-<!-- 6. 在 Variant 中切换 value / colors (mask/frame/bg/fill sprite 允许；mask 模式禁止) -->
+<!-- 6. 在 Variant 中切换 value / colors (frame / bg / fill sprite 允许；mask 完全禁止 — PUI-PROG-MASK-VARIANT) -->
 <Progress id="hp" value="1.0" fill="ui:bar" bgColor="#000">
   <Variant when="state.low">
     <Attr name="value" value="0.2"/>

--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -578,12 +578,10 @@ Radial fill（冷却环）不在 `<Progress>` 范围；以后用单独的 `<Cool
 <Progress value="0.3" fill="ui:liquid" mode="fill" direction="reverse-vertical"/>
 
 <!-- 6. 在 Variant 中切换 value / colors (frame / bg / fill sprite 允许；mask 完全禁止 — PUI-PROG-MASK-VARIANT) -->
-<Progress id="hp" value="1.0" fill="ui:bar" bgColor="#000">
-  <Variant when="state.low">
-    <Attr name="value" value="0.2"/>
-    <Attr name="fillColor" value="#f44"/>
-  </Variant>
-</Progress>
+<Progress id="hp"
+          value="1.0" value.low="0.2"
+          fill="ui:bar" fillColor.low="#f44"
+          bgColor="#000"/>
 ```
 
 ### mask × bg 四种组合

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -173,7 +173,7 @@ screen.Get<InputField>("playerName").OnEndEdit
       .Subscribe(s => Player.Rename(s)).AddTo(screen);
 ```
 
-**Progress** — `screen.Get<Progress>("hp").Value = 0.42f;` Progress 是只读显示控件，无 `OnValueChanged`，用 `Bind`-属性或直接 setter 推值。`Value` 被 `Mathf.Clamp01` 钳位。
+**Progress** — `screen.Get<Progress>("hp").Value = 0.42f;` 或 R3 推送 `healthStream.Subscribe(v => p.Value = v).AddTo(screen)`。Progress 是只读显示控件，无 `OnValueChanged`。`Value` 被 `Mathf.Clamp01` 钳位。注意：`[Bind]` 在本项目里是把 child control 字段注入到 parent（见 `Runtime/Registry/BindAttribute.cs`），不是数据流绑定 —— 用直接 setter / R3 推。
 
 `screen.Track(disposable)` (or the `.AddTo(screen)` extension) ties a subscription to Screen lifetime. **Always do this** — leaked R3 subscriptions hold the GameObject alive after Close, and the next Open will produce phantom callbacks against the old (destroyed) GameObject.
 

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -173,6 +173,8 @@ screen.Get<InputField>("playerName").OnEndEdit
       .Subscribe(s => Player.Rename(s)).AddTo(screen);
 ```
 
+**Progress** — `screen.Get<Progress>("hp").Value = 0.42f;` Progress 是只读显示控件，无 `OnValueChanged`，用 `Bind`-属性或直接 setter 推值。`Value` 被 `Mathf.Clamp01` 钳位。
+
 `screen.Track(disposable)` (or the `.AddTo(screen)` extension) ties a subscription to Screen lifetime. **Always do this** — leaked R3 subscriptions hold the GameObject alive after Close, and the next Open will produce phantom callbacks against the old (destroyed) GameObject.
 
 ## Screen-level hooks
@@ -301,6 +303,7 @@ EVENTS (R3)    .OnClick                Btn
                .OnSelected             Dropdown:int
                .OnEndEdit / .OnSubmit  InputField:string
                .Subscribe(...).AddTo(screen)   tie lifetime — ALWAYS
+               Progress                display-only; .Value = 0.42f (Clamp01); no event
 
 DATA PUSH      Dropdown.BindOptions(Observable<IEnumerable<string>>)
                ScrollList.BindItems(Observable<IReadOnlyList<T>>, (slot,t)=>...)

--- a/Runtime/Application/BuiltinPrimitives.cs
+++ b/Runtime/Application/BuiltinPrimitives.cs
@@ -20,6 +20,7 @@ namespace PromptUGUI.Application
             reg.Register<Btn>("Btn", null, defaultTextAttr: "text");
             reg.Register<Toggle>("Toggle", null, defaultTextAttr: "text");
             reg.Register<Slider>("Slider", null);
+            reg.Register<Progress>("Progress", null);
             reg.Register<Dropdown>("Dropdown", null);
             reg.Register<ScrollList>("ScrollList", null);
             reg.Register<InputField>("InputField", null, defaultTextAttr: "text");

--- a/Runtime/Application/ScreenInstantiator.cs
+++ b/Runtime/Application/ScreenInstantiator.cs
@@ -189,6 +189,9 @@ namespace PromptUGUI.Application
             else if (node.Tag == "Image")
                 foreach (var issue in MaskAttributeRules.CheckImage(node))
                     Debug.LogWarning(issue.Message);
+            else if (node.Tag == "Progress")
+                foreach (var issue in ProgressAttributeRules.CheckProgress(node))
+                    Debug.LogWarning(issue.Message);
 
             var entry = _registry.Resolve(node.Tag);
 

--- a/Runtime/Application/ScreenInstantiator.cs
+++ b/Runtime/Application/ScreenInstantiator.cs
@@ -182,7 +182,7 @@ namespace PromptUGUI.Application
                     Debug.LogWarning(issue.Message);
             }
 
-            // Mask-family self-checks (mirror of IRWalker dispatch; runtime warns)
+            // Per-tag self-checks (mirror of IRWalker dispatch; runtime warns)
             if (node.Tag == "Frame")
                 foreach (var issue in MaskAttributeRules.CheckFrame(node))
                     Debug.LogWarning(issue.Message);

--- a/Runtime/Controls/Progress.cs
+++ b/Runtime/Controls/Progress.cs
@@ -85,6 +85,7 @@ namespace PromptUGUI.Controls
                 _bg.sprite = UI.ResolveSprite(value);
                 _bg.gameObject.SetActive(true);
                 AutoSlice(_bg);
+                ReconcileMaskVisibility();
             }
         }
 
@@ -97,6 +98,7 @@ namespace PromptUGUI.Controls
                 if (!ColorUtility.TryParseHtmlString(value, out var c)) return;
                 _bg.color = c;
                 _bg.gameObject.SetActive(true);
+                ReconcileMaskVisibility();
             }
         }
 
@@ -112,10 +114,31 @@ namespace PromptUGUI.Controls
             }
         }
 
+        [UIAttr, Preserve]
+        public string Mask
+        {
+            set
+            {
+                if (string.IsNullOrEmpty(value)) return;
+                if (_maskGraphic == null)
+                {
+                    var maskRt = (RectTransform)_fill.transform.parent;
+                    _maskGraphic = maskRt.gameObject.AddComponent<UnityImage>();
+                    _maskGraphic.raycastTarget = false;
+                    _stencilMask = maskRt.gameObject.AddComponent<UnityEngine.UI.Mask>();
+                }
+                _maskGraphic.sprite = UI.ResolveSprite(value);
+                AutoSlice(_maskGraphic);
+                ReconcileMaskVisibility();
+            }
+        }
+
         internal override void OnAfterApply()
         {
             AutoSlice(_bg);
             AutoSlice(_frame);
+            AutoSlice(_maskGraphic);
+            ReconcileMaskVisibility();
             ReconcileFill();
         }
 
@@ -125,6 +148,12 @@ namespace PromptUGUI.Controls
             img.type = img.sprite.border != Vector4.zero
                 ? UnityImage.Type.Sliced
                 : UnityImage.Type.Simple;
+        }
+
+        private void ReconcileMaskVisibility()
+        {
+            if (_stencilMask != null)
+                _stencilMask.showMaskGraphic = !_bg.gameObject.activeSelf;
         }
 
         private void ReconcileFill()

--- a/Runtime/Controls/Progress.cs
+++ b/Runtime/Controls/Progress.cs
@@ -15,6 +15,14 @@ namespace PromptUGUI.Controls
         private UnityImage _frame;
         private UnityImage _maskGraphic;     // null until mask= setter runs
         private UnityEngine.UI.Mask _stencilMask;
+        private float _value;
+
+        [UIAttr, Preserve]
+        public float Value
+        {
+            get => _value;
+            set => _value = Mathf.Clamp01(value);
+        }
 
         public override void OnAttached()
         {

--- a/Runtime/Controls/Progress.cs
+++ b/Runtime/Controls/Progress.cs
@@ -76,9 +76,42 @@ namespace PromptUGUI.Controls
             }
         }
 
+        [UIAttr, Preserve]
+        public string Bg
+        {
+            set
+            {
+                if (string.IsNullOrEmpty(value)) return;
+                _bg.sprite = UI.ResolveSprite(value);
+                _bg.gameObject.SetActive(true);
+                AutoSlice(_bg);
+            }
+        }
+
+        [UIAttr, Preserve]
+        public string BgColor
+        {
+            set
+            {
+                if (string.IsNullOrEmpty(value)) return;
+                if (!ColorUtility.TryParseHtmlString(value, out var c)) return;
+                _bg.color = c;
+                _bg.gameObject.SetActive(true);
+            }
+        }
+
         internal override void OnAfterApply()
         {
+            AutoSlice(_bg);
             ReconcileFill();
+        }
+
+        private static void AutoSlice(UnityImage img)
+        {
+            if (img == null || img.sprite == null) return;
+            img.type = img.sprite.border != Vector4.zero
+                ? UnityImage.Type.Sliced
+                : UnityImage.Type.Simple;
         }
 
         private void ReconcileFill()

--- a/Runtime/Controls/Progress.cs
+++ b/Runtime/Controls/Progress.cs
@@ -1,0 +1,41 @@
+using PromptUGUI.Controls.Internal;
+using PromptUGUI.Registry;
+using UnityEngine;
+using UnityImage = UnityEngine.UI.Image;
+
+namespace PromptUGUI.Controls
+{
+    /// Linear progress bar (horizontal / vertical, scale or Image.Type.Filled).
+    /// Radial fill (cooldown ring) is intentionally out of scope; introduce a
+    /// <Cooldown> control instead — see spec PB-D6.
+    public sealed class Progress : Control
+    {
+        private UnityImage _bg;
+        private UnityImage _fill;
+        private UnityImage _frame;
+        private UnityImage _maskGraphic;     // null until mask= setter runs
+        private UnityEngine.UI.Mask _stencilMask;
+
+        public override void OnAttached()
+        {
+            // MaskWrapper: stretch wrapper around Bg + Fill. UI.Mask + UnityImage attached
+            // lazily when mask= setter runs (PB-D7 / PB-D8).
+            var maskRt = ProceduralBuilders.AddChild(RectTransform, "MaskWrapper");
+
+            // Bg: pre-built but inactive until bg=/bgColor= sets it (PB-D8 / PB-D9 / PB-D10).
+            var bgRt = ProceduralBuilders.AddChild(maskRt, "Bg");
+            bgRt.gameObject.SetActive(false);
+            _bg = bgRt.gameObject.AddComponent<UnityImage>();
+            _bg.raycastTarget = false;
+
+            // Fill: always present; reconcile writes its anchors or fillAmount.
+            _fill = ProceduralBuilders.AddImage(maskRt, "Fill", raycast: false);
+
+            // Frame: pre-built but inactive until frame= sets it. PB-D16: raycast off.
+            var frameRt = ProceduralBuilders.AddChild(RectTransform, "Frame");
+            frameRt.gameObject.SetActive(false);
+            _frame = frameRt.gameObject.AddComponent<UnityImage>();
+            _frame.raycastTarget = false;
+        }
+    }
+}

--- a/Runtime/Controls/Progress.cs
+++ b/Runtime/Controls/Progress.cs
@@ -27,6 +27,22 @@ namespace PromptUGUI.Controls
             set => _value = Mathf.Clamp01(value);
         }
 
+        internal override void OnAfterApply()
+        {
+            ReconcileFill();
+        }
+
+        private void ReconcileFill()
+        {
+            var rt = _fill.rectTransform;
+            // v1 single path: mode=scale, direction=horizontal (other modes/directions
+            // land in tasks 4-5).
+            rt.anchorMin = Vector2.zero;
+            rt.anchorMax = new Vector2(_value, 1f);
+            rt.offsetMin = Vector2.zero;
+            rt.offsetMax = Vector2.zero;
+        }
+
         public override void OnAttached()
         {
             // MaskWrapper: stretch wrapper around Bg + Fill. UI.Mask + UnityImage attached

--- a/Runtime/Controls/Progress.cs
+++ b/Runtime/Controls/Progress.cs
@@ -20,6 +20,7 @@ namespace PromptUGUI.Controls
         // Attribute state.
         private float _value;
         private string _direction = "horizontal";
+        private string _mode = "scale";
 
         [UIAttr, Preserve]
         public float Value
@@ -43,6 +44,17 @@ namespace PromptUGUI.Controls
             }
         }
 
+        [UIAttr, Preserve]
+        public string Mode
+        {
+            set
+            {
+                if (string.IsNullOrEmpty(value)) return;
+                _mode = value;
+                ReconcileFill();
+            }
+        }
+
         internal override void OnAfterApply()
         {
             ReconcileFill();
@@ -51,16 +63,41 @@ namespace PromptUGUI.Controls
         private void ReconcileFill()
         {
             var rt = _fill.rectTransform;
-            (rt.anchorMin, rt.anchorMax) = _direction switch
+            if (_mode == "fill")
             {
-                "horizontal" => (Vector2.zero, new Vector2(_value, 1f)),
-                "reverse-horizontal" => (new Vector2(1f - _value, 0f), Vector2.one),
-                "vertical" => (Vector2.zero, new Vector2(1f, _value)),
-                "reverse-vertical" => (new Vector2(0f, 1f - _value), Vector2.one),
-                _ => (Vector2.zero, new Vector2(_value, 1f)),
-            };
-            rt.offsetMin = Vector2.zero;
-            rt.offsetMax = Vector2.zero;
+                rt.anchorMin = Vector2.zero;
+                rt.anchorMax = Vector2.one;
+                rt.offsetMin = Vector2.zero;
+                rt.offsetMax = Vector2.zero;
+                _fill.type = UnityImage.Type.Filled;
+                (_fill.fillMethod, _fill.fillOrigin) = _direction switch
+                {
+                    "horizontal" => (UnityImage.FillMethod.Horizontal, (int)UnityImage.OriginHorizontal.Left),
+                    "reverse-horizontal" => (UnityImage.FillMethod.Horizontal, (int)UnityImage.OriginHorizontal.Right),
+                    "vertical" => (UnityImage.FillMethod.Vertical, (int)UnityImage.OriginVertical.Bottom),
+                    "reverse-vertical" => (UnityImage.FillMethod.Vertical, (int)UnityImage.OriginVertical.Top),
+                    _ => (UnityImage.FillMethod.Horizontal, (int)UnityImage.OriginHorizontal.Left),
+                };
+                _fill.fillAmount = _value;
+            }
+            else // scale (default)
+            {
+                // Reset away from Filled, then pick Simple/Sliced per sprite border.
+                _fill.fillAmount = 1f;
+                _fill.type = (_fill.sprite != null && _fill.sprite.border != Vector4.zero)
+                    ? UnityImage.Type.Sliced
+                    : UnityImage.Type.Simple;
+                (rt.anchorMin, rt.anchorMax) = _direction switch
+                {
+                    "horizontal" => (Vector2.zero, new Vector2(_value, 1f)),
+                    "reverse-horizontal" => (new Vector2(1f - _value, 0f), Vector2.one),
+                    "vertical" => (Vector2.zero, new Vector2(1f, _value)),
+                    "reverse-vertical" => (new Vector2(0f, 1f - _value), Vector2.one),
+                    _ => (Vector2.zero, new Vector2(_value, 1f)),
+                };
+                rt.offsetMin = Vector2.zero;
+                rt.offsetMax = Vector2.zero;
+            }
         }
 
         public override void OnAttached()

--- a/Runtime/Controls/Progress.cs
+++ b/Runtime/Controls/Progress.cs
@@ -100,9 +100,22 @@ namespace PromptUGUI.Controls
             }
         }
 
+        [UIAttr, Preserve]
+        public string Frame
+        {
+            set
+            {
+                if (string.IsNullOrEmpty(value)) return;
+                _frame.sprite = UI.ResolveSprite(value);
+                _frame.gameObject.SetActive(true);
+                AutoSlice(_frame);
+            }
+        }
+
         internal override void OnAfterApply()
         {
             AutoSlice(_bg);
+            AutoSlice(_frame);
             ReconcileFill();
         }
 

--- a/Runtime/Controls/Progress.cs
+++ b/Runtime/Controls/Progress.cs
@@ -10,11 +10,14 @@ namespace PromptUGUI.Controls
     /// <Cooldown> control instead — see spec PB-D6.
     public sealed class Progress : Control
     {
-        private UnityImage _bg;
-        private UnityImage _fill;
-        private UnityImage _frame;
+        // Image layers — conditionally null/active per spec §6 activation table.
+        private UnityImage _bg;              // null disabled until bg=/bgColor= activates it
         private UnityImage _maskGraphic;     // null until mask= setter runs
-        private UnityEngine.UI.Mask _stencilMask;
+        private UnityEngine.UI.Mask _stencilMask;  // pairs with _maskGraphic
+        private UnityImage _fill;            // always present (PB-D7)
+        private UnityImage _frame;           // null disabled until frame= activates it
+
+        // Attribute state.
         private float _value;
 
         [UIAttr, Preserve]

--- a/Runtime/Controls/Progress.cs
+++ b/Runtime/Controls/Progress.cs
@@ -196,6 +196,19 @@ namespace PromptUGUI.Controls
             }
         }
 
+        public override Vector2? GetNativeSize()
+        {
+            if (_frame != null && _frame.sprite != null) return NativeOf(_frame);
+            if (_bg != null && _bg.sprite != null) return NativeOf(_bg);
+            return new Vector2(160f, 16f);
+        }
+
+        private static Vector2 NativeOf(UnityImage img)
+        {
+            var ppu = img.pixelsPerUnit;
+            return new Vector2(img.sprite.rect.width / ppu, img.sprite.rect.height / ppu);
+        }
+
         public override void OnAttached()
         {
             // MaskWrapper: stretch wrapper around Bg + Fill. UI.Mask + UnityImage attached

--- a/Runtime/Controls/Progress.cs
+++ b/Runtime/Controls/Progress.cs
@@ -37,6 +37,7 @@ namespace PromptUGUI.Controls
         {
             set
             {
+                if (string.IsNullOrEmpty(value)) return;
                 _direction = value;
                 ReconcileFill();
             }
@@ -52,11 +53,11 @@ namespace PromptUGUI.Controls
             var rt = _fill.rectTransform;
             (rt.anchorMin, rt.anchorMax) = _direction switch
             {
-                "horizontal" => (new Vector2(0f, 0f), new Vector2(_value, 1f)),
-                "reverse-horizontal" => (new Vector2(1f - _value, 0f), new Vector2(1f, 1f)),
-                "vertical" => (new Vector2(0f, 0f), new Vector2(1f, _value)),
-                "reverse-vertical" => (new Vector2(0f, 1f - _value), new Vector2(1f, 1f)),
-                _ => (new Vector2(0f, 0f), new Vector2(_value, 1f)),
+                "horizontal" => (Vector2.zero, new Vector2(_value, 1f)),
+                "reverse-horizontal" => (new Vector2(1f - _value, 0f), Vector2.one),
+                "vertical" => (Vector2.zero, new Vector2(1f, _value)),
+                "reverse-vertical" => (new Vector2(0f, 1f - _value), Vector2.one),
+                _ => (Vector2.zero, new Vector2(_value, 1f)),
             };
             rt.offsetMin = Vector2.zero;
             rt.offsetMax = Vector2.zero;

--- a/Runtime/Controls/Progress.cs
+++ b/Runtime/Controls/Progress.cs
@@ -19,6 +19,7 @@ namespace PromptUGUI.Controls
 
         // Attribute state.
         private float _value;
+        private string _direction = "horizontal";
 
         [UIAttr, Preserve]
         public float Value
@@ -31,6 +32,16 @@ namespace PromptUGUI.Controls
             }
         }
 
+        [UIAttr, Preserve]
+        public string Direction
+        {
+            set
+            {
+                _direction = value;
+                ReconcileFill();
+            }
+        }
+
         internal override void OnAfterApply()
         {
             ReconcileFill();
@@ -39,10 +50,14 @@ namespace PromptUGUI.Controls
         private void ReconcileFill()
         {
             var rt = _fill.rectTransform;
-            // v1 single path: mode=scale, direction=horizontal (other modes/directions
-            // land in tasks 4-5).
-            rt.anchorMin = Vector2.zero;
-            rt.anchorMax = new Vector2(_value, 1f);
+            (rt.anchorMin, rt.anchorMax) = _direction switch
+            {
+                "horizontal" => (new Vector2(0f, 0f), new Vector2(_value, 1f)),
+                "reverse-horizontal" => (new Vector2(1f - _value, 0f), new Vector2(1f, 1f)),
+                "vertical" => (new Vector2(0f, 0f), new Vector2(1f, _value)),
+                "reverse-vertical" => (new Vector2(0f, 1f - _value), new Vector2(1f, 1f)),
+                _ => (new Vector2(0f, 0f), new Vector2(_value, 1f)),
+            };
             rt.offsetMin = Vector2.zero;
             rt.offsetMax = Vector2.zero;
         }

--- a/Runtime/Controls/Progress.cs
+++ b/Runtime/Controls/Progress.cs
@@ -24,7 +24,11 @@ namespace PromptUGUI.Controls
         public float Value
         {
             get => _value;
-            set => _value = Mathf.Clamp01(value);
+            set
+            {
+                _value = Mathf.Clamp01(value);
+                ReconcileFill();
+            }
         }
 
         internal override void OnAfterApply()

--- a/Runtime/Controls/Progress.cs
+++ b/Runtime/Controls/Progress.cs
@@ -1,3 +1,4 @@
+using PromptUGUI.Application;
 using PromptUGUI.Controls.Internal;
 using PromptUGUI.Registry;
 using UnityEngine;
@@ -52,6 +53,26 @@ namespace PromptUGUI.Controls
                 if (string.IsNullOrEmpty(value)) return;
                 _mode = value;
                 ReconcileFill();
+            }
+        }
+
+        [UIAttr, Preserve]
+        public string Fill
+        {
+            set
+            {
+                _fill.sprite = UI.ResolveSprite(value);
+                ReconcileFill();
+            }
+        }
+
+        [UIAttr, Preserve]
+        public string FillColor
+        {
+            set
+            {
+                if (string.IsNullOrEmpty(value)) return;
+                if (ColorUtility.TryParseHtmlString(value, out var c)) _fill.color = c;
             }
         }
 

--- a/Runtime/Controls/Progress.cs.meta
+++ b/Runtime/Controls/Progress.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 84bc60aabba6f0540a042e5521de1231

--- a/Runtime/Core/Lint/IRWalker.cs
+++ b/Runtime/Core/Lint/IRWalker.cs
@@ -33,8 +33,8 @@ namespace PromptUGUI.Lint
 
         private static IEnumerable<LintIssue> WalkNode(ElementNode node)
         {
-            // Self-checks (tag-specific). Mask rules are about the node itself,
-            // not its parent (unlike LayoutGroupChildRules which is parent-relative).
+            // Per-tag self-checks (mirror of ScreenInstantiator dispatch; CLI errors).
+            // Self-relative — about the node itself, unlike parent-relative LayoutGroupChildRules.
             if (node.Tag == "Frame")
                 foreach (var issue in MaskAttributeRules.CheckFrame(node))
                     yield return issue;

--- a/Runtime/Core/Lint/IRWalker.cs
+++ b/Runtime/Core/Lint/IRWalker.cs
@@ -41,6 +41,9 @@ namespace PromptUGUI.Lint
             else if (node.Tag == "Image")
                 foreach (var issue in MaskAttributeRules.CheckImage(node))
                     yield return issue;
+            else if (node.Tag == "Progress")
+                foreach (var issue in ProgressAttributeRules.CheckProgress(node))
+                    yield return issue;
 
             // CLI-only: pure containers carry no Graphic; sprite/color silently dropped.
             // Intentionally NOT dispatched from ScreenInstantiator — see rule's XML docs.

--- a/Runtime/Core/Lint/ProgressAttributeRules.cs
+++ b/Runtime/Core/Lint/ProgressAttributeRules.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Globalization;
+using PromptUGUI.IR;
+
+namespace PromptUGUI.Lint
+{
+    /// <summary>
+    /// Lint rules for the &lt;Progress&gt; control's attribute family.
+    /// Consumed by both <c>IRWalker</c> (UIXmlLint CLI) and <c>ScreenInstantiator</c>
+    /// (runtime warnings). Single source of truth — mirrors MaskAttributeRules.
+    /// </summary>
+    public static class ProgressAttributeRules
+    {
+        public const string ValueRangeCode = "PUI-PROG-VALUE-RANGE";
+        public const string ModeCode = "PUI-PROG-MODE";
+        public const string DirectionCode = "PUI-PROG-DIRECTION";
+        public const string ChildrenCode = "PUI-PROG-CHILDREN";
+        public const string MaskVariantCode = "PUI-PROG-MASK-VARIANT";
+        public const string NoFillCode = "PUI-PROG-NO-FILL";
+
+        private static readonly HashSet<string> ValidModes = new HashSet<string> { "scale", "fill" };
+        private static readonly HashSet<string> ValidDirections = new HashSet<string>
+        {
+            "horizontal", "vertical", "reverse-horizontal", "reverse-vertical"
+        };
+
+        public static IEnumerable<LintIssue> CheckProgress(ElementNode n)
+        {
+            // value range (literal only — dynamic bindings parse as non-numeric and skip)
+            if (n.Attributes.TryGetValue("value", out var rawValue)
+                && float.TryParse(rawValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var v)
+                && (v < 0f || v > 1f))
+            {
+                yield return new LintIssue(
+                    ValueRangeCode, n.Tag, n.Id,
+                    $"<Progress id='{n.Id}'>: value='{rawValue}' is outside [0..1] and will be clamped. " +
+                    "Adjust the literal, or ignore this if you bind value dynamically.");
+            }
+
+            // mode
+            if (n.Attributes.TryGetValue("mode", out var mode) && !ValidModes.Contains(mode))
+            {
+                yield return new LintIssue(
+                    ModeCode, n.Tag, n.Id,
+                    $"<Progress id='{n.Id}'>: mode='{mode}' is invalid. Valid: scale, fill.");
+            }
+
+            // direction
+            if (n.Attributes.TryGetValue("direction", out var dir) && !ValidDirections.Contains(dir))
+            {
+                yield return new LintIssue(
+                    DirectionCode, n.Tag, n.Id,
+                    $"<Progress id='{n.Id}'>: direction='{dir}' is invalid. " +
+                    "Valid: horizontal, vertical, reverse-horizontal, reverse-vertical.");
+            }
+
+            // children
+            if (n.Children.Count > 0)
+            {
+                yield return new LintIssue(
+                    ChildrenCode, n.Tag, n.Id,
+                    $"<Progress id='{n.Id}'>: Progress is a leaf control and does not accept child elements. " +
+                    "Use the frame / mask / bg / fill attributes to compose the visual layers.");
+            }
+
+            // mask variant override
+            if (n.VariantOverrides.ContainsKey("mask"))
+            {
+                yield return new LintIssue(
+                    MaskVariantCode, n.Tag, n.Id,
+                    $"<Progress id='{n.Id}'>: mask cannot be overridden per Variant (would require " +
+                    "AddComponent/Destroy at runtime). Fix mask in the base declaration; other attrs " +
+                    "(value / fill / bg / mode / direction) are safe in variants.");
+            }
+
+            // no fill (warning when value is set but no fill or fillColor)
+            if (n.Attributes.ContainsKey("value")
+                && !n.Attributes.ContainsKey("fill")
+                && !n.Attributes.ContainsKey("fillColor"))
+            {
+                yield return new LintIssue(
+                    NoFillCode, n.Tag, n.Id,
+                    $"<Progress id='{n.Id}'>: value is set but neither fill nor fillColor — " +
+                    "nothing will be visibly filled.");
+            }
+        }
+    }
+}

--- a/Runtime/Core/Lint/ProgressAttributeRules.cs.meta
+++ b/Runtime/Core/Lint/ProgressAttributeRules.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b6aa034ab48b0054e81f4b2b7c6e44cd

--- a/Tests/EditMode/Controls/ProgressTests.cs
+++ b/Tests/EditMode/Controls/ProgressTests.cs
@@ -95,6 +95,17 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var p = Open("<Progress id='p' value='1'/>");
             var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
             Assert.AreEqual(new Vector2(1f, 1f), fill.anchorMax);
+            Assert.AreEqual(Vector2.zero, fill.offsetMin, "offsetMin must be zeroed by ReconcileFill");
+        }
+
+        [Test]
+        public void Value_Setter_At_Runtime_Reconciles_Fill()
+        {
+            var p = Open("<Progress id='p' value='0.2'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
+            Assert.AreEqual(new Vector2(0.2f, 1f), fill.anchorMax, "initial XML state");
+            p.Value = 0.7f;
+            Assert.AreEqual(new Vector2(0.7f, 1f), fill.anchorMax, "runtime setter must repaint Fill");
         }
     }
 }

--- a/Tests/EditMode/Controls/ProgressTests.cs
+++ b/Tests/EditMode/Controls/ProgressTests.cs
@@ -265,5 +265,25 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var bg = p.GameObject.transform.Find("MaskWrapper/Bg");
             Assert.IsFalse(bg.gameObject.activeSelf);
         }
+
+        [Test]
+        public void Frame_Sprite_Activates_Frame_Layer_With_Raycast_Off()
+        {
+            var p = Open("<Progress id='p' frame='PromptUGUI/Defaults/pugui#pugui_9slice_round'/>");
+            var frame = p.GameObject.transform.Find("Frame");
+            Assert.IsTrue(frame.gameObject.activeSelf);
+            var img = frame.GetComponent<UnityImage>();
+            Assert.IsNotNull(img.sprite);
+            Assert.AreEqual(UnityImage.Type.Sliced, img.type, "9-slice sprite auto-Sliced");
+            Assert.IsFalse(img.raycastTarget, "Frame must not eat input (PB-D16)");
+        }
+
+        [Test]
+        public void No_Frame_Frame_Layer_Stays_Inactive()
+        {
+            var p = Open("<Progress id='p' fill='PromptUGUI/Defaults/pugui#pugui_9slice_round'/>");
+            var frame = p.GameObject.transform.Find("Frame");
+            Assert.IsFalse(frame.gameObject.activeSelf);
+        }
     }
 }

--- a/Tests/EditMode/Controls/ProgressTests.cs
+++ b/Tests/EditMode/Controls/ProgressTests.cs
@@ -48,5 +48,27 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.IsNull(p.GameObject.GetComponent<UnityImage>(),
                 "Progress root is a pure RectTransform host, no Graphic");
         }
+
+        [Test]
+        public void Value_Stores_InRangeAsIs()
+        {
+            var p = Open("<Progress id='p' value='0.5'/>");
+            Assert.AreEqual(0.5f, p.Value);
+        }
+
+        [Test]
+        public void Value_Below_Zero_Clamps_To_Zero()
+        {
+            var p = Open("<Progress id='p'/>");
+            p.Value = -0.3f;
+            Assert.AreEqual(0f, p.Value);
+        }
+
+        [Test]
+        public void Value_Above_One_Clamps_To_One()
+        {
+            var p = Open("<Progress id='p' value='1.7'/>");
+            Assert.AreEqual(1f, p.Value);
+        }
     }
 }

--- a/Tests/EditMode/Controls/ProgressTests.cs
+++ b/Tests/EditMode/Controls/ProgressTests.cs
@@ -107,5 +107,42 @@ namespace PromptUGUI.Tests.EditMode.Controls
             p.Value = 0.7f;
             Assert.AreEqual(new Vector2(0.7f, 1f), fill.anchorMax, "runtime setter must repaint Fill");
         }
+
+        [Test]
+        public void Scale_ReverseHorizontal_Anchors_From_Right()
+        {
+            var p = Open("<Progress id='p' value='0.25' direction='reverse-horizontal'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
+            Assert.AreEqual(new Vector2(0.75f, 0f), fill.anchorMin);
+            Assert.AreEqual(new Vector2(1f, 1f), fill.anchorMax);
+        }
+
+        [Test]
+        public void Scale_Vertical_Anchors_From_Bottom()
+        {
+            var p = Open("<Progress id='p' value='0.4' direction='vertical'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
+            Assert.AreEqual(Vector2.zero, fill.anchorMin);
+            Assert.AreEqual(new Vector2(1f, 0.4f), fill.anchorMax);
+        }
+
+        [Test]
+        public void Scale_ReverseVertical_Anchors_From_Top()
+        {
+            var p = Open("<Progress id='p' value='0.4' direction='reverse-vertical'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
+            Assert.AreEqual(new Vector2(0f, 0.6f), fill.anchorMin);
+            Assert.AreEqual(new Vector2(1f, 1f), fill.anchorMax);
+        }
+
+        [Test]
+        public void Direction_Setter_At_Runtime_Reconciles_Fill()
+        {
+            var p = Open("<Progress id='p' value='0.4'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
+            Assert.AreEqual(new Vector2(0.4f, 1f), fill.anchorMax, "initial horizontal");
+            p.Direction = "vertical";
+            Assert.AreEqual(new Vector2(1f, 0.4f), fill.anchorMax, "runtime direction switch must repaint Fill");
+        }
     }
 }

--- a/Tests/EditMode/Controls/ProgressTests.cs
+++ b/Tests/EditMode/Controls/ProgressTests.cs
@@ -285,5 +285,53 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var frame = p.GameObject.transform.Find("Frame");
             Assert.IsFalse(frame.gameObject.activeSelf);
         }
+
+        [Test]
+        public void Mask_Alone_Adds_Image_Plus_Mask_With_ShowMaskGraphic_True()
+        {
+            var p = Open("<Progress id='p' mask='PromptUGUI/Defaults/pugui#pugui_9slice_mask'/>");
+            var wrapper = p.GameObject.transform.Find("MaskWrapper").gameObject;
+            Assert.IsNotNull(wrapper.GetComponent<UnityImage>(), "mask= adds UnityImage to wrapper");
+            var m = wrapper.GetComponent<UnityMask>();
+            Assert.IsNotNull(m, "mask= adds UI.Mask");
+            Assert.IsTrue(m.showMaskGraphic, "no bg → mask sprite visible (PB-D9)");
+        }
+
+        [Test]
+        public void Mask_With_Bg_Sprite_Hides_Mask_Graphic()
+        {
+            var p = Open("<Progress id='p' mask='PromptUGUI/Defaults/pugui#pugui_9slice_mask' bg='PromptUGUI/Defaults/pugui#pugui_9slice_round'/>");
+            var wrapper = p.GameObject.transform.Find("MaskWrapper").gameObject;
+            var m = wrapper.GetComponent<UnityMask>();
+            Assert.IsFalse(m.showMaskGraphic, "bg present → mask is invisible stencil only (PB-D10)");
+        }
+
+        [Test]
+        public void Mask_With_BgColor_Only_Hides_Mask_Graphic()
+        {
+            var p = Open("<Progress id='p' mask='PromptUGUI/Defaults/pugui#pugui_9slice_mask' bgColor='#222222'/>");
+            var m = p.GameObject.transform.Find("MaskWrapper").GetComponent<UnityMask>();
+            Assert.IsFalse(m.showMaskGraphic, "bgColor alone also counts as bg present");
+        }
+
+        [Test]
+        public void No_Mask_No_Image_No_Mask_Component_On_Wrapper()
+        {
+            var p = Open("<Progress id='p' fill='PromptUGUI/Defaults/pugui#pugui_9slice_round'/>");
+            var wrapper = p.GameObject.transform.Find("MaskWrapper").gameObject;
+            Assert.IsNull(wrapper.GetComponent<UnityImage>());
+            Assert.IsNull(wrapper.GetComponent<UnityMask>());
+        }
+
+        [Test]
+        public void Mask_Then_Bg_At_Runtime_Updates_ShowMaskGraphic()
+        {
+            // Demonstrates the runtime ordering: mask set first, bg added later.
+            var p = Open("<Progress id='p' mask='PromptUGUI/Defaults/pugui#pugui_9slice_mask'/>");
+            var m = p.GameObject.transform.Find("MaskWrapper").GetComponent<UnityMask>();
+            Assert.IsTrue(m.showMaskGraphic, "no bg yet → mask visible");
+            p.Bg = "PromptUGUI/Defaults/pugui#pugui_9slice_round";
+            Assert.IsFalse(m.showMaskGraphic, "runtime bg= activation must hide mask graphic");
+        }
     }
 }

--- a/Tests/EditMode/Controls/ProgressTests.cs
+++ b/Tests/EditMode/Controls/ProgressTests.cs
@@ -336,5 +336,37 @@ namespace PromptUGUI.Tests.EditMode.Controls
             p.Bg = "PromptUGUI/Defaults/pugui#pugui_9slice_round";
             Assert.IsFalse(m.showMaskGraphic, "runtime bg= activation must hide mask graphic");
         }
+
+        [Test]
+        public void GetNativeSize_Default_Is_160x16()
+        {
+            var p = Open("<Progress id='p'/>");
+            var n = p.GetNativeSize();
+            Assert.IsTrue(n.HasValue);
+            Assert.AreEqual(new Vector2(160f, 16f), n.Value);
+        }
+
+        [Test]
+        public void GetNativeSize_Falls_Back_To_Bg_When_No_Frame()
+        {
+            var p = Open("<Progress id='p' bg='PromptUGUI/Defaults/pugui#pugui_9slice_round'/>");
+            var n = p.GetNativeSize();
+            Assert.IsTrue(n.HasValue);
+            var img = p.GameObject.transform.Find("MaskWrapper/Bg").GetComponent<UnityImage>();
+            var expected = new Vector2(img.sprite.rect.width / img.pixelsPerUnit,
+                                       img.sprite.rect.height / img.pixelsPerUnit);
+            Assert.AreEqual(expected, n.Value);
+        }
+
+        [Test]
+        public void GetNativeSize_Prefers_Frame_Over_Bg()
+        {
+            var p = Open("<Progress id='p' bg='PromptUGUI/Defaults/pugui#pugui_9slice_round' frame='PromptUGUI/Defaults/pugui#pugui_9slice_mask'/>");
+            var n = p.GetNativeSize();
+            var img = p.GameObject.transform.Find("Frame").GetComponent<UnityImage>();
+            var expected = new Vector2(img.sprite.rect.width / img.pixelsPerUnit,
+                                       img.sprite.rect.height / img.pixelsPerUnit);
+            Assert.AreEqual(expected, n.Value);
+        }
     }
 }

--- a/Tests/EditMode/Controls/ProgressTests.cs
+++ b/Tests/EditMode/Controls/ProgressTests.cs
@@ -2,7 +2,6 @@ using NUnit.Framework;
 using PromptUGUI.Application;
 using PromptUGUI.Controls;
 using UnityEngine;
-using UnityEngine.UI;
 using UnityImage = UnityEngine.UI.Image;
 using UnityMask = UnityEngine.UI.Mask;
 

--- a/Tests/EditMode/Controls/ProgressTests.cs
+++ b/Tests/EditMode/Controls/ProgressTests.cs
@@ -144,5 +144,62 @@ namespace PromptUGUI.Tests.EditMode.Controls
             p.Direction = "vertical";
             Assert.AreEqual(new Vector2(1f, 0.4f), fill.anchorMax, "runtime direction switch must repaint Fill");
         }
+
+        [Test]
+        public void Fill_Horizontal_Sets_Type_Filled_And_FillAmount()
+        {
+            var p = Open("<Progress id='p' value='0.7' mode='fill'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            Assert.AreEqual(UnityImage.Type.Filled, fill.type);
+            Assert.AreEqual(UnityImage.FillMethod.Horizontal, fill.fillMethod);
+            Assert.AreEqual((int)UnityImage.OriginHorizontal.Left, fill.fillOrigin);
+            Assert.AreEqual(0.7f, fill.fillAmount);
+            var rt = fill.rectTransform;
+            Assert.AreEqual(Vector2.zero, rt.anchorMin);
+            Assert.AreEqual(Vector2.one, rt.anchorMax);
+        }
+
+        [Test]
+        public void Fill_ReverseHorizontal_Origin_Right()
+        {
+            var p = Open("<Progress id='p' value='0.5' mode='fill' direction='reverse-horizontal'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            Assert.AreEqual(UnityImage.FillMethod.Horizontal, fill.fillMethod);
+            Assert.AreEqual((int)UnityImage.OriginHorizontal.Right, fill.fillOrigin);
+        }
+
+        [Test]
+        public void Fill_Vertical_Origin_Bottom()
+        {
+            var p = Open("<Progress id='p' value='0.5' mode='fill' direction='vertical'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            Assert.AreEqual(UnityImage.FillMethod.Vertical, fill.fillMethod);
+            Assert.AreEqual((int)UnityImage.OriginVertical.Bottom, fill.fillOrigin);
+        }
+
+        [Test]
+        public void Fill_ReverseVertical_Origin_Top()
+        {
+            var p = Open("<Progress id='p' value='0.5' mode='fill' direction='reverse-vertical'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            Assert.AreEqual(UnityImage.FillMethod.Vertical, fill.fillMethod);
+            Assert.AreEqual((int)UnityImage.OriginVertical.Top, fill.fillOrigin);
+        }
+
+        [Test]
+        public void Switch_From_Fill_Back_To_Scale_Resets_Type_And_FillAmount()
+        {
+            var p = Open("<Progress id='p' value='0.6' mode='fill'/>");
+            // sanity
+            var fillImg = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            Assert.AreEqual(UnityImage.Type.Filled, fillImg.type, "starts as Filled");
+
+            p.Mode = "scale";
+            Assert.AreNotEqual(UnityImage.Type.Filled, fillImg.type,
+                "switching back to scale must reset away from Filled");
+            Assert.AreEqual(1f, fillImg.fillAmount, "scale mode resets fillAmount to 1");
+            var rt = fillImg.rectTransform;
+            Assert.AreEqual(new Vector2(0.6f, 1f), rt.anchorMax, "scale anchorMax reflects value");
+        }
     }
 }

--- a/Tests/EditMode/Controls/ProgressTests.cs
+++ b/Tests/EditMode/Controls/ProgressTests.cs
@@ -1,0 +1,52 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityImage = UnityEngine.UI.Image;
+using UnityMask = UnityEngine.UI.Mask;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class ProgressTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static Progress Open(string innerXml)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{innerXml}</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S").Get<Progress>("p");
+        }
+
+        [Test]
+        public void Empty_Progress_Has_MaskWrapper_Fill_Frame_Children()
+        {
+            var p = Open("<Progress id='p'/>");
+            var maskWrapper = p.GameObject.transform.Find("MaskWrapper") as RectTransform;
+            var bg = p.GameObject.transform.Find("MaskWrapper/Bg") as RectTransform;
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
+            var frame = p.GameObject.transform.Find("Frame") as RectTransform;
+            Assert.IsNotNull(maskWrapper, "MaskWrapper RT");
+            Assert.IsNotNull(bg, "Bg RT (inside MaskWrapper)");
+            Assert.IsNotNull(fill, "Fill RT (inside MaskWrapper)");
+            Assert.IsNotNull(frame, "Frame RT");
+            Assert.IsFalse(bg.gameObject.activeSelf, "Bg starts disabled");
+            Assert.IsFalse(frame.gameObject.activeSelf, "Frame starts disabled");
+            Assert.IsNull(maskWrapper.gameObject.GetComponent<UnityMask>(),
+                "no mask= → no UI.Mask on MaskWrapper");
+            Assert.IsNull(maskWrapper.gameObject.GetComponent<UnityImage>(),
+                "no mask= → no UnityImage on MaskWrapper");
+        }
+
+        [Test]
+        public void Progress_Root_Has_No_Image()
+        {
+            var p = Open("<Progress id='p'/>");
+            Assert.IsNull(p.GameObject.GetComponent<UnityImage>(),
+                "Progress root is a pure RectTransform host, no Graphic");
+        }
+    }
+}

--- a/Tests/EditMode/Controls/ProgressTests.cs
+++ b/Tests/EditMode/Controls/ProgressTests.cs
@@ -201,5 +201,39 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var rt = fillImg.rectTransform;
             Assert.AreEqual(new Vector2(0.6f, 1f), rt.anchorMax, "scale anchorMax reflects value");
         }
+
+        [Test]
+        public void Fill_Sprite_Resolves_Via_UI_ResolveSprite()
+        {
+            var p = Open("<Progress id='p' fill='PromptUGUI/Defaults/pugui#pugui_9slice_round'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            Assert.IsNotNull(fill.sprite, "sprite resolved from atlas key");
+            Assert.AreEqual("pugui_9slice_round", fill.sprite.name);
+        }
+
+        [Test]
+        public void Fill_9Slice_Sprite_Auto_Sliced_In_Scale_Mode()
+        {
+            var p = Open("<Progress id='p' value='0.5' fill='PromptUGUI/Defaults/pugui#pugui_9slice_round'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            Assert.AreEqual(UnityImage.Type.Sliced, fill.type);
+        }
+
+        [Test]
+        public void Fill_9Slice_Sprite_Becomes_Filled_When_Mode_Is_Fill()
+        {
+            var p = Open("<Progress id='p' value='0.5' mode='fill' fill='PromptUGUI/Defaults/pugui#pugui_9slice_round'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            Assert.AreEqual(UnityImage.Type.Filled, fill.type,
+                "mode=fill must force Filled even for 9-slice sprites");
+        }
+
+        [Test]
+        public void FillColor_Parses_Hex()
+        {
+            var p = Open("<Progress id='p' fillColor='#ff0000'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            Assert.AreEqual(Color.red, fill.color);
+        }
     }
 }

--- a/Tests/EditMode/Controls/ProgressTests.cs
+++ b/Tests/EditMode/Controls/ProgressTests.cs
@@ -69,5 +69,32 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var p = Open("<Progress id='p' value='1.7'/>");
             Assert.AreEqual(1f, p.Value);
         }
+
+        [Test]
+        public void Scale_Horizontal_Value_Half_Anchors_Right_At_Half()
+        {
+            var p = Open("<Progress id='p' value='0.5'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
+            Assert.AreEqual(Vector2.zero, fill.anchorMin);
+            Assert.AreEqual(new Vector2(0.5f, 1f), fill.anchorMax);
+            Assert.AreEqual(Vector2.zero, fill.offsetMin);
+            Assert.AreEqual(Vector2.zero, fill.offsetMax);
+        }
+
+        [Test]
+        public void Scale_Horizontal_Value_Zero_Fill_Is_Zero_Width()
+        {
+            var p = Open("<Progress id='p' value='0'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
+            Assert.AreEqual(new Vector2(0f, 1f), fill.anchorMax);
+        }
+
+        [Test]
+        public void Scale_Horizontal_Value_One_Fill_Full_Width()
+        {
+            var p = Open("<Progress id='p' value='1'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
+            Assert.AreEqual(new Vector2(1f, 1f), fill.anchorMax);
+        }
     }
 }

--- a/Tests/EditMode/Controls/ProgressTests.cs
+++ b/Tests/EditMode/Controls/ProgressTests.cs
@@ -291,7 +291,10 @@ namespace PromptUGUI.Tests.EditMode.Controls
         {
             var p = Open("<Progress id='p' mask='PromptUGUI/Defaults/pugui#pugui_9slice_mask'/>");
             var wrapper = p.GameObject.transform.Find("MaskWrapper").gameObject;
-            Assert.IsNotNull(wrapper.GetComponent<UnityImage>(), "mask= adds UnityImage to wrapper");
+            var img = wrapper.GetComponent<UnityImage>();
+            Assert.IsNotNull(img, "mask= adds UnityImage to wrapper");
+            Assert.IsFalse(img.raycastTarget, "mask graphic must not eat input (PB-D16)");
+            Assert.AreEqual(UnityImage.Type.Sliced, img.type, "9-slice mask sprite auto-Sliced (PB-D15)");
             var m = wrapper.GetComponent<UnityMask>();
             Assert.IsNotNull(m, "mask= adds UI.Mask");
             Assert.IsTrue(m.showMaskGraphic, "no bg → mask sprite visible (PB-D9)");

--- a/Tests/EditMode/Controls/ProgressTests.cs
+++ b/Tests/EditMode/Controls/ProgressTests.cs
@@ -235,5 +235,35 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
             Assert.AreEqual(Color.red, fill.color);
         }
+
+        [Test]
+        public void Bg_Sprite_Activates_Bg_Layer()
+        {
+            var p = Open("<Progress id='p' bg='PromptUGUI/Defaults/pugui#pugui_9slice_round'/>");
+            var bg = p.GameObject.transform.Find("MaskWrapper/Bg");
+            Assert.IsTrue(bg.gameObject.activeSelf, "Bg activated by bg=");
+            var img = bg.GetComponent<UnityImage>();
+            Assert.IsNotNull(img.sprite);
+            Assert.AreEqual(UnityImage.Type.Sliced, img.type, "9-slice sprite auto-Sliced");
+        }
+
+        [Test]
+        public void BgColor_Alone_Activates_Bg_Layer_With_Color()
+        {
+            var p = Open("<Progress id='p' bgColor='#222222'/>");
+            var bg = p.GameObject.transform.Find("MaskWrapper/Bg");
+            Assert.IsTrue(bg.gameObject.activeSelf, "Bg activated by bgColor= alone");
+            var img = bg.GetComponent<UnityImage>();
+            ColorUtility.TryParseHtmlString("#222222", out var expected);
+            Assert.AreEqual(expected, img.color);
+        }
+
+        [Test]
+        public void No_Bg_No_BgColor_Bg_Layer_Stays_Inactive()
+        {
+            var p = Open("<Progress id='p' fill='PromptUGUI/Defaults/pugui#pugui_9slice_round'/>");
+            var bg = p.GameObject.transform.Find("MaskWrapper/Bg");
+            Assert.IsFalse(bg.gameObject.activeSelf);
+        }
     }
 }

--- a/Tests/EditMode/Controls/ProgressTests.cs
+++ b/Tests/EditMode/Controls/ProgressTests.cs
@@ -368,5 +368,19 @@ namespace PromptUGUI.Tests.EditMode.Controls
                                        img.sprite.rect.height / img.pixelsPerUnit);
             Assert.AreEqual(expected, n.Value);
         }
+
+        [Test]
+        public void Value_Variant_Override_Reapplies_On_Activation()
+        {
+            var p = Open("<Progress id='p' value='1.0' value.low='0.2' fill='PromptUGUI/Defaults/pugui#pugui_9slice_round'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
+            Assert.AreEqual(new Vector2(1f, 1f), fill.anchorMax, "base value");
+            try
+            {
+                UI.Variants.Set("low", true);
+                Assert.AreEqual(new Vector2(0.2f, 1f), fill.anchorMax, "variant override should re-reconcile Fill");
+            }
+            finally { UI.Variants.Set("low", false); }
+        }
     }
 }

--- a/Tests/EditMode/Controls/ProgressTests.cs.meta
+++ b/Tests/EditMode/Controls/ProgressTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d3982ea586cfbba41a7c4f996b965b92

--- a/Tests/EditMode/Lint/IRWalkerProgressTests.cs
+++ b/Tests/EditMode/Lint/IRWalkerProgressTests.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.IR;
+using PromptUGUI.Lint;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.EditMode.Lint
+{
+    public class IRWalkerProgressTests
+    {
+        private static UIDocument Parse(string innerXml)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{innerXml}</Screen></PromptUGUI>";
+            return UIDocumentParser.Parse(xml);
+        }
+
+        [Test]
+        public void Walker_Dispatches_Progress_Children_Rule()
+        {
+            var doc = Parse("<Progress id='p' fill='ui:bar'><Image/></Progress>");
+            var codes = IRWalker.Walk(doc).Select(i => i.Code).ToList();
+            CollectionAssert.Contains(codes, ProgressAttributeRules.ChildrenCode);
+        }
+
+        [Test]
+        public void Walker_Dispatches_Progress_Mode_Rule()
+        {
+            var doc = Parse("<Progress id='p' mode='radial' fill='ui:bar'/>");
+            var codes = IRWalker.Walk(doc).Select(i => i.Code).ToList();
+            CollectionAssert.Contains(codes, ProgressAttributeRules.ModeCode);
+        }
+
+        [Test]
+        public void Walker_Clean_Progress_No_Issues()
+        {
+            var doc = Parse("<Progress id='p' value='0.5' fill='ui:bar'/>");
+            Assert.IsEmpty(IRWalker.Walk(doc));
+        }
+    }
+}

--- a/Tests/EditMode/Lint/IRWalkerProgressTests.cs.meta
+++ b/Tests/EditMode/Lint/IRWalkerProgressTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 20ef2168810fbee4681e8d3aaf9fea0f

--- a/Tests/EditMode/Lint/ProgressAttributeRulesTests.cs
+++ b/Tests/EditMode/Lint/ProgressAttributeRulesTests.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.IR;
+using PromptUGUI.Lint;
+
+namespace PromptUGUI.Tests.EditMode.Lint
+{
+    public class ProgressAttributeRulesTests
+    {
+        private static ElementNode N(params (string k, string v)[] attrs)
+        {
+            var n = new ElementNode("Progress") { Id = "p" };
+            foreach (var (k, v) in attrs) n.Attributes[k] = v;
+            return n;
+        }
+
+        [Test]
+        public void Clean_Progress_No_Issues()
+        {
+            var n = N(("value", "0.5"), ("fill", "ui:bar"));
+            Assert.IsEmpty(ProgressAttributeRules.CheckProgress(n));
+        }
+
+        // ===== value range =====
+
+        [Test]
+        public void Value_Below_Zero_ValueRange_Warning()
+        {
+            var n = N(("value", "-0.1"), ("fill", "ui:bar"));
+            var issues = ProgressAttributeRules.CheckProgress(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ProgressAttributeRules.ValueRangeCode, issues[0].Code);
+        }
+
+        [Test]
+        public void Value_Above_One_ValueRange_Warning()
+        {
+            var n = N(("value", "1.5"), ("fill", "ui:bar"));
+            var issues = ProgressAttributeRules.CheckProgress(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ProgressAttributeRules.ValueRangeCode, issues[0].Code);
+        }
+
+        [Test]
+        public void Value_Non_Numeric_No_ValueRange_Issue()
+        {
+            // Dynamic binding sources (e.g. "{state.hp}") parse as non-numeric and must
+            // be ignored — lint can only judge literals.
+            var n = N(("value", "{state.hp}"), ("fill", "ui:bar"));
+            Assert.IsEmpty(ProgressAttributeRules.CheckProgress(n));
+        }
+
+        // ===== mode =====
+
+        [Test]
+        public void Mode_Bogus_ModeCode_Error()
+        {
+            var n = N(("mode", "radial"), ("fill", "ui:bar"));
+            var issues = ProgressAttributeRules.CheckProgress(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ProgressAttributeRules.ModeCode, issues[0].Code);
+        }
+
+        [Test]
+        public void Mode_Scale_And_Fill_Both_OK()
+        {
+            Assert.IsEmpty(ProgressAttributeRules.CheckProgress(N(("mode", "scale"), ("fill", "ui:bar"))));
+            Assert.IsEmpty(ProgressAttributeRules.CheckProgress(N(("mode", "fill"), ("fill", "ui:bar"))));
+        }
+
+        // ===== direction =====
+
+        [Test]
+        public void Direction_Bogus_DirectionCode_Error()
+        {
+            var n = N(("direction", "diagonal"), ("fill", "ui:bar"));
+            var issues = ProgressAttributeRules.CheckProgress(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ProgressAttributeRules.DirectionCode, issues[0].Code);
+        }
+
+        [Test]
+        public void Direction_All_Four_Values_OK()
+        {
+            foreach (var d in new[] { "horizontal", "vertical", "reverse-horizontal", "reverse-vertical" })
+                Assert.IsEmpty(ProgressAttributeRules.CheckProgress(N(("direction", d), ("fill", "ui:bar"))),
+                    $"direction='{d}'");
+        }
+
+        // ===== children =====
+
+        [Test]
+        public void Children_ChildrenCode_Error()
+        {
+            var n = N(("fill", "ui:bar"));
+            n.Children.Add(new ElementNode("Image"));
+            var issues = ProgressAttributeRules.CheckProgress(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ProgressAttributeRules.ChildrenCode, issues[0].Code);
+        }
+
+        // ===== mask variant =====
+
+        [Test]
+        public void Mask_In_Variant_Override_MaskVariantCode_Error()
+        {
+            var n = N(("fill", "ui:bar"));
+            n.VariantOverrides["mask"] =
+                new List<(string Variant, string Value)> { ("mobile", "ui:pill") };
+            var issues = ProgressAttributeRules.CheckProgress(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ProgressAttributeRules.MaskVariantCode, issues[0].Code);
+        }
+
+        // ===== no fill =====
+
+        [Test]
+        public void Value_Set_But_No_Fill_Or_FillColor_NoFillCode_Warning()
+        {
+            var n = N(("value", "0.5"));
+            var issues = ProgressAttributeRules.CheckProgress(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ProgressAttributeRules.NoFillCode, issues[0].Code);
+        }
+
+        [Test]
+        public void Value_Plus_Fill_No_NoFill_Issue()
+        {
+            Assert.IsEmpty(ProgressAttributeRules.CheckProgress(N(("value", "0.5"), ("fill", "ui:bar"))));
+        }
+
+        [Test]
+        public void Value_Plus_FillColor_No_NoFill_Issue()
+        {
+            Assert.IsEmpty(ProgressAttributeRules.CheckProgress(N(("value", "0.5"), ("fillColor", "#f00"))));
+        }
+    }
+}

--- a/Tests/EditMode/Lint/ProgressAttributeRulesTests.cs.meta
+++ b/Tests/EditMode/Lint/ProgressAttributeRulesTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f5bc1b95bac1ba24c9475fd67d396d78

--- a/docs~/superpowers/plans/2026-05-27-progress-control.md
+++ b/docs~/superpowers/plans/2026-05-27-progress-control.md
@@ -1,0 +1,1622 @@
+# `<Progress>` Control Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `<Progress>` built-in control: a linear (horizontal / vertical) progress bar that packages frame / mask / bg / fill / mode (scale or `Image.Type.Filled`) / direction / value into one XML element, per spec `2026-05-27-progress-control-design.md`.
+
+**Architecture:** New leaf control `PromptUGUI.Controls.Progress` (mirrors `Slider`'s programmatic-child-tree pattern). Always builds 4 RectTransforms (`MaskWrapper → [Bg, Fill]`, `Frame`); attaches `UnityImage` / `UnityEngine.UI.Mask` lazily by setter. Lint rules live in `Runtime/Core/Lint/ProgressAttributeRules.cs` and are dispatched by both `IRWalker` (CLI) and `ScreenInstantiator` (runtime warnings), matching the `MaskAttributeRules` pattern.
+
+**Tech Stack:** Unity 6, uGUI (`UnityEngine.UI.Image`, `UnityEngine.UI.Mask`), R3, NUnit + Unity Test Framework, Unity MCP for compile + test orchestration.
+
+**Branch:** `feat/progress-control` (already created; spec already committed).
+
+**Verification cadence:** After every source edit, `mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)` → `mcp__UnityMCP__read_console(action="get", types=["error"])`. Run tests via `mcp__UnityMCP__run_tests(...)` with `filter=` per task. Lint CLI: `dotnet run --project .lint/UIXmlLint -- <path>`.
+
+---
+
+## File Structure
+
+| Path | Role | Action |
+|---|---|---|
+| `Runtime/Controls/Progress.cs` | The control: structure + setters + reconcile | **Create** |
+| `Runtime/Application/BuiltinPrimitives.cs` | Register `Progress` tag | **Modify** (1 line) |
+| `Runtime/Core/Lint/ProgressAttributeRules.cs` | 6 lint rules: value range / mode / direction / children / mask-variant / no-fill | **Create** |
+| `Runtime/Core/Lint/IRWalker.cs` | Dispatch `Progress` self-check | **Modify** (add branch to `WalkNode`) |
+| `Runtime/Application/ScreenInstantiator.cs` | Dispatch `Progress` self-check (runtime warning) | **Modify** (add branch ~line 190) |
+| `Tests/EditMode/Controls/ProgressTests.cs` | Runtime behaviour (instantiation / reconcile / layer activation / GetNativeSize) | **Create** |
+| `Tests/EditMode/Lint/ProgressAttributeRulesTests.cs` | Unit tests for the 6 lint rules | **Create** |
+| `Tests/EditMode/Lint/IRWalkerProgressTests.cs` | IRWalker dispatches Progress rules | **Create** |
+| `.claude/skills/authoring-promptugui-xml/SKILL.md` | Add `<Progress>` row + Progress section + lint codes | **Modify** |
+| `.claude/skills/scripting-promptugui-csharp/SKILL.md` | Add `Get<Progress>().Value` note | **Modify** |
+| `docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md` | Add Progress row in §5 | **Modify** |
+
+---
+
+## Tasks
+
+### Task 1: Stub Progress + register + structure smoke test
+
+**Files:**
+- Create: `Runtime/Controls/Progress.cs`
+- Modify: `Runtime/Application/BuiltinPrimitives.cs:24` (add registration line after Slider)
+- Create: `Tests/EditMode/Controls/ProgressTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/EditMode/Controls/ProgressTests.cs`:
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityImage = UnityEngine.UI.Image;
+using UnityMask = UnityEngine.UI.Mask;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class ProgressTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static Progress Open(string innerXml)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{innerXml}</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S").Get<Progress>("p");
+        }
+
+        [Test]
+        public void Empty_Progress_Has_MaskWrapper_Fill_Frame_Children()
+        {
+            var p = Open("<Progress id='p'/>");
+            var maskWrapper = p.GameObject.transform.Find("MaskWrapper") as RectTransform;
+            var bg = p.GameObject.transform.Find("MaskWrapper/Bg") as RectTransform;
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
+            var frame = p.GameObject.transform.Find("Frame") as RectTransform;
+            Assert.IsNotNull(maskWrapper, "MaskWrapper RT");
+            Assert.IsNotNull(bg, "Bg RT (inside MaskWrapper)");
+            Assert.IsNotNull(fill, "Fill RT (inside MaskWrapper)");
+            Assert.IsNotNull(frame, "Frame RT");
+            Assert.IsFalse(bg.gameObject.activeSelf, "Bg starts disabled");
+            Assert.IsFalse(frame.gameObject.activeSelf, "Frame starts disabled");
+            Assert.IsNull(maskWrapper.gameObject.GetComponent<UnityMask>(),
+                "no mask= → no UI.Mask on MaskWrapper");
+            Assert.IsNull(maskWrapper.gameObject.GetComponent<UnityImage>(),
+                "no mask= → no UnityImage on MaskWrapper");
+        }
+
+        [Test]
+        public void Progress_Root_Has_No_Image()
+        {
+            var p = Open("<Progress id='p'/>");
+            Assert.IsNull(p.GameObject.GetComponent<UnityImage>(),
+                "Progress root is a pure RectTransform host, no Graphic");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails (compile error — Progress tag unknown)**
+
+Run via MCP:
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: compile error referencing `PromptUGUI.Controls.Progress` (type doesn't exist).
+
+- [ ] **Step 3: Write minimal Progress.cs**
+
+Create `Runtime/Controls/Progress.cs`:
+
+```csharp
+using PromptUGUI.Controls.Internal;
+using PromptUGUI.Registry;
+using UnityEngine;
+using UnityImage = UnityEngine.UI.Image;
+
+namespace PromptUGUI.Controls
+{
+    /// Linear progress bar (horizontal / vertical, scale or Image.Type.Filled).
+    /// Radial fill (cooldown ring) is intentionally out of scope; introduce a
+    /// <Cooldown> control instead — see spec PB-D6.
+    public sealed class Progress : Control
+    {
+        private UnityImage _bg;
+        private UnityImage _fill;
+        private UnityImage _frame;
+        private UnityImage _maskGraphic;     // null until mask= setter runs
+        private UnityEngine.UI.Mask _stencilMask;
+
+        public override void OnAttached()
+        {
+            // MaskWrapper: stretch wrapper around Bg + Fill. UI.Mask + UnityImage attached
+            // lazily when mask= setter runs (PB-D7 / PB-D8).
+            var maskRt = ProceduralBuilders.AddChild(RectTransform, "MaskWrapper");
+
+            // Bg: pre-built but inactive until bg=/bgColor= sets it (PB-D8 / PB-D9 / PB-D10).
+            var bgRt = ProceduralBuilders.AddChild(maskRt, "Bg");
+            bgRt.gameObject.SetActive(false);
+            _bg = bgRt.gameObject.AddComponent<UnityImage>();
+            _bg.raycastTarget = false;
+
+            // Fill: always present; reconcile writes its anchors or fillAmount.
+            _fill = ProceduralBuilders.AddImage(maskRt, "Fill", raycast: false);
+
+            // Frame: pre-built but inactive until frame= sets it. PB-D16: raycast off.
+            var frameRt = ProceduralBuilders.AddChild(RectTransform, "Frame");
+            frameRt.gameObject.SetActive(false);
+            _frame = frameRt.gameObject.AddComponent<UnityImage>();
+            _frame.raycastTarget = false;
+        }
+    }
+}
+```
+
+Modify `Runtime/Application/BuiltinPrimitives.cs` — after the Slider line (`reg.Register<Slider>("Slider", null);`):
+
+```csharp
+            reg.Register<Slider>("Slider", null);
+            reg.Register<Progress>("Progress", null);
+            reg.Register<Dropdown>("Dropdown", null);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ProgressTests")
+```
+
+Expected: PASS — both tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Progress.cs Runtime/Controls/Progress.cs.meta Runtime/Application/BuiltinPrimitives.cs Tests/EditMode/Controls/ProgressTests.cs Tests/EditMode/Controls/ProgressTests.cs.meta
+git commit -m "feat(progress): stub control + builtin registration + structure test"
+```
+
+(Note: `.meta` files appear after Unity refresh; if they don't exist yet, omit them and a subsequent commit will catch them once Unity generates them.)
+
+---
+
+### Task 2: `value` attr — clamp [0..1]
+
+**Files:**
+- Modify: `Runtime/Controls/Progress.cs` (add `Value` field + setter)
+- Modify: `Tests/EditMode/Controls/ProgressTests.cs` (3 new tests)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `ProgressTests.cs`:
+
+```csharp
+        [Test]
+        public void Value_Stores_InRangeAsIs()
+        {
+            var p = Open("<Progress id='p' value='0.5'/>");
+            Assert.AreEqual(0.5f, p.Value);
+        }
+
+        [Test]
+        public void Value_Below_Zero_Clamps_To_Zero()
+        {
+            var p = Open("<Progress id='p'/>");
+            p.Value = -0.3f;
+            Assert.AreEqual(0f, p.Value);
+        }
+
+        [Test]
+        public void Value_Above_One_Clamps_To_One()
+        {
+            var p = Open("<Progress id='p' value='1.7'/>");
+            Assert.AreEqual(1f, p.Value);
+        }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ProgressTests")
+```
+
+Expected: 3 new tests FAIL ("Value not found" or compile error).
+
+- [ ] **Step 3: Add Value field + setter to Progress.cs**
+
+In `Progress.cs`, add private field below the `_stencilMask` line:
+
+```csharp
+        private float _value;
+```
+
+Add public attr below `OnAttached()`:
+
+```csharp
+        [UIAttr, Preserve]
+        public float Value
+        {
+            get => _value;
+            set => _value = Mathf.Clamp01(value);
+        }
+```
+
+Note: `Mathf.Clamp01` handles NaN → 0 (PB-D19) because `Clamp01` returns 0 for NaN inputs.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ProgressTests")
+```
+
+Expected: PASS — 5 total tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Progress.cs Tests/EditMode/Controls/ProgressTests.cs
+git commit -m "feat(progress): value attr with [0..1] clamp"
+```
+
+---
+
+### Task 3: scale mode + horizontal direction reconcile
+
+Implements the default `mode="scale"` + `direction="horizontal"` path: writing `value` updates `Fill` `anchorMin/anchorMax`.
+
+**Files:**
+- Modify: `Runtime/Controls/Progress.cs` (add `OnAfterApply` + `ReconcileFill`)
+- Modify: `Tests/EditMode/Controls/ProgressTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+Append:
+
+```csharp
+        [Test]
+        public void Scale_Horizontal_Value_Half_Anchors_Right_At_Half()
+        {
+            var p = Open("<Progress id='p' value='0.5'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
+            Assert.AreEqual(Vector2.zero, fill.anchorMin);
+            Assert.AreEqual(new Vector2(0.5f, 1f), fill.anchorMax);
+            Assert.AreEqual(Vector2.zero, fill.offsetMin);
+            Assert.AreEqual(Vector2.zero, fill.offsetMax);
+        }
+
+        [Test]
+        public void Scale_Horizontal_Value_Zero_Fill_Is_Zero_Width()
+        {
+            var p = Open("<Progress id='p' value='0'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
+            Assert.AreEqual(new Vector2(0f, 1f), fill.anchorMax);
+        }
+
+        [Test]
+        public void Scale_Horizontal_Value_One_Fill_Full_Width()
+        {
+            var p = Open("<Progress id='p' value='1'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
+            Assert.AreEqual(new Vector2(1f, 1f), fill.anchorMax);
+        }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Expected: 3 new tests FAIL (anchorMax still default `(1,1)` since reconcile doesn't exist yet).
+
+- [ ] **Step 3: Add OnAfterApply + ReconcileFill (scale-horizontal only)**
+
+In `Progress.cs`, add private fields:
+
+```csharp
+        private string _mode = "scale";
+        private string _direction = "horizontal";
+```
+
+Override `OnAfterApply` (it's `internal virtual` on `Control` — see `Runtime/Controls/Control.cs:54`):
+
+```csharp
+        internal override void OnAfterApply()
+        {
+            ReconcileFill();
+        }
+
+        private void ReconcileFill()
+        {
+            var rt = _fill.rectTransform;
+            // v1 single path: mode=scale, direction=horizontal (other modes/directions
+            // land in tasks 4-5).
+            rt.anchorMin = Vector2.zero;
+            rt.anchorMax = new Vector2(_value, 1f);
+            rt.offsetMin = Vector2.zero;
+            rt.offsetMax = Vector2.zero;
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ProgressTests")
+```
+
+Expected: PASS — 8 total green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Progress.cs Tests/EditMode/Controls/ProgressTests.cs
+git commit -m "feat(progress): scale-mode horizontal reconcile from value"
+```
+
+---
+
+### Task 4: `direction` attr — all four directions in scale mode
+
+**Files:**
+- Modify: `Runtime/Controls/Progress.cs`
+- Modify: `Tests/EditMode/Controls/ProgressTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+Append:
+
+```csharp
+        [Test]
+        public void Scale_ReverseHorizontal_Anchors_From_Right()
+        {
+            var p = Open("<Progress id='p' value='0.25' direction='reverse-horizontal'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
+            Assert.AreEqual(new Vector2(0.75f, 0f), fill.anchorMin);
+            Assert.AreEqual(new Vector2(1f, 1f), fill.anchorMax);
+        }
+
+        [Test]
+        public void Scale_Vertical_Anchors_From_Bottom()
+        {
+            var p = Open("<Progress id='p' value='0.4' direction='vertical'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
+            Assert.AreEqual(Vector2.zero, fill.anchorMin);
+            Assert.AreEqual(new Vector2(1f, 0.4f), fill.anchorMax);
+        }
+
+        [Test]
+        public void Scale_ReverseVertical_Anchors_From_Top()
+        {
+            var p = Open("<Progress id='p' value='0.4' direction='reverse-vertical'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill") as RectTransform;
+            Assert.AreEqual(new Vector2(0f, 0.6f), fill.anchorMin);
+            Assert.AreEqual(new Vector2(1f, 1f), fill.anchorMax);
+        }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Expected: 3 new tests FAIL.
+
+- [ ] **Step 3: Add Direction setter + 4-way switch in ReconcileFill**
+
+Add setter below `Value`:
+
+```csharp
+        [UIAttr, Preserve]
+        public string Direction { set => _direction = value; }
+```
+
+Replace `ReconcileFill` body with the 4-way switch:
+
+```csharp
+        private void ReconcileFill()
+        {
+            var rt = _fill.rectTransform;
+            (rt.anchorMin, rt.anchorMax) = _direction switch
+            {
+                "horizontal"          => (new Vector2(0f, 0f),        new Vector2(_value, 1f)),
+                "reverse-horizontal"  => (new Vector2(1f - _value, 0f), new Vector2(1f, 1f)),
+                "vertical"            => (new Vector2(0f, 0f),        new Vector2(1f, _value)),
+                "reverse-vertical"    => (new Vector2(0f, 1f - _value), new Vector2(1f, 1f)),
+                _                     => (new Vector2(0f, 0f),        new Vector2(_value, 1f)),
+            };
+            rt.offsetMin = Vector2.zero;
+            rt.offsetMax = Vector2.zero;
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ProgressTests")
+```
+
+Expected: PASS — 11 total green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Progress.cs Tests/EditMode/Controls/ProgressTests.cs
+git commit -m "feat(progress): direction attr (4-way switch for scale mode)"
+```
+
+---
+
+### Task 5: `mode="fill"` — Image.Type.Filled with fillMethod/fillOrigin/fillAmount
+
+**Files:**
+- Modify: `Runtime/Controls/Progress.cs`
+- Modify: `Tests/EditMode/Controls/ProgressTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+Append:
+
+```csharp
+        [Test]
+        public void Fill_Horizontal_Sets_Type_Filled_And_FillAmount()
+        {
+            var p = Open("<Progress id='p' value='0.7' mode='fill'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            Assert.AreEqual(UnityImage.Type.Filled, fill.type);
+            Assert.AreEqual(UnityImage.FillMethod.Horizontal, fill.fillMethod);
+            Assert.AreEqual((int)UnityImage.OriginHorizontal.Left, fill.fillOrigin);
+            Assert.AreEqual(0.7f, fill.fillAmount);
+            var rt = fill.rectTransform;
+            Assert.AreEqual(Vector2.zero, rt.anchorMin);
+            Assert.AreEqual(Vector2.one, rt.anchorMax);
+        }
+
+        [Test]
+        public void Fill_ReverseHorizontal_Origin_Right()
+        {
+            var p = Open("<Progress id='p' value='0.5' mode='fill' direction='reverse-horizontal'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            Assert.AreEqual(UnityImage.FillMethod.Horizontal, fill.fillMethod);
+            Assert.AreEqual((int)UnityImage.OriginHorizontal.Right, fill.fillOrigin);
+        }
+
+        [Test]
+        public void Fill_Vertical_Origin_Bottom()
+        {
+            var p = Open("<Progress id='p' value='0.5' mode='fill' direction='vertical'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            Assert.AreEqual(UnityImage.FillMethod.Vertical, fill.fillMethod);
+            Assert.AreEqual((int)UnityImage.OriginVertical.Bottom, fill.fillOrigin);
+        }
+
+        [Test]
+        public void Fill_ReverseVertical_Origin_Top()
+        {
+            var p = Open("<Progress id='p' value='0.5' mode='fill' direction='reverse-vertical'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            Assert.AreEqual(UnityImage.FillMethod.Vertical, fill.fillMethod);
+            Assert.AreEqual((int)UnityImage.OriginVertical.Top, fill.fillOrigin);
+        }
+
+        [Test]
+        public void Switch_From_Fill_Back_To_Scale_Resets_Type_And_FillAmount()
+        {
+            var p = Open("<Progress id='p' value='0.6' mode='fill'/>");
+            p.Mode = "scale";
+            // ReSolve isn't auto-fired; simulate by writing Value to trigger setter path,
+            // but actual reconcile happens in OnAfterApply. We need to call it via re-apply.
+            // Instead use the public setter pattern: setting Mode then Value won't call
+            // OnAfterApply by itself; for this test, set both via XML reload.
+            var p2 = Open("<Progress id='p' value='0.6' mode='scale'/>");
+            var fill = p2.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            Assert.AreNotEqual(UnityImage.Type.Filled, fill.type,
+                "scale mode must reset away from Filled");
+            Assert.AreEqual(1f, fill.fillAmount, "scale mode resets fillAmount to 1");
+            var rt = fill.rectTransform;
+            Assert.AreEqual(new Vector2(0.6f, 1f), rt.anchorMax);
+        }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Expected: 5 new tests FAIL.
+
+- [ ] **Step 3: Add Mode setter + fill branch in ReconcileFill**
+
+Add setter:
+
+```csharp
+        [UIAttr, Preserve]
+        public string Mode { set => _mode = value; }
+```
+
+Replace `ReconcileFill` body with mode dispatch:
+
+```csharp
+        private void ReconcileFill()
+        {
+            var rt = _fill.rectTransform;
+            if (_mode == "fill")
+            {
+                rt.anchorMin = Vector2.zero;
+                rt.anchorMax = Vector2.one;
+                rt.offsetMin = Vector2.zero;
+                rt.offsetMax = Vector2.zero;
+                _fill.type = UnityImage.Type.Filled;
+                (_fill.fillMethod, _fill.fillOrigin) = _direction switch
+                {
+                    "horizontal"         => (UnityImage.FillMethod.Horizontal, (int)UnityImage.OriginHorizontal.Left),
+                    "reverse-horizontal" => (UnityImage.FillMethod.Horizontal, (int)UnityImage.OriginHorizontal.Right),
+                    "vertical"           => (UnityImage.FillMethod.Vertical,   (int)UnityImage.OriginVertical.Bottom),
+                    "reverse-vertical"   => (UnityImage.FillMethod.Vertical,   (int)UnityImage.OriginVertical.Top),
+                    _                    => (UnityImage.FillMethod.Horizontal, (int)UnityImage.OriginHorizontal.Left),
+                };
+                _fill.fillAmount = _value;
+            }
+            else // scale (default)
+            {
+                // Reset away from Filled, then pick Simple/Sliced per sprite border.
+                _fill.fillAmount = 1f;
+                _fill.type = (_fill.sprite != null && _fill.sprite.border != Vector4.zero)
+                    ? UnityImage.Type.Sliced
+                    : UnityImage.Type.Simple;
+                (rt.anchorMin, rt.anchorMax) = _direction switch
+                {
+                    "horizontal"         => (new Vector2(0f, 0f),         new Vector2(_value, 1f)),
+                    "reverse-horizontal" => (new Vector2(1f - _value, 0f), new Vector2(1f, 1f)),
+                    "vertical"           => (new Vector2(0f, 0f),         new Vector2(1f, _value)),
+                    "reverse-vertical"   => (new Vector2(0f, 1f - _value), new Vector2(1f, 1f)),
+                    _                    => (new Vector2(0f, 0f),         new Vector2(_value, 1f)),
+                };
+                rt.offsetMin = Vector2.zero;
+                rt.offsetMax = Vector2.zero;
+            }
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ProgressTests")
+```
+
+Expected: PASS — 16 total green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Progress.cs Tests/EditMode/Controls/ProgressTests.cs
+git commit -m "feat(progress): mode=fill (Image.Type.Filled) + 4-way fillOrigin"
+```
+
+---
+
+### Task 6: `fill` + `fillColor` attrs
+
+**Files:**
+- Modify: `Runtime/Controls/Progress.cs`
+- Modify: `Tests/EditMode/Controls/ProgressTests.cs`
+
+The fill sprite goes through `UI.ResolveSprite` (matches `Image.cs:38`). 9-slice auto-detect happens in `ReconcileFill`'s scale branch (already wired in Task 5).
+
+- [ ] **Step 1: Write failing tests**
+
+Append:
+
+```csharp
+        [Test]
+        public void Fill_Sprite_Resolves_Via_UI_ResolveSprite()
+        {
+            // Use the default atlas sprite shipped with the package
+            var p = Open("<Progress id='p' fill='pugui#pugui_9slice_round'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            Assert.IsNotNull(fill.sprite, "sprite resolved from atlas key");
+            Assert.AreEqual("pugui_9slice_round", fill.sprite.name);
+        }
+
+        [Test]
+        public void Fill_9Slice_Sprite_Auto_Sliced_In_Scale_Mode()
+        {
+            var p = Open("<Progress id='p' value='0.5' fill='pugui#pugui_9slice_round'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            // pugui_9slice_round has non-zero border → Sliced
+            Assert.AreEqual(UnityImage.Type.Sliced, fill.type);
+        }
+
+        [Test]
+        public void Fill_9Slice_Sprite_Becomes_Filled_When_Mode_Is_Fill()
+        {
+            var p = Open("<Progress id='p' value='0.5' mode='fill' fill='pugui#pugui_9slice_round'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            Assert.AreEqual(UnityImage.Type.Filled, fill.type,
+                "mode=fill must force Filled even for 9-slice sprites");
+        }
+
+        [Test]
+        public void FillColor_Parses_Hex()
+        {
+            var p = Open("<Progress id='p' fillColor='#ff0000'/>");
+            var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            Assert.AreEqual(Color.red, fill.color);
+        }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Expected: 4 new tests FAIL.
+
+- [ ] **Step 3: Add Fill + FillColor setters**
+
+In `Progress.cs`, add `using PromptUGUI.Application;` if not present (for `UI.ResolveSprite`).
+
+Add setters below `Direction`:
+
+```csharp
+        [UIAttr, Preserve]
+        public string Fill
+        {
+            set => _fill.sprite = UI.ResolveSprite(value);
+        }
+
+        [UIAttr, Preserve]
+        public string FillColor
+        {
+            set
+            {
+                if (string.IsNullOrEmpty(value)) return;
+                if (ColorUtility.TryParseHtmlString(value, out var c)) _fill.color = c;
+            }
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ProgressTests")
+```
+
+Expected: PASS — 20 total green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Progress.cs Tests/EditMode/Controls/ProgressTests.cs
+git commit -m "feat(progress): fill (sprite) + fillColor attrs"
+```
+
+---
+
+### Task 7: `bg` + `bgColor` attrs — activate Bg layer + auto-Slice
+
+**Files:**
+- Modify: `Runtime/Controls/Progress.cs`
+- Modify: `Tests/EditMode/Controls/ProgressTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+Append:
+
+```csharp
+        [Test]
+        public void Bg_Sprite_Activates_Bg_Layer()
+        {
+            var p = Open("<Progress id='p' bg='pugui#pugui_9slice_round'/>");
+            var bg = p.GameObject.transform.Find("MaskWrapper/Bg");
+            Assert.IsTrue(bg.gameObject.activeSelf, "Bg activated by bg=");
+            var img = bg.GetComponent<UnityImage>();
+            Assert.IsNotNull(img.sprite);
+            Assert.AreEqual(UnityImage.Type.Sliced, img.type, "9-slice sprite auto-Sliced");
+        }
+
+        [Test]
+        public void BgColor_Alone_Activates_Bg_Layer_With_Color()
+        {
+            var p = Open("<Progress id='p' bgColor='#222222'/>");
+            var bg = p.GameObject.transform.Find("MaskWrapper/Bg");
+            Assert.IsTrue(bg.gameObject.activeSelf, "Bg activated by bgColor= alone");
+            var img = bg.GetComponent<UnityImage>();
+            ColorUtility.TryParseHtmlString("#222222", out var expected);
+            Assert.AreEqual(expected, img.color);
+        }
+
+        [Test]
+        public void No_Bg_No_BgColor_Bg_Layer_Stays_Inactive()
+        {
+            var p = Open("<Progress id='p' fill='pugui#pugui_9slice_round'/>");
+            var bg = p.GameObject.transform.Find("MaskWrapper/Bg");
+            Assert.IsFalse(bg.gameObject.activeSelf);
+        }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Expected: 3 new tests FAIL.
+
+- [ ] **Step 3: Add Bg + BgColor setters + AutoSlice call in OnAfterApply**
+
+Add to `Progress.cs`:
+
+```csharp
+        [UIAttr, Preserve]
+        public string Bg
+        {
+            set
+            {
+                _bg.sprite = UI.ResolveSprite(value);
+                _bg.gameObject.SetActive(true);
+            }
+        }
+
+        [UIAttr, Preserve]
+        public string BgColor
+        {
+            set
+            {
+                if (string.IsNullOrEmpty(value)) return;
+                if (!ColorUtility.TryParseHtmlString(value, out var c)) return;
+                _bg.color = c;
+                _bg.gameObject.SetActive(true);
+            }
+        }
+```
+
+Update `OnAfterApply` to also auto-Slice Bg:
+
+```csharp
+        internal override void OnAfterApply()
+        {
+            AutoSlice(_bg);
+            ReconcileFill();
+        }
+
+        private static void AutoSlice(UnityImage img)
+        {
+            if (img == null || img.sprite == null) return;
+            img.type = img.sprite.border != Vector4.zero
+                ? UnityImage.Type.Sliced
+                : UnityImage.Type.Simple;
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Expected: PASS — 23 total green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Progress.cs Tests/EditMode/Controls/ProgressTests.cs
+git commit -m "feat(progress): bg + bgColor attrs (activate Bg layer, auto-Slice)"
+```
+
+---
+
+### Task 8: `frame` attr — activate Frame layer
+
+**Files:**
+- Modify: `Runtime/Controls/Progress.cs`
+- Modify: `Tests/EditMode/Controls/ProgressTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+Append:
+
+```csharp
+        [Test]
+        public void Frame_Sprite_Activates_Frame_Layer_With_Raycast_Off()
+        {
+            var p = Open("<Progress id='p' frame='pugui#pugui_9slice_round'/>");
+            var frame = p.GameObject.transform.Find("Frame");
+            Assert.IsTrue(frame.gameObject.activeSelf);
+            var img = frame.GetComponent<UnityImage>();
+            Assert.IsNotNull(img.sprite);
+            Assert.AreEqual(UnityImage.Type.Sliced, img.type, "9-slice sprite auto-Sliced");
+            Assert.IsFalse(img.raycastTarget, "Frame must not eat input (PB-D16)");
+        }
+
+        [Test]
+        public void No_Frame_Frame_Layer_Stays_Inactive()
+        {
+            var p = Open("<Progress id='p' fill='pugui#pugui_9slice_round'/>");
+            var frame = p.GameObject.transform.Find("Frame");
+            Assert.IsFalse(frame.gameObject.activeSelf);
+        }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Expected: 2 new tests FAIL (no Frame setter yet).
+
+- [ ] **Step 3: Add Frame setter + AutoSlice in OnAfterApply**
+
+```csharp
+        [UIAttr, Preserve]
+        public string Frame
+        {
+            set
+            {
+                _frame.sprite = UI.ResolveSprite(value);
+                _frame.gameObject.SetActive(true);
+            }
+        }
+```
+
+Extend `OnAfterApply`:
+
+```csharp
+        internal override void OnAfterApply()
+        {
+            AutoSlice(_bg);
+            AutoSlice(_frame);
+            ReconcileFill();
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Expected: PASS — 25 total green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Progress.cs Tests/EditMode/Controls/ProgressTests.cs
+git commit -m "feat(progress): frame attr (decorative overlay, raycast off)"
+```
+
+---
+
+### Task 9: `mask` attr + `showMaskGraphic` reconcile
+
+**Files:**
+- Modify: `Runtime/Controls/Progress.cs`
+- Modify: `Tests/EditMode/Controls/ProgressTests.cs`
+
+`UnityEngine.UI.Mask` requires a Graphic on the same GameObject (`UnityImage` in our case). The combined setter creates both. `showMaskGraphic` is determined in `OnAfterApply` (after all setters have run) based on whether `Bg` is active.
+
+- [ ] **Step 1: Write failing tests**
+
+Append:
+
+```csharp
+        [Test]
+        public void Mask_Alone_Adds_Image_Plus_Mask_With_ShowMaskGraphic_True()
+        {
+            var p = Open("<Progress id='p' mask='pugui#pugui_9slice_mask'/>");
+            var wrapper = p.GameObject.transform.Find("MaskWrapper").gameObject;
+            Assert.IsNotNull(wrapper.GetComponent<UnityImage>(), "mask= adds UnityImage to wrapper");
+            var m = wrapper.GetComponent<UnityMask>();
+            Assert.IsNotNull(m, "mask= adds UI.Mask");
+            Assert.IsTrue(m.showMaskGraphic, "no bg → mask sprite visible (PB-D9)");
+        }
+
+        [Test]
+        public void Mask_With_Bg_Sprite_Hides_Mask_Graphic()
+        {
+            var p = Open("<Progress id='p' mask='pugui#pugui_9slice_mask' bg='pugui#pugui_9slice_round'/>");
+            var wrapper = p.GameObject.transform.Find("MaskWrapper").gameObject;
+            var m = wrapper.GetComponent<UnityMask>();
+            Assert.IsFalse(m.showMaskGraphic, "bg present → mask is invisible stencil only (PB-D10)");
+        }
+
+        [Test]
+        public void Mask_With_BgColor_Only_Hides_Mask_Graphic()
+        {
+            var p = Open("<Progress id='p' mask='pugui#pugui_9slice_mask' bgColor='#222222'/>");
+            var m = p.GameObject.transform.Find("MaskWrapper").GetComponent<UnityMask>();
+            Assert.IsFalse(m.showMaskGraphic, "bgColor alone also counts as bg present");
+        }
+
+        [Test]
+        public void No_Mask_No_Image_No_Mask_Component_On_Wrapper()
+        {
+            var p = Open("<Progress id='p' fill='pugui#pugui_9slice_round'/>");
+            var wrapper = p.GameObject.transform.Find("MaskWrapper").gameObject;
+            Assert.IsNull(wrapper.GetComponent<UnityImage>());
+            Assert.IsNull(wrapper.GetComponent<UnityMask>());
+        }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Expected: 4 new tests FAIL.
+
+- [ ] **Step 3: Add Mask setter + showMaskGraphic reconcile**
+
+Add setter (lazy `AddComponent` per PB-D7):
+
+```csharp
+        [UIAttr, Preserve]
+        public string Mask
+        {
+            set
+            {
+                if (_maskGraphic == null)
+                {
+                    var maskRt = (RectTransform)_fill.transform.parent;
+                    _maskGraphic = maskRt.gameObject.AddComponent<UnityImage>();
+                    _maskGraphic.raycastTarget = false;
+                    _stencilMask = maskRt.gameObject.AddComponent<UnityEngine.UI.Mask>();
+                }
+                _maskGraphic.sprite = UI.ResolveSprite(value);
+            }
+        }
+```
+
+Extend `OnAfterApply` to settle `showMaskGraphic` after all setters (incl. Bg) have run:
+
+```csharp
+        internal override void OnAfterApply()
+        {
+            AutoSlice(_bg);
+            AutoSlice(_frame);
+            AutoSlice(_maskGraphic);
+            if (_stencilMask != null)
+                _stencilMask.showMaskGraphic = !_bg.gameObject.activeSelf;
+            ReconcileFill();
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Expected: PASS — 29 total green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Progress.cs Tests/EditMode/Controls/ProgressTests.cs
+git commit -m "feat(progress): mask attr + showMaskGraphic reconcile from bg state"
+```
+
+---
+
+### Task 10: `GetNativeSize()` fallback chain
+
+**Files:**
+- Modify: `Runtime/Controls/Progress.cs`
+- Modify: `Tests/EditMode/Controls/ProgressTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+Append:
+
+```csharp
+        [Test]
+        public void GetNativeSize_Default_Is_160x16()
+        {
+            var p = Open("<Progress id='p'/>");
+            var n = p.GetNativeSize();
+            Assert.IsTrue(n.HasValue);
+            Assert.AreEqual(new Vector2(160f, 16f), n.Value);
+        }
+
+        [Test]
+        public void GetNativeSize_Falls_Back_To_Bg_When_No_Frame()
+        {
+            var p = Open("<Progress id='p' bg='pugui#pugui_9slice_round'/>");
+            var n = p.GetNativeSize();
+            Assert.IsTrue(n.HasValue);
+            // Expected = bg sprite rect / pixelsPerUnit (same formula as Image.GetNativeSize)
+            var img = p.GameObject.transform.Find("MaskWrapper/Bg").GetComponent<UnityImage>();
+            var expected = new Vector2(img.sprite.rect.width / img.pixelsPerUnit,
+                                       img.sprite.rect.height / img.pixelsPerUnit);
+            Assert.AreEqual(expected, n.Value);
+        }
+
+        [Test]
+        public void GetNativeSize_Prefers_Frame_Over_Bg()
+        {
+            var p = Open("<Progress id='p' bg='pugui#pugui_9slice_round' frame='pugui#pugui_9slice_mask'/>");
+            var n = p.GetNativeSize();
+            var img = p.GameObject.transform.Find("Frame").GetComponent<UnityImage>();
+            var expected = new Vector2(img.sprite.rect.width / img.pixelsPerUnit,
+                                       img.sprite.rect.height / img.pixelsPerUnit);
+            Assert.AreEqual(expected, n.Value);
+        }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Expected: 3 new tests FAIL (base `GetNativeSize` returns `null`).
+
+- [ ] **Step 3: Override GetNativeSize**
+
+Add to `Progress.cs`:
+
+```csharp
+        public override Vector2? GetNativeSize()
+        {
+            if (_frame != null && _frame.sprite != null) return NativeOf(_frame);
+            if (_bg != null && _bg.sprite != null) return NativeOf(_bg);
+            return new Vector2(160f, 16f);
+        }
+
+        private static Vector2 NativeOf(UnityImage img)
+        {
+            var ppu = img.pixelsPerUnit;
+            return new Vector2(img.sprite.rect.width / ppu, img.sprite.rect.height / ppu);
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Expected: PASS — 32 total green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Progress.cs Tests/EditMode/Controls/ProgressTests.cs
+git commit -m "feat(progress): GetNativeSize fallback (frame > bg > 160x16)"
+```
+
+---
+
+### Task 11: `ProgressAttributeRules` — 6 lint rules
+
+**Files:**
+- Create: `Runtime/Core/Lint/ProgressAttributeRules.cs`
+- Create: `Tests/EditMode/Lint/ProgressAttributeRulesTests.cs`
+
+Mirrors `MaskAttributeRules.cs`. Rules implemented in this order to make the test file easy to read.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `Tests/EditMode/Lint/ProgressAttributeRulesTests.cs`:
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.IR;
+using PromptUGUI.Lint;
+
+namespace PromptUGUI.Tests.EditMode.Lint
+{
+    public class ProgressAttributeRulesTests
+    {
+        private static ElementNode N(params (string k, string v)[] attrs)
+        {
+            var n = new ElementNode("Progress") { Id = "p" };
+            foreach (var (k, v) in attrs) n.Attributes[k] = v;
+            return n;
+        }
+
+        [Test]
+        public void Clean_Progress_No_Issues()
+        {
+            var n = N(("value", "0.5"), ("fill", "ui:bar"));
+            Assert.IsEmpty(ProgressAttributeRules.CheckProgress(n));
+        }
+
+        // ===== value range =====
+
+        [Test]
+        public void Value_Below_Zero_ValueRange_Warning()
+        {
+            var n = N(("value", "-0.1"), ("fill", "ui:bar"));
+            var issues = ProgressAttributeRules.CheckProgress(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ProgressAttributeRules.ValueRangeCode, issues[0].Code);
+        }
+
+        [Test]
+        public void Value_Above_One_ValueRange_Warning()
+        {
+            var n = N(("value", "1.5"), ("fill", "ui:bar"));
+            var issues = ProgressAttributeRules.CheckProgress(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ProgressAttributeRules.ValueRangeCode, issues[0].Code);
+        }
+
+        [Test]
+        public void Value_Non_Numeric_No_ValueRange_Issue()
+        {
+            // Dynamic binding sources (e.g. "{state.hp}") parse as non-numeric and must
+            // be ignored — lint can only judge literals.
+            var n = N(("value", "{state.hp}"), ("fill", "ui:bar"));
+            Assert.IsEmpty(ProgressAttributeRules.CheckProgress(n));
+        }
+
+        // ===== mode =====
+
+        [Test]
+        public void Mode_Bogus_ModeCode_Error()
+        {
+            var n = N(("mode", "radial"), ("fill", "ui:bar"));
+            var issues = ProgressAttributeRules.CheckProgress(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ProgressAttributeRules.ModeCode, issues[0].Code);
+        }
+
+        [Test]
+        public void Mode_Scale_And_Fill_Both_OK()
+        {
+            Assert.IsEmpty(ProgressAttributeRules.CheckProgress(N(("mode", "scale"), ("fill", "ui:bar"))));
+            Assert.IsEmpty(ProgressAttributeRules.CheckProgress(N(("mode", "fill"), ("fill", "ui:bar"))));
+        }
+
+        // ===== direction =====
+
+        [Test]
+        public void Direction_Bogus_DirectionCode_Error()
+        {
+            var n = N(("direction", "diagonal"), ("fill", "ui:bar"));
+            var issues = ProgressAttributeRules.CheckProgress(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ProgressAttributeRules.DirectionCode, issues[0].Code);
+        }
+
+        [Test]
+        public void Direction_All_Four_Values_OK()
+        {
+            foreach (var d in new[] { "horizontal", "vertical", "reverse-horizontal", "reverse-vertical" })
+                Assert.IsEmpty(ProgressAttributeRules.CheckProgress(N(("direction", d), ("fill", "ui:bar"))),
+                    $"direction='{d}'");
+        }
+
+        // ===== children =====
+
+        [Test]
+        public void Children_ChildrenCode_Error()
+        {
+            var n = N(("fill", "ui:bar"));
+            n.Children.Add(new ElementNode("Image"));
+            var issues = ProgressAttributeRules.CheckProgress(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ProgressAttributeRules.ChildrenCode, issues[0].Code);
+        }
+
+        // ===== mask variant =====
+
+        [Test]
+        public void Mask_In_Variant_Override_MaskVariantCode_Error()
+        {
+            var n = N(("fill", "ui:bar"));
+            n.VariantOverrides["mask"] =
+                new List<(string Variant, string Value)> { ("mobile", "ui:pill") };
+            var issues = ProgressAttributeRules.CheckProgress(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ProgressAttributeRules.MaskVariantCode, issues[0].Code);
+        }
+
+        // ===== no fill =====
+
+        [Test]
+        public void Value_Set_But_No_Fill_Or_FillColor_NoFillCode_Warning()
+        {
+            var n = N(("value", "0.5"));
+            var issues = ProgressAttributeRules.CheckProgress(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ProgressAttributeRules.NoFillCode, issues[0].Code);
+        }
+
+        [Test]
+        public void Value_Plus_Fill_No_NoFill_Issue()
+        {
+            Assert.IsEmpty(ProgressAttributeRules.CheckProgress(N(("value", "0.5"), ("fill", "ui:bar"))));
+        }
+
+        [Test]
+        public void Value_Plus_FillColor_No_NoFill_Issue()
+        {
+            Assert.IsEmpty(ProgressAttributeRules.CheckProgress(N(("value", "0.5"), ("fillColor", "#f00"))));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (compile error — type missing)**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: compile errors referencing `ProgressAttributeRules`.
+
+- [ ] **Step 3: Create ProgressAttributeRules.cs**
+
+Create `Runtime/Core/Lint/ProgressAttributeRules.cs`:
+
+```csharp
+using System.Collections.Generic;
+using System.Globalization;
+using PromptUGUI.IR;
+
+namespace PromptUGUI.Lint
+{
+    /// <summary>
+    /// Lint rules for the <Progress> control's attribute family.
+    /// Consumed by both <c>IRWalker</c> (UIXmlLint CLI) and <c>ScreenInstantiator</c>
+    /// (runtime warnings). Single source of truth — mirrors MaskAttributeRules.
+    /// </summary>
+    public static class ProgressAttributeRules
+    {
+        public const string ValueRangeCode  = "PUI-PROG-VALUE-RANGE";
+        public const string ModeCode        = "PUI-PROG-MODE";
+        public const string DirectionCode   = "PUI-PROG-DIRECTION";
+        public const string ChildrenCode    = "PUI-PROG-CHILDREN";
+        public const string MaskVariantCode = "PUI-PROG-MASK-VARIANT";
+        public const string NoFillCode      = "PUI-PROG-NO-FILL";
+
+        private static readonly HashSet<string> ValidModes = new() { "scale", "fill" };
+        private static readonly HashSet<string> ValidDirections = new()
+        {
+            "horizontal", "vertical", "reverse-horizontal", "reverse-vertical"
+        };
+
+        public static IEnumerable<LintIssue> CheckProgress(ElementNode n)
+        {
+            // value range (literal only — dynamic bindings parse as non-numeric and skip)
+            if (n.Attributes.TryGetValue("value", out var rawValue)
+                && float.TryParse(rawValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var v)
+                && (v < 0f || v > 1f))
+            {
+                yield return new LintIssue(
+                    ValueRangeCode, n.Tag, n.Id,
+                    $"<Progress id='{n.Id}'>: value='{rawValue}' is outside [0..1] and will be clamped. " +
+                    "Adjust the literal, or ignore this if you bind value dynamically.");
+            }
+
+            // mode
+            if (n.Attributes.TryGetValue("mode", out var mode) && !ValidModes.Contains(mode))
+            {
+                yield return new LintIssue(
+                    ModeCode, n.Tag, n.Id,
+                    $"<Progress id='{n.Id}'>: mode='{mode}' is invalid. Valid: scale, fill.");
+            }
+
+            // direction
+            if (n.Attributes.TryGetValue("direction", out var dir) && !ValidDirections.Contains(dir))
+            {
+                yield return new LintIssue(
+                    DirectionCode, n.Tag, n.Id,
+                    $"<Progress id='{n.Id}'>: direction='{dir}' is invalid. " +
+                    "Valid: horizontal, vertical, reverse-horizontal, reverse-vertical.");
+            }
+
+            // children
+            if (n.Children.Count > 0)
+            {
+                yield return new LintIssue(
+                    ChildrenCode, n.Tag, n.Id,
+                    $"<Progress id='{n.Id}'>: Progress is a leaf control and does not accept child elements. " +
+                    "Use the frame / mask / bg / fill attributes to compose the visual layers.");
+            }
+
+            // mask variant override
+            if (n.VariantOverrides.ContainsKey("mask"))
+            {
+                yield return new LintIssue(
+                    MaskVariantCode, n.Tag, n.Id,
+                    $"<Progress id='{n.Id}'>: mask cannot be overridden per Variant (would require " +
+                    "AddComponent/Destroy at runtime). Fix mask in the base declaration; other attrs " +
+                    "(value / fill / bg / mode / direction) are safe in variants.");
+            }
+
+            // no fill (warning when value is set but no fill+fillColor)
+            if (n.Attributes.ContainsKey("value")
+                && !n.Attributes.ContainsKey("fill")
+                && !n.Attributes.ContainsKey("fillColor"))
+            {
+                yield return new LintIssue(
+                    NoFillCode, n.Tag, n.Id,
+                    $"<Progress id='{n.Id}'>: value is set but neither fill nor fillColor — " +
+                    "nothing will be visibly filled.");
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ProgressAttributeRulesTests")
+```
+
+Expected: PASS — 13 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Core/Lint/ProgressAttributeRules.cs Runtime/Core/Lint/ProgressAttributeRules.cs.meta Tests/EditMode/Lint/ProgressAttributeRulesTests.cs Tests/EditMode/Lint/ProgressAttributeRulesTests.cs.meta
+git commit -m "feat(progress): lint rules (value-range / mode / direction / children / mask-variant / no-fill)"
+```
+
+---
+
+### Task 12: Wire IRWalker + ScreenInstantiator dispatch
+
+**Files:**
+- Modify: `Runtime/Core/Lint/IRWalker.cs:38-43` (add Progress branch)
+- Modify: `Runtime/Application/ScreenInstantiator.cs:186-190` (add Progress branch)
+- Create: `Tests/EditMode/Lint/IRWalkerProgressTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `Tests/EditMode/Lint/IRWalkerProgressTests.cs`:
+
+```csharp
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.IR;
+using PromptUGUI.Lint;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.EditMode.Lint
+{
+    public class IRWalkerProgressTests
+    {
+        private static UIDocument Parse(string innerXml)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{innerXml}</Screen></PromptUGUI>";
+            return UIDocumentParser.Parse(xml);
+        }
+
+        [Test]
+        public void Walker_Dispatches_Progress_Children_Rule()
+        {
+            var doc = Parse("<Progress id='p' fill='ui:bar'><Image/></Progress>");
+            var codes = IRWalker.Walk(doc).Select(i => i.Code).ToList();
+            CollectionAssert.Contains(codes, ProgressAttributeRules.ChildrenCode);
+        }
+
+        [Test]
+        public void Walker_Dispatches_Progress_Mode_Rule()
+        {
+            var doc = Parse("<Progress id='p' mode='radial' fill='ui:bar'/>");
+            var codes = IRWalker.Walk(doc).Select(i => i.Code).ToList();
+            CollectionAssert.Contains(codes, ProgressAttributeRules.ModeCode);
+        }
+
+        [Test]
+        public void Walker_Clean_Progress_No_Issues()
+        {
+            var doc = Parse("<Progress id='p' value='0.5' fill='ui:bar'/>");
+            Assert.IsEmpty(IRWalker.Walk(doc));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="IRWalkerProgressTests")
+```
+
+Expected: FAIL — dispatch not wired, codes don't appear in walker output.
+
+- [ ] **Step 3: Add dispatch branches**
+
+In `Runtime/Core/Lint/IRWalker.cs:38-43`, extend the `if/else if` chain:
+
+```csharp
+            if (node.Tag == "Frame")
+                foreach (var issue in MaskAttributeRules.CheckFrame(node))
+                    yield return issue;
+            else if (node.Tag == "Image")
+                foreach (var issue in MaskAttributeRules.CheckImage(node))
+                    yield return issue;
+            else if (node.Tag == "Progress")
+                foreach (var issue in ProgressAttributeRules.CheckProgress(node))
+                    yield return issue;
+```
+
+In `Runtime/Application/ScreenInstantiator.cs:186-190`, add the matching branch (use the same `Debug.LogWarning(issue.Message)` pattern already used for Mask rules):
+
+```csharp
+            if (node.Tag == "Frame")
+                foreach (var issue in MaskAttributeRules.CheckFrame(node))
+                    Debug.LogWarning(issue.Message);
+            else if (node.Tag == "Image")
+                foreach (var issue in MaskAttributeRules.CheckImage(node))
+                    Debug.LogWarning(issue.Message);
+            else if (node.Tag == "Progress")
+                foreach (var issue in ProgressAttributeRules.CheckProgress(node))
+                    Debug.LogWarning(issue.Message);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="IRWalkerProgressTests")
+```
+
+Expected: PASS — 3 green. Also re-run `ProgressTests` and `ProgressAttributeRulesTests` to confirm no regression.
+
+- [ ] **Step 5: Lint CLI smoke**
+
+Create a temp file to confirm the CLI now reports Progress issues:
+
+```bash
+printf '%s\n' '<?xml version="1.0" encoding="utf-8"?>' \
+              '<PromptUGUI version="1"><Screen name="S">' \
+              '  <Progress id="p" mode="radial" fill="ui:bar"/>' \
+              '</Screen></PromptUGUI>' > /tmp/progress-lint-smoke.ui.xml
+dotnet run --project .lint/UIXmlLint -- /tmp/progress-lint-smoke.ui.xml; echo "exit=$?"
+```
+
+Expected: stdout contains `PUI-PROG-MODE`; `exit=1`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Runtime/Core/Lint/IRWalker.cs Runtime/Application/ScreenInstantiator.cs Tests/EditMode/Lint/IRWalkerProgressTests.cs Tests/EditMode/Lint/IRWalkerProgressTests.cs.meta
+git commit -m "feat(progress): wire IRWalker + ScreenInstantiator dispatch"
+```
+
+---
+
+### Task 13: SKILL.md + main spec updates
+
+**Files:**
+- Modify: `.claude/skills/authoring-promptugui-xml/SKILL.md`
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md`
+- Modify: `docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md`
+
+- [ ] **Step 1: Locate the built-in primitives table in the XML skill**
+
+Run:
+
+```bash
+grep -n '<Slider>\|<Dropdown>\|Built-in primitives\|## Controls' .claude/skills/authoring-promptugui-xml/SKILL.md
+```
+
+Identify the row position for `<Progress>` (insert after `<Slider>` to match `BuiltinPrimitives.cs` ordering).
+
+- [ ] **Step 2: Add `<Progress>` row to the built-ins table**
+
+Insert a row after `<Slider>` describing:
+- Tag: `<Progress>`
+- Attrs: `value`, `fill`, `fillColor`, `bg`, `bgColor`, `frame`, `mask`, `mode` (`scale`/`fill`), `direction` (`horizontal`/`vertical`/`reverse-horizontal`/`reverse-vertical`)
+- Purpose: 显示型线性进度条；frame / mask / bg 都可选
+
+- [ ] **Step 3: Add a "Progress" section**
+
+Insert a new section (after the existing Slider section if present, otherwise after the controls table) containing:
+
+1. The 6 examples from spec §4 (verbatim from `docs~/superpowers/specs/2026-05-27-progress-control-design.md` §4).
+2. The 4-row "mask × bg combination" table from spec §6.
+3. The 6 lint codes from spec §8 with one-line summaries.
+4. The boundary note: "radial fill is not supported by `<Progress>` — future `<Cooldown>` control".
+
+- [ ] **Step 4: Update the C# skill**
+
+In `.claude/skills/scripting-promptugui-csharp/SKILL.md`, find the `Get<T>()` / `IControl` section. Insert a paragraph:
+
+> `screen.Get<Progress>("hp").Value = 0.42f;` — Progress 是显示型控件，无 `OnValueChanged`，用 `Bind`-属性或直接 setter 推值。`Value` 被 `Mathf.Clamp01` 钳位。
+
+(If a `## 进度 / Progress` subsection doesn't exist, add a one-line entry under the existing controls list.)
+
+- [ ] **Step 5: Update the main spec controls table**
+
+In `docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md`, find the `<Slider>` row in §5 controls table and add a `<Progress>` row after it:
+
+```markdown
+| `<Progress>` | 线性进度条 (scale / Image.Type.Filled, horizontal / vertical, +可选 frame / mask / bg / fill 装饰) | RectTransform（+ 内部 4 个图层；详见 [`2026-05-27-progress-control-design.md`](2026-05-27-progress-control-design.md)） |
+```
+
+- [ ] **Step 6: Verify rendering / no broken links**
+
+```bash
+grep -n 'Progress' .claude/skills/authoring-promptugui-xml/SKILL.md .claude/skills/scripting-promptugui-csharp/SKILL.md
+grep -n '2026-05-27-progress-control-design' docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
+```
+
+Expected: all three files now reference `<Progress>` / the design doc.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .claude/skills/authoring-promptugui-xml/SKILL.md .claude/skills/scripting-promptugui-csharp/SKILL.md docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
+git commit -m "docs(progress): SKILL.md + main spec entries for <Progress>"
+```
+
+---
+
+### Task 14: Lint + full-suite verification
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Run dotnet format checks**
+
+```bash
+cd .lint && dotnet restore PromptUGUI.Lint.slnx
+dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+Expected: exit 0 (no format violations).
+
+If failures: fix in place, re-run.
+
+- [ ] **Step 2: Run the full EditMode test assembly**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+```
+
+Expected: all green. No regressions in pre-existing tests (especially `ImageMaskTests`, `FrameMaskTests`, `IRWalkerMaskTests` — they share the dispatch path we extended).
+
+- [ ] **Step 3: Run UIXmlLint over the repo's example XML**
+
+```bash
+dotnet run --project .lint/UIXmlLint -- Runtime/Resources/
+```
+
+Expected: exit 0 — no Progress lint issues introduced into shipped XML.
+
+- [ ] **Step 4: Push the branch and open PR**
+
+```bash
+git push -u origin feat/progress-control
+```
+
+Open PR via `gh pr create` (title: `feat: <Progress> control (linear scale + Image.Type.Filled)`). Body should reference the spec at `docs~/superpowers/specs/2026-05-27-progress-control-design.md` and summarise the user-visible additions (1 new tag, 9 attrs, 6 lint codes).
+
+---
+
+## Self-Review
+
+**Spec coverage** (cross-reference against `2026-05-27-progress-control-design.md`):
+
+| Spec section | Task |
+|---|---|
+| §3 attribute table — value | T2 |
+| §3 attribute table — fill / fillColor | T6 |
+| §3 attribute table — bg / bgColor | T7 |
+| §3 attribute table — frame | T8 |
+| §3 attribute table — mask | T9 |
+| §3 attribute table — mode | T5 |
+| §3 attribute table — direction | T4, T5 |
+| §6 fixed hierarchy + activation table | T1 (skeleton), T7 (bg activation), T8 (frame activation), T9 (mask AddComponent + showMaskGraphic) |
+| §7.1 scale-mode anchor formulae | T3 (horizontal default), T4 (other directions) |
+| §7.2 fill-mode fillMethod/Origin | T5 |
+| §7.3 reconcile timing (OnAfterApply) | T3 |
+| §8 lint rules (×6) | T11 (rules + tests), T12 (dispatch) |
+| §9.1 Progress.cs骨架 | T1–T10 incrementally |
+| §9.2 BuiltinPrimitives registration | T1 |
+| §9.3 ProgressAttributeRules | T11 |
+| §9.4 IRWalker dispatch | T12 |
+| §9.5 ScreenInstantiator dispatch | T12 |
+| §10 SKILL + main-spec sync | T13 |
+| §11 out-of-scope (radial, tween, min/max, segmented) | comment in T1 source + no task added (correct) |
+| §12 risks — reconcile resets both branches | T5 step 3 (scale branch resets fillAmount=1 + type away from Filled) |
+| §12 risks — Mask setter `??=` survives variant override bypass | T9 step 3 (the `if (_maskGraphic == null)` gate) |
+| §12 risks — frame raycast off | T1 OnAttached + T8 test |
+
+All spec sections covered. PB-D2 (clamp NaN→0) is handled by `Mathf.Clamp01` (Unity's docs confirm); a test isn't added because NaN literals can't appear in XML — runtime callers writing `p.Value = float.NaN` get clamped to 0.
+
+**Placeholder scan:** no `TBD` / `TODO` / `similar to Task N` / unspecified test bodies. Every code block is complete.
+
+**Type consistency:**
+- `Value` is `float` (T2, T11), matches `Mathf.Clamp01` signature.
+- `Mode` / `Direction` / `Fill` / `FillColor` / `Bg` / `BgColor` / `Frame` / `Mask` all `string` setters, matches `Image.cs` / `Slider.cs` precedent (`[UIAttr]` requires string-typed setters for non-float / non-bool attrs).
+- `ReconcileFill` private void — called from `OnAfterApply`. `AutoSlice` private static void — called from `OnAfterApply`. `NativeOf` private static `Vector2`.
+- `ProgressAttributeRules.CheckProgress` returns `IEnumerable<LintIssue>` (matches `MaskAttributeRules.CheckFrame` / `CheckImage`).
+- All 6 lint code constants (`ValueRangeCode` etc.) referenced in T11 tests match the constants defined in T11 step 3.
+
+No inconsistencies found.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs~/superpowers/plans/2026-05-27-progress-control.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
+++ b/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
@@ -154,6 +154,7 @@ Template 同名（含 commons 与各 Import 的任意组合）→ 报错；`as="
 | `<Icon>` | 项目级 IconSet 中的图标（按名查找，打包期剪枝） | Image |
 | `<Toggle>` | 复选 / 单选（OnValueChanged: bool；group= 字符串键互斥） | Image + Toggle (uGUI) + 内置 label |
 | `<Slider>` | 数值滑块（OnValueChanged: float） | Image + Slider (uGUI) |
+| `<Progress>` | 线性进度条 (scale / Image.Type.Filled, horizontal / vertical, +可选 frame / mask / bg / fill 装饰) | RectTransform（+ 内部 4 个图层；详见 [`2026-05-27-progress-control-design.md`](2026-05-27-progress-control-design.md)） |
 | `<Dropdown>` | 下拉选择（OnSelected: int；BindOptions 推送选项） | TMP_Dropdown |
 | `<ScrollList>` | 滚动列表（BindItems 推送数据；itemTemplate 引用 Template/Control 类） | ScrollRect + Mask |
 

--- a/docs~/superpowers/specs/2026-05-27-progress-control-design.md
+++ b/docs~/superpowers/specs/2026-05-27-progress-control-design.md
@@ -1,0 +1,468 @@
+# `<Progress>` 控件设计
+
+**日期**: 2026-05-27
+**状态**: 设计阶段（待 review，未进入实施）
+**作用域**:
+1. 新增 `Runtime/Controls/Progress.cs`（程序化建子节点，复用 `ProceduralBuilders`）
+2. `Runtime/Application/BuiltinPrimitives.cs` 注册 `Progress`
+3. 新增 `Runtime/Core/Lint/ProgressAttributeRules.cs`（与 `ScreenInstantiator` 共享）
+4. `authoring-promptugui-xml` SKILL.md 新增 `<Progress>` 行 + 一节用例
+5. `scripting-promptugui-csharp` SKILL.md 加上 `Get<Progress>().Value = ...` 的提示
+6. 主 spec `2026-05-07-promptugui-description-language-design.md` §5（控件表）追加行
+
+**依赖**: 无（独立扩展，复用 `UI.ResolveSprite` / `ProceduralBuilders` / Image auto-Sliced 等已有机制）
+
+---
+
+## 1. 背景
+
+当前作者要做进度条只能用现有原语手糊：
+
+```xml
+<Frame>
+  <Image sprite="ui:track"/>              <!-- 底 -->
+  <Image sprite="ui:mask" mask="self">    <!-- 形状裁剪 -->
+    <Image sprite="ui:fill" anchor="stretch" margin="..."/>  <!-- 填充 -->
+  </Image>
+  <Image sprite="ui:frame"/>              <!-- 边框 -->
+</Frame>
+```
+
+问题：
+
+- 4 层手写，padding / anchor / margin 容易写错。
+- 进度变化要 author 自己改 fill 的 `width` 或 `margin`，不直观。
+- `Image.Type.Filled` 截断渲染模式作者基本不知道怎么搭。
+- 一旦想换"mask 不设时 mask sprite 兼任可见底"这种轻量场景，又得改结构。
+
+需要一个**显示型**控件 `<Progress>`，把"边框 + 形状遮罩 + 底/轨道 + 填充 + 填充模式 + 进度值"打包成一行 XML，attr 命名跟现有 `<Image>` / `<Slider>` 词汇对齐。
+
+---
+
+## 2. 决策一览
+
+| # | 决策 | 选择 | 理由 |
+|---|---|---|---|
+| PB-D1 | 控件类型 | 显示型（只读），不暴露 `Observable` / `OnValueChanged` | Progress 是 view，不接 input；C# 侧直接 `Get<Progress>().Value = x` 或 `Bind` 数据源即可 |
+| PB-D2 | 值模型 | 归一化 `[0..1]`，无 `min`/`max`/`wholeNumbers` | Progress 不是 Slider；调用方自行归一化更简单。Clamp 到 [0,1]，超界静默裁剪 |
+| PB-D3 | `bg` vs `back` 命名 | `bg` + `bgColor` | `fill`/`fillColor` 已成对；`bg`/`bgColor` 闭环。Slider 内部字段 `_bg` 同名。CSS / Tailwind 通用词汇 |
+| PB-D4 | `scale` vs `fill` 术语 | `mode="scale"` = 改 Fill 的 RectTransform 拉伸；`mode="fill"` = `UnityImage.Type.Filled` 截断渲染 | 跟 Unity Image 行为绑死；作者一看就知道是 RectTransform 动还是 Image fillAmount 动 |
+| PB-D5 | 方向词汇 | `direction="horizontal\|vertical\|reverse-horizontal\|reverse-vertical"` | 跟现有 `Slider.direction` 完全一致（`Runtime/Controls/Slider.cs:100`），author 心智复用 |
+| PB-D6 | radial 模式 | **不在 v1**，未来开 `<Cooldown>` 控件单独做 | radial 需要 `origin` (90/180/360) + `clockwise`，attr 表会膨胀；冷却环的语义跟"线性进度"也分得开 |
+| PB-D7 | 层级始终统一（固定结构） | `Progress → [MaskWrapper → [Bg, Fill], Frame]` 永远 4 个 RT | 避免"mask 设没设导致 Fill 父节点不同"的结构分支；`Mask` / `UnityImage` 组件按需 `AddComponent`，但 RT 树形不变 |
+| PB-D8 | mask 没设、bg 没设 | MaskWrapper 不挂 `Mask` / `UnityImage`，仅作 stretch wrapper | 零开销；语义上"没 mask 没底"就是空 |
+| PB-D9 | mask 设了、bg 没设 | MaskWrapper.Mask.showMaskGraphic = `true`，mask sprite 兼任可见底（用户提出的优化路径） | 一个 sprite 干两件事，最常见的"圆角胶囊条 + 单色 fill"零冗余 |
+| PB-D10 | mask 设了、bg 设了 | MaskWrapper.Mask.showMaskGraphic = `false`；Bg 作为 MaskWrapper 第一个子节点（被裁剪到 mask 形状） | bg 跟 fill 同处 mask 内部，共享形状；mask sprite 当 stencil 不可见 |
+| PB-D11 | mask 没设、bg 设了 | Bg 仍是 MaskWrapper 第一个子节点（MaskWrapper 此时是透明 wrapper） | 结构一致；bg 占满整个 Progress rect 时就是普通矩形底 |
+| PB-D12 | Progress 是否接 XML 子元素 | 否（leaf control） | 跟 Slider / Btn 一致；Progress 内部 4 个图层全部程序化建 |
+| PB-D13 | `value` 变化的代价 | 只动 Fill 的 anchor (scale 模式) 或 `UnityImage.fillAmount` (fill 模式)，不重建 GO，不改 Bg/Frame/Mask | 跟 Variant 规则一致；可被 R3 高频 `Bind` |
+| PB-D14 | 模式/方向变化代价 | OnAfterApply 一次性 reconcile：算出目标 (anchor, image.type, fillMethod, fillOrigin, fillAmount) 写入 Fill | setter 顺序无关；mode + direction + value 任意 setter 跑过都触发同一次 reconcile |
+| PB-D15 | sprite 9-slice 自动 Sliced | Bg / Fill / Frame / Mask 四个 UnityImage 都跑 Image 现有"sprite.border != 0 → Type.Sliced"逻辑 | 复用 `Image.OnAfterApply` 的思路；fill 模式下 fill 这层例外（强制 Filled） |
+| PB-D16 | Frame 层的 raycast | `raycastTarget = false` | 装饰层，不能挡 Progress 父级或同级控件的事件 |
+| PB-D17 | `GetNativeSize()` | frame sprite 设了 → frame.nativeSize；否则 bg 设了 → bg.nativeSize；否则 `(160, 16)` | 跟 `Image.GetNativeSize` 同样按 `sprite.rect / pixelsPerUnit`；细长条是最合理默认 |
+| PB-D18 | variant override 范围 | 允许 override `value` / `fill` / `fillColor` / `bg` / `bgColor` / `frame` / `mode` / `direction`；**禁止** override `mask` | mask 切换需要 `AddComponent`/`Destroy`（同 FIM-D8 逻辑）；其他 attr 都是值写入，安全。lint 阻断 mask 出现在 Variant |
+| PB-D19 | clamp 行为 | value < 0 → 0；value > 1 → 1；NaN → 0 | 显示控件，宁可显示边界值也不让 fillAmount/anchor 进入未定义区间 |
+| PB-D20 | lint 规则地点 | `Runtime/Core/Lint/ProgressAttributeRules.cs`，跟 `MaskAttributeRules` / `LayoutGroupChildRules` 同模式 | Single source of truth：CLI exit code + runtime `Debug.LogWarning` 共享 |
+
+---
+
+## 3. 属性表
+
+| 属性 | 取值 | 默认 | 作用 |
+|---|---|---|---|
+| `value` | `[0..1]` 浮点 | `0` | 进度；超界 clamp。改它只动 Fill |
+| `fill` | sprite key | (none) | 填充层 sprite；走 `UI.ResolveSprite` |
+| `fillColor` | `#rrggbb` / `#rrggbbaa` / 命名色 | white | 填充层 tint |
+| `bg` | sprite key | (none) | 底/轨道 sprite |
+| `bgColor` | 颜色 | white | 底色 tint；`bg` 没设但 `bgColor` 设了 → MaskWrapper 子节点画纯色矩形当底 |
+| `frame` | sprite key | (none) | 装饰边框 sprite；画在最上层，`raycastTarget=false` |
+| `mask` | sprite key | (none) | 形状遮罩 sprite，挂 `UnityEngine.UI.Mask` 做 stencil 裁剪 |
+| `mode` | `scale` \| `fill` | `scale` | `scale` = 改 Fill RectTransform 拉伸；`fill` = `UnityImage.Type.Filled` 截断渲染 |
+| `direction` | `horizontal` \| `vertical` \| `reverse-horizontal` \| `reverse-vertical` | `horizontal` | 进度增长方向（决定 anchor 原点 / fillOrigin） |
+
+约束：
+- 不接受 XML 子元素（PB-D12）；写了会被 `ScreenInstantiator` 当 unknown control 忽略 + 一条 warning。
+- `mask` 不能出现在 `Variant` 覆盖里（PB-D18，lint error）。
+
+---
+
+## 4. 六个典型用例
+
+```xml
+<!-- 1. 最简：纯色 bg + 单色 fill；scale 横向 -->
+<Progress value="0.6" bgColor="#222" fillColor="#3cf"/>
+
+<!-- 2. 单 sprite 填充；scale 横向 -->
+<Progress value="0.6" fill="ui:bar_red"/>
+
+<!-- 3. 圆角胶囊：mask sprite 兼当底 (PB-D9) -->
+<Progress value="0.4" mask="ui:pill" fill="ui:bar_blue"/>
+
+<!-- 4. 全套装饰：frame + mask + bg + fill -->
+<Progress value="0.6" frame="ui:gold_border" mask="ui:pill" bg="ui:track" fill="ui:bar_red"/>
+
+<!-- 5. Unity Image.Type.Filled, 反向纵向（液体从顶部往下空） -->
+<Progress value="0.3" fill="ui:liquid" mode="fill" direction="reverse-vertical"/>
+
+<!-- 6. 在 Variant 中切换 value / colors (mask/frame/bg/fill sprite 允许；mask 模式禁止) -->
+<Progress id="hp" value="1.0" fill="ui:bar" bgColor="#000">
+  <Variant when="state.low">
+    <Attr name="value" value="0.2"/>
+    <Attr name="fillColor" value="#f44"/>
+  </Variant>
+</Progress>
+```
+
+---
+
+## 5. C# 侧用法
+
+```csharp
+var p = screen.Get<Progress>("hp");
+p.Value = 0.42f;                              // 直接赋值
+healthStream.Subscribe(v => p.Value = v);     // R3 推送
+```
+
+`Progress.Value` 是 `public float` getter+setter（与 `Slider.Value` 镜像）。无 `OnValueChanged`（PB-D1）。`[Bind]` 是用于把 child control 字段注入到 parent 的（参见 `Runtime/Registry/BindAttribute.cs`），不是数据流绑定 —— Progress 这种基础数值控件直接用 `Get<Progress>("id").Value = v` 即可。
+
+---
+
+## 6. 程序化层级（固定）
+
+```
+Progress (RectTransform, 无 Graphic)
+├── MaskWrapper (RectTransform; 按需挂 UnityImage + UI.Mask)
+│   ├── Bg   (RectTransform + UnityImage; 按需 SetActive)
+│   └── Fill (RectTransform + UnityImage; 永远存在)
+└── Frame (RectTransform + UnityImage; 按需 SetActive, raycastTarget=false)
+```
+
+组件按 `mask` / `bg` / `bgColor` / `frame` 是否设值条件性 `AddComponent`：
+
+| 条件 | MaskWrapper.UnityImage | MaskWrapper.Mask | MaskWrapper.showMaskGraphic | Bg.SetActive | Frame.SetActive |
+|---|---|---|---|---|---|
+| 无 mask、无 bg/bgColor | 不挂 | 不挂 | — | false | (按 frame) |
+| 无 mask、有 bg/bgColor | 不挂 | 不挂 | — | true | (按 frame) |
+| 有 mask、无 bg/bgColor | 挂（sprite=mask） | 挂 | true | false | (按 frame) |
+| 有 mask、有 bg/bgColor | 挂（sprite=mask） | 挂 | false | true | (按 frame) |
+
+Frame 行：`frame` 设了 → SetActive(true) + sprite/Sliced；没设 → SetActive(false)。
+
+---
+
+## 7. 行为细节
+
+### 7.1 `mode="scale"` (默认)
+
+Fill 的 RT 根据 value + direction 设 anchorMin/anchorMax：
+
+| direction | anchorMin | anchorMax |
+|---|---|---|
+| `horizontal` (forward) | `(0, 0)` | `(value, 1)` |
+| `reverse-horizontal` | `(1-value, 0)` | `(1, 1)` |
+| `vertical` | `(0, 0)` | `(1, value)` |
+| `reverse-vertical` | `(0, 1-value)` | `(1, 1)` |
+
+`offsetMin = offsetMax = Vector2.zero`。`UnityImage.type` 走 sprite border 自动 Sliced/Simple（与 `Image.OnAfterApply` 同逻辑）。
+
+### 7.2 `mode="fill"`
+
+Fill 的 RT 满铺 `(0,0)..(1,1)`；UnityImage 配置：
+
+| direction | type | fillMethod | fillOrigin |
+|---|---|---|---|
+| `horizontal` | Filled | Horizontal | Left (0) |
+| `reverse-horizontal` | Filled | Horizontal | Right (1) |
+| `vertical` | Filled | Vertical | Bottom (0) |
+| `reverse-vertical` | Filled | Vertical | Top (1) |
+
+`fillAmount = value`. 切换 `mode` 时反转 type 回 Simple/Sliced (按 sprite border) + 重置 RT 到 value 模式。
+
+### 7.3 reconcile 时机
+
+`value` / `fill` / `mode` / `direction` 任一 setter 跑过 → 在 `OnAfterApply` 里跑一次 `ReconcileFill()`，集中处理上面表 7.1 / 7.2 的写入。setter 顺序无关。
+
+---
+
+## 8. Lint 规则
+
+`Runtime/Core/Lint/ProgressAttributeRules.cs`；`IRWalker.WalkNode` 增 `node.Tag == "Progress"` 分支；`ScreenInstantiator.InstantiateRecursive` 同源 `Debug.LogWarning`。
+
+| Code | 触发条件 | 信息（节选） | 级别 |
+|---|---|---|---|
+| `PUI-PROG-VALUE-RANGE` | `value` 字面量解析出 < 0 或 > 1 | "Progress.value 期望 [0..1]，当前 '{v}' 会被 clamp。如果是动态绑定可忽略；字面量请改成合法范围。" | warning |
+| `PUI-PROG-MODE` | `mode` 不在 `scale` / `fill` | "Progress.mode 合法值: scale, fill。" | error |
+| `PUI-PROG-DIRECTION` | `direction` 不在四值集合 | "Progress.direction 合法值: horizontal, vertical, reverse-horizontal, reverse-vertical。" | error |
+| `PUI-PROG-CHILDREN` | `<Progress>` 包含子元素 | "Progress 是 leaf 控件，不接受子元素。把装饰图层用 frame / mask / bg / fill 属性表达。" | error |
+| `PUI-PROG-MASK-VARIANT` | `mask` 出现在 `Variant` 覆盖里 | "Progress.mask 不支持 variant override（涉及 AddComponent/Destroy）。把 mask 固定在主声明；其他 attr 可以在 variant 中改。" | error |
+| `PUI-PROG-NO-FILL` | `fill` / `fillColor` 都没设 且 `value` 有值 | "Progress 设了 value 但没设 fill 也没设 fillColor，看不到任何填充。" | warning |
+
+runtime 一律 `Debug.LogWarning`（跟 `LayoutGroupChildRules` 同步），不抛异常；CLI `UIXmlLint` 用规则级别决定 exit code。
+
+---
+
+## 9. 实现要点
+
+### 9.1 `Runtime/Controls/Progress.cs`（新文件）
+
+骨架（详细 reconcile 逻辑放 plan 里）：
+
+```csharp
+using PromptUGUI.Application;
+using PromptUGUI.Controls.Internal;
+using PromptUGUI.Registry;
+using UnityEngine;
+using UnityImage = UnityEngine.UI.Image;
+using UnityMask = UnityEngine.UI.Mask;
+
+namespace PromptUGUI.Controls
+{
+    // Progress 是显示型线性进度条 (horizontal / vertical, scale / Image.Type.Filled).
+    // Radial fill (cooldown ring) 不在范围; 未来需要时新增 <Cooldown> 控件, 不要扩这里. (PB-D6)
+    public sealed class Progress : Control
+    {
+        private UnityImage _bg;          // 可能为 null (无 bg 且无 bgColor)
+        private UnityImage _maskGraphic; // 可能为 null (无 mask)
+        private UnityMask _stencilMask;  // 可能为 null
+        private UnityImage _fill;        // 永远非 null
+        private UnityImage _frame;       // 可能为 null
+
+        private float _value;
+        private string _mode = "scale";
+        private string _direction = "horizontal";
+        private bool _hasBgColor;
+        private bool _fillTypeExplicit; // 跟 Image 一样
+
+        public override void OnAttached()
+        {
+            // MaskWrapper
+            var maskRt = ProceduralBuilders.AddChild(RectTransform, "MaskWrapper");
+            // Bg (lazy via setter; 总是先创建禁用)
+            var bgRt = ProceduralBuilders.AddChild(maskRt, "Bg");
+            bgRt.gameObject.SetActive(false);
+            _bg = bgRt.gameObject.AddComponent<UnityImage>();
+            _bg.raycastTarget = false;
+            // Fill (永远存在)
+            _fill = ProceduralBuilders.AddImage(maskRt, "Fill", raycast: false);
+            // Frame (lazy via setter; 总是先创建禁用)
+            var frameRt = ProceduralBuilders.AddChild(RectTransform, "Frame");
+            frameRt.gameObject.SetActive(false);
+            _frame = frameRt.gameObject.AddComponent<UnityImage>();
+            _frame.raycastTarget = false;
+        }
+
+        [UIAttr, Preserve] public float Value { get => _value; set => _value = Mathf.Clamp01(value); }
+        [UIAttr, Preserve] public string Mode      { set => _mode = value; }
+        [UIAttr, Preserve] public string Direction { set => _direction = value; }
+
+        [UIAttr, Preserve]
+        public string Fill { set { _fill.sprite = UI.ResolveSprite(value); } }
+        [UIAttr, Preserve]
+        public string FillColor { set { if (ColorUtility.TryParseHtmlString(value, out var c)) _fill.color = c; } }
+
+        [UIAttr, Preserve]
+        public string Bg
+        {
+            set
+            {
+                _bg.sprite = UI.ResolveSprite(value);
+                _bg.gameObject.SetActive(true);
+            }
+        }
+        [UIAttr, Preserve]
+        public string BgColor
+        {
+            set
+            {
+                if (!ColorUtility.TryParseHtmlString(value, out var c)) return;
+                _bg.color = c;
+                _hasBgColor = true;
+                _bg.gameObject.SetActive(true);
+            }
+        }
+
+        [UIAttr, Preserve]
+        public string Frame
+        {
+            set
+            {
+                _frame.sprite = UI.ResolveSprite(value);
+                _frame.gameObject.SetActive(true);
+            }
+        }
+
+        [UIAttr, Preserve]
+        public string Mask
+        {
+            set
+            {
+                if (_maskGraphic == null)
+                {
+                    var maskRt = (RectTransform)_fill.transform.parent;
+                    _maskGraphic = maskRt.gameObject.AddComponent<UnityImage>();
+                    _maskGraphic.raycastTarget = false;
+                    _stencilMask = maskRt.gameObject.AddComponent<UnityMask>();
+                }
+                _maskGraphic.sprite = UI.ResolveSprite(value);
+                _stencilMask.showMaskGraphic = !_bg.gameObject.activeSelf;
+            }
+        }
+
+        internal override void OnAfterApply()
+        {
+            // bg/frame/mask 各自 sprite border 自动 Sliced
+            AutoSlice(_bg);
+            AutoSlice(_frame);
+            AutoSlice(_maskGraphic);
+            // 如果 bg 在 Mask 设值之后才打开, 同步 showMaskGraphic
+            if (_stencilMask != null) _stencilMask.showMaskGraphic = !_bg.gameObject.activeSelf;
+            ReconcileFill();
+        }
+
+        private void ReconcileFill()
+        {
+            var rt = _fill.rectTransform;
+            if (_mode == "fill")
+            {
+                rt.anchorMin = Vector2.zero;
+                rt.anchorMax = Vector2.one;
+                rt.offsetMin = rt.offsetMax = Vector2.zero;
+                _fill.type = UnityImage.Type.Filled;
+                (_fill.fillMethod, _fill.fillOrigin) = _direction switch
+                {
+                    "horizontal" => (UnityImage.FillMethod.Horizontal, (int)UnityImage.OriginHorizontal.Left),
+                    "reverse-horizontal" => (UnityImage.FillMethod.Horizontal, (int)UnityImage.OriginHorizontal.Right),
+                    "vertical" => (UnityImage.FillMethod.Vertical, (int)UnityImage.OriginVertical.Bottom),
+                    "reverse-vertical" => (UnityImage.FillMethod.Vertical, (int)UnityImage.OriginVertical.Top),
+                    _ => (UnityImage.FillMethod.Horizontal, (int)UnityImage.OriginHorizontal.Left),
+                };
+                _fill.fillAmount = _value;
+            }
+            else // scale (默认)
+            {
+                // 回到 Simple/Sliced (按 sprite border)
+                _fill.type = (_fill.sprite != null && _fill.sprite.border != Vector4.zero)
+                    ? UnityImage.Type.Sliced
+                    : UnityImage.Type.Simple;
+                _fill.fillAmount = 1f;
+                (rt.anchorMin, rt.anchorMax) = _direction switch
+                {
+                    "horizontal" => (new Vector2(0f, 0f), new Vector2(_value, 1f)),
+                    "reverse-horizontal" => (new Vector2(1f - _value, 0f), new Vector2(1f, 1f)),
+                    "vertical" => (new Vector2(0f, 0f), new Vector2(1f, _value)),
+                    "reverse-vertical" => (new Vector2(0f, 1f - _value), new Vector2(1f, 1f)),
+                    _ => (new Vector2(0f, 0f), new Vector2(_value, 1f)),
+                };
+                rt.offsetMin = rt.offsetMax = Vector2.zero;
+            }
+        }
+
+        private static void AutoSlice(UnityImage img)
+        {
+            if (img == null || img.sprite == null) return;
+            img.type = img.sprite.border != Vector4.zero ? UnityImage.Type.Sliced : UnityImage.Type.Simple;
+        }
+
+        public override Vector2? GetNativeSize()
+        {
+            if (_frame != null && _frame.sprite != null) return Native(_frame);
+            if (_bg != null && _bg.sprite != null) return Native(_bg);
+            return new Vector2(160f, 16f);
+        }
+
+        private static Vector2 Native(UnityImage img)
+        {
+            var ppu = img.pixelsPerUnit;
+            return new Vector2(img.sprite.rect.width / ppu, img.sprite.rect.height / ppu);
+        }
+    }
+}
+```
+
+> 注：上面 `OnAfterApply` 用 `internal override` —— 跟 `Image.OnAfterApply` 同签名（`Runtime/Controls/Image.cs:111`）。`ControlAttributeApplier` 在所有 setter 跑完后调一次。
+
+### 9.2 `Runtime/Application/BuiltinPrimitives.cs`
+
+```csharp
+reg.Register<Progress>("Progress", null);  // 跟 Slider 一行同位置
+```
+
+### 9.3 `Runtime/Core/Lint/ProgressAttributeRules.cs`（新文件）
+
+跟 `MaskAttributeRules` 同模式：static class，几个 `Check*` 方法返回 `IEnumerable<LintIssue>`。
+
+```csharp
+public static class ProgressAttributeRules
+{
+    public const string ValueRangeCode    = "PUI-PROG-VALUE-RANGE";
+    public const string ModeCode          = "PUI-PROG-MODE";
+    public const string DirectionCode     = "PUI-PROG-DIRECTION";
+    public const string ChildrenCode      = "PUI-PROG-CHILDREN";
+    public const string MaskVariantCode   = "PUI-PROG-MASK-VARIANT";
+    public const string NoFillCode        = "PUI-PROG-NO-FILL";
+
+    public static IEnumerable<LintIssue> CheckProgress(ElementNode n) { /* see plan */ }
+}
+```
+
+### 9.4 `Runtime/Core/Lint/IRWalker.cs` 改动
+
+`WalkNode` 入口 self-check 追加：
+
+```csharp
+else if (node.Tag == "Progress")
+    foreach (var issue in ProgressAttributeRules.CheckProgress(node))
+        yield return issue;
+```
+
+### 9.5 `Runtime/Application/ScreenInstantiator.cs` 改动
+
+self-check 块同步追加 `Progress` 分支（与 `Image` / `Frame` 同位置）。
+
+---
+
+## 10. 跟现有 spec / SKILL 的整合点
+
+### 10.1 主 spec `2026-05-07-promptugui-description-language-design.md`
+
+§5（控件表）追加一行：
+
+> `<Progress>` | 线性进度条 (scale / Image.Type.Filled, horizontal / vertical, +可选 frame / mask / bg 装饰) | RectTransform（+ 内部 4 个图层；详见 [`2026-05-27-progress-control-design.md`](2026-05-27-progress-control-design.md)）
+
+### 10.2 `authoring-promptugui-xml/SKILL.md`
+
+1. Built-in primitives 表追加 `<Progress>` 行（attrs：`value`, `fill`, `fillColor`, `bg`, `bgColor`, `frame`, `mask`, `mode`, `direction`）。
+2. 新增 "Progress" 小节，含 6 个用例（§4）+ lint codes 列表（§8）+ "mask 配 bg 的四种组合表"（§6）。
+3. Quick reference 末尾加一行：
+   > `<Progress value="0.6" fill="ui:bar"/>` 最简；`mask=` + 不设 `bg` → mask sprite 自动可见兼当底；radial 进度环不在 `<Progress>` 范围。
+
+### 10.3 `scripting-promptugui-csharp/SKILL.md`
+
+R3 / `Get<T>` 段加一句：
+> `screen.Get<Progress>("hp").Value = 0.42f;` — Progress 是只读显示控件，无 `OnValueChanged`；用 `Bind`-属性或直接 setter 推值。
+
+---
+
+## 11. Out of Scope
+
+- **Radial fill (cooldown 环)** —— 未来 `<Cooldown>` 控件（PB-D6）。
+- **Value tween / 动画过渡** —— 用现有 `<Animation>` 控件或调用方自己缓动；Progress 本身只写当前值。
+- **`min` / `max` / `wholeNumbers`** —— Progress 不是 Slider（PB-D2）；要离散段数自己量化。
+- **多段进度条 (segmented bar)** —— 暂用多个 `<Progress>` 横排或 Variant 模拟。
+- **soft / alpha mask** —— 跟 FIM 同 out-of-scope；stencil Mask 足够。
+- **Variant 切换 mask 模式** —— PB-D18 / PB-D20 阻断。
+
+---
+
+## 12. 风险与回滚
+
+| 风险 | 缓解 |
+|---|---|
+| `mode="scale"` ↔ `mode="fill"` 切换后 fillAmount / RT 残值导致首帧错位 | `ReconcileFill()` 永远把两边都写一遍（scale 模式重置 fillAmount=1，fill 模式重置 RT 到满铺）；OnAfterApply 每次都跑 |
+| 反射 setter 顺序：`Mask` 先跑、`Bg` 后跑 → `showMaskGraphic` 计算错 | `OnAfterApply` 末尾再写一次 `_stencilMask.showMaskGraphic = !_bg.gameObject.activeSelf` |
+| Variant override `mask=` 绕过 lint | runtime `Mask` setter 用 `??=`（同 FIM-D9），不重建组件；只更新 sprite |
+| `direction` 拼写错（如 `"reverse_horizontal"` 下划线） | lint error `PUI-PROG-DIRECTION`；runtime 落入 default 分支按 horizontal 兜底 |
+| `value` 高频赋值（每帧）→ 每次 ReconcileFill 跑完整 switch | switch 极轻；fillAmount / anchor 是直接字段赋值，UI rebatch 只在 RT 改时触发，跟 Slider 相同量级 |
+| Frame 层 raycast 漏关 → 挡掉父级点击 | `OnAttached` 时直接 `raycastTarget = false`（PB-D16），无 attr 暴露不让 author 改 |
+| `<Progress>` 节点写了子元素被静默忽略 | lint error `PUI-PROG-CHILDREN`；ScreenInstantiator 已有"未知子节点 warning"路径 |
+| XSD 不自动更新 | 跟所有新 `[UIAttr]` 一样手动 `Tools → PromptUGUI → Schema → Generate XSD`；SKILL.md 已说明 |

--- a/docs~/superpowers/specs/2026-05-27-progress-control-design.md
+++ b/docs~/superpowers/specs/2026-05-27-progress-control-design.md
@@ -104,7 +104,7 @@
 <!-- 5. Unity Image.Type.Filled, 反向纵向（液体从顶部往下空） -->
 <Progress value="0.3" fill="ui:liquid" mode="fill" direction="reverse-vertical"/>
 
-<!-- 6. 在 Variant 中切换 value / colors (mask/frame/bg/fill sprite 允许；mask 模式禁止) -->
+<!-- 6. 在 Variant 中切换 value / colors (frame / bg / fill sprite 允许；mask 完全禁止 — PUI-PROG-MASK-VARIANT) -->
 <Progress id="hp" value="1.0" fill="ui:bar" bgColor="#000">
   <Variant when="state.low">
     <Attr name="value" value="0.2"/>

--- a/docs~/superpowers/specs/2026-05-27-progress-control-design.md
+++ b/docs~/superpowers/specs/2026-05-27-progress-control-design.md
@@ -105,12 +105,10 @@
 <Progress value="0.3" fill="ui:liquid" mode="fill" direction="reverse-vertical"/>
 
 <!-- 6. 在 Variant 中切换 value / colors (frame / bg / fill sprite 允许；mask 完全禁止 — PUI-PROG-MASK-VARIANT) -->
-<Progress id="hp" value="1.0" fill="ui:bar" bgColor="#000">
-  <Variant when="state.low">
-    <Attr name="value" value="0.2"/>
-    <Attr name="fillColor" value="#f44"/>
-  </Variant>
-</Progress>
+<Progress id="hp"
+          value="1.0" value.low="0.2"
+          fill="ui:bar" fillColor.low="#f44"
+          bgColor="#000"/>
 ```
 
 ---


### PR DESCRIPTION
## Summary

新增 `<Progress>` 内置控件 —— 显示型线性进度条，一行 XML 配齐 frame / mask / bg / fill / mode / direction / value 七个图层与行为，零手糊原语。

- **控件**：`Runtime/Controls/Progress.cs` 程序化建固定 4-RT 层级 (`Progress → [MaskWrapper → [Bg, Fill], Frame]`)，按 attr 条件 `AddComponent` 或 `SetActive`。setter-self-reconcile 模式保证 R3 / `p.Value = x` runtime 推送立刻重绘。
- **模式**：`mode="scale"` (默认) 改 Fill RectTransform 拉伸；`mode="fill"` 走 `UnityImage.Type.Filled` 截断渲染。`direction` 沿用 `<Slider>` 词汇 (`horizontal` / `vertical` / `reverse-*`)。Radial 留给以后 `<Cooldown>` (PB-D6)。
- **Mask × bg 巧合**：`mask=` 没配 `bg=` 时自动 `showMaskGraphic=true`，mask sprite 兼当可见底 (PB-D9)；配了 bg 就当 stencil only (PB-D10)。Bg/BgColor setter 也会重算 `showMaskGraphic`，跨 runtime 加 bg 路径也对。
- **Lint**：新增 `ProgressAttributeRules`，6 条规则 (`PUI-PROG-VALUE-RANGE` / `MODE` / `DIRECTION` / `CHILDREN` / `MASK-VARIANT` / `NO-FILL`)，复用 `IRWalker` + `ScreenInstantiator` 双 dispatch 模式 (跟 `MaskAttributeRules` 同源)。
- **测试**：36 runtime + 13 lint rule + 3 walker = **52 个 Progress-specific 测试**，含 runtime variant override 路径。全套 EditMode 903/903 通过，shipped XML lint 干净。

设计：[`docs~/superpowers/specs/2026-05-27-progress-control-design.md`](docs~/superpowers/specs/2026-05-27-progress-control-design.md) (20 决策 PB-D1..PB-D20)
计划：[`docs~/superpowers/plans/2026-05-27-progress-control.md`](docs~/superpowers/plans/2026-05-27-progress-control.md) (14 task TDD)

## Test plan

- [ ] `mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])` — 全绿 (903/903)
- [ ] `mcp__UnityMCP__run_tests(filter="ProgressTests")` — 36/36
- [ ] `mcp__UnityMCP__run_tests(filter="ProgressAttributeRulesTests")` — 13/13
- [ ] `mcp__UnityMCP__run_tests(filter="IRWalkerProgressTests")` — 3/3
- [ ] `cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx` — exit 0
- [ ] `dotnet run --project .lint/UIXmlLint -- Runtime/Resources/` — exit 0 (shipped XML clean)
- [ ] 在 host Unity 项目里 `Tools → PromptUGUI → Schema → Generate XSD` 刷新 XSD，看 `<Progress>` 9 个 attr 出现
- [ ] 写一个测试 Screen 跑 6 个用例 (spec §4) 观察实际渲染：scale + fill 双模式，4 个方向，mask + bg 4 种组合

🤖 Generated with [Claude Code](https://claude.com/claude-code)