### PR TITLE
feat: <TabBar> / <Tab> controls with declarative Frame binding

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -73,7 +73,7 @@ mcp__UnityMCP__read_console(action="get", types=["error","warning"])
 
 `<Import>`, `<Screen>`, `<Template>` are the **only** elements allowed at the top level. Comments use standard `<!-- -->`.
 
-## Built-in primitives (15)
+## Built-in primitives (17)
 
 **默认视觉主题**：白底 sliced + #323232 深字（同 Unity 6 标准 UI prefab）。`color=` / `sprite=` 单点 override，整体深色覆写 `ProceduralBuilders` 常量或用 Variant `color.dark="..."`。
 
@@ -96,8 +96,10 @@ Pre-registered on `UI.Registry`. Use as XML tags by name:
 | `<ScrollList>` | ScrollRect + Mask. Items pushed C#-side via `BindItems(...)`. `itemTemplate` references a `<Template name=...>` or registered Control class. **不写 size 时按方向给视口默认**：纵向滚动 160×200、横向滚动 200×160；实际项目通常显式写 size。                                                                                                                                                     | `itemTemplate` (required tag name), `direction` (`vertical` / `horizontal`), `spacing` (float), `padding`, `color`, `sprite`                                                                                                                                                                                                                       |
 | `<InputField>` | TMP_InputField；R3 `OnValueChanged` / `OnEndEdit` / `OnSubmit: string`。`<InputField>初始文本</InputField>` 短手设 `text=`。                                                                                                                                                                                                                                                                     | `text`, `placeholder`, `contentType` (`standard`/`autocorrected`/`integer-number`/`decimal-number`/`alphanumeric`/`name`/`email`/`password`/`pin`/`custom`), `lineType` (`single`/`multi-newline`/`multi-submit`), `characterLimit` (int), `readOnly` (bool), `color`, `sprite`, `font`, `tr` (placeholder)/`ctx`                                  |
 | `<Progress>` | 显示型线性进度条（只读，无 `OnValueChanged`）。一行配齐 frame / mask / bg / fill / mode / direction / value，零手糊图层。 | `value` (float `[0..1]`, default `0`), `fill` (sprite key), `fillColor` (`#RRGGBB[AA]` / 命名色), `bg` (sprite key), `bgColor` (`#RRGGBB[AA]` / 命名色;单独设也激活 bg 层), `frame` (sprite key), `frameColor` (`#RRGGBB[AA]` / 命名色;单独设也激活 frame 层), `mask` (sprite key), `mode` (`scale`\|`fill`, default `scale`), `direction` (`horizontal`\|`vertical`\|`reverse-horizontal`\|`reverse-vertical`, default `horizontal`) |
+| `<TabBar>`   | Tab container; private `ToggleGroup` (`allowSwitchOff=false`) + `Horizontal`/`VerticalLayoutGroup`. All child Tabs share `sprite` (normal bg) + `selectedSprite` (overlay shown when on, bound to `UnityToggle.graphic`). Supports `itemTemplate` + `BindItems` for dynamic content (same shape as `<ScrollList>`). Behaves as a layout group for children — Tabs can't declare `anchor` / `margin`. | `sprite` (normal bg, shared), `selectedSprite` (overlay sprite when selected), `direction` (`horizontal` / `vertical`, default `horizontal`), `spacing` (float), `padding` (`T,R,B,L`), `itemTemplate` (tag name, default `Tab`) |
+| `<Tab>`      | Child of `<TabBar>`; uGUI `Toggle` + centered TMP label + optional left-side icon + optional selected overlay. Mutex via TabBar's `ToggleGroup` (automatic). `bind="frame_id"` declaratively shows/hides a sibling `<Frame>` on selection (lazy lookup, cached). No `bind=` → only `OnSelected`. No nested XML children allowed. | `text`, `isOn` (bool, default `false`), `bind` (id of sibling `<Frame>` to show/hide), `font`, `fontSize` (int), `icon` (sprite key, left-aligned 24×24 with 4px gap) |
 
-`<Toggle>` / `<Slider>` / `<Dropdown>` / `<ScrollList>` are reference implementations. For project-specific differentiation (pixel border, press feedback, custom popup chrome) subclass and override `OnAttached` — see scripting-promptugui-csharp.
+`<Toggle>` / `<Slider>` / `<Dropdown>` / `<ScrollList>` / `<TabBar>` are reference implementations. For project-specific differentiation (pixel border, press feedback, custom popup chrome) subclass and override `OnAttached` — see scripting-promptugui-csharp.
 
 ### `<Icon>`
 
@@ -197,6 +199,8 @@ Other notes:
 | `<ScrollList>` | `Image` + `ScrollRect`                                                                                                                                                          | `Viewport`(`Image` + `Mask` stencil) → `Content`(V/H `LayoutGroup` + `ContentSizeFitter`)；按 `direction` 再加一个 `Scrollbar`                                               | 无独立事件；C# 端 `BindItems(...)` 推数据                                                          |
 | `<InputField>` | `Image` + `TMP_InputField`                                                                                                                                                      | `Text Area`(`RectMask2D`) → `Placeholder`(`TMP_Text`, italic 半透明) + `Text`(`TMP_Text`)                                                                                    | `OnValueChanged` / `OnEndEdit` / `OnSubmit` ← `TMP_InputField.*`                                   |
 | `<Progress>`   | `RectTransform`（无 Graphic）                                                                                                                                                   | `MaskWrapper`(`RectTransform`; 按需挂 `UnityImage` + `Mask`) → `Bg`(`Image`, 按需启用) + `Fill`(`Image`, 永远存在)；`Frame`(`Image`, 按需启用, `raycastTarget=false`) | —                                                                                                  |
+| `<TabBar>`     | `ToggleGroup` + `HorizontalLayoutGroup`（或 `VerticalLayoutGroup` 看 `direction=`）                                                                                              | XML 写的或 `BindItems` 推的 `<Tab>` children；shared `sprite` / `selectedSprite` 在每个 Tab 上压平                                                                            | `OnSelectionChanged` ← per-Tab `OnValueChanged.Where(on => on)`                                    |
+| `<Tab>`        | `UnityImage`（bg, `targetGraphic`）+ `UnityToggle`（`transition=ColorTint`）；Toggle 的 `group` 在 `OnAttached` 用 transform-ancestor walk 找 TabBar 的 `ToggleGroup`           | `Label`(`TMP_Text`, stretch fill, `Center` 对齐, raycast off)；可选 `Icon`(`Image`, 左 16px + 24×24)；可选 `Overlay`(`Image`, stretch fill, 绑到 `Toggle.graphic` 当选中态) | `OnValueChanged: bool` / `OnSelected: Unit`（只在 isOn=true 时 fire）                              |
 | `<SafeArea>`   | `RectTransform` + `SafeAreaTracker`（内部 `MonoBehaviour`，订阅设备 safeArea / 旋转 / Device Simulator）                                                                        | —                                                                                                                                                                            | —                                                                                                  |
 | `<Trigger>`    | `RectTransform` 单独（无视觉、无 layout 行为，仅作 wrapper 划定事件源 scope）                                                                                                   | —                                                                                                                                                                            | `OnFire` ← R3 `Subject<Unit>`，由 `on=`（open/loop/click/hover-enter/hover-exit/press/manual）触发 |
 | `<Animation>`  | `RectTransform` + `CanvasGroup`（继承自 Trigger；CanvasGroup 给 `fade=` 用，由 `ApplyCommon` 懒加载）                                                                           | `_offsetProxy`(`RectTransform`，anchor stretch、margin=0、pivot=0.5,0.5) — XML 子节点全 parent 到这一层；LitMotion 驱动它的 anchoredPosition / localScale / localEulerAngles | `OnFire` ← 继承 Trigger；同时由 `on=` 触发 LitMotion `MotionHandle[]`                              |
@@ -606,6 +610,39 @@ Radial fill（冷却环）不在 `<Progress>` 范围；以后用单独的 `<Cool
 | `PUI-PROG-MASK-VARIANT` | `mask` 出现在 Variant 覆盖里 | error |
 | `PUI-PROG-NO-FILL` | `value` 有值但 `fill`/`fillColor` 均未设 | warning |
 
+## Tabs
+
+`<TabBar>` 是 Tab 的容器；私有 `ToggleGroup`（`allowSwitchOff=false`）保证互斥，私有 `HorizontalLayoutGroup` / `VerticalLayoutGroup`（看 `direction=`）排布。所有 Tab 共享 TabBar 的 `sprite`（常态底）和 `selectedSprite`（选中时显示的 overlay，绑到 `UnityToggle.graphic`）。不写 `selectedSprite` Tabs 退化成"按钮"视觉（仍互斥，但没有选中态反馈）。
+
+```xml
+<TabBar id="topbar" anchor="top-stretch" height="40"
+        sprite="ui:tab_normal" selectedSprite="ui:tab_selected">
+  <Tab text="Edit" bind="editor_panel" isOn="true"/>
+  <Tab text="Help" bind="help_panel"/>
+  <Tab text="Settings" bind="settings_panel"/>
+</TabBar>
+
+<Frame id="editor_panel"   anchor="fill" margin="40,0,0,0">...</Frame>
+<Frame id="help_panel"     anchor="fill" margin="40,0,0,0">...</Frame>
+<Frame id="settings_panel" anchor="fill" margin="40,0,0,0">...</Frame>
+```
+
+`bind="frame_id"` 让 Tab 选中时显示、未选时隐藏命名 Frame。lookup 是 lazy 的 —— 首次切换才解析并缓存。Tab `isOn="true"` 在 XML 里指定初始选中；都没写时 TabBar 自动选第一个。`bind=` 省略时只 fire `OnSelected`（C# 端自己处理）。
+
+用自定义 `itemTemplate` 时（`<TabBar itemTemplate="MyTabTemplate"/>`），Template body 必须在树里某处包含恰好一个 `<Tab>`（通过 `ScopedIds` 或递归 `Control.Children` walk 在 `BindItems` 时定位）。
+
+Tab 是 TabBar 的 layout group child —— 不能写 `anchor=` / `margin=`（`HorizontalLayoutGroup` 接管排布；TabBar 在 `selfIsLayoutGroup` 名单里）。
+
+### Lint 规则
+
+| Code | 触发条件 | 级别 |
+|---|---|---|
+| `PUI-TAB-PARENT` | `<Tab>` 不在 `<TabBar>` 直接父节点下 | warning |
+| `PUI-TABBAR-CHILD` | `<TabBar>` 的直接子节点不是 `<Tab>` | warning |
+| `PUI-TAB-CHILDREN` | `<Tab>` 包含嵌套 XML children（auto label / icon 由属性驱动） | error |
+| `PUI-TABBAR-DIRECTION` | `direction` 不是 `horizontal` / `vertical` | error |
+| `PUI-TAB-BIND-EMPTY` | `bind=""`（空字符串） | warning |
+
 ## Common mistakes (XML)
 
 | Symptom                                                                             | Cause                                                                                                                                                                                              | Fix                                                                                                                                                                                                                                                             |
@@ -639,6 +676,7 @@ TOP LEVEL     <Import src="" [as=""]/>  <Screen name="" [canvas="overlay|camera|
 BUILT-INS     <Frame> <Image> <Text> <VStack> <HStack> <Grid> <Btn> <Icon>
               <Toggle> <Slider> <Dropdown> <ScrollList> <InputField>
               <Progress value="0.6" fill="ui:bar"/>  最简；mask= + 不设 bg → mask sprite 自动可见兼当底；radial 进度环不在 <Progress> 范围
+              <TabBar><Tab text="A" bind="frame_a" isOn="true"/>...</TabBar>  互斥 + shared sprite/selectedSprite + bind 自动 toggle Frame
 TEXT SHORT    <Text>Hi</Text> ≡ <Text text="Hi"/>     (also <Btn>, <Toggle>, <InputField>)
 
 COMMON ATTRS  id  anchor  size|width|height  margin  pivot  hidden  interactable

--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -622,9 +622,9 @@ Radial fill（冷却环）不在 `<Progress>` 范围；以后用单独的 `<Cool
   <Tab text="Settings" bind="settings_panel"/>
 </TabBar>
 
-<Frame id="editor_panel"   anchor="fill" margin="40,0,0,0">...</Frame>
-<Frame id="help_panel"     anchor="fill" margin="40,0,0,0">...</Frame>
-<Frame id="settings_panel" anchor="fill" margin="40,0,0,0">...</Frame>
+<Frame id="editor_panel"   margin="40,0,0,0">...</Frame>
+<Frame id="help_panel"     margin="40,0,0,0">...</Frame>
+<Frame id="settings_panel" margin="40,0,0,0">...</Frame>
 ```
 
 `bind="frame_id"` 让 Tab 选中时显示、未选时隐藏命名 Frame。lookup 是 lazy 的 —— 首次切换才解析并缓存。Tab `isOn="true"` 在 XML 里指定初始选中；都没写时 TabBar 自动选第一个。`bind=` 省略时只 fire `OnSelected`（C# 端自己处理）。

--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -96,7 +96,7 @@ Pre-registered on `UI.Registry`. Use as XML tags by name:
 | `<ScrollList>` | ScrollRect + Mask. Items pushed C#-side via `BindItems(...)`. `itemTemplate` references a `<Template name=...>` or registered Control class. **不写 size 时按方向给视口默认**：纵向滚动 160×200、横向滚动 200×160；实际项目通常显式写 size。                                                                                                                                                     | `itemTemplate` (required tag name), `direction` (`vertical` / `horizontal`), `spacing` (float), `padding`, `color`, `sprite`                                                                                                                                                                                                                       |
 | `<InputField>` | TMP_InputField；R3 `OnValueChanged` / `OnEndEdit` / `OnSubmit: string`。`<InputField>初始文本</InputField>` 短手设 `text=`。                                                                                                                                                                                                                                                                     | `text`, `placeholder`, `contentType` (`standard`/`autocorrected`/`integer-number`/`decimal-number`/`alphanumeric`/`name`/`email`/`password`/`pin`/`custom`), `lineType` (`single`/`multi-newline`/`multi-submit`), `characterLimit` (int), `readOnly` (bool), `color`, `sprite`, `font`, `tr` (placeholder)/`ctx`                                  |
 | `<Progress>` | 显示型线性进度条（只读，无 `OnValueChanged`）。一行配齐 frame / mask / bg / fill / mode / direction / value，零手糊图层。 | `value` (float `[0..1]`, default `0`), `fill` (sprite key), `fillColor` (`#RRGGBB[AA]` / 命名色), `bg` (sprite key), `bgColor` (`#RRGGBB[AA]` / 命名色;单独设也激活 bg 层), `frame` (sprite key), `frameColor` (`#RRGGBB[AA]` / 命名色;单独设也激活 frame 层), `mask` (sprite key), `mode` (`scale`\|`fill`, default `scale`), `direction` (`horizontal`\|`vertical`\|`reverse-horizontal`\|`reverse-vertical`, default `horizontal`) |
-| `<TabBar>`   | Tab container; private `ToggleGroup` (`allowSwitchOff=false`) + `Horizontal`/`VerticalLayoutGroup`. All child Tabs share `sprite` (normal bg) + `selectedSprite` (overlay shown when on, bound to `UnityToggle.graphic`). Supports `itemTemplate` + `BindItems` for dynamic content (same shape as `<ScrollList>`). Behaves as a layout group for children — Tabs can't declare `anchor` / `margin`. | `sprite` (normal bg, shared), `selectedSprite` (overlay sprite when selected), `direction` (`horizontal` / `vertical`, default `horizontal`), `spacing` (float), `padding` (`T,R,B,L`), `itemTemplate` (tag name, default `Tab`) |
+| `<TabBar>`   | Tab container; private `ToggleGroup` (`allowSwitchOff=false`) + `Horizontal`/`VerticalLayoutGroup`. All child Tabs share `sprite` (normal bg) + `selectedSprite` (overlay shown when on, bound to `UnityToggle.graphic`). Children may be direct `<Tab>` or Template wrappers containing a `<Tab>` (recursive collect). Supports `itemTemplate` + `BindItems` for dynamic content (same shape as `<ScrollList>`). Behaves as a layout group for children — Tabs can't declare `anchor` / `margin`. | `sprite` (normal bg, shared), `selectedSprite` (overlay sprite when selected), `direction` (`horizontal` / `vertical`, default `horizontal`), `spacing` (float), `padding` (`T,R,B,L`), `itemTemplate` (tag name, default `Tab`) |
 | `<Tab>`      | Child of `<TabBar>`; uGUI `Toggle` + centered TMP label + optional left-side icon + optional selected overlay. Mutex via TabBar's `ToggleGroup` (automatic). `bind="frame_id"` declaratively shows/hides a sibling `<Frame>` on selection (lazy lookup, cached). No `bind=` → only `OnSelected`. No nested XML children allowed. | `text`, `isOn` (bool, default `false`), `bind` (id of sibling `<Frame>` to show/hide), `font`, `fontSize` (int), `icon` (sprite key, left-aligned 24×24 with 4px gap) |
 
 `<Toggle>` / `<Slider>` / `<Dropdown>` / `<ScrollList>` / `<TabBar>` are reference implementations. For project-specific differentiation (pixel border, press feedback, custom popup chrome) subclass and override `OnAttached` — see scripting-promptugui-csharp.
@@ -633,12 +633,42 @@ Radial fill（冷却环）不在 `<Progress>` 范围；以后用单独的 `<Cool
 
 Tab 是 TabBar 的 layout group child —— 不能写 `anchor=` / `margin=`（`HorizontalLayoutGroup` 接管排布；TabBar 在 `selfIsLayoutGroup` 名单里）。
 
+### Custom Tab layout via Template
+
+For richer cells (big icon + multi-line text, Explorer-style file tiles, etc.), wrap a `<Tab>` in a Template and invoke it as TabBar's child:
+
+```xml
+<Template name="FileTab">
+  <Param name="text"/>
+  <Param name="icon"/>
+  <Param name="bind"/>
+  <Param name="isOn" default="false"/>
+  <Frame width="80" height="96">
+    <Tab id="tab" isOn="{{isOn}}" bind="{{bind}}"/>
+    <Icon id="icon" sprite="ui:icon_{{icon}}"
+          anchor="top-center" width="48" height="48"
+          margin="8,0,0,0"/>
+    <Text id="name" anchor="top-stretch" margin="60,4,0,4"
+          fontSize="12" align="center" raycastTarget="false">{{text}}</Text>
+  </Frame>
+</Template>
+
+<TabBar id="files" sprite="ui:cell_normal" selectedSprite="ui:cell_selected">
+  <FileTab text="111.png" icon="png" isOn="true" bind="panel1"/>
+  <FileTab text="222.jpg" icon="jpg" bind="panel2"/>
+</TabBar>
+```
+
+TabBar walks Template wrappers recursively to find the inner `<Tab>`; sprite push, auto-select, and `OnSelectionChanged` all work as if the wrappers were direct Tab children. Lint rules `PUI-TABBAR-CHILD` and `PUI-TAB-PARENT` are suppressed for Template-instance roots. Use `<Icon>` (hardcoded `raycastTarget=false`) for decorative imagery and `raycastTarget="false"` on `<Text>` so clicks pass through to the underlying Tab.
+
+For dynamic data, use `BindItems` with `itemTemplate="FileTab"` (the same Template works for both patterns).
+
 ### Lint 规则
 
 | Code | 触发条件 | 级别 |
 |---|---|---|
-| `PUI-TAB-PARENT` | `<Tab>` 不在 `<TabBar>` 直接父节点下 | warning |
-| `PUI-TABBAR-CHILD` | `<TabBar>` 的直接子节点不是 `<Tab>` | warning |
+| `PUI-TAB-PARENT` | `<Tab>` 不在 `<TabBar>` 直接父节点下（Template-instance root 内的 Tab 已豁免） | warning |
+| `PUI-TABBAR-CHILD` | `<TabBar>` 的直接子节点不是 `<Tab>` 且子树里也没有 `<Tab>`（Template wrapper 已豁免） | warning |
 | `PUI-TAB-CHILDREN` | `<Tab>` 包含嵌套 XML children（auto label / icon 由属性驱动） | error |
 | `PUI-TABBAR-DIRECTION` | `direction` 不是 `horizontal` / `vertical` | error |
 | `PUI-TAB-BIND-EMPTY` | `bind=""`（空字符串） | warning |

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -201,6 +201,43 @@ screen.Get<ScrollList>("inv")
 - `itemTemplate=` in the XML resolves to either a `<Template name="...">` (slot root is the template body) or a registered Control class (slot is that Control). Use `slot.Get<T>("childId")` inside the binder to reach into Template bodies.
 - After hot-reload, you must **re-Bind** — the underlying ScrollList is rebuilt.
 
+### TabBar
+
+```csharp
+var bar = screen.Get<TabBar>("topbar");
+
+// Static XML tabs already exist; subscribe to selection changes:
+bar.OnSelectionChanged
+   .Subscribe(tab => Debug.Log($"selected: {tab?.Id}"))
+   .AddTo(screen);
+
+// Or per-Tab:
+screen.Get<Tab>("edit").OnSelected
+      .Subscribe(_ => OpenEditor()).AddTo(screen);
+
+// Dynamic: clear and rebuild from a data source (same shape as ScrollList.BindItems):
+bar.BindItems(
+    items,
+    (Tab tab, MyModel m) => { tab.Text = m.Name; tab.Bind = m.FrameId; })
+   .AddTo(screen);
+
+// Custom Template (when Tab needs to be wrapped — e.g. <HStack><Icon/><Tab id="tab"/></HStack>):
+bar.BindItems<MyModel, IControl>(
+    items,
+    (slot, m) => slot.Get<Tab>("tab").Text = m.Name)
+   .AddTo(screen);
+
+// Query API:
+bar.Count;          // current tab count
+bar.SelectedIndex;  // -1 if none (only possible right after BindItems with empty list)
+bar.SelectedTab;    // Tab ref or null
+bar.GetAt(i);
+```
+
+Setting `tab.IsOn = true` triggers mutex (other Tabs flip to false via the TabBar's private `ToggleGroup`) AND auto-shows the `bind`-ed Frame — no manual `frame.GameObject.SetActive(...)` needed. If `BindItems` is called with an empty list, `OnSelectionChanged` fires with `null` to let subscribers clear UI state. After hot-reload, re-Bind just like ScrollList.
+
+`bar.BindItems<T, TSlot>` lets the template root be any `IControl`; `bar.BindItems<T>` is shorthand when the template root *is* a `<Tab>` directly. The `<Tab>` reachable inside the slot is found via `ScopedIds` first, then a recursive child walk — Templates without an id'd Tab still work as long as exactly one `<Tab>` exists in the subtree.
+
 ## Variant switching at runtime
 
 ```csharp
@@ -300,15 +337,19 @@ GET            screen.Get<Btn>("id")                          typed
                screen.Get<Btn>("outerId/innerId")             path into Template body
 
 EVENTS (R3)    .OnClick                Btn
-               .OnValueChanged         Toggle:bool / Slider:float / InputField:string
-               .OnSelected             Dropdown:int
+               .OnValueChanged         Toggle:bool / Slider:float / InputField:string / Tab:bool
+               .OnSelected             Dropdown:int / Tab:Unit (on=true only)
+               .OnSelectionChanged     TabBar:Tab (the newly-on Tab, or null when emptied)
                .OnEndEdit / .OnSubmit  InputField:string
                .Subscribe(...).AddTo(screen)   tie lifetime — ALWAYS
                Progress                display-only; .Value = 0.42f (Clamp01); no event
 
 DATA PUSH      Dropdown.BindOptions(Observable<IEnumerable<string>>)
                ScrollList.BindItems(Observable<IReadOnlyList<T>>, (slot,t)=>...)
+               TabBar.BindItems(Observable<IReadOnlyList<T>>, (Tab tab,t)=>...)
+                                       or BindItems<T,TSlot>(...) for wrapped templates
                .AddTo(screen)
+               TabBar query: .Count / .SelectedIndex (-1 if empty) / .SelectedTab / .GetAt(i)
 
 VARIANT        UI.Variants.Set("name", true|false)            re-applies, no rebuild
 ORIENTATION    UI.Orientation.IsPortrait                      auto-tracked: portrait / landscape variants

--- a/Runtime/Application/BuiltinPrimitives.cs
+++ b/Runtime/Application/BuiltinPrimitives.cs
@@ -19,6 +19,8 @@ namespace PromptUGUI.Application
             reg.Register<Grid>("Grid", null);
             reg.Register<Btn>("Btn", null, defaultTextAttr: "text");
             reg.Register<Toggle>("Toggle", null, defaultTextAttr: "text");
+            reg.Register<Tab>("Tab", null, defaultTextAttr: "text");
+            reg.Register<TabBar>("TabBar", null);
             reg.Register<Slider>("Slider", null);
             reg.Register<Progress>("Progress", null);
             reg.Register<Dropdown>("Dropdown", null);

--- a/Runtime/Application/BuiltinPrimitives.cs
+++ b/Runtime/Application/BuiltinPrimitives.cs
@@ -19,7 +19,7 @@ namespace PromptUGUI.Application
             reg.Register<Grid>("Grid", null);
             reg.Register<Btn>("Btn", null, defaultTextAttr: "text");
             reg.Register<Toggle>("Toggle", null, defaultTextAttr: "text");
-            reg.Register<Tab>("Tab", null);
+            reg.Register<Tab>("Tab", null, defaultTextAttr: "text");
             reg.Register<TabBar>("TabBar", null);
             reg.Register<Slider>("Slider", null);
             reg.Register<Progress>("Progress", null);

--- a/Runtime/Application/BuiltinPrimitives.cs
+++ b/Runtime/Application/BuiltinPrimitives.cs
@@ -19,7 +19,7 @@ namespace PromptUGUI.Application
             reg.Register<Grid>("Grid", null);
             reg.Register<Btn>("Btn", null, defaultTextAttr: "text");
             reg.Register<Toggle>("Toggle", null, defaultTextAttr: "text");
-            reg.Register<Tab>("Tab", null, defaultTextAttr: "text");
+            reg.Register<Tab>("Tab", null);
             reg.Register<TabBar>("TabBar", null);
             reg.Register<Slider>("Slider", null);
             reg.Register<Progress>("Progress", null);

--- a/Runtime/Application/ScreenInstantiator.cs
+++ b/Runtime/Application/ScreenInstantiator.cs
@@ -176,6 +176,13 @@ namespace PromptUGUI.Application
                                            Control parentControl = null,
                                            List<ElementNode> applyOrder = null)
         {
+            if (node.Tag == "Tab" && parentControl != null && !(parentControl is Controls.TabBar))
+            {
+                Debug.LogWarning(
+                    $"<Tab id='{node.Id}'>: must be a direct child of <TabBar>; current parent is " +
+                    $"<{parentControl.GetType().Name}>. Mutual exclusion and shared visuals will not apply.");
+            }
+
             if (parentIsLayoutGroup)
             {
                 foreach (var issue in LayoutGroupChildRules.CheckChild(node))
@@ -191,6 +198,12 @@ namespace PromptUGUI.Application
                     Debug.LogWarning(issue.Message);
             else if (node.Tag == "Progress")
                 foreach (var issue in ProgressAttributeRules.CheckProgress(node))
+                    Debug.LogWarning(issue.Message);
+            else if (node.Tag == "Tab")
+                foreach (var issue in TabRules.CheckTab(node))
+                    Debug.LogWarning(issue.Message);
+            else if (node.Tag == "TabBar")
+                foreach (var issue in TabRules.CheckTabBar(node))
                     Debug.LogWarning(issue.Message);
 
             var entry = _registry.Resolve(node.Tag);
@@ -234,7 +247,7 @@ namespace PromptUGUI.Application
                 control.ReplaceScopedIds(childScope);
             }
 
-            var selfIsLayoutGroup = node.Tag is "VStack" or "HStack" or "Grid";
+            var selfIsLayoutGroup = node.Tag is "VStack" or "HStack" or "Grid" or "TabBar";
             foreach (var c in node.Children)
                 InstantiateRecursive(c, control.ChildHostTransform, selfIsLayoutGroup, childScope, nodeMap,
                                      parentControl: control, applyOrder: applyOrder);

--- a/Runtime/Application/ScreenInstantiator.cs
+++ b/Runtime/Application/ScreenInstantiator.cs
@@ -176,13 +176,6 @@ namespace PromptUGUI.Application
                                            Control parentControl = null,
                                            List<ElementNode> applyOrder = null)
         {
-            if (node.Tag == "Tab" && parentControl != null && !(parentControl is Controls.TabBar))
-            {
-                Debug.LogWarning(
-                    $"<Tab id='{node.Id}'>: must be a direct child of <TabBar>; current parent is " +
-                    $"<{parentControl.GetType().Name}>. Mutual exclusion and shared visuals will not apply.");
-            }
-
             if (parentIsLayoutGroup)
             {
                 foreach (var issue in LayoutGroupChildRules.CheckChild(node))

--- a/Runtime/Controls/Tab.cs
+++ b/Runtime/Controls/Tab.cs
@@ -40,11 +40,11 @@ namespace PromptUGUI.Controls
             lrt.offsetMin = Vector2.zero; lrt.offsetMax = Vector2.zero;
             ApplyFont();
 
-            var bar = FindAncestorTabBar();
-            if (bar == null)
+            var group = FindAncestorToggleGroup();
+            if (group == null)
                 Debug.LogWarning($"Tab '{Id}' has no <TabBar> ancestor; mutual exclusion disabled.");
             else
-                _toggle.group = bar.InternalToggleGroup;
+                _toggle.group = group;
 
             _toggle.onValueChanged.AddListener(v =>
             {
@@ -54,20 +54,18 @@ namespace PromptUGUI.Controls
             UI.Locale.Changed += ApplyFont;
         }
 
-        private TabBar FindAncestorTabBar()
+        private ToggleGroup FindAncestorToggleGroup()
         {
-            // TabBar is a POCO Control (not a Component), so we can't GetComponent it.
-            // Walk transform ancestors and look each GameObject up via the owning Screen's
-            // NodeMap to find the Control instance.
-            var screen = UI.OwnerScreenOf(this);
-            if (screen == null) return null;
+            // OnAttached runs before Screen._nodeMap is populated, so we can't look up
+            // the TabBar control by GameObject yet. TabBar.OnAttached has already added
+            // its ToggleGroup component to its own GameObject (parent created first
+            // during DFS instantiation), so a transform-ancestor GetComponent walk
+            // finds it directly without depending on _nodeMap.
             var t = RectTransform.parent;
             while (t != null)
             {
-                foreach (var c in screen.NodeMap.Values)
-                {
-                    if (c is TabBar bar && c.GameObject == t.gameObject) return bar;
-                }
+                var g = t.GetComponent<UnityEngine.UI.ToggleGroup>();
+                if (g != null) return g;
                 t = t.parent;
             }
             return null;

--- a/Runtime/Controls/Tab.cs
+++ b/Runtime/Controls/Tab.cs
@@ -82,6 +82,13 @@ namespace PromptUGUI.Controls
         }
 
         [UIAttr, Preserve]
+        public bool IsOn
+        {
+            get => _toggle != null && _toggle.isOn;
+            set { if (_toggle != null) _toggle.isOn = value; }
+        }
+
+        [UIAttr, Preserve]
         public string Text
         {
             set

--- a/Runtime/Controls/Tab.cs
+++ b/Runtime/Controls/Tab.cs
@@ -108,6 +108,28 @@ namespace PromptUGUI.Controls
             set { if (_label != null) _label.fontSize = value; }
         }
 
+        [UIAttr(IsSprite = true), Preserve]
+        public string Icon
+        {
+            set
+            {
+                if (_icon == null)
+                {
+                    _icon = ProceduralBuilders.AddImage(RectTransform, "Icon", raycast: false);
+                    var rt = _icon.rectTransform;
+                    rt.anchorMin = new Vector2(0f, 0.5f);
+                    rt.anchorMax = new Vector2(0f, 0.5f);
+                    rt.pivot = new Vector2(0.5f, 0.5f);
+                    rt.sizeDelta = new Vector2(24f, 24f);
+                    rt.anchoredPosition = new Vector2(16f, 0f);     // 4px gap from left edge then center of 24
+                    // Shift label right to make room for icon
+                    var lrt = _label.rectTransform;
+                    lrt.offsetMin = new Vector2(32f, 0f);
+                }
+                _icon.sprite = UI.ResolveSprite(value);
+            }
+        }
+
         public Observable<bool> OnValueChanged => _changed;
         public Observable<Unit> OnSelected => _selected;
 

--- a/Runtime/Controls/Tab.cs
+++ b/Runtime/Controls/Tab.cs
@@ -92,6 +92,22 @@ namespace PromptUGUI.Controls
 
         internal override string PeekDefaultText() => _label != null ? _label.text : null;
 
+        [UIAttr, Preserve]
+        public string Font
+        {
+            set
+            {
+                _fontType = string.IsNullOrEmpty(value) ? "default" : value;
+                ApplyFont();
+            }
+        }
+
+        [UIAttr("fontSize"), Preserve]
+        public int FontSize
+        {
+            set { if (_label != null) _label.fontSize = value; }
+        }
+
         public Observable<bool> OnValueChanged => _changed;
         public Observable<Unit> OnSelected => _selected;
 

--- a/Runtime/Controls/Tab.cs
+++ b/Runtime/Controls/Tab.cs
@@ -18,6 +18,9 @@ namespace PromptUGUI.Controls
         private TMP_Text _label;
         private UnityToggle _toggle;
         private string _fontType = "default";
+        private string _bindId;
+        private bool _bindResolved;
+        private Frame _boundFrame;
         private readonly Subject<bool> _changed = new();
         private readonly Subject<Unit> _selected = new();
 
@@ -47,13 +50,33 @@ namespace PromptUGUI.Controls
             else
                 _toggle.group = group;
 
-            _toggle.onValueChanged.AddListener(v =>
-            {
-                _changed.OnNext(v);
-                if (v) _selected.OnNext(Unit.Default);
-            });
+            _toggle.onValueChanged.AddListener(OnIsOnChanged);
             UI.Locale.Changed += ApplyFont;
         }
+
+        private void OnIsOnChanged(bool isOn)
+        {
+            _changed.OnNext(isOn);
+            if (isOn) _selected.OnNext(Unit.Default);
+            ApplyBindFrame(isOn);
+        }
+
+        private void ApplyBindFrame(bool isOn)
+        {
+            if (_bindId == null && !_bindResolved) return;
+            if (!_bindResolved)
+            {
+                try { _boundFrame = UI.OwnerScreenOf(this)?.Get<Frame>(_bindId); }
+                catch { _boundFrame = null; }
+                if (_boundFrame == null)
+                    Debug.LogWarning($"Tab.bind='{_bindId}' did not resolve to a Frame; ignoring.");
+                _bindResolved = true;
+                _bindId = null;     // prevent re-warn
+            }
+            if (_boundFrame != null) _boundFrame.GameObject.SetActive(isOn);
+        }
+
+        internal void ForceSyncBindFrame(bool isOn) => ApplyBindFrame(isOn);
 
         private ToggleGroup FindAncestorToggleGroup()
         {
@@ -87,6 +110,9 @@ namespace PromptUGUI.Controls
             get => _toggle != null && _toggle.isOn;
             set { if (_toggle != null) _toggle.isOn = value; }
         }
+
+        [UIAttr, Preserve]
+        public string Bind { set => _bindId = value; }
 
         [UIAttr, Preserve]
         public string Text

--- a/Runtime/Controls/Tab.cs
+++ b/Runtime/Controls/Tab.cs
@@ -35,6 +35,7 @@ namespace PromptUGUI.Controls
             _label.alignment = TextAlignmentOptions.Center;
             _label.raycastTarget = false;
             _label.fontSize = 24;
+            _label.text = "";
             var lrt = _label.rectTransform;
             lrt.anchorMin = Vector2.zero; lrt.anchorMax = Vector2.one;
             lrt.offsetMin = Vector2.zero; lrt.offsetMax = Vector2.zero;
@@ -79,6 +80,17 @@ namespace PromptUGUI.Controls
             var asset = settings?.ResolveFont(locale, _fontType);
             if (asset != null) _label.font = asset;
         }
+
+        [UIAttr, Preserve]
+        public string Text
+        {
+            set
+            {
+                if (_label != null) _label.text = value ?? "";
+            }
+        }
+
+        internal override string PeekDefaultText() => _label != null ? _label.text : null;
 
         public Observable<bool> OnValueChanged => _changed;
         public Observable<Unit> OnSelected => _selected;

--- a/Runtime/Controls/Tab.cs
+++ b/Runtime/Controls/Tab.cs
@@ -137,6 +137,25 @@ namespace PromptUGUI.Controls
             _bg.type = sprite.border != Vector4.zero ? UnityImage.Type.Sliced : UnityImage.Type.Simple;
         }
 
+        internal void EnsureOverlay(Sprite selectedSprite)
+        {
+            if (_overlay == null)
+            {
+                _overlay = ProceduralBuilders.AddImage(RectTransform, "Overlay", raycast: false);
+                _overlay.rectTransform.SetSiblingIndex(0);   // draw under Label / Icon
+                var rt = _overlay.rectTransform;
+                rt.anchorMin = Vector2.zero; rt.anchorMax = Vector2.one;
+                rt.offsetMin = Vector2.zero; rt.offsetMax = Vector2.zero;
+                _toggle.graphic = _overlay;
+                _toggle.toggleTransition = UnityToggle.ToggleTransition.None;   // instant; TB-D5
+            }
+            if (selectedSprite == null) return;
+            _overlay.sprite = selectedSprite;
+            _overlay.type = selectedSprite.border != Vector4.zero
+                ? UnityImage.Type.Sliced
+                : UnityImage.Type.Simple;
+        }
+
         public Observable<bool> OnValueChanged => _changed;
         public Observable<Unit> OnSelected => _selected;
 

--- a/Runtime/Controls/Tab.cs
+++ b/Runtime/Controls/Tab.cs
@@ -130,6 +130,13 @@ namespace PromptUGUI.Controls
             }
         }
 
+        internal void ApplyBgSprite(Sprite sprite)
+        {
+            if (sprite == null) return;
+            _bg.sprite = sprite;
+            _bg.type = sprite.border != Vector4.zero ? UnityImage.Type.Sliced : UnityImage.Type.Simple;
+        }
+
         public Observable<bool> OnValueChanged => _changed;
         public Observable<Unit> OnSelected => _selected;
 

--- a/Runtime/Controls/Tab.cs
+++ b/Runtime/Controls/Tab.cs
@@ -1,0 +1,96 @@
+using PromptUGUI.Application;
+using PromptUGUI.Controls.Internal;
+using PromptUGUI.Registry;
+using R3;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityImage = UnityEngine.UI.Image;
+using UnityToggle = UnityEngine.UI.Toggle;
+
+namespace PromptUGUI.Controls
+{
+    public sealed class Tab : Control
+    {
+        private UnityImage _bg;
+        private UnityImage _overlay;
+        private UnityImage _icon;
+        private TMP_Text _label;
+        private UnityToggle _toggle;
+        private string _fontType = "default";
+        private readonly Subject<bool> _changed = new();
+        private readonly Subject<Unit> _selected = new();
+
+        public override void OnAttached()
+        {
+            _bg = GameObject.GetComponent<UnityImage>() ?? GameObject.AddComponent<UnityImage>();
+            _bg.color = ProceduralBuilders.DefaultBtnColor;
+            ProceduralBuilders.ApplyDefaultSlicedSprite(_bg);
+
+            _toggle = GameObject.GetComponent<UnityToggle>() ?? GameObject.AddComponent<UnityToggle>();
+            _toggle.targetGraphic = _bg;
+            _toggle.transition = Selectable.Transition.ColorTint;
+
+            _label = ProceduralBuilders.AddText(RectTransform, "Label");
+            _label.alignment = TextAlignmentOptions.Center;
+            _label.raycastTarget = false;
+            _label.fontSize = 24;
+            var lrt = _label.rectTransform;
+            lrt.anchorMin = Vector2.zero; lrt.anchorMax = Vector2.one;
+            lrt.offsetMin = Vector2.zero; lrt.offsetMax = Vector2.zero;
+            ApplyFont();
+
+            var bar = FindAncestorTabBar();
+            if (bar == null)
+                Debug.LogWarning($"Tab '{Id}' has no <TabBar> ancestor; mutual exclusion disabled.");
+            else
+                _toggle.group = bar.InternalToggleGroup;
+
+            _toggle.onValueChanged.AddListener(v =>
+            {
+                _changed.OnNext(v);
+                if (v) _selected.OnNext(Unit.Default);
+            });
+            UI.Locale.Changed += ApplyFont;
+        }
+
+        private TabBar FindAncestorTabBar()
+        {
+            // TabBar is a POCO Control (not a Component), so we can't GetComponent it.
+            // Walk transform ancestors and look each GameObject up via the owning Screen's
+            // NodeMap to find the Control instance.
+            var screen = UI.OwnerScreenOf(this);
+            if (screen == null) return null;
+            var t = RectTransform.parent;
+            while (t != null)
+            {
+                foreach (var c in screen.NodeMap.Values)
+                {
+                    if (c is TabBar bar && c.GameObject == t.gameObject) return bar;
+                }
+                t = t.parent;
+            }
+            return null;
+        }
+
+        private void ApplyFont()
+        {
+            if (_label == null) return;
+            var settings = PromptUGUISettings.Instance;
+            var locale = UI.Locale.Current;
+            var asset = settings?.ResolveFont(locale, _fontType);
+            if (asset != null) _label.font = asset;
+        }
+
+        public Observable<bool> OnValueChanged => _changed;
+        public Observable<Unit> OnSelected => _selected;
+
+        public override void Dispose()
+        {
+            UI.Locale.Changed -= ApplyFont;
+            _changed.Dispose();
+            _selected.Dispose();
+            base.Dispose();
+        }
+    }
+}

--- a/Runtime/Controls/Tab.cs.meta
+++ b/Runtime/Controls/Tab.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 53df2ecb5f8067146aa1df2bc97a3dc9

--- a/Runtime/Controls/TabBar.cs
+++ b/Runtime/Controls/TabBar.cs
@@ -44,6 +44,21 @@ namespace PromptUGUI.Controls
         {
             CollectStaticTabs();
             PushVisualToTabs();
+            SyncInitialSelection();
+        }
+
+        private void SyncInitialSelection()
+        {
+            if (_tabs.Count == 0) return;
+
+            // (1) Reconcile: any unselected Tab with a bind clears its Frame
+            foreach (var t in _tabs)
+                if (!t.IsOn) t.ForceSyncBindFrame(isOn: false);
+
+            // (2) Auto-select first if nothing on
+            bool anyOn = false;
+            foreach (var t in _tabs) if (t.IsOn) { anyOn = true; break; }
+            if (!anyOn) _tabs[0].IsOn = true;
         }
 
         private void CollectStaticTabs()

--- a/Runtime/Controls/TabBar.cs
+++ b/Runtime/Controls/TabBar.cs
@@ -34,8 +34,6 @@ namespace PromptUGUI.Controls
         // both on dynamic Rebuild and on static OnAfterApply so reapply replaces them.
         private CompositeDisposable _tabSubs;
 
-        internal ToggleGroup InternalToggleGroup => _group;
-
         public override void OnAttached()
         {
             _group = GameObject.AddComponent<ToggleGroup>();

--- a/Runtime/Controls/TabBar.cs
+++ b/Runtime/Controls/TabBar.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Collections.Generic;
 using PromptUGUI.Application;
+using PromptUGUI.IR;
+using PromptUGUI.Parser;
 using PromptUGUI.Registry;
 using R3;
 using UnityEngine;
@@ -19,6 +22,13 @@ namespace PromptUGUI.Controls
         private Sprite _sprite;
         private Sprite _selectedSprite;
         private bool _selectedSpriteDeclared;
+
+        // BindItems / itemTemplate state — factory resolution is deferred to first
+        // Rebuild so that OwnerScreenOf(this) sees the Screen registered in UI._open
+        // (XML setter time may pre-date Open(); also lets tests rely on default "Tab").
+        private string _itemTemplate = "Tab";
+        private Func<RectTransform, IControl> _factory;
+        private IDisposable _itemsSub;
 
         internal ToggleGroup InternalToggleGroup => _group;
 
@@ -56,6 +66,107 @@ namespace PromptUGUI.Controls
                 _selectedSpriteDeclared = true;
                 _selectedSprite = UI.ResolveSprite(value);
             }
+        }
+
+        [UIAttr, Preserve]
+        public string ItemTemplate
+        {
+            set { _itemTemplate = string.IsNullOrEmpty(value) ? "Tab" : value; _factory = null; }
+        }
+
+        public int Count => _tabs.Count;
+
+        public int SelectedIndex
+        {
+            get
+            {
+                for (int i = 0; i < _tabs.Count; i++)
+                    if (_tabs[i].IsOn) return i;
+                return -1;
+            }
+        }
+
+        public Tab SelectedTab
+        {
+            get
+            {
+                var idx = SelectedIndex;
+                return idx >= 0 ? _tabs[idx] : null;
+            }
+        }
+
+        public Tab GetAt(int index) => _tabs[index];
+
+        public IDisposable BindItems<T>(
+            Observable<IReadOnlyList<T>> source,
+            Action<Tab, T> bind)
+            => BindItems<T, Tab>(source, bind);
+
+        public IDisposable BindItems<T, TSlot>(
+            Observable<IReadOnlyList<T>> source,
+            Action<TSlot, T> bind) where TSlot : class, IControl
+        {
+            _itemsSub?.Dispose();
+            _itemsSub = source.Subscribe(items => Rebuild(items, bind));
+            return _itemsSub;
+        }
+
+        private void Rebuild<T, TSlot>(IReadOnlyList<T> items, Action<TSlot, T> bind)
+            where TSlot : class, IControl
+        {
+            if (_factory == null) _factory = ResolveFactory(_itemTemplate);
+            ClearTabs();
+            for (int i = 0; i < items.Count; i++)
+            {
+                var node = _factory(RectTransform);
+                var typed = node as TSlot;
+                if (typed == null)
+                    throw new InvalidCastException(
+                        $"itemTemplate='{_itemTemplate}' instantiated {node.GetType().Name}, expected {typeof(TSlot).Name}");
+
+                var tab = node as Tab
+                          ?? ((Control)node).GameObject.GetComponentInChildren<Tab>();
+                if (tab == null)
+                    throw new InvalidCastException(
+                        $"itemTemplate='{_itemTemplate}' root contains no <Tab>; cannot bind.");
+
+                _tabs.Add(tab);
+                // Tab.OnAttached already wired ToggleGroup via FindAncestorToggleGroup; push shared visuals now.
+                tab.ApplyBgSprite(_sprite);
+                if (_selectedSpriteDeclared) tab.EnsureOverlay(_selectedSprite);
+                bind(typed, items[i]);
+            }
+            SyncInitialSelection();
+        }
+
+        private void ClearTabs()
+        {
+            foreach (var t in _tabs) t.Dispose();
+            _tabs.Clear();
+        }
+
+        private Func<RectTransform, IControl> ResolveFactory(string tag)
+        {
+            var owner = UI.OwnerScreenOf(this);
+            if (owner?.Def?.Templates != null && owner.Def.Templates.TryGetValue(tag, out var tpl))
+            {
+                return parent =>
+                {
+                    var instantiator = UI.GetInstantiator();
+                    return instantiator.InstantiateNode(tpl.Body, parent, owner);
+                };
+            }
+            if (UI.Registry.Has(tag))
+            {
+                return parent =>
+                {
+                    var instantiator = UI.GetInstantiator();
+                    var node = new ElementNode(tag);
+                    return instantiator.InstantiateNode(node, parent, owner);
+                };
+            }
+            throw new ParseException(
+                $"<TabBar itemTemplate='{tag}'>: tag is neither a registered Control nor a Template");
         }
 
         internal override void OnAfterApply()
@@ -99,8 +210,8 @@ namespace PromptUGUI.Controls
         {
             if (_layout != null)
             {
-                if (UnityEngine.Application.isPlaying) Object.Destroy((Component)_layout);
-                else Object.DestroyImmediate((Component)_layout);
+                if (UnityEngine.Application.isPlaying) UnityEngine.Object.Destroy((Component)_layout);
+                else UnityEngine.Object.DestroyImmediate((Component)_layout);
                 _layout = null;
             }
             _layout = _direction == "vertical"
@@ -138,6 +249,7 @@ namespace PromptUGUI.Controls
 
         public override void Dispose()
         {
+            _itemsSub?.Dispose();
             _selectionChanged.Dispose();
             base.Dispose();
         }

--- a/Runtime/Controls/TabBar.cs
+++ b/Runtime/Controls/TabBar.cs
@@ -234,7 +234,14 @@ namespace PromptUGUI.Controls
         {
             _tabs.Clear();
             foreach (var child in Children)
-                if (child is Tab tab) _tabs.Add(tab);
+            {
+                if (child is Tab tab) { _tabs.Add(tab); continue; }
+                // Template-wrapper case: a <Tab> nested inside a Template-expanded
+                // child (e.g. <FileTab><Frame><Tab/></Frame></FileTab>). Reuse the
+                // same recursive walk used by BindItems for itemTemplate.
+                var found = FindTabIn(child);
+                if (found != null) _tabs.Add(found);
+            }
         }
 
         private void PushVisualToTabs()

--- a/Runtime/Controls/TabBar.cs
+++ b/Runtime/Controls/TabBar.cs
@@ -30,6 +30,10 @@ namespace PromptUGUI.Controls
         private Func<RectTransform, IControl> _factory;
         private IDisposable _itemsSub;
 
+        // Per-Tab subscriptions kept alive until next rebuild / Dispose; reset
+        // both on dynamic Rebuild and on static OnAfterApply so reapply replaces them.
+        private CompositeDisposable _tabSubs;
+
         internal ToggleGroup InternalToggleGroup => _group;
 
         public override void OnAttached()
@@ -136,10 +140,14 @@ namespace PromptUGUI.Controls
                 bind(typed, items[i]);
             }
             SyncInitialSelection();
+            WireTabSubscriptions();
+            if (_tabs.Count == 0) _selectionChanged.OnNext(null);
         }
 
         private void ClearTabs()
         {
+            _tabSubs?.Dispose();
+            _tabSubs = null;
             foreach (var t in _tabs) t.Dispose();
             _tabs.Clear();
         }
@@ -193,6 +201,21 @@ namespace PromptUGUI.Controls
             CollectStaticTabs();
             PushVisualToTabs();
             SyncInitialSelection();
+            WireTabSubscriptions();
+        }
+
+        private void WireTabSubscriptions()
+        {
+            _tabSubs?.Dispose();
+            _tabSubs = new CompositeDisposable();
+            foreach (var t in _tabs)
+            {
+                var captured = t;
+                captured.OnValueChanged
+                    .Where(on => on)
+                    .Subscribe(_ => _selectionChanged.OnNext(captured))
+                    .AddTo(_tabSubs);
+            }
         }
 
         private void SyncInitialSelection()
@@ -268,6 +291,7 @@ namespace PromptUGUI.Controls
 
         public override void Dispose()
         {
+            _tabSubs?.Dispose();
             _itemsSub?.Dispose();
             _selectionChanged.Dispose();
             base.Dispose();

--- a/Runtime/Controls/TabBar.cs
+++ b/Runtime/Controls/TabBar.cs
@@ -14,6 +14,7 @@ namespace PromptUGUI.Controls
         private string _direction = "horizontal";
         private readonly List<Tab> _tabs = new();
         private readonly Subject<Tab> _selectionChanged = new();
+        private Sprite _sprite;
 
         internal ToggleGroup InternalToggleGroup => _group;
 
@@ -22,6 +23,27 @@ namespace PromptUGUI.Controls
             _group = GameObject.AddComponent<ToggleGroup>();
             _group.allowSwitchOff = false;
             ApplyDirection();
+        }
+
+        [UIAttr(IsSprite = true), Preserve]
+        public string Sprite { set => _sprite = UI.ResolveSprite(value); }
+
+        internal override void OnAfterApply()
+        {
+            CollectStaticTabs();
+            PushVisualToTabs();
+        }
+
+        private void CollectStaticTabs()
+        {
+            _tabs.Clear();
+            foreach (var child in Children)
+                if (child is Tab tab) _tabs.Add(tab);
+        }
+
+        private void PushVisualToTabs()
+        {
+            foreach (var t in _tabs) t.ApplyBgSprite(_sprite);
         }
 
         private void ApplyDirection()

--- a/Runtime/Controls/TabBar.cs
+++ b/Runtime/Controls/TabBar.cs
@@ -12,6 +12,8 @@ namespace PromptUGUI.Controls
         private ToggleGroup _group;
         private LayoutGroup _layout;
         private string _direction = "horizontal";
+        private float _spacing;
+        private string _padding;
         private readonly List<Tab> _tabs = new();
         private readonly Subject<Tab> _selectionChanged = new();
         private Sprite _sprite;
@@ -36,6 +38,12 @@ namespace PromptUGUI.Controls
                 ApplyDirection();
             }
         }
+
+        [UIAttr, Preserve]
+        public float Spacing { set { _spacing = value; ApplySpacingPadding(); } }
+
+        [UIAttr, Preserve]
+        public string Padding { set { _padding = value; ApplySpacingPadding(); } }
 
         [UIAttr(IsSprite = true), Preserve]
         public string Sprite { set => _sprite = UI.ResolveSprite(value); }
@@ -98,6 +106,32 @@ namespace PromptUGUI.Controls
             _layout = _direction == "vertical"
                 ? (LayoutGroup)GameObject.AddComponent<VerticalLayoutGroup>()
                 : GameObject.AddComponent<HorizontalLayoutGroup>();
+            ApplySpacingPadding();
+        }
+
+        private void ApplySpacingPadding()
+        {
+            switch (_layout)
+            {
+                case HorizontalLayoutGroup h: h.spacing = _spacing; break;
+                case VerticalLayoutGroup v: v.spacing = _spacing; break;
+            }
+            if (string.IsNullOrEmpty(_padding) || _layout == null) return;
+            var parts = _padding.Split(',');
+            int t = 0, r = 0, b = 0, l = 0;
+            switch (parts.Length)
+            {
+                case 1: int.TryParse(parts[0], out t); r = b = l = t; break;
+                case 2:
+                    int.TryParse(parts[0], out t); b = t;
+                    int.TryParse(parts[1], out r); l = r; break;
+                case 4:
+                    int.TryParse(parts[0], out t);
+                    int.TryParse(parts[1], out r);
+                    int.TryParse(parts[2], out b);
+                    int.TryParse(parts[3], out l); break;
+            }
+            _layout.padding = new RectOffset(l, r, t, b);
         }
 
         public Observable<Tab> OnSelectionChanged => _selectionChanged;

--- a/Runtime/Controls/TabBar.cs
+++ b/Runtime/Controls/TabBar.cs
@@ -27,6 +27,16 @@ namespace PromptUGUI.Controls
             ApplyDirection();
         }
 
+        [UIAttr, Preserve]
+        public string Direction
+        {
+            set
+            {
+                _direction = string.IsNullOrEmpty(value) ? "horizontal" : value;
+                ApplyDirection();
+            }
+        }
+
         [UIAttr(IsSprite = true), Preserve]
         public string Sprite { set => _sprite = UI.ResolveSprite(value); }
 

--- a/Runtime/Controls/TabBar.cs
+++ b/Runtime/Controls/TabBar.cs
@@ -15,6 +15,8 @@ namespace PromptUGUI.Controls
         private readonly List<Tab> _tabs = new();
         private readonly Subject<Tab> _selectionChanged = new();
         private Sprite _sprite;
+        private Sprite _selectedSprite;
+        private bool _selectedSpriteDeclared;
 
         internal ToggleGroup InternalToggleGroup => _group;
 
@@ -27,6 +29,16 @@ namespace PromptUGUI.Controls
 
         [UIAttr(IsSprite = true), Preserve]
         public string Sprite { set => _sprite = UI.ResolveSprite(value); }
+
+        [UIAttr(IsSprite = true), Preserve]
+        public string SelectedSprite
+        {
+            set
+            {
+                _selectedSpriteDeclared = true;
+                _selectedSprite = UI.ResolveSprite(value);
+            }
+        }
 
         internal override void OnAfterApply()
         {
@@ -43,7 +55,11 @@ namespace PromptUGUI.Controls
 
         private void PushVisualToTabs()
         {
-            foreach (var t in _tabs) t.ApplyBgSprite(_sprite);
+            foreach (var t in _tabs)
+            {
+                t.ApplyBgSprite(_sprite);
+                if (_selectedSpriteDeclared) t.EnsureOverlay(_selectedSprite);
+            }
         }
 
         private void ApplyDirection()

--- a/Runtime/Controls/TabBar.cs
+++ b/Runtime/Controls/TabBar.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using PromptUGUI.Application;
+using PromptUGUI.Registry;
+using R3;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Controls
+{
+    public sealed class TabBar : Control
+    {
+        private ToggleGroup _group;
+        private LayoutGroup _layout;
+        private string _direction = "horizontal";
+        private readonly List<Tab> _tabs = new();
+        private readonly Subject<Tab> _selectionChanged = new();
+
+        internal ToggleGroup InternalToggleGroup => _group;
+
+        public override void OnAttached()
+        {
+            _group = GameObject.AddComponent<ToggleGroup>();
+            _group.allowSwitchOff = false;
+            ApplyDirection();
+        }
+
+        private void ApplyDirection()
+        {
+            if (_layout != null)
+            {
+                if (UnityEngine.Application.isPlaying) Object.Destroy((Component)_layout);
+                else Object.DestroyImmediate((Component)_layout);
+                _layout = null;
+            }
+            _layout = _direction == "vertical"
+                ? (LayoutGroup)GameObject.AddComponent<VerticalLayoutGroup>()
+                : GameObject.AddComponent<HorizontalLayoutGroup>();
+        }
+
+        public Observable<Tab> OnSelectionChanged => _selectionChanged;
+
+        public override void Dispose()
+        {
+            _selectionChanged.Dispose();
+            base.Dispose();
+        }
+    }
+}

--- a/Runtime/Controls/TabBar.cs
+++ b/Runtime/Controls/TabBar.cs
@@ -124,8 +124,7 @@ namespace PromptUGUI.Controls
                     throw new InvalidCastException(
                         $"itemTemplate='{_itemTemplate}' instantiated {node.GetType().Name}, expected {typeof(TSlot).Name}");
 
-                var tab = node as Tab
-                          ?? ((Control)node).GameObject.GetComponentInChildren<Tab>();
+                var tab = node as Tab ?? FindTabIn(node);
                 if (tab == null)
                     throw new InvalidCastException(
                         $"itemTemplate='{_itemTemplate}' root contains no <Tab>; cannot bind.");
@@ -143,6 +142,26 @@ namespace PromptUGUI.Controls
         {
             foreach (var t in _tabs) t.Dispose();
             _tabs.Clear();
+        }
+
+        // Tab is a pure C# Control (not a MonoBehaviour), so GetComponentInChildren
+        // can't find it. ScrollList-style template wrappers expose the full id scope on
+        // the root via ReplaceScopedIds — look there first; if the template has no
+        // id'd Tab, fall back to a recursive Children walk so wrappers without ids still work.
+        private static Tab FindTabIn(IControl node)
+        {
+            foreach (var c in node.ScopedIds.Values)
+                if (c is Tab t) return t;
+            if (node is Control ctrl)
+            {
+                foreach (var child in ctrl.Children)
+                {
+                    if (child is Tab t) return t;
+                    var nested = FindTabIn(child);
+                    if (nested != null) return nested;
+                }
+            }
+            return null;
         }
 
         private Func<RectTransform, IControl> ResolveFactory(string tag)

--- a/Runtime/Controls/TabBar.cs.meta
+++ b/Runtime/Controls/TabBar.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a35b8c808f647564c9dc253daf4023ee

--- a/Runtime/Core/Lint/IRWalker.cs
+++ b/Runtime/Core/Lint/IRWalker.cs
@@ -44,6 +44,12 @@ namespace PromptUGUI.Lint
             else if (node.Tag == "Progress")
                 foreach (var issue in ProgressAttributeRules.CheckProgress(node))
                     yield return issue;
+            else if (node.Tag == "Tab")
+                foreach (var issue in TabRules.CheckTab(node))
+                    yield return issue;
+            else if (node.Tag == "TabBar")
+                foreach (var issue in TabRules.CheckTabBar(node))
+                    yield return issue;
 
             // CLI-only: pure containers carry no Graphic; sprite/color silently dropped.
             // Intentionally NOT dispatched from ScreenInstantiator — see rule's XML docs.
@@ -51,12 +57,18 @@ namespace PromptUGUI.Lint
                 foreach (var issue in PureContainerVisualAttrRules.Check(node))
                     yield return issue;
 
-            var isLayoutGroup = node.Tag is "VStack" or "HStack" or "Grid";
+            var isLayoutGroup = node.Tag is "VStack" or "HStack" or "Grid" or "TabBar";
+            var isTabBar = node.Tag == "TabBar";
             foreach (var child in node.Children)
             {
                 if (isLayoutGroup)
                     foreach (var issue in LayoutGroupChildRules.CheckChild(child))
                         yield return issue;
+                if (child.Tag == "Tab" && !isTabBar)
+                    yield return new LintIssue(
+                        TabRules.TabParentCode, child.Tag, child.Id,
+                        $"<Tab id='{child.Id}'>: must be a direct child of <TabBar>; current parent is <{node.Tag}>. " +
+                        "Mutual exclusion and shared visuals will not apply.");
                 foreach (var issue in WalkNode(child))
                     yield return issue;
             }

--- a/Runtime/Core/Lint/IRWalker.cs
+++ b/Runtime/Core/Lint/IRWalker.cs
@@ -13,25 +13,29 @@ namespace PromptUGUI.Lint
         {
             foreach (var screen in doc.Screens)
             {
-                foreach (var issue in WalkNode(screen.Root))
+                foreach (var issue in WalkNode(screen.Root, inTemplateBody: false))
                     yield return issue;
 
                 foreach (var variant in screen.Variants)
                     foreach (var add in variant.Adds)
                         foreach (var addChild in add.Children)
-                            foreach (var issue in WalkNode(addChild))
+                            foreach (var issue in WalkNode(addChild, inTemplateBody: false))
                                 yield return issue;
             }
 
             foreach (var template in doc.Templates.Values)
             {
+                // Template bodies live in declaration-space, not in any actual TabBar
+                // hierarchy. The PARENT check is meaningless here: TabBar.CollectStaticTabs
+                // walks Template-expanded wrappers recursively, so a Frame>Tab pattern
+                // inside a Template body is intentional structure, not a misuse.
                 if (template.Body != null)
-                    foreach (var issue in WalkNode(template.Body))
+                    foreach (var issue in WalkNode(template.Body, inTemplateBody: true))
                         yield return issue;
             }
         }
 
-        private static IEnumerable<LintIssue> WalkNode(ElementNode node)
+        private static IEnumerable<LintIssue> WalkNode(ElementNode node, bool inTemplateBody)
         {
             // Per-tag self-checks (mirror of ScreenInstantiator dispatch; CLI errors).
             // Self-relative — about the node itself, unlike parent-relative LayoutGroupChildRules.
@@ -64,12 +68,18 @@ namespace PromptUGUI.Lint
                 if (isLayoutGroup)
                     foreach (var issue in LayoutGroupChildRules.CheckChild(child))
                         yield return issue;
-                if (child.Tag == "Tab" && !isTabBar)
+                // Exempt Template-instance roots and bodies: <Tab> wrapped in a
+                // Template (e.g. <Template name='FileTab'><Frame><Tab/>...) is
+                // intentional — TabBar.CollectStaticTabs walks wrappers via FindTabIn.
+                if (child.Tag == "Tab"
+                    && !isTabBar
+                    && !node.IsTemplateInstanceRoot
+                    && !inTemplateBody)
                     yield return new LintIssue(
                         TabRules.TabParentCode, child.Tag, child.Id,
                         $"<Tab id='{child.Id}'>: must be a direct child of <TabBar>; current parent is <{node.Tag}>. " +
                         "Mutual exclusion and shared visuals will not apply.");
-                foreach (var issue in WalkNode(child))
+                foreach (var issue in WalkNode(child, inTemplateBody))
                     yield return issue;
             }
         }

--- a/Runtime/Core/Lint/TabRules.cs
+++ b/Runtime/Core/Lint/TabRules.cs
@@ -43,12 +43,26 @@ namespace PromptUGUI.Lint
 
             foreach (var c in n.Children)
             {
-                if (c.Tag != "Tab")
-                    yield return new LintIssue(
-                        TabBarChildCode, n.Tag, n.Id,
-                        $"<TabBar id='{n.Id}'>: expected <Tab> children; found <{c.Tag}>. " +
-                        "Layout will still render via LayoutGroup but tab semantics will not apply to non-Tab nodes.");
+                if (c.Tag == "Tab") continue;
+                // Template wrapper around a Tab is OK — TabBar.CollectStaticTabs walks
+                // into the wrapper via FindTabIn so sprite push / auto-select / events
+                // still work. Suppress the CHILD warning to match runtime behaviour.
+                if (ContainsTabDescendant(c)) continue;
+                yield return new LintIssue(
+                    TabBarChildCode, n.Tag, n.Id,
+                    $"<TabBar id='{n.Id}'>: expected <Tab> children; found <{c.Tag}>. " +
+                    "Layout will still render via LayoutGroup but tab semantics will not apply to non-Tab nodes.");
             }
+        }
+
+        private static bool ContainsTabDescendant(ElementNode node)
+        {
+            foreach (var c in node.Children)
+            {
+                if (c.Tag == "Tab") return true;
+                if (ContainsTabDescendant(c)) return true;
+            }
+            return false;
         }
     }
 }

--- a/Runtime/Core/Lint/TabRules.cs
+++ b/Runtime/Core/Lint/TabRules.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using PromptUGUI.IR;
+
+namespace PromptUGUI.Lint
+{
+    /// <summary>
+    /// Lint rules for &lt;Tab&gt; / &lt;TabBar&gt;.
+    /// Consumed by both IRWalker (UIXmlLint CLI) and ScreenInstantiator (runtime warnings).
+    /// PARENT check is parent-relative and lives inline in IRWalker / ScreenInstantiator —
+    /// it cannot be expressed as a self-check.
+    /// </summary>
+    public static class TabRules
+    {
+        public const string TabParentCode = "PUI-TAB-PARENT";
+        public const string TabBarChildCode = "PUI-TABBAR-CHILD";
+        public const string TabChildrenCode = "PUI-TAB-CHILDREN";
+        public const string DirectionCode = "PUI-TABBAR-DIRECTION";
+        public const string BindEmptyCode = "PUI-TAB-BIND-EMPTY";
+
+        public static IEnumerable<LintIssue> CheckTab(ElementNode n)
+        {
+            if (n.Children.Count > 0)
+                yield return new LintIssue(
+                    TabChildrenCode, n.Tag, n.Id,
+                    $"<Tab id='{n.Id}'>: Tab is a leaf control; nested children are not allowed. " +
+                    "Use text / icon attributes to express content.");
+
+            if (n.Attributes.TryGetValue("bind", out var bindVal) && bindVal == "")
+                yield return new LintIssue(
+                    BindEmptyCode, n.Tag, n.Id,
+                    $"<Tab id='{n.Id}'>: bind='' (empty string) is meaningless. " +
+                    "Remove the attribute or set a Frame id.");
+        }
+
+        public static IEnumerable<LintIssue> CheckTabBar(ElementNode n)
+        {
+            if (n.Attributes.TryGetValue("direction", out var dir)
+                && dir != "horizontal" && dir != "vertical")
+                yield return new LintIssue(
+                    DirectionCode, n.Tag, n.Id,
+                    $"<TabBar id='{n.Id}'>: direction='{dir}' is invalid. " +
+                    "Valid: horizontal, vertical.");
+
+            foreach (var c in n.Children)
+            {
+                if (c.Tag != "Tab")
+                    yield return new LintIssue(
+                        TabBarChildCode, n.Tag, n.Id,
+                        $"<TabBar id='{n.Id}'>: expected <Tab> children; found <{c.Tag}>. " +
+                        "Layout will still render via LayoutGroup but tab semantics will not apply to non-Tab nodes.");
+            }
+        }
+    }
+}

--- a/Runtime/Core/Lint/TabRules.cs.meta
+++ b/Runtime/Core/Lint/TabRules.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 24190172ceea6cc48b22eed78bac3245

--- a/Tests/EditMode/Controls/TabBarBindItemsTests.cs
+++ b/Tests/EditMode/Controls/TabBarBindItemsTests.cs
@@ -54,5 +54,25 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.AreEqual(0, bar.Count);
             Assert.AreEqual(-1, bar.SelectedIndex);
         }
+
+        [Test]
+        public void BindItems_With_Custom_Template_Resolves_Tab_Via_GetComponentInChildren()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='MyTab'><Frame id='wrap'><Tab id='tab'/></Frame></Template>
+  <Screen name='S'>
+    <TabBar id='bar' itemTemplate='MyTab'/>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var bar = UI.Open("S").Get<TabBar>("bar");
+            using var sub = bar.BindItems<string, IControl>(
+                Observable.Return<IReadOnlyList<string>>(new[] { "X", "Y" }),
+                (slot, s) => slot.Get<Tab>("tab").Text = s);
+
+            Assert.AreEqual(2, bar.Count);
+            Assert.AreEqual("X", bar.GetAt(0).GameObject.transform.Find("Label").GetComponent<TMPro.TMP_Text>().text);
+        }
     }
 }

--- a/Tests/EditMode/Controls/TabBarBindItemsTests.cs
+++ b/Tests/EditMode/Controls/TabBarBindItemsTests.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using R3;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class TabBarBindItemsTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static TabBar OpenBar(string innerXml)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{innerXml}</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S").Get<TabBar>("bar");
+        }
+
+        [Test]
+        public void BindItems_With_Default_Template_Instantiates_Tabs()
+        {
+            var bar = OpenBar("<TabBar id='bar'/>");
+            using var sub = bar.BindItems(
+                Observable.Return<IReadOnlyList<string>>(new[] { "A", "B", "C" }),
+                (Tab tab, string s) => tab.Text = s);
+
+            Assert.AreEqual(3, bar.Count);
+            Assert.AreEqual("A", bar.GetAt(0).GameObject.transform.Find("Label").GetComponent<TMPro.TMP_Text>().text);
+        }
+
+        [Test]
+        public void BindItems_Clears_Existing_Static_Tabs()
+        {
+            var bar = OpenBar("<TabBar id='bar'><Tab text='static1'/><Tab text='static2'/></TabBar>");
+            Assert.AreEqual(2, bar.Count, "starts with 2 static tabs");
+
+            using var sub = bar.BindItems(
+                Observable.Return<IReadOnlyList<string>>(new[] { "dyn1" }),
+                (Tab tab, string s) => tab.Text = s);
+
+            Assert.AreEqual(1, bar.Count, "BindItems clears static and rebuilds from dynamic");
+        }
+
+        [Test]
+        public void BindItems_With_Empty_List_Leaves_TabBar_Empty()
+        {
+            var bar = OpenBar("<TabBar id='bar'><Tab text='static'/></TabBar>");
+            using var sub = bar.BindItems(
+                Observable.Return<IReadOnlyList<string>>(new string[0]),
+                (Tab tab, string s) => tab.Text = s);
+            Assert.AreEqual(0, bar.Count);
+            Assert.AreEqual(-1, bar.SelectedIndex);
+        }
+    }
+}

--- a/Tests/EditMode/Controls/TabBarBindItemsTests.cs.meta
+++ b/Tests/EditMode/Controls/TabBarBindItemsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b0dc4c1d15c24e5a8e35b40f373f51b9

--- a/Tests/EditMode/Controls/TabBarTests.cs
+++ b/Tests/EditMode/Controls/TabBarTests.cs
@@ -49,5 +49,44 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var bgB = b.GameObject.GetComponent<UnityEngine.UI.Image>();
             Assert.AreEqual(bgA.sprite, bgB.sprite, "both Tabs received the same (possibly null) sprite from TabBar");
         }
+
+        [Test]
+        public void TabBar_SelectedSprite_Creates_Overlay_On_Each_Tab()
+        {
+            LogAssert.Expect(LogType.Error,
+                new System.Text.RegularExpressions.Regex("UI.SpriteResolver is not registered"));
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar' selectedSprite='ui:fake_selected'>
+    <Tab id='a'/>
+    <Tab id='b'/>
+  </TabBar>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            foreach (var id in new[] { "a", "b" })
+            {
+                var tab = screen.Get<Tab>(id);
+                var overlay = tab.GameObject.transform.Find("Overlay") as RectTransform;
+                Assert.IsNotNull(overlay, $"Tab '{id}' has Overlay RT");
+                var img = overlay.GetComponent<UnityEngine.UI.Image>();
+                var toggle = tab.GameObject.GetComponent<UnityEngine.UI.Toggle>();
+                Assert.AreSame(img, toggle.graphic, $"Tab '{id}' UnityToggle.graphic = overlay");
+                Assert.IsFalse(img.raycastTarget, "Overlay does not block raycasts");
+            }
+        }
+
+        [Test]
+        public void TabBar_Without_SelectedSprite_Has_No_Overlay()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'><Tab id='a'/></TabBar>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            var tab = screen.Get<Tab>("a");
+            Assert.IsNull(tab.GameObject.transform.Find("Overlay"), "no Overlay when selectedSprite absent");
+        }
     }
 }

--- a/Tests/EditMode/Controls/TabBarTests.cs
+++ b/Tests/EditMode/Controls/TabBarTests.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class TabBarTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static TabBar OpenBar(string innerXml)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{innerXml}</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S").Get<TabBar>("bar");
+        }
+
+        [Test]
+        public void TabBar_Has_ToggleGroup_And_HorizontalLayoutGroup()
+        {
+            var bar = OpenBar("<TabBar id='bar'/>");
+            Assert.IsNotNull(bar.GameObject.GetComponent<ToggleGroup>(), "ToggleGroup on self");
+            Assert.IsNotNull(bar.GameObject.GetComponent<HorizontalLayoutGroup>(), "HLG default");
+            Assert.IsFalse(bar.GameObject.GetComponent<ToggleGroup>().allowSwitchOff, "TB-D7 fixed false");
+        }
+    }
+}

--- a/Tests/EditMode/Controls/TabBarTests.cs
+++ b/Tests/EditMode/Controls/TabBarTests.cs
@@ -108,5 +108,47 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.AreSame(group, a.group);
             Assert.AreSame(group, b.group);
         }
+
+        [Test]
+        public void Tab_Bind_Toggle_Switches_Frame_SetActive()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'>
+    <Tab id='a' bind='fa'/>
+    <Tab id='b' bind='fb'/>
+  </TabBar>
+  <Frame id='fa'/>
+  <Frame id='fb'/>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            var fa = screen.Get<Frame>("fa");
+            var fb = screen.Get<Frame>("fb");
+            var a = screen.Get<Tab>("a");
+            var b = screen.Get<Tab>("b");
+            a.IsOn = true;
+            Assert.IsTrue(fa.GameObject.activeSelf);
+            b.IsOn = true;
+            Assert.IsFalse(fa.GameObject.activeSelf);
+            Assert.IsTrue(fb.GameObject.activeSelf);
+        }
+
+        [Test]
+        public void Tab_Bind_To_Missing_Frame_Warns_Once_Then_Silent()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.bind='nope'.*did not resolve"));
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'><Tab id='a' bind='nope' isOn='true'/></TabBar>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            var a = screen.Get<Tab>("a");
+            a.IsOn = false;
+            a.IsOn = true;
+            // No further warn expected — LogAssert would fail if a 2nd warning fires.
+        }
     }
 }

--- a/Tests/EditMode/Controls/TabBarTests.cs
+++ b/Tests/EditMode/Controls/TabBarTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using PromptUGUI.Application;
 using PromptUGUI.Controls;
+using R3;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.UI;
@@ -193,6 +194,36 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.AreEqual(6, hlg.padding.right);
             Assert.AreEqual(4, hlg.padding.top);
             Assert.AreEqual(4, hlg.padding.bottom);
+        }
+
+        [Test]
+        public void TabBar_OnSelectionChanged_Fires_With_Newly_Selected_Tab()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'><Tab id='a' isOn='true'/><Tab id='b'/></TabBar>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            var bar = screen.Get<TabBar>("bar");
+            Tab observed = null;
+            using var sub = bar.OnSelectionChanged.Subscribe(t => observed = t);
+
+            screen.Get<Tab>("b").IsOn = true;
+            Assert.AreSame(screen.Get<Tab>("b"), observed);
+        }
+
+        [Test]
+        public void TabBar_SelectedTab_And_SelectedIndex_Reflect_State()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'><Tab id='a'/><Tab id='b' isOn='true'/><Tab id='c'/></TabBar>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var bar = UI.Open("S").Get<TabBar>("bar");
+            Assert.AreEqual(1, bar.SelectedIndex);
+            Assert.AreEqual("b", bar.SelectedTab.Id);
         }
 
         [Test]

--- a/Tests/EditMode/Controls/TabBarTests.cs
+++ b/Tests/EditMode/Controls/TabBarTests.cs
@@ -178,6 +178,24 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
+        public void TabBar_Spacing_And_Padding_Apply_To_LayoutGroup()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar' spacing='8' padding='4,6'/>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var bar = UI.Open("S").Get<TabBar>("bar");
+            var hlg = bar.GameObject.GetComponent<HorizontalLayoutGroup>();
+            Assert.AreEqual(8f, hlg.spacing);
+            // RectOffset is a reference type with no value-equality, assert fields individually.
+            Assert.AreEqual(6, hlg.padding.left);
+            Assert.AreEqual(6, hlg.padding.right);
+            Assert.AreEqual(4, hlg.padding.top);
+            Assert.AreEqual(4, hlg.padding.bottom);
+        }
+
+        [Test]
         public void TabBar_Non_Selected_Bind_Frames_Are_Deactivated_Initially()
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>

--- a/Tests/EditMode/Controls/TabBarTests.cs
+++ b/Tests/EditMode/Controls/TabBarTests.cs
@@ -88,5 +88,25 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var tab = screen.Get<Tab>("a");
             Assert.IsNull(tab.GameObject.transform.Find("Overlay"), "no Overlay when selectedSprite absent");
         }
+
+        [Test]
+        public void TabBar_Children_Share_ToggleGroup()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'>
+    <Tab id='a'/>
+    <Tab id='b'/>
+  </TabBar>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            var bar = screen.Get<TabBar>("bar");
+            var a = screen.Get<Tab>("a").GameObject.GetComponent<UnityEngine.UI.Toggle>();
+            var b = screen.Get<Tab>("b").GameObject.GetComponent<UnityEngine.UI.Toggle>();
+            var group = bar.GameObject.GetComponent<UnityEngine.UI.ToggleGroup>();
+            Assert.AreSame(group, a.group);
+            Assert.AreSame(group, b.group);
+        }
     }
 }

--- a/Tests/EditMode/Controls/TabBarTests.cs
+++ b/Tests/EditMode/Controls/TabBarTests.cs
@@ -227,6 +227,58 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
+        public void TabBar_With_Static_Template_Wrapper_Collects_Inner_Tab()
+        {
+            LogAssert.Expect(LogType.Error,
+                new System.Text.RegularExpressions.Regex("UI.SpriteResolver is not registered"));
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='FileTab'>
+    <Param name='isOn' default='false'/>
+    <Frame><Tab id='tab' isOn='{{isOn}}'/></Frame>
+  </Template>
+  <Screen name='S'>
+    <TabBar id='bar' sprite='ui:fake_normal'>
+      <FileTab isOn='true'/>
+      <FileTab isOn='false'/>
+    </TabBar>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var bar = UI.Open("S").Get<TabBar>("bar");
+            Assert.AreEqual(2, bar.Count, "TabBar collected 2 inner Tabs via FindTabIn");
+            Assert.AreEqual(0, bar.SelectedIndex, "first Tab IsOn");
+            // sprite push verification — bg.sprite equal across both wrapped Tabs
+            var bgA = bar.GetAt(0).GameObject.GetComponent<UnityEngine.UI.Image>();
+            var bgB = bar.GetAt(1).GameObject.GetComponent<UnityEngine.UI.Image>();
+            Assert.AreEqual(bgA.sprite, bgB.sprite);
+        }
+
+        [Test]
+        public void TabBar_With_Static_Template_Wrapper_Fires_OnSelectionChanged()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='FileTab'>
+    <Param name='isOn' default='false'/>
+    <Frame><Tab id='tab' isOn='{{isOn}}'/></Frame>
+  </Template>
+  <Screen name='S'>
+    <TabBar id='bar'>
+      <FileTab isOn='true'/>
+      <FileTab isOn='false'/>
+    </TabBar>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var bar = UI.Open("S").Get<TabBar>("bar");
+            Tab observed = null;
+            using var sub = bar.OnSelectionChanged.Subscribe(t => observed = t);
+            bar.GetAt(1).IsOn = true;
+            Assert.AreSame(bar.GetAt(1), observed);
+        }
+
+        [Test]
         public void TabBar_Non_Selected_Bind_Frames_Are_Deactivated_Initially()
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>

--- a/Tests/EditMode/Controls/TabBarTests.cs
+++ b/Tests/EditMode/Controls/TabBarTests.cs
@@ -165,6 +165,19 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
+        public void TabBar_Direction_Vertical_Uses_VerticalLayoutGroup()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar' direction='vertical'/>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var bar = UI.Open("S").Get<TabBar>("bar");
+            Assert.IsNull(bar.GameObject.GetComponent<HorizontalLayoutGroup>(), "HLG removed");
+            Assert.IsNotNull(bar.GameObject.GetComponent<VerticalLayoutGroup>(), "VLG present");
+        }
+
+        [Test]
         public void TabBar_Non_Selected_Bind_Frames_Are_Deactivated_Initially()
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>

--- a/Tests/EditMode/Controls/TabBarTests.cs
+++ b/Tests/EditMode/Controls/TabBarTests.cs
@@ -2,6 +2,7 @@ using NUnit.Framework;
 using PromptUGUI.Application;
 using PromptUGUI.Controls;
 using UnityEngine;
+using UnityEngine.TestTools;
 using UnityEngine.UI;
 
 namespace PromptUGUI.Tests.EditMode.Controls
@@ -26,6 +27,27 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.IsNotNull(bar.GameObject.GetComponent<ToggleGroup>(), "ToggleGroup on self");
             Assert.IsNotNull(bar.GameObject.GetComponent<HorizontalLayoutGroup>(), "HLG default");
             Assert.IsFalse(bar.GameObject.GetComponent<ToggleGroup>().allowSwitchOff, "TB-D7 fixed false");
+        }
+
+        [Test]
+        public void TabBar_Sprite_Pushes_To_All_Child_Tabs()
+        {
+            LogAssert.Expect(LogType.Error,
+                new System.Text.RegularExpressions.Regex("UI.SpriteResolver is not registered"));
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar' sprite='ui:fake_normal'>
+    <Tab id='a' text='A'/>
+    <Tab id='b' text='B'/>
+  </TabBar>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            var a = screen.Get<Tab>("a");
+            var b = screen.Get<Tab>("b");
+            var bgA = a.GameObject.GetComponent<UnityEngine.UI.Image>();
+            var bgB = b.GameObject.GetComponent<UnityEngine.UI.Image>();
+            Assert.AreEqual(bgA.sprite, bgB.sprite, "both Tabs received the same (possibly null) sprite from TabBar");
         }
     }
 }

--- a/Tests/EditMode/Controls/TabBarTests.cs
+++ b/Tests/EditMode/Controls/TabBarTests.cs
@@ -150,5 +150,39 @@ namespace PromptUGUI.Tests.EditMode.Controls
             a.IsOn = true;
             // No further warn expected — LogAssert would fail if a 2nd warning fires.
         }
+
+        [Test]
+        public void TabBar_With_No_Initial_IsOn_Auto_Selects_First_Tab()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'><Tab id='a'/><Tab id='b'/></TabBar>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            Assert.IsTrue(screen.Get<Tab>("a").IsOn);
+            Assert.IsFalse(screen.Get<Tab>("b").IsOn);
+        }
+
+        [Test]
+        public void TabBar_Non_Selected_Bind_Frames_Are_Deactivated_Initially()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'>
+    <Tab id='a' bind='fa' isOn='true'/>
+    <Tab id='b' bind='fb'/>
+    <Tab id='c' bind='fc'/>
+  </TabBar>
+  <Frame id='fa'/>
+  <Frame id='fb'/>
+  <Frame id='fc'/>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            Assert.IsTrue(screen.Get<Frame>("fa").GameObject.activeSelf);
+            Assert.IsFalse(screen.Get<Frame>("fb").GameObject.activeSelf);
+            Assert.IsFalse(screen.Get<Frame>("fc").GameObject.activeSelf);
+        }
     }
 }

--- a/Tests/EditMode/Controls/TabBarTests.cs.meta
+++ b/Tests/EditMode/Controls/TabBarTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f35fc3357f34dcf46ba4fca22682aa92

--- a/Tests/EditMode/Controls/TabTests.cs
+++ b/Tests/EditMode/Controls/TabTests.cs
@@ -92,5 +92,28 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var label = t.GameObject.transform.Find("Label").GetComponent<TMP_Text>();
             Assert.AreEqual(24f, label.fontSize);
         }
+
+        [Test]
+        public void Tab_With_Icon_Creates_Icon_Child()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
+            LogAssert.Expect(LogType.Error,
+                new System.Text.RegularExpressions.Regex("UI.SpriteResolver is not registered"));
+            var t = OpenTab("<Tab id='t' text='X' icon='ui:nope'/>");
+            var icon = t.GameObject.transform.Find("Icon") as RectTransform;
+            Assert.IsNotNull(icon, "Icon RT child created");
+            Assert.IsNotNull(icon.GetComponent<UnityImage>(), "Icon UnityImage");
+            Assert.IsFalse(icon.GetComponent<UnityImage>().raycastTarget, "Icon does not block raycasts");
+        }
+
+        [Test]
+        public void Tab_Without_Icon_Attr_Has_No_Icon_Child()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
+            var t = OpenTab("<Tab id='t' text='X'/>");
+            Assert.IsNull(t.GameObject.transform.Find("Icon"), "no Icon RT when icon attr absent");
+        }
     }
 }

--- a/Tests/EditMode/Controls/TabTests.cs
+++ b/Tests/EditMode/Controls/TabTests.cs
@@ -38,12 +38,19 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
-        public void Tab_With_No_TabBar_Parent_Logs_Warning_But_Instantiates()
+        public void Tab_Inside_TabBar_Has_ToggleGroup_Wired()
         {
-            LogAssert.Expect(LogType.Warning,
-                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
-            var t = OpenTab("<Tab id='t'/>");
-            Assert.IsNotNull(t);
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'><Tab id='t'/></TabBar>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            var tab = screen.Get<Tab>("t");
+            var bar = screen.Get<TabBar>("bar");
+            var toggle = tab.GameObject.GetComponent<UnityToggle>();
+            var group = bar.GameObject.GetComponent<ToggleGroup>();
+            Assert.AreSame(group, toggle.group, "Tab's UnityToggle.group is the TabBar's ToggleGroup");
         }
     }
 }

--- a/Tests/EditMode/Controls/TabTests.cs
+++ b/Tests/EditMode/Controls/TabTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using PromptUGUI.Application;
 using PromptUGUI.Controls;
+using R3;
 using TMPro;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -114,6 +115,42 @@ namespace PromptUGUI.Tests.EditMode.Controls
                 new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
             var t = OpenTab("<Tab id='t' text='X'/>");
             Assert.IsNull(t.GameObject.transform.Find("Icon"), "no Icon RT when icon attr absent");
+        }
+
+        [Test]
+        public void Tab_IsOn_Roundtrip()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
+            var t = OpenTab("<Tab id='t' isOn='true'/>");
+            Assert.IsTrue(t.IsOn);
+            t.IsOn = false;
+            Assert.IsFalse(t.IsOn);
+        }
+
+        [Test]
+        public void Tab_OnValueChanged_Fires_On_Set()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
+            var t = OpenTab("<Tab id='t'/>");
+            bool? observed = null;
+            using var sub = t.OnValueChanged.Subscribe(v => observed = v);
+            t.IsOn = true;
+            Assert.IsTrue(observed == true);
+        }
+
+        [Test]
+        public void Tab_OnSelected_Fires_Only_On_False_To_True()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
+            var t = OpenTab("<Tab id='t' isOn='true'/>");
+            int fires = 0;
+            using var sub = t.OnSelected.Subscribe(_ => fires++);
+            t.IsOn = false;
+            t.IsOn = true;
+            Assert.AreEqual(1, fires);
         }
     }
 }

--- a/Tests/EditMode/Controls/TabTests.cs
+++ b/Tests/EditMode/Controls/TabTests.cs
@@ -52,5 +52,25 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var group = bar.GameObject.GetComponent<ToggleGroup>();
             Assert.AreSame(group, toggle.group, "Tab's UnityToggle.group is the TabBar's ToggleGroup");
         }
+
+        [Test]
+        public void Tab_Text_Sets_Label()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
+            var t = OpenTab("<Tab id='t' text='Hello'/>");
+            var label = t.GameObject.transform.Find("Label").GetComponent<TMP_Text>();
+            Assert.AreEqual("Hello", label.text);
+        }
+
+        [Test]
+        public void Tab_With_Empty_Text_Has_Empty_Label()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
+            var t = OpenTab("<Tab id='t'/>");
+            var label = t.GameObject.transform.Find("Label").GetComponent<TMP_Text>();
+            Assert.AreEqual("", label.text);
+        }
     }
 }

--- a/Tests/EditMode/Controls/TabTests.cs
+++ b/Tests/EditMode/Controls/TabTests.cs
@@ -72,5 +72,25 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var label = t.GameObject.transform.Find("Label").GetComponent<TMP_Text>();
             Assert.AreEqual("", label.text);
         }
+
+        [Test]
+        public void Tab_FontSize_Sets_TMP_FontSize()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
+            var t = OpenTab("<Tab id='t' text='X' fontSize='18'/>");
+            var label = t.GameObject.transform.Find("Label").GetComponent<TMP_Text>();
+            Assert.AreEqual(18f, label.fontSize);
+        }
+
+        [Test]
+        public void Tab_Default_FontSize_Is_24()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
+            var t = OpenTab("<Tab id='t' text='X'/>");
+            var label = t.GameObject.transform.Find("Label").GetComponent<TMP_Text>();
+            Assert.AreEqual(24f, label.fontSize);
+        }
     }
 }

--- a/Tests/EditMode/Controls/TabTests.cs
+++ b/Tests/EditMode/Controls/TabTests.cs
@@ -1,0 +1,49 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using TMPro;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+using UnityImage = UnityEngine.UI.Image;
+using UnityToggle = UnityEngine.UI.Toggle;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class TabTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static Tab OpenTab(string innerXml)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{innerXml}</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S").Get<Tab>("t");
+        }
+
+        [Test]
+        public void Tab_Has_Bg_Toggle_And_Label_Children()
+        {
+            // Suppress the no-ancestor warning fired by OnAttached.
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
+            var t = OpenTab("<Tab id='t'/>");
+            Assert.IsNotNull(t.GameObject.GetComponent<UnityImage>(), "bg UnityImage on self");
+            Assert.IsNotNull(t.GameObject.GetComponent<UnityToggle>(), "UnityToggle on self");
+            var label = t.GameObject.transform.Find("Label") as RectTransform;
+            Assert.IsNotNull(label, "Label RT child");
+            Assert.IsNotNull(label.GetComponent<TMP_Text>(), "TMP on Label");
+        }
+
+        [Test]
+        public void Tab_With_No_TabBar_Parent_Logs_Warning_But_Instantiates()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
+            var t = OpenTab("<Tab id='t'/>");
+            Assert.IsNotNull(t);
+        }
+    }
+}

--- a/Tests/EditMode/Controls/TabTests.cs.meta
+++ b/Tests/EditMode/Controls/TabTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 58e596086ea825d48a725fec9e9cb057

--- a/Tests/EditMode/Lint/TabRulesTests.cs
+++ b/Tests/EditMode/Lint/TabRulesTests.cs
@@ -58,5 +58,38 @@ namespace PromptUGUI.Tests.EditMode.Lint
             var issues = TabRules.CheckTabBar(bar).ToList();
             Assert.That(issues.Any(i => i.Code == TabRules.TabBarChildCode));
         }
+
+        [Test]
+        public void IRWalker_Dispatches_Tab_Children_Rule()
+        {
+            var doc = UIDocumentParser.Parse(@"<?xml version='1.0'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar><Tab><Frame/></Tab></TabBar>
+</Screen></PromptUGUI>");
+            var issues = IRWalker.Walk(doc).ToList();
+            Assert.That(issues.Any(i => i.Code == TabRules.TabChildrenCode));
+        }
+
+        [Test]
+        public void IRWalker_Dispatches_TabBar_Direction_Rule()
+        {
+            var doc = UIDocumentParser.Parse(@"<?xml version='1.0'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar direction='nope'/>
+</Screen></PromptUGUI>");
+            var issues = IRWalker.Walk(doc).ToList();
+            Assert.That(issues.Any(i => i.Code == TabRules.DirectionCode));
+        }
+
+        [Test]
+        public void IRWalker_Inline_Tab_Parent_Rule_When_Tab_Outside_TabBar()
+        {
+            var doc = UIDocumentParser.Parse(@"<?xml version='1.0'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <HStack><Tab/></HStack>
+</Screen></PromptUGUI>");
+            var issues = IRWalker.Walk(doc).ToList();
+            Assert.That(issues.Any(i => i.Code == TabRules.TabParentCode));
+        }
     }
 }

--- a/Tests/EditMode/Lint/TabRulesTests.cs
+++ b/Tests/EditMode/Lint/TabRulesTests.cs
@@ -1,0 +1,62 @@
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.IR;
+using PromptUGUI.Lint;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.EditMode.Lint
+{
+    public class TabRulesTests
+    {
+        private static ElementNode Parse(string xml)
+            => UIDocumentParser.Parse(xml).Screens[0].Root;
+
+        [Test]
+        public void Tab_With_Children_Triggers_TabChildren()
+        {
+            var root = Parse(@"<?xml version='1.0'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar><Tab id='t'><Frame/></Tab></TabBar>
+</Screen></PromptUGUI>");
+            var tab = root.Children[0].Children[0];
+            var issues = TabRules.CheckTab(tab).ToList();
+            Assert.That(issues.Any(i => i.Code == TabRules.TabChildrenCode));
+        }
+
+        [Test]
+        public void Tab_Bind_Empty_String_Triggers_TabBindEmpty()
+        {
+            var root = Parse(@"<?xml version='1.0'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar><Tab bind=''/></TabBar>
+</Screen></PromptUGUI>");
+            var tab = root.Children[0].Children[0];
+            var issues = TabRules.CheckTab(tab).ToList();
+            Assert.That(issues.Any(i => i.Code == TabRules.BindEmptyCode));
+        }
+
+        [Test]
+        public void TabBar_Direction_Invalid_Triggers_TabBarDirection()
+        {
+            var root = Parse(@"<?xml version='1.0'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar direction='diagonal'/>
+</Screen></PromptUGUI>");
+            var bar = root.Children[0];
+            var issues = TabRules.CheckTabBar(bar).ToList();
+            Assert.That(issues.Any(i => i.Code == TabRules.DirectionCode));
+        }
+
+        [Test]
+        public void TabBar_With_NonTab_Child_Triggers_TabBarChild()
+        {
+            var root = Parse(@"<?xml version='1.0'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar><Tab/><Btn/></TabBar>
+</Screen></PromptUGUI>");
+            var bar = root.Children[0];
+            var issues = TabRules.CheckTabBar(bar).ToList();
+            Assert.That(issues.Any(i => i.Code == TabRules.TabBarChildCode));
+        }
+    }
+}

--- a/Tests/EditMode/Lint/TabRulesTests.cs
+++ b/Tests/EditMode/Lint/TabRulesTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using PromptUGUI.IR;
 using PromptUGUI.Lint;
 using PromptUGUI.Parser;
+using PromptUGUI.Template;
 
 namespace PromptUGUI.Tests.EditMode.Lint
 {
@@ -90,6 +91,63 @@ namespace PromptUGUI.Tests.EditMode.Lint
 </Screen></PromptUGUI>");
             var issues = IRWalker.Walk(doc).ToList();
             Assert.That(issues.Any(i => i.Code == TabRules.TabParentCode));
+        }
+
+        [Test]
+        public void TabBar_With_Template_Wrapper_Child_Does_Not_Trigger_TabBarChild()
+        {
+            // After TemplateExpander, the Frame containing a Tab is a TabBar child.
+            // Build the IR manually since TemplateExpander runs in the loader, not parser.
+            var root = new ElementNode("TabBar");
+            var frame = new ElementNode("Frame");
+            frame.Children.Add(new ElementNode("Tab"));
+            root.Children.Add(frame);
+            var issues = TabRules.CheckTabBar(root).ToList();
+            Assert.IsFalse(issues.Any(i => i.Code == TabRules.TabBarChildCode),
+                "Template-wrapper Frame containing a Tab should not trigger TABBAR-CHILD warning");
+        }
+
+        [Test]
+        public void TabBar_With_NonTab_Child_Without_Tab_Descendant_Still_Triggers_TabBarChild()
+        {
+            // Sanity: the relaxation should ONLY exempt subtrees containing a Tab.
+            var root = new ElementNode("TabBar");
+            var frame = new ElementNode("Frame");   // no Tab anywhere inside
+            frame.Children.Add(new ElementNode("Text"));
+            root.Children.Add(frame);
+            var issues = TabRules.CheckTabBar(root).ToList();
+            Assert.That(issues.Any(i => i.Code == TabRules.TabBarChildCode),
+                "Frame without a Tab descendant should still trigger TABBAR-CHILD");
+        }
+
+        [Test]
+        public void IRWalker_Does_Not_Warn_Tab_Parent_When_Wrapped_In_Template_Instance_Root()
+        {
+            // After expansion: <TabBar><Frame IsTemplateInstanceRoot=true><Tab/></Frame></TabBar>
+            // The Frame wrapper has IsTemplateInstanceRoot=true; Tab inside should not warn PARENT.
+            var doc = UIDocumentParser.Parse(@"<?xml version='1.0'?>
+<PromptUGUI version='1'>
+  <Template name='FT'><Frame><Tab/></Frame></Template>
+  <Screen name='S'><TabBar><FT/></TabBar></Screen>
+</PromptUGUI>");
+            var expanded = TemplateExpander.Expand(doc);
+            var issues = IRWalker.Walk(expanded).ToList();
+            Assert.IsFalse(issues.Any(i => i.Code == TabRules.TabParentCode),
+                "Tab wrapped in IsTemplateInstanceRoot wrapper should not warn PARENT");
+        }
+
+        [Test]
+        public void IRWalker_Still_Warns_Tab_Parent_When_Wrapped_In_Plain_Frame()
+        {
+            // Sanity: non-Template Frame containing a Tab should still warn PARENT,
+            // since IsTemplateInstanceRoot is only set by TemplateExpander.
+            var doc = UIDocumentParser.Parse(@"<?xml version='1.0'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar><Frame><Tab/></Frame></TabBar>
+</Screen></PromptUGUI>");
+            var issues = IRWalker.Walk(doc).ToList();
+            Assert.That(issues.Any(i => i.Code == TabRules.TabParentCode),
+                "Plain Frame wrapper (no Template) should still warn PARENT");
         }
     }
 }

--- a/Tests/EditMode/Lint/TabRulesTests.cs.meta
+++ b/Tests/EditMode/Lint/TabRulesTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bac3922e4f659a5419636ce6278bb109

--- a/Tests/PlayMode/Controls/TabBarPlayTests.cs
+++ b/Tests/PlayMode/Controls/TabBarPlayTests.cs
@@ -1,0 +1,49 @@
+using System.Collections;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.PlayMode.Controls
+{
+    public class TabBarPlayTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [UnityTest]
+        public IEnumerator TabBar_Runtime_Switching_Mutex_And_Bind()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'>
+    <Tab id='a' bind='fa' isOn='true'/>
+    <Tab id='b' bind='fb'/>
+  </TabBar>
+  <Frame id='fa'/>
+  <Frame id='fb'/>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            yield return null;
+
+            var a = screen.Get<Tab>("a");
+            var b = screen.Get<Tab>("b");
+            var fa = screen.Get<Frame>("fa");
+            var fb = screen.Get<Frame>("fb");
+
+            Assert.IsTrue(a.IsOn);
+            Assert.IsFalse(b.IsOn);
+            Assert.IsTrue(fa.GameObject.activeSelf);
+            Assert.IsFalse(fb.GameObject.activeSelf);
+
+            b.IsOn = true;
+            yield return null;
+
+            Assert.IsFalse(a.IsOn, "mutex demoted a");
+            Assert.IsTrue(b.IsOn);
+            Assert.IsFalse(fa.GameObject.activeSelf);
+            Assert.IsTrue(fb.GameObject.activeSelf);
+        }
+    }
+}

--- a/Tests/PlayMode/Controls/TabBarPlayTests.cs
+++ b/Tests/PlayMode/Controls/TabBarPlayTests.cs
@@ -45,5 +45,40 @@ namespace PromptUGUI.Tests.PlayMode.Controls
             Assert.IsFalse(fa.GameObject.activeSelf);
             Assert.IsTrue(fb.GameObject.activeSelf);
         }
+
+        [UnityTest]
+        public IEnumerator TabBar_Static_Template_Wrapper_Mutex_And_Bind()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='FileTab'>
+    <Param name='isOn' default='false'/>
+    <Param name='bind'/>
+    <Frame><Tab id='tab' isOn='{{isOn}}' bind='{{bind}}'/></Frame>
+  </Template>
+  <Screen name='S'>
+    <TabBar id='bar'>
+      <FileTab isOn='true' bind='fa'/>
+      <FileTab isOn='false' bind='fb'/>
+    </TabBar>
+    <Frame id='fa'/>
+    <Frame id='fb'/>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            yield return null;
+            var bar = screen.Get<TabBar>("bar");
+            var fa = screen.Get<Frame>("fa");
+            var fb = screen.Get<Frame>("fb");
+            Assert.AreEqual(2, bar.Count);
+            Assert.IsTrue(bar.GetAt(0).IsOn);
+            Assert.IsTrue(fa.GameObject.activeSelf);
+            Assert.IsFalse(fb.GameObject.activeSelf);
+            bar.GetAt(1).IsOn = true;
+            yield return null;
+            Assert.IsFalse(fa.GameObject.activeSelf);
+            Assert.IsTrue(fb.GameObject.activeSelf);
+        }
     }
 }

--- a/Tests/PlayMode/Controls/TabBarPlayTests.cs.meta
+++ b/Tests/PlayMode/Controls/TabBarPlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b85beeece274bac43b9fd6a88f408c19

--- a/docs~/superpowers/plans/2026-05-27-tabbar.md
+++ b/docs~/superpowers/plans/2026-05-27-tabbar.md
@@ -1,0 +1,2363 @@
+# `<TabBar>` / `<Tab>` Control Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `<TabBar>` (container) and `<Tab>` (leaf) built-in controls implementing the design in `docs~/superpowers/specs/2026-05-27-tabbar-design.md`: private `ToggleGroup` mutex, shared normal/selected sprite at TabBar level, `bind="frame_id"` declarative Frame visibility, `itemTemplate` + `BindItems` dynamic content (mirrors `ScrollList`).
+
+**Architecture:**
+- `Tab` is a leaf control: `RectTransform + UnityImage[bg] + UnityToggle` on self; child Overlay (created lazily when TabBar exposes `selectedSprite`, bound to `UnityToggle.graphic`); child Icon (lazily, when `icon=` set); child Label (always).
+- `TabBar` is a container: `RectTransform + ToggleGroup + HorizontalLayoutGroup|VerticalLayoutGroup` on self; its children are `Tab` instances (static XML or dynamic via `BindItems`).
+- Bind resolution is **lazy + cached**: `Tab.Bind` setter only stores the id; first `OnValueChanged` fire resolves via `Screen.Get<Frame>(id)`, caches, and `SetActive`s on subsequent toggles.
+- `TabBar.OnAfterApply` does the post-attribute reconcile pass: collects child Tabs, pushes sprite/selectedSprite to each, runs `SyncInitialSelection` (force-deactivates non-selected bind frames + auto-selects Tab[0] if none on), wires `OnSelectionChanged`.
+- Lint rules in `Runtime/Core/Lint/TabRules.cs`; dispatched by both `IRWalker` (CLI) and `ScreenInstantiator` (runtime warnings), matching the `MaskAttributeRules` / `ProgressAttributeRules` pattern.
+
+**Tech Stack:** Unity 6, uGUI (`UnityEngine.UI.Toggle`, `ToggleGroup`, `Image`, `LayoutGroup`), TMP_Text, R3, NUnit + Unity Test Framework, Unity MCP for compile + test orchestration.
+
+**Branch:** `feat/tabbar` (already created; spec already committed at `9165d31`).
+
+**Verification cadence:** After every source edit, `mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)` → `mcp__UnityMCP__read_console(action="get", types=["error"])`. Run tests via `mcp__UnityMCP__run_tests(...)` with `filter=` per task. Lint CLI: `dotnet run --project .lint/UIXmlLint -- <path>`.
+
+> **Unity MCP gotcha** (from project memory): `run_tests` can flake with "failed to initialize" (usually = unsaved scene; restart Unity fixes). Compile-checks (`read_console` after `refresh_unity`) are more reliable than test runs — prefer them as the primary signal.
+
+---
+
+## File Structure
+
+| Path | Role | Action |
+|---|---|---|
+| `Runtime/Controls/Tab.cs` | Leaf control: bg + label + UnityToggle; lazy Overlay/Icon; bind frame on toggle | **Create** |
+| `Runtime/Controls/TabBar.cs` | Container: ToggleGroup + LayoutGroup; push sprites to children; ItemTemplate + BindItems; query/events | **Create** |
+| `Runtime/Application/BuiltinPrimitives.cs` | Register `Tab` / `TabBar` tags | **Modify** (2 lines added after `Toggle` registration) |
+| `Runtime/Application/ScreenInstantiator.cs` | Add `TabBar` to `selfIsLayoutGroup` list; add `Tab`/`TabBar` self-check dispatch | **Modify** (L237 + L185-194 block) |
+| `Runtime/Core/Lint/TabRules.cs` | 5 lint rules: PARENT / CHILD / CHILDREN / DIRECTION / BIND-EMPTY | **Create** |
+| `Runtime/Core/Lint/IRWalker.cs` | Dispatch `Tab` / `TabBar` self-checks | **Modify** (add branches to `WalkNode`) |
+| `Tests/EditMode/Controls/TabTests.cs` | Tab in isolation: structure, attrs, missing TabBar warn | **Create** |
+| `Tests/EditMode/Controls/TabBarTests.cs` | TabBar structure, direction/spacing/padding, sprite push, mutex, bind frame, initial sync, query API | **Create** |
+| `Tests/EditMode/Controls/TabBarBindItemsTests.cs` | BindItems both overloads, ItemTemplate (default + custom), clear-and-rebuild | **Create** |
+| `Tests/EditMode/Lint/TabRulesTests.cs` | Unit tests for 5 lint rules + IRWalker dispatch | **Create** |
+| `Tests/PlayMode/Controls/TabBarPlayTests.cs` | Runtime click → mutex + bind frame visibility, OnSelectionChanged fires | **Create** |
+| `.claude/skills/authoring-promptugui-xml/SKILL.md` | Add `<TabBar>` / `<Tab>` rows + Tabs section + lint codes | **Modify** |
+| `.claude/skills/scripting-promptugui-csharp/SKILL.md` | Add `BindItems<Tab,T>` + `OnSelectionChanged` notes | **Modify** |
+| `docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md` | Add `<TabBar>` + `<Tab>` rows in §5 | **Modify** |
+
+---
+
+## Tasks
+
+### Task 1: Stub `Tab` + `TabBar` + register + structure smoke tests
+
+> Combined into one task because Tab references TabBar (`FindAncestorTabBar`) and splitting forces a "write then revert" dance. Both stubs are tiny — together they're still bite-sized.
+
+**Files:**
+- Create: `Runtime/Controls/Tab.cs`
+- Create: `Runtime/Controls/TabBar.cs`
+- Modify: `Runtime/Application/BuiltinPrimitives.cs` (add `Tab` + `TabBar` registrations after Toggle line)
+- Create: `Tests/EditMode/Controls/TabTests.cs`
+- Create: `Tests/EditMode/Controls/TabBarTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/EditMode/Controls/TabTests.cs`:
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.TestTools;
+using TMPro;
+using UnityImage = UnityEngine.UI.Image;
+using UnityToggle = UnityEngine.UI.Toggle;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class TabTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static Tab OpenTab(string innerXml)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{innerXml}</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S").Get<Tab>("t");
+        }
+
+        [Test]
+        public void Tab_Has_Bg_Toggle_And_Label_Children()
+        {
+            // Suppress the no-ancestor warning fired by OnAttached.
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
+            var t = OpenTab("<Tab id='t'/>");
+            Assert.IsNotNull(t.GameObject.GetComponent<UnityImage>(), "bg UnityImage on self");
+            Assert.IsNotNull(t.GameObject.GetComponent<UnityToggle>(), "UnityToggle on self");
+            var label = t.GameObject.transform.Find("Label") as RectTransform;
+            Assert.IsNotNull(label, "Label RT child");
+            Assert.IsNotNull(label.GetComponent<TMP_Text>(), "TMP on Label");
+        }
+
+        [Test]
+        public void Tab_With_No_TabBar_Parent_Logs_Warning_But_Instantiates()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
+            var t = OpenTab("<Tab id='t'/>");
+            Assert.IsNotNull(t);
+        }
+    }
+}
+```
+
+Create `Tests/EditMode/Controls/TabBarTests.cs`:
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class TabBarTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static TabBar OpenBar(string innerXml)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{innerXml}</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S").Get<TabBar>("bar");
+        }
+
+        [Test]
+        public void TabBar_Has_ToggleGroup_And_HorizontalLayoutGroup()
+        {
+            var bar = OpenBar("<TabBar id='bar'/>");
+            Assert.IsNotNull(bar.GameObject.GetComponent<ToggleGroup>(), "ToggleGroup on self");
+            Assert.IsNotNull(bar.GameObject.GetComponent<HorizontalLayoutGroup>(), "HLG default");
+            Assert.IsFalse(bar.GameObject.GetComponent<ToggleGroup>().allowSwitchOff, "TB-D7 fixed false");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify compile failure**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: compile errors referencing `PromptUGUI.Controls.Tab` and `PromptUGUI.Controls.TabBar` (types don't exist).
+
+- [ ] **Step 3: Write Tab.cs and TabBar.cs**
+
+Create `Runtime/Controls/Tab.cs`:
+
+```csharp
+using PromptUGUI.Application;
+using PromptUGUI.Controls.Internal;
+using PromptUGUI.Registry;
+using R3;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityImage = UnityEngine.UI.Image;
+using UnityToggle = UnityEngine.UI.Toggle;
+
+namespace PromptUGUI.Controls
+{
+    public sealed class Tab : Control
+    {
+        private UnityImage _bg;
+        private UnityImage _overlay;
+        private UnityImage _icon;
+        private TMP_Text _label;
+        private UnityToggle _toggle;
+        private string _fontType = "default";
+        private readonly Subject<bool> _changed = new();
+        private readonly Subject<Unit> _selected = new();
+
+        public override void OnAttached()
+        {
+            _bg = GameObject.GetComponent<UnityImage>() ?? GameObject.AddComponent<UnityImage>();
+            _bg.color = ProceduralBuilders.DefaultBtnColor;
+            ProceduralBuilders.ApplyDefaultSlicedSprite(_bg);
+
+            _toggle = GameObject.GetComponent<UnityToggle>() ?? GameObject.AddComponent<UnityToggle>();
+            _toggle.targetGraphic = _bg;
+            _toggle.transition = Selectable.Transition.ColorTint;
+
+            _label = ProceduralBuilders.AddText(RectTransform, "Label");
+            _label.alignment = TextAlignmentOptions.Center;
+            _label.raycastTarget = false;
+            _label.fontSize = 24;
+            var lrt = _label.rectTransform;
+            lrt.anchorMin = Vector2.zero; lrt.anchorMax = Vector2.one;
+            lrt.offsetMin = Vector2.zero; lrt.offsetMax = Vector2.zero;
+            ApplyFont();
+
+            var bar = FindAncestorTabBar();
+            if (bar == null)
+                Debug.LogWarning($"Tab '{Id}' has no <TabBar> ancestor; mutual exclusion disabled.");
+            else
+                _toggle.group = bar.InternalToggleGroup;
+
+            _toggle.onValueChanged.AddListener(v =>
+            {
+                _changed.OnNext(v);
+                if (v) _selected.OnNext(Unit.Default);
+            });
+            UI.Locale.Changed += ApplyFont;
+        }
+
+        private TabBar FindAncestorTabBar()
+        {
+            var t = RectTransform.parent;
+            while (t != null)
+            {
+                var bar = t.GetComponent<TabBar>();
+                if (bar != null) return bar;
+                t = t.parent;
+            }
+            return null;
+        }
+
+        private void ApplyFont()
+        {
+            if (_label == null) return;
+            var settings = PromptUGUISettings.Instance;
+            var locale = UI.Locale.Current;
+            var asset = settings?.ResolveFont(locale, _fontType);
+            if (asset != null) _label.font = asset;
+        }
+
+        public Observable<bool> OnValueChanged => _changed;
+        public Observable<Unit> OnSelected => _selected;
+
+        public override void Dispose()
+        {
+            UI.Locale.Changed -= ApplyFont;
+            _changed.Dispose();
+            _selected.Dispose();
+            base.Dispose();
+        }
+    }
+}
+```
+
+Create `Runtime/Controls/TabBar.cs`:
+
+```csharp
+using System.Collections.Generic;
+using PromptUGUI.Application;
+using PromptUGUI.Registry;
+using R3;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Controls
+{
+    public sealed class TabBar : Control
+    {
+        private ToggleGroup _group;
+        private LayoutGroup _layout;
+        private string _direction = "horizontal";
+        private readonly List<Tab> _tabs = new();
+        private readonly Subject<Tab> _selectionChanged = new();
+
+        internal ToggleGroup InternalToggleGroup => _group;
+
+        public override void OnAttached()
+        {
+            _group = GameObject.AddComponent<ToggleGroup>();
+            _group.allowSwitchOff = false;
+            ApplyDirection();
+        }
+
+        private void ApplyDirection()
+        {
+            if (_layout != null)
+            {
+                if (UnityEngine.Application.isPlaying) Object.Destroy((Component)_layout);
+                else Object.DestroyImmediate((Component)_layout);
+                _layout = null;
+            }
+            _layout = _direction == "vertical"
+                ? (LayoutGroup)GameObject.AddComponent<VerticalLayoutGroup>()
+                : GameObject.AddComponent<HorizontalLayoutGroup>();
+        }
+
+        public Observable<Tab> OnSelectionChanged => _selectionChanged;
+
+        public override void Dispose()
+        {
+            _selectionChanged.Dispose();
+            base.Dispose();
+        }
+    }
+}
+```
+
+Modify `Runtime/Application/BuiltinPrimitives.cs` — add after line 21 (`reg.Register<Toggle>(...)`):
+
+```csharp
+reg.Register<Tab>("Tab", null, defaultTextAttr: "text");
+reg.Register<TabBar>("TabBar", null);
+```
+
+- [ ] **Step 4: Run tests + compile check**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabTests")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarTests")
+```
+
+Expected: 2 + 1 = 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Tab.cs Runtime/Controls/TabBar.cs Runtime/Application/BuiltinPrimitives.cs Tests/EditMode/Controls/TabTests.cs Tests/EditMode/Controls/TabBarTests.cs
+git commit -m "feat(tab,tabbar): stub controls (Tab bg/toggle/label; TabBar ToggleGroup+LayoutGroup; ancestor wiring)"
+```
+
+---
+
+### Task 2: ~~merged into Task 1~~ — skipped
+
+---
+
+### Task 3: `Tab.Text` attribute + label content
+
+**Files:**
+- Modify: `Runtime/Controls/Tab.cs` (add `Text` property)
+- Modify: `Tests/EditMode/Controls/TabTests.cs` (add test)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TabTests.cs` inside the `TabTests` class:
+
+```csharp
+[Test]
+public void Tab_Text_Sets_Label()
+{
+    var t = OpenTab("<Tab id='t' text='Hello'/>");
+    var label = t.GameObject.transform.Find("Label").GetComponent<TMP_Text>();
+    Assert.AreEqual("Hello", label.text);
+}
+
+[Test]
+public void Tab_With_Empty_Text_Has_Empty_Label()
+{
+    var t = OpenTab("<Tab id='t'/>");
+    var label = t.GameObject.transform.Find("Label").GetComponent<TMP_Text>();
+    Assert.AreEqual("", label.text);
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabTests")
+```
+
+Expected: `Tab_Text_Sets_Label` fails (no `text` attribute).
+
+- [ ] **Step 3: Add Text setter**
+
+In `Runtime/Controls/Tab.cs`, after the `Dispose()` method (or near other setters), add:
+
+```csharp
+[UIAttr, Preserve]
+public string Text
+{
+    set
+    {
+        if (_label != null) _label.text = value ?? "";
+    }
+}
+
+internal override string PeekDefaultText() => _label != null ? _label.text : null;
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabTests")
+```
+
+Expected: all TabTests pass (4 total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Tab.cs Tests/EditMode/Controls/TabTests.cs
+git commit -m "feat(tab): text attribute and label content"
+```
+
+---
+
+### Task 4: `Tab.Font` + `Tab.FontSize`
+
+**Files:**
+- Modify: `Runtime/Controls/Tab.cs`
+- Modify: `Tests/EditMode/Controls/TabTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TabTests.cs`:
+
+```csharp
+[Test]
+public void Tab_FontSize_Sets_TMP_FontSize()
+{
+    var t = OpenTab("<Tab id='t' text='X' fontSize='18'/>");
+    var label = t.GameObject.transform.Find("Label").GetComponent<TMP_Text>();
+    Assert.AreEqual(18f, label.fontSize);
+}
+
+[Test]
+public void Tab_Default_FontSize_Is_24()
+{
+    var t = OpenTab("<Tab id='t' text='X'/>");
+    var label = t.GameObject.transform.Find("Label").GetComponent<TMP_Text>();
+    Assert.AreEqual(24f, label.fontSize);
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabTests")
+```
+
+Expected: `Tab_FontSize_Sets_TMP_FontSize` fails.
+
+- [ ] **Step 3: Add Font + FontSize setters**
+
+In `Runtime/Controls/Tab.cs`, add (near Text setter):
+
+```csharp
+[UIAttr, Preserve]
+public string Font
+{
+    set
+    {
+        _fontType = string.IsNullOrEmpty(value) ? "default" : value;
+        ApplyFont();
+    }
+}
+
+[UIAttr("fontSize"), Preserve]
+public int FontSize
+{
+    set { if (_label != null) _label.fontSize = value; }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabTests")
+```
+
+Expected: 6 TabTests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Tab.cs Tests/EditMode/Controls/TabTests.cs
+git commit -m "feat(tab): font and fontSize attributes"
+```
+
+---
+
+### Task 5: `Tab.Icon` (optional, left-of-label)
+
+**Files:**
+- Modify: `Runtime/Controls/Tab.cs`
+- Modify: `Tests/EditMode/Controls/TabTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TabTests.cs`:
+
+```csharp
+[Test]
+public void Tab_With_Icon_Creates_Icon_Child()
+{
+    // Use a registered placeholder sprite key; UI.ResolveSprite returns null if not found,
+    // but the Icon child should still be created (sprite is just null).
+    var t = OpenTab("<Tab id='t' text='X' icon='ui:nope'/>");
+    var icon = t.GameObject.transform.Find("Icon") as RectTransform;
+    Assert.IsNotNull(icon, "Icon RT child created");
+    Assert.IsNotNull(icon.GetComponent<UnityImage>(), "Icon UnityImage");
+    Assert.IsFalse(icon.GetComponent<UnityImage>().raycastTarget, "Icon does not block raycasts");
+}
+
+[Test]
+public void Tab_Without_Icon_Attr_Has_No_Icon_Child()
+{
+    var t = OpenTab("<Tab id='t' text='X'/>");
+    Assert.IsNull(t.GameObject.transform.Find("Icon"), "no Icon RT when icon attr absent");
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabTests")
+```
+
+Expected: `Tab_With_Icon_Creates_Icon_Child` fails (no Icon attr handler).
+
+- [ ] **Step 3: Add Icon setter**
+
+In `Runtime/Controls/Tab.cs`:
+
+```csharp
+[UIAttr(IsSprite = true), Preserve]
+public string Icon
+{
+    set
+    {
+        if (_icon == null)
+        {
+            _icon = ProceduralBuilders.AddImage(RectTransform, "Icon", raycast: false);
+            var rt = _icon.rectTransform;
+            rt.anchorMin = new Vector2(0f, 0.5f);
+            rt.anchorMax = new Vector2(0f, 0.5f);
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            rt.sizeDelta = new Vector2(24f, 24f);
+            rt.anchoredPosition = new Vector2(16f, 0f);     // 4px gap from left edge then center of 24
+            // Shift label right to make room for icon
+            var lrt = _label.rectTransform;
+            lrt.offsetMin = new Vector2(32f, 0f);
+        }
+        _icon.sprite = UI.ResolveSprite(value);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabTests")
+```
+
+Expected: 8 TabTests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Tab.cs Tests/EditMode/Controls/TabTests.cs
+git commit -m "feat(tab): optional icon attribute (left of label)"
+```
+
+---
+
+### Task 6: `TabBar.Sprite` — push bg sprite to children
+
+**Files:**
+- Modify: `Runtime/Controls/TabBar.cs` (add Sprite attr + OnAfterApply collect+push)
+- Modify: `Runtime/Controls/Tab.cs` (add `internal void ApplyBgSprite(Sprite)` helper)
+- Modify: `Tests/EditMode/Controls/TabBarTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TabBarTests.cs`:
+
+```csharp
+[Test]
+public void TabBar_Sprite_Pushes_To_All_Child_Tabs()
+{
+    const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar' sprite='ui:fake_normal'>
+    <Tab id='a' text='A'/>
+    <Tab id='b' text='B'/>
+  </TabBar>
+</Screen></PromptUGUI>";
+    UI.LoadDocument("t", xml);
+    var screen = UI.Open("S");
+    var a = screen.Get<Tab>("a");
+    var b = screen.Get<Tab>("b");
+    // sprite key resolves via UI.ResolveSprite (Sprite or null); we only check the push happened.
+    // Since UI.ResolveSprite returns null for unknown keys, the assertion is on bg.sprite being set
+    // identically across children — i.e. both are null but the code path ran. Replace with stronger
+    // assertion via a registered fake sprite if desired.
+    var bgA = a.GameObject.GetComponent<UnityEngine.UI.Image>();
+    var bgB = b.GameObject.GetComponent<UnityEngine.UI.Image>();
+    Assert.AreEqual(bgA.sprite, bgB.sprite, "both Tabs received the same (possibly null) sprite from TabBar");
+}
+```
+
+> Better assertion: register a real fake Sprite via `UI.RegisterIconSprites` (if the API exists) or set up a `SpriteSet` fixture. For now, the equality test guarantees the push code ran.
+
+- [ ] **Step 2: Run to verify failure**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarTests")
+```
+
+Expected: `TabBar_Sprite_Pushes_To_All_Child_Tabs` fails (Sprite attr not implemented; no OnAfterApply push).
+
+- [ ] **Step 3: Implementation**
+
+In `Runtime/Controls/Tab.cs`, add internal helper near `ApplyFont`:
+
+```csharp
+internal void ApplyBgSprite(Sprite sprite)
+{
+    if (sprite == null) return;
+    _bg.sprite = sprite;
+    _bg.type = sprite.border != Vector4.zero ? UnityImage.Type.Sliced : UnityImage.Type.Simple;
+}
+```
+
+In `Runtime/Controls/TabBar.cs`, add field + Sprite attr + OnAfterApply:
+
+```csharp
+private Sprite _sprite;
+
+[UIAttr(IsSprite = true), Preserve]
+public string Sprite { set => _sprite = UI.ResolveSprite(value); }
+
+internal override void OnAfterApply()
+{
+    CollectStaticTabs();
+    PushVisualToTabs();
+}
+
+private void CollectStaticTabs()
+{
+    _tabs.Clear();
+    for (int i = 0; i < RectTransform.childCount; i++)
+    {
+        var child = RectTransform.GetChild(i);
+        var tab = child.GetComponent<TabBarTabMarker>()?.Tab;   // see note below
+        if (tab != null) _tabs.Add(tab);
+    }
+}
+
+private void PushVisualToTabs()
+{
+    foreach (var t in _tabs) t.ApplyBgSprite(_sprite);
+}
+```
+
+> **Tab discovery**: `Control` base already exposes `public IReadOnlyList<IControl> Children` (`Control.cs:74`) populated via `parentControl.AddChild(control)` in `ScreenInstantiator.cs:220`. No base-class changes needed.
+
+Replace `CollectStaticTabs` with:
+
+```csharp
+private void CollectStaticTabs()
+{
+    _tabs.Clear();
+    foreach (var child in Children)
+        if (child is Tab tab) _tabs.Add(tab);
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarTests")
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/TabBar.cs Runtime/Controls/Tab.cs Tests/EditMode/Controls/TabBarTests.cs
+git commit -m "feat(tabbar): sprite attribute pushes bg to all child Tabs in OnAfterApply"
+```
+
+---
+
+### Task 7: `TabBar.SelectedSprite` — create Overlay (UnityToggle.graphic)
+
+**Files:**
+- Modify: `Runtime/Controls/Tab.cs` (add `EnsureOverlay`)
+- Modify: `Runtime/Controls/TabBar.cs` (add SelectedSprite + push)
+- Modify: `Tests/EditMode/Controls/TabBarTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TabBarTests.cs`:
+
+```csharp
+[Test]
+public void TabBar_SelectedSprite_Creates_Overlay_On_Each_Tab()
+{
+    const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar' selectedSprite='ui:fake_selected'>
+    <Tab id='a'/>
+    <Tab id='b'/>
+  </TabBar>
+</Screen></PromptUGUI>";
+    UI.LoadDocument("t", xml);
+    var screen = UI.Open("S");
+    foreach (var id in new[] { "a", "b" })
+    {
+        var tab = screen.Get<Tab>(id);
+        var overlay = tab.GameObject.transform.Find("Overlay") as RectTransform;
+        Assert.IsNotNull(overlay, $"Tab '{id}' has Overlay RT");
+        var img = overlay.GetComponent<UnityEngine.UI.Image>();
+        var toggle = tab.GameObject.GetComponent<UnityEngine.UI.Toggle>();
+        Assert.AreSame(img, toggle.graphic, $"Tab '{id}' UnityToggle.graphic = overlay");
+        Assert.IsFalse(img.raycastTarget, "Overlay does not block raycasts");
+    }
+}
+
+[Test]
+public void TabBar_Without_SelectedSprite_Has_No_Overlay()
+{
+    const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'><Tab id='a'/></TabBar>
+</Screen></PromptUGUI>";
+    UI.LoadDocument("t", xml);
+    var screen = UI.Open("S");
+    var tab = screen.Get<Tab>("a");
+    Assert.IsNull(tab.GameObject.transform.Find("Overlay"), "no Overlay when selectedSprite absent");
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarTests")
+```
+
+Expected: 1 new test fails.
+
+- [ ] **Step 3: Implementation**
+
+In `Runtime/Controls/Tab.cs`, add helper:
+
+```csharp
+internal void EnsureOverlay(Sprite selectedSprite)
+{
+    if (selectedSprite == null) return;
+    if (_overlay == null)
+    {
+        _overlay = ProceduralBuilders.AddImage(RectTransform, "Overlay", raycast: false);
+        var rt = _overlay.rectTransform;
+        rt.anchorMin = Vector2.zero; rt.anchorMax = Vector2.one;
+        rt.offsetMin = Vector2.zero; rt.offsetMax = Vector2.zero;
+        _toggle.graphic = _overlay;
+        _toggle.toggleTransition = UnityToggle.ToggleTransition.None;   // instant; TB-D5
+    }
+    _overlay.sprite = selectedSprite;
+    _overlay.type = selectedSprite.border != Vector4.zero
+        ? UnityImage.Type.Sliced
+        : UnityImage.Type.Simple;
+}
+```
+
+> Note: `ProceduralBuilders.AddImage` places the new child **after** existing children in sibling order. We want Overlay above Label (z-order is by sibling order in uGUI — last drawn). Since AddImage appends, Overlay will draw on top of Label, hiding the text when selected. To fix: after creating, call `rt.SetSiblingIndex(0)` so Overlay is drawn first (under Label/Icon). Let me revise:
+
+```csharp
+_overlay = ProceduralBuilders.AddImage(RectTransform, "Overlay", raycast: false);
+_overlay.rectTransform.SetSiblingIndex(0);   // draw under Label / Icon
+```
+
+In `Runtime/Controls/TabBar.cs`, add `_selectedSprite` + `SelectedSprite` setter + extend `PushVisualToTabs`:
+
+```csharp
+private Sprite _selectedSprite;
+
+[UIAttr(IsSprite = true), Preserve]
+public string SelectedSprite { set => _selectedSprite = UI.ResolveSprite(value); }
+
+private void PushVisualToTabs()
+{
+    foreach (var t in _tabs)
+    {
+        t.ApplyBgSprite(_sprite);
+        t.EnsureOverlay(_selectedSprite);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarTests")
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Tab.cs Runtime/Controls/TabBar.cs Tests/EditMode/Controls/TabBarTests.cs
+git commit -m "feat(tabbar): selectedSprite creates Overlay bound to UnityToggle.graphic"
+```
+
+---
+
+### Task 8: Tab → TabBar ancestor lookup + ToggleGroup assignment (mutex) — test lock-in
+
+> Wiring already in Task 1 (`FindAncestorTabBar` + `_toggle.group = bar.InternalToggleGroup`). This task adds the dedicated mutex test that locks in the wiring.
+
+**Files:**
+- Modify: `Tests/EditMode/Controls/TabBarTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TabBarTests.cs`:
+
+```csharp
+[Test]
+public void TabBar_Children_Share_ToggleGroup()
+{
+    const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'>
+    <Tab id='a'/>
+    <Tab id='b'/>
+  </TabBar>
+</Screen></PromptUGUI>";
+    UI.LoadDocument("t", xml);
+    var screen = UI.Open("S");
+    var bar = screen.Get<TabBar>("bar");
+    var a = screen.Get<Tab>("a").GameObject.GetComponent<UnityEngine.UI.Toggle>();
+    var b = screen.Get<Tab>("b").GameObject.GetComponent<UnityEngine.UI.Toggle>();
+    var group = bar.GameObject.GetComponent<UnityEngine.UI.ToggleGroup>();
+    Assert.AreSame(group, a.group);
+    Assert.AreSame(group, b.group);
+}
+```
+
+- [ ] **Step 2: Run to verify pass (already wired in Task 1)**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarTests")
+```
+
+Expected: pass directly (no impl change needed; locks in Task 1's wiring).
+
+- [ ] **Step 3: Commit (test-only)**
+
+```bash
+git add Tests/EditMode/Controls/TabBarTests.cs
+git commit -m "test(tabbar): lock in Tab→TabBar ToggleGroup wiring"
+```
+
+---
+
+### Task 9: `Tab.IsOn` attribute + `OnValueChanged` / `OnSelected` events
+
+**Files:**
+- Modify: `Runtime/Controls/Tab.cs`
+- Modify: `Tests/EditMode/Controls/TabTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TabTests.cs`:
+
+```csharp
+[Test]
+public void Tab_IsOn_Roundtrip()
+{
+    var t = OpenTab("<Tab id='t' isOn='true'/>");
+    Assert.IsTrue(t.IsOn);
+    t.IsOn = false;
+    Assert.IsFalse(t.IsOn);
+}
+
+[Test]
+public void Tab_OnValueChanged_Fires_On_Set()
+{
+    var t = OpenTab("<Tab id='t'/>");
+    bool? observed = null;
+    using var sub = t.OnValueChanged.Subscribe(v => observed = v);
+    t.IsOn = true;
+    Assert.IsTrue(observed == true);
+}
+
+[Test]
+public void Tab_OnSelected_Fires_Only_On_False_To_True()
+{
+    var t = OpenTab("<Tab id='t' isOn='true'/>");
+    int fires = 0;
+    using var sub = t.OnSelected.Subscribe(_ => fires++);
+    t.IsOn = false;
+    t.IsOn = true;
+    Assert.AreEqual(1, fires);
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabTests")
+```
+
+Expected: `Tab_IsOn_Roundtrip` fails (no IsOn property).
+
+- [ ] **Step 3: Add IsOn**
+
+In `Runtime/Controls/Tab.cs`:
+
+```csharp
+[UIAttr, Preserve]
+public bool IsOn
+{
+    get => _toggle != null && _toggle.isOn;
+    set { if (_toggle != null) _toggle.isOn = value; }
+}
+```
+
+(OnValueChanged / OnSelected are already exposed and wired in Task 1's `_toggle.onValueChanged` AddListener.)
+
+- [ ] **Step 4: Run tests**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabTests")
+```
+
+Expected: 11 TabTests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Tab.cs Tests/EditMode/Controls/TabTests.cs
+git commit -m "feat(tab): isOn attribute + OnValueChanged / OnSelected observables"
+```
+
+---
+
+### Task 10: `Tab.Bind` — lazy resolve + Frame SetActive + missing-frame warning
+
+**Files:**
+- Modify: `Runtime/Controls/Tab.cs` (add Bind + OnIsOnChanged path + ForceSyncBindFrame helper)
+- Modify: `Tests/EditMode/Controls/TabBarTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TabBarTests.cs`:
+
+```csharp
+[Test]
+public void Tab_Bind_To_Frame_Toggles_Frame_SetActive()
+{
+    const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'>
+    <Tab id='a' bind='fa' isOn='true'/>
+    <Tab id='b' bind='fb'/>
+  </TabBar>
+  <Frame id='fa'/>
+  <Frame id='fb'/>
+</Screen></PromptUGUI>";
+    UI.LoadDocument("t", xml);
+    var screen = UI.Open("S");
+    var fa = screen.Get<Frame>("fa");
+    var fb = screen.Get<Frame>("fb");
+    var a = screen.Get<Tab>("a");
+    var b = screen.Get<Tab>("b");
+
+    Assert.IsTrue(fa.GameObject.activeSelf, "initially selected Tab's bind frame is active");
+    Assert.IsFalse(fb.GameObject.activeSelf, "other Tab's bind frame is inactive after SyncInitialSelection (Task 11)");
+
+    b.IsOn = true;     // mutex flips a→false, b→true
+    Assert.IsFalse(fa.GameObject.activeSelf);
+    Assert.IsTrue(fb.GameObject.activeSelf);
+}
+
+[Test]
+public void Tab_Bind_To_Missing_Frame_Warns_Once_Then_Silent()
+{
+    LogAssert.Expect(LogType.Warning,
+        new System.Text.RegularExpressions.Regex("Tab.bind='nope'.*did not resolve"));
+    const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'><Tab id='a' bind='nope' isOn='true'/></TabBar>
+</Screen></PromptUGUI>";
+    UI.LoadDocument("t", xml);
+    var screen = UI.Open("S");
+    var a = screen.Get<Tab>("a");
+    a.IsOn = false;
+    a.IsOn = true;
+    // No further warn expected — LogAssert would fail if a 2nd warning fires.
+}
+```
+
+> The second test depends on `Tab.Bind` setting `_bindId=null` after first warn — implementation must match.
+
+> Note: the first test asserts `fb` is inactive after instantiation. That depends on `SyncInitialSelection` running, which is Task 11. **This test will partially fail at this task** (the second half about `fb` initial state). To keep TDD honest, **split this test**: introduce only the `Tab_Bind_Toggle_Switches_Frame_SetActive` portion here, and defer the "initial state of unselected frames" assertion to Task 11.
+
+Replace the first test with:
+
+```csharp
+[Test]
+public void Tab_Bind_Toggle_Switches_Frame_SetActive()
+{
+    const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'>
+    <Tab id='a' bind='fa'/>
+    <Tab id='b' bind='fb'/>
+  </TabBar>
+  <Frame id='fa'/>
+  <Frame id='fb'/>
+</Screen></PromptUGUI>";
+    UI.LoadDocument("t", xml);
+    var screen = UI.Open("S");
+    var fa = screen.Get<Frame>("fa");
+    var fb = screen.Get<Frame>("fb");
+    var a = screen.Get<Tab>("a");
+    var b = screen.Get<Tab>("b");
+    // After SyncInitialSelection (Task 11), a should be IsOn and fa active.
+    // For this task, manually drive a→true to validate the toggle→SetActive path.
+    a.IsOn = true;
+    Assert.IsTrue(fa.GameObject.activeSelf);
+    b.IsOn = true;
+    Assert.IsFalse(fa.GameObject.activeSelf);
+    Assert.IsTrue(fb.GameObject.activeSelf);
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarTests")
+```
+
+Expected: both new tests fail (no Bind attr).
+
+- [ ] **Step 3: Add Bind + OnIsOnChanged path**
+
+In `Runtime/Controls/Tab.cs`:
+
+Add fields:
+
+```csharp
+private string _bindId;
+private bool _bindResolved;
+private Frame _boundFrame;
+```
+
+Replace the existing `_toggle.onValueChanged.AddListener(v => ...)` in `OnAttached` with:
+
+```csharp
+_toggle.onValueChanged.AddListener(OnIsOnChanged);
+```
+
+Add methods:
+
+```csharp
+private void OnIsOnChanged(bool isOn)
+{
+    _changed.OnNext(isOn);
+    if (isOn) _selected.OnNext(Unit.Default);
+    ApplyBindFrame(isOn);
+}
+
+private void ApplyBindFrame(bool isOn)
+{
+    if (_bindId == null && !_bindResolved) return;
+    if (!_bindResolved)
+    {
+        _boundFrame = UI.OwnerScreenOf(this)?.Get<Frame>(_bindId);
+        if (_boundFrame == null)
+            Debug.LogWarning($"Tab.bind='{_bindId}' did not resolve to a Frame; ignoring.");
+        _bindResolved = true;
+        _bindId = null;     // prevent re-warn
+    }
+    if (_boundFrame != null) _boundFrame.GameObject.SetActive(isOn);
+}
+
+internal void ForceSyncBindFrame(bool isOn) => ApplyBindFrame(isOn);
+
+[UIAttr, Preserve]
+public string Bind { set => _bindId = value; }
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarTests")
+```
+
+Expected: both new tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Tab.cs Tests/EditMode/Controls/TabBarTests.cs
+git commit -m "feat(tab): bind attribute lazy-resolves Frame and toggles SetActive"
+```
+
+---
+
+### Task 11: `TabBar.SyncInitialSelection` — reconcile non-selected bind frames + auto-select first
+
+**Files:**
+- Modify: `Runtime/Controls/TabBar.cs` (extend `OnAfterApply`)
+- Modify: `Tests/EditMode/Controls/TabBarTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TabBarTests.cs`:
+
+```csharp
+[Test]
+public void TabBar_With_No_Initial_IsOn_Auto_Selects_First_Tab()
+{
+    const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'><Tab id='a'/><Tab id='b'/></TabBar>
+</Screen></PromptUGUI>";
+    UI.LoadDocument("t", xml);
+    var screen = UI.Open("S");
+    Assert.IsTrue(screen.Get<Tab>("a").IsOn);
+    Assert.IsFalse(screen.Get<Tab>("b").IsOn);
+}
+
+[Test]
+public void TabBar_Non_Selected_Bind_Frames_Are_Deactivated_Initially()
+{
+    const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'>
+    <Tab id='a' bind='fa' isOn='true'/>
+    <Tab id='b' bind='fb'/>
+    <Tab id='c' bind='fc'/>
+  </TabBar>
+  <Frame id='fa'/>
+  <Frame id='fb'/>
+  <Frame id='fc'/>
+</Screen></PromptUGUI>";
+    UI.LoadDocument("t", xml);
+    var screen = UI.Open("S");
+    Assert.IsTrue(screen.Get<Frame>("fa").GameObject.activeSelf);
+    Assert.IsFalse(screen.Get<Frame>("fb").GameObject.activeSelf);
+    Assert.IsFalse(screen.Get<Frame>("fc").GameObject.activeSelf);
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarTests")
+```
+
+Expected: both new tests fail.
+
+- [ ] **Step 3: Extend `TabBar.OnAfterApply`**
+
+In `Runtime/Controls/TabBar.cs`, replace the existing `OnAfterApply` with:
+
+```csharp
+internal override void OnAfterApply()
+{
+    CollectStaticTabs();
+    PushVisualToTabs();
+    SyncInitialSelection();
+}
+
+private void SyncInitialSelection()
+{
+    if (_tabs.Count == 0) return;
+
+    // (1) Reconcile: any unselected Tab with a bind clears its Frame
+    foreach (var t in _tabs)
+        if (!t.IsOn) t.ForceSyncBindFrame(isOn: false);
+
+    // (2) Auto-select first if nothing on
+    bool anyOn = false;
+    foreach (var t in _tabs) if (t.IsOn) { anyOn = true; break; }
+    if (!anyOn) _tabs[0].IsOn = true;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarTests")
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/TabBar.cs Tests/EditMode/Controls/TabBarTests.cs
+git commit -m "feat(tabbar): SyncInitialSelection auto-selects first + reconciles non-selected bind frames"
+```
+
+---
+
+### Task 12: `TabBar.Direction` — vertical layout option
+
+**Files:**
+- Modify: `Runtime/Controls/TabBar.cs` (add Direction setter)
+- Modify: `Tests/EditMode/Controls/TabBarTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TabBarTests.cs`:
+
+```csharp
+[Test]
+public void TabBar_Direction_Vertical_Uses_VerticalLayoutGroup()
+{
+    const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar' direction='vertical'/>
+</Screen></PromptUGUI>";
+    UI.LoadDocument("t", xml);
+    var bar = UI.Open("S").Get<TabBar>("bar");
+    Assert.IsNull(bar.GameObject.GetComponent<HorizontalLayoutGroup>(), "HLG removed");
+    Assert.IsNotNull(bar.GameObject.GetComponent<VerticalLayoutGroup>(), "VLG present");
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarTests")
+```
+
+Expected: fail (no Direction attr).
+
+- [ ] **Step 3: Add Direction setter**
+
+In `Runtime/Controls/TabBar.cs`:
+
+```csharp
+[UIAttr, Preserve]
+public string Direction
+{
+    set
+    {
+        _direction = string.IsNullOrEmpty(value) ? "horizontal" : value;
+        ApplyDirection();
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarTests")
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/TabBar.cs Tests/EditMode/Controls/TabBarTests.cs
+git commit -m "feat(tabbar): direction attribute (horizontal | vertical)"
+```
+
+---
+
+### Task 13: `TabBar.Spacing` + `TabBar.Padding`
+
+**Files:**
+- Modify: `Runtime/Controls/TabBar.cs`
+- Modify: `Tests/EditMode/Controls/TabBarTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TabBarTests.cs`:
+
+```csharp
+[Test]
+public void TabBar_Spacing_And_Padding_Apply_To_LayoutGroup()
+{
+    const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar' spacing='8' padding='4,6'/>
+</Screen></PromptUGUI>";
+    UI.LoadDocument("t", xml);
+    var bar = UI.Open("S").Get<TabBar>("bar");
+    var hlg = bar.GameObject.GetComponent<HorizontalLayoutGroup>();
+    Assert.AreEqual(8f, hlg.spacing);
+    Assert.AreEqual(new RectOffset(6, 6, 4, 4), hlg.padding);
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarTests")
+```
+
+Expected: fail.
+
+- [ ] **Step 3: Add Spacing + Padding**
+
+In `Runtime/Controls/TabBar.cs`:
+
+```csharp
+private float _spacing;
+private string _padding;
+
+[UIAttr, Preserve]
+public float Spacing { set { _spacing = value; ApplySpacingPadding(); } }
+
+[UIAttr, Preserve]
+public string Padding { set { _padding = value; ApplySpacingPadding(); } }
+
+private void ApplySpacingPadding()
+{
+    switch (_layout)
+    {
+        case HorizontalLayoutGroup h: h.spacing = _spacing; break;
+        case VerticalLayoutGroup v: v.spacing = _spacing; break;
+    }
+    if (string.IsNullOrEmpty(_padding) || _layout == null) return;
+    var parts = _padding.Split(',');
+    int t = 0, r = 0, b = 0, l = 0;
+    switch (parts.Length)
+    {
+        case 1: int.TryParse(parts[0], out t); r = b = l = t; break;
+        case 2:
+            int.TryParse(parts[0], out t); b = t;
+            int.TryParse(parts[1], out r); l = r; break;
+        case 4:
+            int.TryParse(parts[0], out t);
+            int.TryParse(parts[1], out r);
+            int.TryParse(parts[2], out b);
+            int.TryParse(parts[3], out l); break;
+    }
+    _layout.padding = new RectOffset(l, r, t, b);
+}
+```
+
+Also call `ApplySpacingPadding()` at the end of `ApplyDirection()` (so direction change preserves spacing/padding).
+
+- [ ] **Step 4: Run tests**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarTests")
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/TabBar.cs Tests/EditMode/Controls/TabBarTests.cs
+git commit -m "feat(tabbar): spacing + padding attributes (forwarded to LayoutGroup)"
+```
+
+---
+
+### Task 14: `TabBar.ItemTemplate` + `BindItems<T>` (default Tab overload)
+
+**Files:**
+- Modify: `Runtime/Controls/TabBar.cs`
+- Create: `Tests/EditMode/Controls/TabBarBindItemsTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/EditMode/Controls/TabBarBindItemsTests.cs`:
+
+```csharp
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using R3;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class TabBarBindItemsTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static TabBar OpenBar(string innerXml)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{innerXml}</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S").Get<TabBar>("bar");
+        }
+
+        [Test]
+        public void BindItems_With_Default_Template_Instantiates_Tabs()
+        {
+            var bar = OpenBar("<TabBar id='bar'/>");
+            using var sub = bar.BindItems(
+                Observable.Return<IReadOnlyList<string>>(new[] { "A", "B", "C" }),
+                (Tab tab, string s) => tab.Text = s);
+
+            Assert.AreEqual(3, bar.Count);
+            Assert.AreEqual("A", ((TMPro.TMP_Text)bar.GetAt(0).GameObject.transform.Find("Label").GetComponent<TMPro.TMP_Text>()).text);
+        }
+
+        [Test]
+        public void BindItems_Clears_Existing_Static_Tabs()
+        {
+            var bar = OpenBar("<TabBar id='bar'><Tab text='static1'/><Tab text='static2'/></TabBar>");
+            Assert.AreEqual(2, bar.Count, "starts with 2 static tabs");
+
+            using var sub = bar.BindItems(
+                Observable.Return<IReadOnlyList<string>>(new[] { "dyn1" }),
+                (Tab tab, string s) => tab.Text = s);
+
+            Assert.AreEqual(1, bar.Count, "BindItems clears static and rebuilds from dynamic");
+        }
+
+        [Test]
+        public void BindItems_With_Empty_List_Leaves_TabBar_Empty()
+        {
+            var bar = OpenBar("<TabBar id='bar'><Tab text='static'/></TabBar>");
+            using var sub = bar.BindItems(
+                Observable.Return<IReadOnlyList<string>>(new string[0]),
+                (Tab tab, string s) => tab.Text = s);
+            Assert.AreEqual(0, bar.Count);
+            Assert.AreEqual(-1, bar.SelectedIndex);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarBindItemsTests")
+```
+
+Expected: compile failure (no `Count` / `GetAt` / `SelectedIndex` / `BindItems`).
+
+- [ ] **Step 3: Implement ItemTemplate + BindItems + query API**
+
+In `Runtime/Controls/TabBar.cs`, add:
+
+```csharp
+using System;
+using PromptUGUI.IR;
+using PromptUGUI.Parser;
+// (existing usings: System.Collections.Generic, R3, UnityEngine, UnityEngine.UI...)
+
+// fields:
+private string _itemTemplate = "Tab";
+private Func<RectTransform, IControl> _factory;
+private IDisposable _itemsSub;
+
+[UIAttr, Preserve]
+public string ItemTemplate
+{
+    set { _itemTemplate = string.IsNullOrEmpty(value) ? "Tab" : value; _factory = null; }
+}
+
+public int Count => _tabs.Count;
+
+public int SelectedIndex
+{
+    get
+    {
+        for (int i = 0; i < _tabs.Count; i++)
+            if (_tabs[i].IsOn) return i;
+        return -1;
+    }
+}
+
+public Tab SelectedTab
+{
+    get
+    {
+        var idx = SelectedIndex;
+        return idx >= 0 ? _tabs[idx] : null;
+    }
+}
+
+public Tab GetAt(int index) => _tabs[index];
+
+public IDisposable BindItems<T>(
+    Observable<IReadOnlyList<T>> source,
+    Action<Tab, T> bind)
+    => BindItems<T, Tab>(source, bind);
+
+public IDisposable BindItems<T, TSlot>(
+    Observable<IReadOnlyList<T>> source,
+    Action<TSlot, T> bind) where TSlot : class, IControl
+{
+    _itemsSub?.Dispose();
+    _itemsSub = source.Subscribe(items => Rebuild(items, bind));
+    return _itemsSub;
+}
+
+private void Rebuild<T, TSlot>(IReadOnlyList<T> items, Action<TSlot, T> bind)
+    where TSlot : class, IControl
+{
+    if (_factory == null) _factory = ResolveFactory(_itemTemplate);
+    ClearTabs();
+    for (int i = 0; i < items.Count; i++)
+    {
+        var node = _factory(RectTransform);
+        var typed = node as TSlot;
+        if (typed == null)
+            throw new InvalidCastException(
+                $"itemTemplate='{_itemTemplate}' instantiated {node.GetType().Name}, expected {typeof(TSlot).Name}");
+
+        // Locate the Tab: if the factory returned a Tab directly, use it; otherwise scan the template root.
+        var tab = node as Tab
+                  ?? ((Control)node).GameObject.GetComponentInChildren<Tab>();
+        if (tab == null)
+            throw new InvalidCastException(
+                $"itemTemplate='{_itemTemplate}' root contains no <Tab>; cannot bind.");
+
+        _tabs.Add(tab);
+        // Tab.OnAttached has already wired ToggleGroup via FindAncestorTabBar; push shared visuals now.
+        tab.ApplyBgSprite(_sprite);
+        tab.EnsureOverlay(_selectedSprite);
+        bind(typed, items[i]);
+    }
+    SyncInitialSelection();
+}
+
+private void ClearTabs()
+{
+    foreach (var t in _tabs) t.Dispose();
+    _tabs.Clear();
+}
+
+private Func<RectTransform, IControl> ResolveFactory(string tag)
+{
+    var owner = UI.OwnerScreenOf(this);
+    if (owner?.Def?.Templates != null && owner.Def.Templates.TryGetValue(tag, out var tpl))
+    {
+        return parent =>
+        {
+            var instantiator = UI.GetInstantiator();
+            return instantiator.InstantiateNode(tpl.Body, parent, owner);
+        };
+    }
+    if (UI.Registry.Has(tag))
+    {
+        return parent =>
+        {
+            var instantiator = UI.GetInstantiator();
+            var node = new ElementNode(tag);
+            return instantiator.InstantiateNode(node, parent, owner);
+        };
+    }
+    throw new ParseException(
+        $"<TabBar itemTemplate='{tag}'>: tag is neither a registered Control nor a Template");
+}
+```
+
+> Tab discovery: when `_itemTemplate=="Tab"` the factory returns a Tab directly; for custom Templates the factory returns the Template root (a Frame or other wrapper) and we use `GameObject.GetComponentInChildren<Tab>()` to find the embedded Tab. Document this convention in the SKILL.md update (Task 20): "When using a custom `itemTemplate`, the Template root must contain exactly one `<Tab>` somewhere in its tree."
+
+Also extend `Dispose`:
+
+```csharp
+public override void Dispose()
+{
+    _itemsSub?.Dispose();
+    _selectionChanged.Dispose();
+    base.Dispose();
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarBindItemsTests")
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/TabBar.cs Tests/EditMode/Controls/TabBarBindItemsTests.cs
+git commit -m "feat(tabbar): itemTemplate + BindItems (default Tab + generic TSlot overloads)"
+```
+
+---
+
+### Task 15: `BindItems<T, TSlot>` — custom Template path
+
+**Files:**
+- Modify: `Tests/EditMode/Controls/TabBarBindItemsTests.cs`
+
+> Task 14's implementation already handles `node is not Tab` via `GetComponentInChildren<Tab>()`. This task adds an exclusive test for that path.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TabBarBindItemsTests.cs`:
+
+```csharp
+[Test]
+public void BindItems_With_Custom_Template_Resolves_Tab_Via_GetComponentInChildren()
+{
+    const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='MyTab'><Frame id='wrap'><Tab id='tab'/></Frame></Template>
+  <Screen name='S'>
+    <TabBar id='bar' itemTemplate='MyTab'/>
+  </Screen>
+</PromptUGUI>";
+    UI.LoadDocument("t", xml);
+    var bar = UI.Open("S").Get<TabBar>("bar");
+    using var sub = bar.BindItems<string, IControl>(
+        Observable.Return<IReadOnlyList<string>>(new[] { "X", "Y" }),
+        (slot, s) => slot.Get<Tab>("tab").Text = s);
+
+    Assert.AreEqual(2, bar.Count);
+    Assert.AreEqual("X", bar.GetAt(0).GameObject.transform.Find("Label").GetComponent<TMPro.TMP_Text>().text);
+}
+```
+
+> Inspect `Runtime/Application/UI.cs:GetInstantiator` / `IControl.Get<T>` first to confirm `slot.Get<Tab>("tab")` is the correct accessor for ScopedIds inside a Template instance. If not, adapt to whatever ScrollList uses in `Runtime/Controls/ScrollList.cs:240-246`.
+
+- [ ] **Step 2: Run to verify pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarBindItemsTests")
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/EditMode/Controls/TabBarBindItemsTests.cs
+git commit -m "test(tabbar): BindItems with custom Template wrapping Tab"
+```
+
+---
+
+### Task 16: TabBar query API + `OnSelectionChanged` event wiring
+
+**Files:**
+- Modify: `Runtime/Controls/TabBar.cs` (wire per-Tab OnValueChanged subscriptions; fire `_selectionChanged`)
+- Modify: `Tests/EditMode/Controls/TabBarTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TabBarTests.cs`:
+
+```csharp
+[Test]
+public void TabBar_OnSelectionChanged_Fires_With_Newly_Selected_Tab()
+{
+    const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'><Tab id='a' isOn='true'/><Tab id='b'/></TabBar>
+</Screen></PromptUGUI>";
+    UI.LoadDocument("t", xml);
+    var screen = UI.Open("S");
+    var bar = screen.Get<TabBar>("bar");
+    Tab observed = null;
+    using var sub = bar.OnSelectionChanged.Subscribe(t => observed = t);
+
+    screen.Get<Tab>("b").IsOn = true;
+    Assert.AreSame(screen.Get<Tab>("b"), observed);
+}
+
+[Test]
+public void TabBar_SelectedTab_And_SelectedIndex_Reflect_State()
+{
+    const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'><Tab id='a'/><Tab id='b' isOn='true'/><Tab id='c'/></TabBar>
+</Screen></PromptUGUI>";
+    UI.LoadDocument("t", xml);
+    var bar = UI.Open("S").Get<TabBar>("bar");
+    Assert.AreEqual(1, bar.SelectedIndex);
+    Assert.AreEqual("b", bar.SelectedTab.Id);
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarTests")
+```
+
+Expected: `TabBar_OnSelectionChanged_Fires_With_Newly_Selected_Tab` fails (no subscription wiring).
+
+- [ ] **Step 3: Wire subscriptions in `OnAfterApply`**
+
+In `Runtime/Controls/TabBar.cs`, add field + helper, and extend `OnAfterApply`:
+
+```csharp
+private CompositeDisposable _tabSubs;
+
+internal override void OnAfterApply()
+{
+    CollectStaticTabs();
+    PushVisualToTabs();
+    SyncInitialSelection();
+    WireTabSubscriptions();
+}
+
+private void WireTabSubscriptions()
+{
+    _tabSubs?.Dispose();
+    _tabSubs = new CompositeDisposable();
+    foreach (var t in _tabs)
+    {
+        var captured = t;
+        captured.OnValueChanged
+            .Where(on => on)
+            .Subscribe(_ => _selectionChanged.OnNext(captured))
+            .AddTo(_tabSubs);
+    }
+}
+```
+
+In `ClearTabs` (called by `Rebuild`), also reset subs before clearing:
+
+```csharp
+private void ClearTabs()
+{
+    _tabSubs?.Dispose();
+    _tabSubs = null;
+    foreach (var t in _tabs) t.Dispose();
+    _tabs.Clear();
+}
+```
+
+In `Rebuild`, call `WireTabSubscriptions()` after `SyncInitialSelection()`:
+
+```csharp
+private void Rebuild<T, TSlot>(...)
+{
+    ...
+    SyncInitialSelection();
+    WireTabSubscriptions();
+    if (_tabs.Count == 0) _selectionChanged.OnNext(null);
+}
+```
+
+In `Dispose`:
+
+```csharp
+public override void Dispose()
+{
+    _tabSubs?.Dispose();
+    _itemsSub?.Dispose();
+    _selectionChanged.Dispose();
+    base.Dispose();
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarTests")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarBindItemsTests")
+```
+
+Expected: all pass (including 14's BindItems flow which now also wires subs after Rebuild).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/TabBar.cs Tests/EditMode/Controls/TabBarTests.cs
+git commit -m "feat(tabbar): OnSelectionChanged wiring + SelectedTab/SelectedIndex queries"
+```
+
+---
+
+### Task 17: `TabRules` lint — 5 codes
+
+**Files:**
+- Create: `Runtime/Core/Lint/TabRules.cs`
+- Create: `Tests/EditMode/Lint/TabRulesTests.cs`
+
+> Reference: `Runtime/Core/Lint/ProgressAttributeRules.cs` (same module + pattern). `LintIssue` has signature `(code, tag, id, message)` — there is no `LintSeverity` enum in v1 (`Runtime/Core/Lint/LintIssue.cs`). CLI treats every issue as an error and exits non-zero (`.lint/UIXmlLint/README.md:8`). The severity column in the spec §9 is informational for future ranking, not a constructor argument today.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/EditMode/Lint/TabRulesTests.cs`:
+
+```csharp
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Lint;
+using PromptUGUI.IR;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.EditMode.Lint
+{
+    public class TabRulesTests
+    {
+        private static ElementNode Parse(string xml)
+            => UIDocumentParser.Parse(xml).Screens[0].Root;
+
+        [Test]
+        public void Tab_With_Children_Triggers_TabChildren()
+        {
+            var root = Parse(@"<?xml version='1.0'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar><Tab id='t'><Frame/></Tab></TabBar>
+</Screen></PromptUGUI>");
+            var tab = root.Children[0].Children[0];
+            var issues = TabRules.CheckTab(tab).ToList();
+            Assert.That(issues.Any(i => i.Code == TabRules.TabChildrenCode));
+        }
+
+        [Test]
+        public void Tab_Bind_Empty_String_Triggers_TabBindEmpty()
+        {
+            var root = Parse(@"<?xml version='1.0'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar><Tab bind=''/></TabBar>
+</Screen></PromptUGUI>");
+            var tab = root.Children[0].Children[0];
+            var issues = TabRules.CheckTab(tab).ToList();
+            Assert.That(issues.Any(i => i.Code == TabRules.BindEmptyCode));
+        }
+
+        [Test]
+        public void TabBar_Direction_Invalid_Triggers_TabBarDirection()
+        {
+            var root = Parse(@"<?xml version='1.0'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar direction='diagonal'/>
+</Screen></PromptUGUI>");
+            var bar = root.Children[0];
+            var issues = TabRules.CheckTabBar(bar).ToList();
+            Assert.That(issues.Any(i => i.Code == TabRules.DirectionCode));
+        }
+
+        [Test]
+        public void TabBar_With_NonTab_Child_Triggers_TabBarChild()
+        {
+            var root = Parse(@"<?xml version='1.0'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar><Tab/><Btn/></TabBar>
+</Screen></PromptUGUI>");
+            var bar = root.Children[0];
+            var issues = TabRules.CheckTabBar(bar).ToList();
+            Assert.That(issues.Any(i => i.Code == TabRules.TabBarChildCode));
+        }
+    }
+}
+```
+
+> `PUI-TAB-PARENT` requires parent context which a per-node `CheckTab(node)` cannot see. We handle it inline in `IRWalker`'s recursion loop (Task 18) and runtime in `ScreenInstantiator` (also Task 18).
+
+- [ ] **Step 2: Run to verify failure**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabRulesTests")
+```
+
+Expected: compile failure (`TabRules` doesn't exist).
+
+- [ ] **Step 3: Implement TabRules**
+
+Create `Runtime/Core/Lint/TabRules.cs`:
+
+```csharp
+using System.Collections.Generic;
+using PromptUGUI.IR;
+
+namespace PromptUGUI.Lint
+{
+    /// <summary>
+    /// Lint rules for <c>&lt;Tab&gt;</c> / <c>&lt;TabBar&gt;</c>.
+    /// Consumed by both <c>IRWalker</c> (UIXmlLint CLI) and <c>ScreenInstantiator</c>
+    /// (runtime warnings). PARENT check is parent-relative and lives inline in IRWalker /
+    /// ScreenInstantiator — it cannot be expressed as a self-check.
+    /// </summary>
+    public static class TabRules
+    {
+        public const string TabParentCode    = "PUI-TAB-PARENT";
+        public const string TabBarChildCode  = "PUI-TABBAR-CHILD";
+        public const string TabChildrenCode  = "PUI-TAB-CHILDREN";
+        public const string DirectionCode    = "PUI-TABBAR-DIRECTION";
+        public const string BindEmptyCode    = "PUI-TAB-BIND-EMPTY";
+
+        public static IEnumerable<LintIssue> CheckTab(ElementNode n)
+        {
+            if (n.Children.Count > 0)
+                yield return new LintIssue(
+                    TabChildrenCode, n.Tag, n.Id,
+                    $"<Tab id='{n.Id}'>: Tab is a leaf control; nested children are not allowed. " +
+                    "Use text / icon attributes to express content.");
+
+            if (n.Attributes.TryGetValue("bind", out var bindVal) && bindVal == "")
+                yield return new LintIssue(
+                    BindEmptyCode, n.Tag, n.Id,
+                    $"<Tab id='{n.Id}'>: bind='' (empty string) is meaningless. " +
+                    "Remove the attribute or set a Frame id.");
+        }
+
+        public static IEnumerable<LintIssue> CheckTabBar(ElementNode n)
+        {
+            if (n.Attributes.TryGetValue("direction", out var dir)
+                && dir != "horizontal" && dir != "vertical")
+                yield return new LintIssue(
+                    DirectionCode, n.Tag, n.Id,
+                    $"<TabBar id='{n.Id}'>: direction='{dir}' is invalid. " +
+                    "Valid: horizontal, vertical.");
+
+            foreach (var c in n.Children)
+            {
+                if (c.Tag != "Tab")
+                    yield return new LintIssue(
+                        TabBarChildCode, n.Tag, n.Id,
+                        $"<TabBar id='{n.Id}'>: expected <Tab> children; found <{c.Tag}>. " +
+                        "Layout will still render via LayoutGroup but tab semantics will not apply to non-Tab nodes.");
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabRulesTests")
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Core/Lint/TabRules.cs Tests/EditMode/Lint/TabRulesTests.cs
+git commit -m "feat(lint): TabRules with 4 self-check codes (CHILDREN/BIND-EMPTY/DIRECTION/TABBAR-CHILD)"
+```
+
+---
+
+### Task 18: IRWalker + ScreenInstantiator dispatch + add TabBar to `selfIsLayoutGroup`
+
+**Files:**
+- Modify: `Runtime/Core/Lint/IRWalker.cs` (add Tab/TabBar self-check dispatch + inline PARENT check in recursion loop)
+- Modify: `Runtime/Application/ScreenInstantiator.cs` (L185-194 self-check block + L237 `selfIsLayoutGroup` list + inline PARENT check)
+- Modify: `Tests/EditMode/Lint/TabRulesTests.cs` (add IRWalker dispatch tests)
+
+> `IRWalker` is a `public static class` (`Runtime/Core/Lint/IRWalker.cs:10`) — call as `IRWalker.Walk(doc)`, never `new IRWalker()`. `WalkNode` does not receive parent context, so PARENT-relative rules go in the parent's recursion loop alongside `LayoutGroupChildRules.CheckChild(child)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/EditMode/Lint/TabRulesTests.cs`:
+
+```csharp
+[Test]
+public void IRWalker_Dispatches_Tab_Children_Rule()
+{
+    var doc = UIDocumentParser.Parse(@"<?xml version='1.0'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar><Tab><Frame/></Tab></TabBar>
+</Screen></PromptUGUI>");
+    var issues = IRWalker.Walk(doc).ToList();
+    Assert.That(issues.Any(i => i.Code == TabRules.TabChildrenCode));
+}
+
+[Test]
+public void IRWalker_Dispatches_TabBar_Direction_Rule()
+{
+    var doc = UIDocumentParser.Parse(@"<?xml version='1.0'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar direction='nope'/>
+</Screen></PromptUGUI>");
+    var issues = IRWalker.Walk(doc).ToList();
+    Assert.That(issues.Any(i => i.Code == TabRules.DirectionCode));
+}
+
+[Test]
+public void IRWalker_Inline_Tab_Parent_Rule_When_Tab_Outside_TabBar()
+{
+    var doc = UIDocumentParser.Parse(@"<?xml version='1.0'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <HStack><Tab/></HStack>
+</Screen></PromptUGUI>");
+    var issues = IRWalker.Walk(doc).ToList();
+    Assert.That(issues.Any(i => i.Code == TabRules.TabParentCode));
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabRulesTests")
+```
+
+Expected: 3 new tests fail.
+
+- [ ] **Step 3: Wire IRWalker**
+
+In `Runtime/Core/Lint/IRWalker.cs`, modify `WalkNode` to:
+
+(a) Add Tab/TabBar self-check dispatch in the existing tag chain at L38-46:
+
+```csharp
+else if (node.Tag == "Tab")
+    foreach (var issue in TabRules.CheckTab(node))
+        yield return issue;
+else if (node.Tag == "TabBar")
+    foreach (var issue in TabRules.CheckTabBar(node))
+        yield return issue;
+```
+
+(b) Update `isLayoutGroup` at L54 and add inline TAB-PARENT check in the recursion loop at L55-62:
+
+```csharp
+var isLayoutGroup = node.Tag is "VStack" or "HStack" or "Grid" or "TabBar";
+var isTabBar = node.Tag == "TabBar";
+foreach (var child in node.Children)
+{
+    if (isLayoutGroup)
+        foreach (var issue in LayoutGroupChildRules.CheckChild(child))
+            yield return issue;
+    if (child.Tag == "Tab" && !isTabBar)
+        yield return new LintIssue(
+            TabRules.TabParentCode, child.Tag, child.Id,
+            $"<Tab id='{child.Id}'>: must be a direct child of <TabBar>; current parent is <{node.Tag}>. " +
+            "Mutual exclusion and shared visuals will not apply.");
+    foreach (var issue in WalkNode(child))
+        yield return issue;
+}
+```
+
+- [ ] **Step 4: Wire ScreenInstantiator**
+
+In `Runtime/Application/ScreenInstantiator.cs`:
+
+(a) Extend the self-check block at L185-194:
+
+```csharp
+else if (node.Tag == "Tab")
+    foreach (var issue in TabRules.CheckTab(node))
+        Debug.LogWarning(issue.Message);
+else if (node.Tag == "TabBar")
+    foreach (var issue in TabRules.CheckTabBar(node))
+        Debug.LogWarning(issue.Message);
+```
+
+(b) Update L237:
+
+```csharp
+var selfIsLayoutGroup = node.Tag is "VStack" or "HStack" or "Grid" or "TabBar";
+```
+
+(c) Add the inline TAB-PARENT runtime warning at the top of `InstantiateRecursive` (just before the existing `parentIsLayoutGroup` LayoutGroup check, ~L179):
+
+```csharp
+// TAB-PARENT runtime warning — mirrors IRWalker inline check.
+// parentIsLayoutGroup tells us we're inside a layout container; we also need to know
+// if the container is specifically TabBar. parentControl gives us that.
+if (node.Tag == "Tab" && parentControl != null && !(parentControl is TabBar))
+{
+    Debug.LogWarning(
+        $"<Tab id='{node.Id}'>: must be a direct child of <TabBar>; current parent is " +
+        $"<{parentControl.GetType().Name}>. Mutual exclusion and shared visuals will not apply.");
+}
+```
+
+> Add `using PromptUGUI.Controls;` if not already imported.
+
+- [ ] **Step 5: Run tests**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabRulesTests")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabBarTests")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="TabTests")
+```
+
+Expected: all green.
+
+> Note on warning interaction: Task 1's `Tab_With_No_TabBar_Parent_Logs_Warning_But_Instantiates` test uses a Tab at Screen root, where `parentControl` is null — the new ScreenInstantiator inline PARENT check (which requires non-null parentControl) won't fire. Only Tab.OnAttached's "has no ancestor" warning fires, matching the existing LogAssert regex. For the two-warning case (Tab inside HStack inside Screen root) both warnings would fire, but no runtime test in this plan exercises that path.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Runtime/Core/Lint/IRWalker.cs Runtime/Application/ScreenInstantiator.cs Tests/EditMode/Lint/TabRulesTests.cs
+git commit -m "feat(lint): dispatch Tab/TabBar rules from IRWalker + ScreenInstantiator; TabBar joins selfIsLayoutGroup"
+```
+
+---
+
+### Task 19: PlayMode end-to-end test — click → mutex + bind frame
+
+**Files:**
+- Create: `Tests/PlayMode/Controls/TabBarPlayTests.cs`
+
+- [ ] **Step 1: Write the test**
+
+Create `Tests/PlayMode/Controls/TabBarPlayTests.cs`:
+
+```csharp
+using System.Collections;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.PlayMode.Controls
+{
+    public class TabBarPlayTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [UnityTest]
+        public IEnumerator TabBar_Runtime_Switching_Mutex_And_Bind()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'>
+    <Tab id='a' bind='fa' isOn='true'/>
+    <Tab id='b' bind='fb'/>
+  </TabBar>
+  <Frame id='fa'/>
+  <Frame id='fb'/>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            yield return null;
+
+            var a = screen.Get<Tab>("a");
+            var b = screen.Get<Tab>("b");
+            var fa = screen.Get<Frame>("fa");
+            var fb = screen.Get<Frame>("fb");
+
+            Assert.IsTrue(a.IsOn);
+            Assert.IsFalse(b.IsOn);
+            Assert.IsTrue(fa.GameObject.activeSelf);
+            Assert.IsFalse(fb.GameObject.activeSelf);
+
+            b.IsOn = true;
+            yield return null;
+
+            Assert.IsFalse(a.IsOn, "mutex demoted a");
+            Assert.IsTrue(b.IsOn);
+            Assert.IsFalse(fa.GameObject.activeSelf);
+            Assert.IsTrue(fb.GameObject.activeSelf);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run via MCP**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], filter="TabBarPlayTests")
+```
+
+Expected: pass. If "failed to initialize", restart Unity per the gotcha in the plan header.
+
+- [ ] **Step 3: (no impl change expected; if test fails, debug runtime path)**
+
+- [ ] **Step 4: (covered)**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Tests/PlayMode/Controls/TabBarPlayTests.cs
+git commit -m "test(tabbar): PlayMode end-to-end click/mutex/bind-frame"
+```
+
+---
+
+### Task 20: SKILL.md updates + main spec row + lint CLI run
+
+**Files:**
+- Modify: `.claude/skills/authoring-promptugui-xml/SKILL.md`
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md`
+- Modify: `docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md`
+
+- [ ] **Step 1: Read current SKILL files**
+
+```bash
+grep -n "Toggle\|ScrollList\|Progress" .claude/skills/authoring-promptugui-xml/SKILL.md | head -20
+grep -n "BindItems\|Get<" .claude/skills/scripting-promptugui-csharp/SKILL.md | head -20
+```
+
+Identify the "Built-in primitives" table location and the BindItems section.
+
+- [ ] **Step 2: Add TabBar/Tab rows in authoring-xml SKILL**
+
+In `.claude/skills/authoring-promptugui-xml/SKILL.md`, locate the built-in primitives table and add two rows in alphabetical or logical-grouping order (place near `Toggle` / `ScrollList`):
+
+```markdown
+| `<TabBar>` | container | private ToggleGroup + HorizontalLayoutGroup/VerticalLayoutGroup; shares `sprite` (normal bg) + `selectedSprite` (overlay) with all child Tabs; `itemTemplate` + `BindItems` for dynamic content | `sprite`, `selectedSprite`, `direction`, `spacing`, `padding`, `itemTemplate` |
+| `<Tab>` | leaf | child of TabBar; clickable toggle with optional icon + label; `bind="frame_id"` declarative Frame visibility | `text`, `isOn`, `bind`, `font`, `fontSize`, `icon` |
+```
+
+Add a "Tabs" section after the Toggle / ScrollList section, ~200 words:
+
+```markdown
+## Tabs
+
+Tabs are a `<TabBar>` container holding `<Tab>` children. Mutual exclusion is automatic (a private `ToggleGroup` on the TabBar, `allowSwitchOff=false`). All Tabs in a TabBar share the same `sprite` (normal bg) and `selectedSprite` (overlay shown when the Tab is selected, bound to UnityToggle.graphic). If `selectedSprite` is omitted, Tabs visually degrade to "buttons" (still mutex-enforced, no selected feedback).
+
+```xml
+<TabBar id="topbar" anchor="top-stretch" height="40"
+        sprite="ui:tab_normal" selectedSprite="ui:tab_selected">
+  <Tab text="Edit" bind="editor_panel" isOn="true"/>
+  <Tab text="Help" bind="help_panel"/>
+  <Tab text="Settings" bind="settings_panel"/>
+</TabBar>
+
+<Frame id="editor_panel"   anchor="fill" margin="40,0,0,0">...</Frame>
+<Frame id="help_panel"     anchor="fill" margin="40,0,0,0">...</Frame>
+<Frame id="settings_panel" anchor="fill" margin="40,0,0,0">...</Frame>
+```
+
+`bind="frame_id"` makes the Tab show/hide the named Frame on selection. The lookup is lazy — the Frame is resolved on first toggle and cached. If no Tab has `isOn="true"`, TabBar auto-selects the first one. If `bind` is omitted, the Tab fires `OnSelected` for code-side handling.
+
+**Lint codes:**
+- `PUI-TAB-PARENT` (warning): Tab outside TabBar
+- `PUI-TABBAR-CHILD` (warning): non-Tab child inside TabBar
+- `PUI-TAB-CHILDREN` (error): Tab with nested XML children
+- `PUI-TABBAR-DIRECTION` (error): direction other than `horizontal` / `vertical`
+- `PUI-TAB-BIND-EMPTY` (warning): `bind=""` empty string
+
+Tab is `selfIsLayoutGroup`'d under TabBar — Tab cannot declare `anchor=` / `margin=` (HorizontalLayoutGroup owns layout).
+```
+
+- [ ] **Step 3: Add to scripting-csharp SKILL**
+
+In `.claude/skills/scripting-promptugui-csharp/SKILL.md`, locate the BindItems section and add:
+
+```markdown
+### TabBar
+
+```csharp
+var bar = screen.Get<TabBar>("topbar");
+
+// Static XML tabs already exist; subscribe to selection changes:
+bar.OnSelectionChanged.Subscribe(tab => Debug.Log($"selected: {tab?.Id}"));
+
+// Or per-Tab:
+screen.Get<Tab>("edit").OnSelected.Subscribe(_ => OpenEditor());
+
+// Dynamic: clear and rebuild from a data source (same shape as ScrollList.BindItems):
+bar.BindItems(
+    items,
+    (Tab tab, MyModel m) => { tab.Text = m.Name; tab.Bind = m.FrameId; });
+
+// Custom Template (when Tab needs to be wrapped):
+bar.BindItems<MyModel, IControl>(
+    items,
+    (slot, m) => slot.Get<Tab>("tab").Text = m.Name);
+
+// Query API:
+bar.Count;          // current tab count
+bar.SelectedIndex;  // -1 if none (only possible right after BindItems with empty list)
+bar.SelectedTab;    // Tab ref or null
+bar.GetAt(i);
+```
+
+Setting `tab.IsOn = true` triggers mutex (other Tabs flip to false) AND auto-shows the `bind`-ed Frame — no manual `frame.GameObject.SetActive(...)` needed.
+```
+
+- [ ] **Step 4: Add to main spec §5 control table**
+
+In `docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md` §5, add after the Toggle / Slider / Progress rows:
+
+```markdown
+| `<TabBar>` | Tab container with private ToggleGroup + LayoutGroup; shares `sprite`/`selectedSprite`; supports `itemTemplate` + `BindItems` | RectTransform + ToggleGroup + LayoutGroup (see [`2026-05-27-tabbar-design.md`](2026-05-27-tabbar-design.md)) |
+| `<Tab>` | TabBar child; UnityToggle + centered label + optional icon + optional selected overlay; `bind="frame_id"` declarative Frame toggle | RectTransform + UnityImage + UnityToggle |
+```
+
+- [ ] **Step 5: Run lint CLI to verify spec / docs / runtime example consistency**
+
+Create a quick smoke fixture, then run lint:
+
+```bash
+cat > /tmp/tabbar_lint_smoke.ui.xml <<'EOF'
+<?xml version='1.0'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar' direction='nope'><Btn/></TabBar>
+  <HStack><Tab/></HStack>
+</Screen></PromptUGUI>
+EOF
+cd /workspace-PromptUGUI/.lint && dotnet run --project UIXmlLint -- /tmp/tabbar_lint_smoke.ui.xml
+```
+
+Expected: non-zero exit; messages include `PUI-TABBAR-DIRECTION`, `PUI-TABBAR-CHILD`, `PUI-TAB-PARENT`.
+
+- [ ] **Step 6: Run full test suite**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])
+```
+
+Expected: all green.
+
+Also run `dotnet format --verify-no-changes --severity warn` on the lint solution:
+
+```bash
+cd /workspace-PromptUGUI/.lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+- [ ] **Step 7: Commit + push branch**
+
+```bash
+git add .claude/skills/authoring-promptugui-xml/SKILL.md .claude/skills/scripting-promptugui-csharp/SKILL.md docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
+git commit -m "docs(tabbar): SKILL.md and main spec row updates"
+
+# Branch already exists; push when ready for PR:
+# git push -u origin feat/tabbar
+```
+
+> Do **NOT** push or open PR without user explicit approval (CLAUDE.md gate).
+
+---
+
+## Spec Coverage Map
+
+| Spec § | Plan task |
+|---|---|
+| §3 XML form / static / button mode / custom template | Task 1 (static), 14-15 (custom template); button mode covered implicitly by Task 7 (no SelectedSprite → no Overlay) |
+| §4.1 TabBar attrs | sprite=Task 6, selectedSprite=Task 7, direction=Task 12, spacing/padding=Task 13, itemTemplate=Task 14 |
+| §4.2 Tab attrs | text=Task 3, isOn=Task 9, bind=Task 10, font/fontSize=Task 4, icon=Task 5 |
+| §5 C# API (Tab/TabBar surface) | Task 9 (Tab events), Tasks 14+16 (TabBar BindItems + query + OnSelectionChanged) |
+| §6 程序化层级 | Task 1 (Tab + TabBar structure), Task 7 (Overlay), Task 5 (Icon) |
+| §7.1 mutex | Task 1 (wiring) + Task 8 (test) |
+| §7.2 SyncInitialSelection | Task 11 |
+| §7.3 Bind → Frame | Task 10 |
+| §7.4 BindItems rebuild | Tasks 14 + 15 |
+| §7.5 OnSelectionChanged | Task 16 |
+| §7.6 Tab visual layout | Task 1 (label) + Task 5 (icon offset) + Task 7 (overlay) |
+| §8 边界 / 错误处理 | TabRules in Task 17; runtime warnings in Tasks 1/10/18 |
+| §9 lint 5 codes | Task 17 (4 self-check codes) + Task 18 (PARENT inline + dispatch) |
+| §10 实现要点 (Tab.cs/TabBar.cs/BuiltinPrimitives/ScreenInstantiator/TabRules/IRWalker) | Task 1 (stubs+register) + Tasks 17-18 (lint+dispatch) + Task 13 (spacing/padding) |
+| §11 SKILL + main spec | Task 20 |
+| §12 Out of Scope | Not implemented (correctly excluded) |
+| §13 Risk mitigations | Covered by tests (Tasks 9-11, 15, 19) |

--- a/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
+++ b/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
@@ -140,7 +140,7 @@ Template 同名（含 commons 与各 Import 的任意组合）→ 报错；`as="
 
 ## 5. 内置控件原语
 
-刻意保持极少：12 个原语，覆盖布局、最基础视觉、点击交互与四个常用控件，其他全部通过自定义控件或 `<Template>` 扩展。
+刻意保持极少：14 个原语，覆盖布局、最基础视觉、点击交互与五个常用控件（含 Tab 容器），其他全部通过自定义控件或 `<Template>` 扩展。
 
 | 标签 | 作用 | 对应 uGUI |
 |---|---|---|
@@ -157,10 +157,12 @@ Template 同名（含 commons 与各 Import 的任意组合）→ 报错；`as="
 | `<Progress>` | 线性进度条 (scale / Image.Type.Filled, horizontal / vertical, +可选 frame / mask / bg / fill 装饰) | RectTransform（+ 内部 4 个图层；详见 [`2026-05-27-progress-control-design.md`](2026-05-27-progress-control-design.md)） |
 | `<Dropdown>` | 下拉选择（OnSelected: int；BindOptions 推送选项） | TMP_Dropdown |
 | `<ScrollList>` | 滚动列表（BindItems 推送数据；itemTemplate 引用 Template/Control 类） | ScrollRect + Mask |
+| `<TabBar>` | Tab 容器；私有 ToggleGroup + Horizontal/VerticalLayoutGroup；所有子 Tab 共享 `sprite` / `selectedSprite`；支持 `itemTemplate` + `BindItems` 动态构建 | RectTransform + ToggleGroup + LayoutGroup（详见 [`2026-05-27-tabbar-design.md`](2026-05-27-tabbar-design.md)） |
+| `<Tab>` | `<TabBar>` 子节点；uGUI Toggle + 居中 label + 可选 icon + 可选 selected overlay；`bind="frame_id"` 声明式切换 Frame 可见性 | RectTransform + UnityImage + UnityToggle |
 
 `<Btn>` 提供"按钮"这一通用交互原语：可作为 Template 根，配合 `<Image>` / `<Text>` 子节点组合出 PrimaryButton / DangerButton / IconButton 等业务变体而无需额外 prefab。`Btn` 内部用 R3 `Subject<Unit>` 暴露 `OnClick`（与 §9.4 的"事件统一为 `Observable<T>`"约束一致）。
 
-`<Toggle>` / `<Slider>` / `<Dropdown>` / `<ScrollList>` 默认开启的参考实现（详见 [`2026-05-09-m5-common-controls-design.md`](2026-05-09-m5-common-controls-design.md)）。视觉风格用 `sprite` / `color` 等属性表达；需要项目级强差异化样式（像素描边、按下震动等）时作者继承相应类重写 `OnAttached`。
+`<Toggle>` / `<Slider>` / `<Dropdown>` / `<ScrollList>` / `<TabBar>` 默认开启的参考实现（详见 [`2026-05-09-m5-common-controls-design.md`](2026-05-09-m5-common-controls-design.md)）。视觉风格用 `sprite` / `color` 等属性表达；需要项目级强差异化样式（像素描边、按下震动等）时作者继承相应类重写 `OnAttached`。
 
 ### 5.1 通用属性（任何标签可用）
 

--- a/docs~/superpowers/specs/2026-05-27-tabbar-design.md
+++ b/docs~/superpowers/specs/2026-05-27-tabbar-design.md
@@ -1,0 +1,667 @@
+# `<TabBar>` / `<Tab>` 控件设计
+
+**日期**: 2026-05-27
+**状态**: 设计阶段（待 review，未进入实施）
+**作用域**:
+1. 新增 `Runtime/Controls/TabBar.cs`（HorizontalLayoutGroup + 私有 ToggleGroup 容器）
+2. 新增 `Runtime/Controls/Tab.cs`（UnityToggle + 可选 selected overlay + label + 可选 icon）
+3. `Runtime/Application/BuiltinPrimitives.cs` 注册 `TabBar` / `Tab`
+4. `Runtime/Application/ScreenInstantiator.cs` 把 `"TabBar"` 加进 `selfIsLayoutGroup` 集合
+5. 新增 `Runtime/Core/Lint/TabRules.cs`（Tab 必须是 TabBar 直接子；TabBar 子只能是 Tab）
+6. `Runtime/Core/Lint/IRWalker.cs` 入口 self-check 加 `Tab` / `TabBar` 分支
+7. `authoring-promptugui-xml` SKILL.md 新增 `<TabBar>` / `<Tab>` 行 + 一节用例
+8. `scripting-promptugui-csharp` SKILL.md 加 `BindItems<Tab,T>` / `OnSelectionChanged` / `SelectedTab` 用法
+9. 主 spec `2026-05-07-promptugui-description-language-design.md` §5（控件表）追加两行
+
+**依赖**: 无（复用 `Toggle` 已用的 `UnityEngine.UI.ToggleGroup`、`ScrollList` 的 `BindItems` 模式、`ProceduralBuilders` 共享图层）
+
+---
+
+## 1. 背景
+
+当前作者想做"页卡切换"只能这么写：
+
+```xml
+<HStack>
+  <Toggle group="page" isOn="true" text="编辑"/>
+  <Toggle group="page" text="帮助"/>
+  <Toggle group="page" text="设置"/>
+</HStack>
+
+<Frame id="editor_panel">...</Frame>
+<Frame id="help_panel">...</Frame>
+<Frame id="settings_panel">...</Frame>
+```
+
+问题：
+
+- `Toggle` 视觉硬编码 "左 20x20 checkmark + 右 label"（`Toggle.cs:39-72`），做不了"整条按钮换底图"的 tab 外观
+- 没有 selected-sprite 通道：`Color` setter 改的是 bg，但不随 `IsOn` 联动
+- Frame 显示/隐藏要 author 自己写 `R3.Subscribe` 把 `Toggle.OnValueChanged` 接到 `frame.GameObject.SetActive`，每个 Toggle 都重复一遍
+- 没有"模板 + 动态添加"机制，要从代码批量加 tab 只能调用方手糊 GameObject
+
+需要一个**容器型**控件 `<TabBar>` 统一管理：互斥 group、共享的 normal/selected 视觉、可选的 itemTemplate + BindItems；以及配套的**叶子**控件 `<Tab>` 暴露 `bind="frame_id"` 声明式联动一个 Frame，省掉手写订阅。
+
+为什么不在 `Toggle` 上加 mode？已在 brainstorm 中评估并否决（参见对话）：Toggle 的 OnAttached 全部围绕 checkmark 布局编排，添加"full-button 模式" + selected 视觉属性会让 OnAttached 分支化、`GetNativeSize` 公式分裂、常量动态化；新做 Tab 几乎零回归风险、零共享代码损失（共享面只有 30 行的 font/ToggleGroup 模板）。
+
+---
+
+## 2. 决策一览
+
+| # | 决策 | 选择 | 理由 |
+|---|---|---|---|
+| TB-D1 | 不复用 Toggle | 新写 `Tab` 独立类，不继承 / 不扩 Toggle 模式 | Toggle 的 checkmark 布局硬编码；加 mode = OnAttached 分支化、常量动态化、`GetNativeSize` 公式分裂；新写 Tab 零回归 |
+| TB-D2 | 容器形态 | `<TabBar>` 必填（不允许散在 HStack 里靠 group= 字符串维系） | 模板/动态添加/共享视觉都需要容器；和 ScrollList 形态对齐 |
+| TB-D3 | 互斥载体 | `TabBar` OnAttached 在自己 GameObject 上 `AddComponent<UnityEngine.UI.ToggleGroup>`，私有；不入 `ToggleGroupRegistry` | TabBar 的 group 跟 Screen 级 `Toggle group="x"` 的语义不同（容器边界天然定义 group 范围），不要混用同一注册表 |
+| TB-D4 | sprite 声明位置 | 仅 TabBar 暴露 `sprite` / `selectedSprite`，所有子 Tab 共享 | 一个 tab bar 内 99% 用例 tabs 长得一样；per-Tab override 留 v2 |
+| TB-D5 | selected 视觉实现 | overlay 图层挂到 `UnityToggle.graphic` 通道，由 Unity 按 isOn 自动显隐 | 复用 UnityToggle 内置机制；不写 isOn listener；transition 默认 `None`（即时切换），未来要 fade 在一个地方改 |
+| TB-D6 | pressed 视觉 | UnityToggle/Selectable 内置 color tint（默认 pressed 色 ≈ 0.78 灰），不暴露 attr | 跟 Btn 一致；author 不需要为 tab 单独学一套；要自定义可后续加 |
+| TB-D7 | `allowSwitchOff` | **不暴露**，固定 `false` | 99% 用例总有一个 tab 选中；需求 #4 "按钮模式"靠"不写 selectedSprite"实现视觉退化，互斥仍在 |
+| TB-D8 | 初始选中 | 解析所有 Tab 后，若没有任何 Tab `isOn="true"` → TabBar 自动把第一个 Tab 置 `IsOn=true` | 避免 Unity ToggleGroup 在 `allowSwitchOff=false` 下首帧仍无选中 + 所有 bind frame 显示的反直觉行为 |
+| TB-D9 | Bind 解析时机 | Tab.Bind setter 只存字符串；首次 `OnValueChanged` fire 时调 `Screen.Get<Frame>(id)` 缓存 ref；找不到 → warn 一次 + 后续静默 | lazy 避开属性 apply 顺序问题；缓存避免每次 toggle 都查表 |
+| TB-D10 | Bind 失败处理 | warn 一次（设置 `_bindId=null` 防重复 warn），后续静默；找到但不是 Frame → 也 warn | 显示控件失联不应崩 |
+| TB-D11 | itemTemplate 默认 | 不写 = `"Tab"`（直接实例化 Tab 类） | 90% 动态场景 tabs 都长得一样，免去写 `<Template name="X"><Tab/></Template>` 样板 |
+| TB-D12 | BindItems 重载 | 提供两个：`Action<Tab,T>`（默认 Tab 模板免泛型）+ `Action<TSlot,T>`（自定义 Template，与 ScrollList 完全一致） | 90% 场景 author 直接 `(tab, m) => tab.Text = m.Name`；复杂场景退回通用形态 |
+| TB-D13 | 静态 XML 子 vs BindItems | 与 ScrollList 一致：BindItems 调用 = Dispose 现有所有 Tab + 重建；混用 BindItems 赢 | 心智一致；不引入新规则 |
+| TB-D14 | TabBar 是否 layout group | 是，加进 `ScreenInstantiator.selfIsLayoutGroup` 列表；Tab 不能写 `anchor=` / `margin=`（被 HorizontalLayoutGroup 接管） | 跟 HStack 子项规则一致 |
+| TB-D15 | TabBar 方向 | `direction="horizontal"`（默认） / `"vertical"`；同 ScrollList 命名 | 垂直 tab bar 稀少但有用；几乎免费（换 LayoutGroup 类型） |
+| TB-D16 | 选中事件层级 | Tab 暴露 `OnValueChanged` / `OnSelected`；TabBar 暴露 `OnSelectionChanged: Observable<Tab>` | 静态 author 订阅个别 Tab；动态 BindItems 场景订阅 TabBar 拿当前 Tab 引用 |
+| TB-D17 | OnSelectionChanged payload | `Observable<Tab>`（新激活的 Tab 引用，可能为 null） | author 拿到 Tab 后再走 `tabBar.SelectedIndex` 或自己维护 idx→model 映射；refs 比 idx 信息更多 |
+| TB-D18 | Tab 不在 TabBar 下 | runtime `Debug.LogWarning` + Tab.\_toggle.group=null（仍能点，但无互斥）；lint warning | 不阻拦运行，便于 Editor 临时拖测试 |
+| TB-D19 | TabBar 下混入非 Tab | runtime 不阻拦（HorizontalLayoutGroup 照常布局非 Tab 节点）；lint warning | 不破坏运行；author 知道后能修 |
+| TB-D20 | Tab 自身是 layout group？ | 否；Tab 内部固定布局（bg/overlay/icon/label），不接 XML 子 | 跟 Btn / Toggle 一致；要复杂内容用 itemTemplate |
+| TB-D21 | Variant override 范围 | 允许 override Tab 的 `text` / `isOn` / `bind` / `icon`；TabBar 上 `sprite` / `selectedSprite` / `direction` 也允许 | 都是值写入；切方向只是换 LayoutGroup（OnAfterApply 一次 reconcile） |
+
+---
+
+## 3. XML 形态
+
+### 3.1 静态写法
+
+```xml
+<Screen name="Main">
+  <TabBar id="topbar" anchor="top-stretch" height="40"
+          sprite="ui:tab_normal" selectedSprite="ui:tab_selected"
+          spacing="4">
+    <Tab text="编辑" bind="editor_panel" isOn="true"/>
+    <Tab text="帮助" bind="help_panel"/>
+    <Tab text="设置" bind="settings_panel"/>
+  </TabBar>
+
+  <Frame id="editor_panel"   margin="40,0,0,0">...</Frame>
+  <Frame id="help_panel"     margin="40,0,0,0">...</Frame>
+  <Frame id="settings_panel" margin="40,0,0,0">...</Frame>
+</Screen>
+```
+
+或包到 VStack 里：
+
+```xml
+<VStack>
+  <TabBar id="topbar" height="40" sprite="..." selectedSprite="..."/>
+  <Frame id="content">
+    <Frame id="editor_panel">...</Frame>
+    <Frame id="help_panel">...</Frame>
+    <Frame id="settings_panel">...</Frame>
+  </Frame>
+</VStack>
+```
+
+（Frame 默认 anchor 是双轴 stretch，`Frame.cs:16-19`；Screen 根 / 普通 Frame 不挂 LayoutGroup，兄弟节点重叠是默认行为。）
+
+### 3.2 button 模式（需求 #4）
+
+不写 `selectedSprite` → overlay 不创建，selected 态视觉无反馈，但互斥/事件/Bind 全在：
+
+```xml
+<TabBar id="actions" sprite="ui:btn">
+  <Tab text="保存"/>
+  <Tab text="导出"/>
+  <Tab text="删除"/>
+</TabBar>
+```
+
+### 3.3 自定义 Template
+
+```xml
+<Template name="IconTab">
+  <Tab id="tab">
+    <!-- Tab 不接子，所以 Template 只是给 Tab 实例一个外层 id；icon 走 Tab.icon -->
+  </Tab>
+</Template>
+
+<TabBar id="bar" itemTemplate="IconTab" sprite="..." selectedSprite="..."/>
+```
+
+> 注：itemTemplate 指向 Template 时，Template root 必须能 `Get<Tab>(...)` 到一个 Tab 实例（同 ScrollList itemTemplate）。
+
+---
+
+## 4. 属性表
+
+### 4.1 `<TabBar>`
+
+| 属性 | 取值 | 默认 | 作用 |
+|---|---|---|---|
+| `sprite` | sprite key | (none) | 所有子 Tab 的 normal bg；走 `UI.ResolveSprite` |
+| `selectedSprite` | sprite key | (none) | 所有子 Tab 的 selected overlay；不写 → overlay 不创建（按钮模式，需求 #4） |
+| `direction` | `horizontal` \| `vertical` | `horizontal` | 决定挂 `HorizontalLayoutGroup` 还是 `VerticalLayoutGroup` |
+| `spacing` | float | `0` | LayoutGroup spacing |
+| `padding` | `X` / `V,H` / `T,R,B,L` | (none) | LayoutGroup padding，同 ScrollList 解析 |
+| `itemTemplate` | tag / Template 名 | `"Tab"` | BindItems 实例化的元素 tag；默认直接实例化 Tab 类 |
+
+### 4.2 `<Tab>`
+
+| 属性 | 取值 | 默认 | 作用 |
+|---|---|---|---|
+| `text` | string | `""` | label 文本，居中 |
+| `isOn` | bool | `false` | 初始选中状态；多个 `true` → 后写的赢；都 false → TabBar 自动选第一个（TB-D8） |
+| `bind` | Frame id | (none) | 同 Screen 内 Frame 的 id；选中 → `SetActive(true)`，未选中 → `SetActive(false)`；lazy 解析（TB-D9） |
+| `font` | string | `"default"` | font type，同 Btn/Toggle |
+| `fontSize` | int | `24` | TMP fontSize；跟 Btn 默认 24 对齐 |
+| `icon` | sprite key | (none) | 可选 icon，居 label 左；不写则不创建 |
+
+约束：
+- `<Tab>` 不接受 XML 子元素；写了会 lint error（`PUI-TAB-CHILDREN`）。
+- `<Tab>` 不能写 `anchor=` / `margin=`（TabBar 是 LayoutGroup 父，TB-D14）；lint error 同 HStack/VStack 子项规则。
+
+---
+
+## 5. C# API
+
+### 5.1 `Tab`
+
+```csharp
+public sealed class Tab : Control
+{
+    [UIAttr, Preserve] public string Text { set; }
+    [UIAttr, Preserve] public bool IsOn { get; set; }
+    [UIAttr, Preserve] public string Bind { set; }
+    [UIAttr, Preserve] public string Font { set; }
+    [UIAttr("fontSize"), Preserve] public int FontSize { set; }
+    [UIAttr(IsSprite = true), Preserve] public string Icon { set; }
+
+    public Observable<bool> OnValueChanged { get; }
+    public Observable<Unit> OnSelected { get; }   // 仅在 false → true 时 fire
+}
+```
+
+### 5.2 `TabBar`
+
+```csharp
+public sealed class TabBar : Control
+{
+    [UIAttr(IsSprite = true), Preserve] public string Sprite { set; }
+    [UIAttr(IsSprite = true), Preserve] public string SelectedSprite { set; }
+    [UIAttr, Preserve] public string Direction { set; }   // "horizontal" | "vertical"
+    [UIAttr, Preserve] public float Spacing { set; }
+    [UIAttr, Preserve] public string Padding { set; }
+    [UIAttr, Preserve] public string ItemTemplate { set; } // 默认 "Tab"
+
+    public int Count { get; }
+    public int SelectedIndex { get; }    // -1 表示无选中（仅在空列表场景出现，TB-D7 禁了 allowSwitchOff）
+    public Tab SelectedTab { get; }
+    public Tab GetAt(int index);
+
+    public Observable<Tab> OnSelectionChanged { get; }   // 新激活的 Tab，可能为 null
+
+    public IDisposable BindItems<T>(
+        Observable<IReadOnlyList<T>> source,
+        Action<Tab, T> bind);            // 默认 itemTemplate="Tab" 的简易重载
+
+    public IDisposable BindItems<T, TSlot>(
+        Observable<IReadOnlyList<T>> source,
+        Action<TSlot, T> bind) where TSlot : class, IControl;   // 同 ScrollList 通用
+}
+```
+
+### 5.3 用法示例
+
+```csharp
+// 静态 XML 已写好 3 个 Tab：
+var bar = screen.Get<TabBar>("topbar");
+bar.OnSelectionChanged.Subscribe(tab => Debug.Log($"selected: {tab?.Get<Text>("...")}"));
+
+// 动态：
+bar.BindItems(
+    Observable.Return<IReadOnlyList<TabModel>>(new[] {
+        new TabModel("编辑",  "editor_panel"),
+        new TabModel("帮助",  "help_panel"),
+        new TabModel("设置",  "settings_panel"),
+    }),
+    (tab, m) => { tab.Text = m.Name; tab.Bind = m.FrameId; });
+
+// 手动切：
+bar.GetAt(1).IsOn = true;     // 同时取消其他 Tab 的 IsOn
+```
+
+---
+
+## 6. 程序化层级（固定）
+
+### 6.1 TabBar
+
+```
+TabBar (RectTransform + ToggleGroup + HorizontalLayoutGroup | VerticalLayoutGroup + ContentSizeFitter?)
+└── Tab[0], Tab[1], ... （直接挂在 TabBar 下，HorizontalLayoutGroup 自动排）
+```
+
+无 Content/Viewport 嵌套（不是 ScrollList，不滚动）。`ContentSizeFitter` 按是否有显式 size 决定挂不挂（与 ScrollList 决策一致）。
+
+### 6.2 Tab
+
+```
+Tab (RectTransform + UnityImage[bg] + UnityToggle)
+├── Overlay (RectTransform + UnityImage; 按需创建; UnityToggle.graphic 绑这个，按 isOn 自动 SetActive)
+├── Icon    (RectTransform + UnityImage; 按需创建; raycastTarget=false; 居 label 左侧)
+└── Label   (RectTransform + TMP_Text; 永远存在; raycastTarget=false)
+```
+
+- bg = TabBar.Sprite，targetGraphic（Selectable 用它做 pressed tint）
+- Overlay = TabBar.SelectedSprite；TabBar 没设 SelectedSprite → 不创建该子节点
+- Icon = Tab.Icon；不设 → 不创建
+- Label 永远存在；居中（无 icon）或居 icon 右（有 icon）
+
+---
+
+## 7. 行为细节
+
+### 7.1 互斥（mutex）
+
+- **TabBar.OnAttached**: 加 `ToggleGroup` 组件到自己 GameObject，`allowSwitchOff = false`（TB-D7）
+- **Tab.OnAttached**: 沿 `transform.parent` 向上找第一个带 `ToggleGroup` 的 ancestor；找到 → `_toggle.group = it`；找不到 → `Debug.LogWarning("Tab '{id}' has no <TabBar> ancestor; mutual exclusion disabled")`
+
+### 7.2 初始 IsOn 同步（TB-D8）
+
+属性 apply 完毕后，`TabBar.OnAfterApply()` 末段触发 `SyncInitialSelection()`。它要解决两个问题：
+
+1. **未被选中的 Tab 对应的 Frame 仍是 active**——UnityToggle 只在 `isOn` 真正发生变化时 fire `onValueChanged`，所以"attr 写 false（=默认值）"的 Tab 永远不会触发 §7.3 的 `OnIsOnChanged(false)` 路径，对应 bind frame 还是 GameObject 默认的 `activeSelf=true`。
+2. **全部 Tab 都没写 isOn=true 时无选中**——`allowSwitchOff=false` 的 Unity ToggleGroup 不会自动补选。
+
+```csharp
+internal void SyncInitialSelection()
+{
+    if (_tabs.Count == 0) return;
+
+    // (1) 先 reconcile: 对所有未选中 + 有 bind 的 Tab，强制把对应 Frame 关掉
+    foreach (var t in _tabs)
+    {
+        if (!t.IsOn) t.ForceSyncBindFrame(isOn: false);   // 等价于 OnIsOnChanged(false)，但即使 _bindId 已 resolved 过也跑
+    }
+
+    // (2) 没有任何 Tab 在线 → 自动选第一个（这一步会触发 Tab[0] 的 onValueChanged，进而 bind frame SetActive(true)）
+    bool anyOn = false;
+    foreach (var t in _tabs) if (t.IsOn) { anyOn = true; break; }
+    if (!anyOn) _tabs[0].IsOn = true;
+}
+```
+
+`Tab.ForceSyncBindFrame(bool)` 是 internal helper：跟 §7.3 的 `OnIsOnChanged` 主体一样调 lazy-resolve + `_boundFrame.GameObject.SetActive(isOn)`，但**不**经过 UnityToggle 的 onValueChanged 路径（避免 fire 多余的 `_changed` / `_selected` 事件给 author 订阅）。
+
+### 7.3 Bind → Frame 同步
+
+```csharp
+// Tab 内部
+private string _bindId;
+private bool _bindResolved;
+private Frame _boundFrame;
+
+public string Bind { set => _bindId = value; }   // 只存
+
+// UnityToggle.onValueChanged 监听
+private void OnIsOnChanged(bool isOn)
+{
+    _changed.OnNext(isOn);
+    if (isOn) _selected.OnNext(Unit.Default);
+    if (_bindId == null) return;
+    if (!_bindResolved)
+    {
+        _boundFrame = UI.OwnerScreenOf(this)?.Get<Frame>(_bindId);
+        if (_boundFrame == null)
+            Debug.LogWarning($"Tab.bind='{_bindId}' did not resolve to a Frame; ignoring.");
+        _bindResolved = true;
+        _bindId = null;       // 防重复 warn
+    }
+    if (_boundFrame != null) _boundFrame.GameObject.SetActive(isOn);
+}
+```
+
+初始化序列：
+
+1. `ScreenInstantiator` DFS 创建所有 GameObject（含 TabBar / Tabs / Frames）
+2. `SetActive(true)` 整树（Screen.cs:128 注释）
+3. 属性 apply 按 DFS post-order：Tab.Bind setter 存字符串，Tab.IsOn setter 写 `_toggle.isOn`
+4. UnityToggle.PlayEffect → `onValueChanged` fire → 走 7.3 的 `OnIsOnChanged` → 第一次解析 Frame + SetActive
+5. TabBar.OnAfterApply 末段调 `SyncInitialSelection()`（兜底 7.2）
+
+> 注：步骤 4 仅在 isOn 真正发生变化时触发；attr 写 false（=默认值）的 Tab 不会走这条路径。这意味着"未被选中 + bind 不空"的 Frame 还保持 GameObject 默认的 active=true。这个 reconcile gap 由步骤 5 的 `SyncInitialSelection`（§7.2）补齐。
+
+### 7.4 BindItems 重建
+
+跟 ScrollList 模式一致（`ScrollList.cs:230-247`）：
+
+```csharp
+public IDisposable BindItems<T>(Observable<IReadOnlyList<T>> src, Action<Tab, T> bind)
+    => BindItems<T, Tab>(src, bind);
+
+public IDisposable BindItems<T, TSlot>(Observable<IReadOnlyList<T>> src, Action<TSlot, T> bind)
+    where TSlot : class, IControl
+    => src.Subscribe(items => Rebuild(items, bind));
+
+private void Rebuild<T, TSlot>(IReadOnlyList<T> items, Action<TSlot, T> bind)
+    where TSlot : class, IControl
+{
+    if (_factory == null) _factory = ResolveFactory(_itemTemplate ?? "Tab");
+    ClearTabs();          // Dispose 所有现有 Tab（含静态 XML 写的）
+    for (int i = 0; i < items.Count; i++)
+    {
+        var node = _factory(RectTransform);   // node 可能是 Tab 直接实例，也可能是 Template root
+        var tab = node as Tab ?? node.Get<Tab>(...);   // 失败抛 InvalidCastException
+        _tabs.Add(tab);
+        // 把新 Tab 绑到自己的 ToggleGroup（Tab.OnAttached 已经走了一次，但 BindItems 期间 _factory 创建的也会走）
+        if (node is TSlot typed) bind(typed, items[i]);
+        else throw new InvalidCastException($"itemTemplate='{_itemTemplate}' instantiated {node.GetType().Name}, expected {typeof(TSlot).Name}");
+    }
+    SyncInitialSelection();
+}
+```
+
+### 7.5 OnSelectionChanged 触发
+
+TabBar 在每个 Tab.OnValueChanged 上挂内部订阅；当某 Tab 变 `IsOn=true` 时，`OnSelectionChanged.OnNext(that_tab)`；当 BindItems 清空且新列表为空时 `OnSelectionChanged.OnNext(null)`。
+
+### 7.6 Tab 视觉布局（OnAttached 末段）
+
+```
+Bg: RT 满铺 Tab (anchor stretch + offsetMin=Max=0)
+Overlay (按需): RT 满铺 Tab; UnityImage; 父 UnityToggle.graphic 指它
+Icon (按需): RT anchor left-middle, sizeDelta (24,24), 偏移由 padding 决定
+Label: RT 满铺 Tab（无 icon）或 offsetMin.x = iconWidth + gap（有 icon）；TMP 居中
+```
+
+Tab 不暴露 padding/font color attribute（v1 用 ProceduralBuilders 的默认值），跟 Btn 风格一致。
+
+---
+
+## 8. 边界 / 错误处理
+
+| 场景 | 处理 |
+|---|---|
+| `<Tab>` 不在 `<TabBar>` 下 | lint warning `PUI-TAB-PARENT`；runtime LogWarning，`_toggle.group=null`（仍能 toggle，无互斥） |
+| `<TabBar>` 下混入非 `<Tab>` 元素 | lint warning `PUI-TABBAR-CHILD`；runtime 不阻拦（HorizontalLayoutGroup 照常排版） |
+| `bind="x"` 但 `x` 不存在 / 不是 Frame | 首次 OnValueChanged 时 LogWarning 一次，`_bindId=null` 防重复（TB-D10） |
+| 多个 Tab 写 `isOn="true"` | 后写的覆盖（Unity ToggleGroup `allowSwitchOff=false` 标准行为） |
+| 全部 Tab 都没写 `isOn` | TabBar.SyncInitialSelection 自动把第 0 个 Tab 置 IsOn=true（TB-D8） |
+| BindItems 传空列表 | ClearTabs；`SelectedIndex=-1`；`OnSelectionChanged.OnNext(null)`；所有 bind 过的 Frame 保留最后状态（不主动复原；和 ScrollList 一致） |
+| `itemTemplate` 指向不存在的 tag/Template | `ResolveFactory` 抛 `ParseException`（同 ScrollList） |
+| `<Tab>` 包含子元素 | lint error `PUI-TAB-CHILDREN`；runtime "未知子节点" 路径 warn + 忽略 |
+| `<Tab>` 写 `anchor=` / `margin=` | lint error `PUI-LAYOUTCHILD-*`（沿用 HStack 子项规则；TabBar 加入 selfIsLayoutGroup 后自动覆盖） |
+| `<TabBar>` 自身嵌在 HStack / VStack 下 | 合法；TabBar 走 LayoutGroupChildRules 不允许 anchor/margin（与 HStack 嵌 HStack 一致） |
+| Tab.Bind 指向的 Frame 在 BindItems 重建期间被某 Tab Dispose 触发 SetActive | 不会发生 —— Tab Dispose 不动 Frame，仅断 toggle 订阅；Frame 是 Screen 共享节点 |
+
+---
+
+## 9. Lint 规则
+
+`Runtime/Core/Lint/TabRules.cs`（新文件）；`IRWalker.WalkNode` 入口 self-check 加 `Tab` / `TabBar` 分支；`ScreenInstantiator.InstantiateRecursive` 同源 `Debug.LogWarning`。
+
+| Code | 触发条件 | 信息（节选） | 级别 |
+|---|---|---|---|
+| `PUI-TAB-PARENT` | `<Tab>` 的父不是 `<TabBar>`（也不是 itemTemplate 展开的 Template root 在 BindItems 阶段，这种情况 lint 不可见） | "Tab 必须是 TabBar 的直接子元素；当前父为 '{tag}'，互斥/共享视觉将失效。" | warning |
+| `PUI-TABBAR-CHILD` | `<TabBar>` 子中存在非 `<Tab>` 节点（且非 Template invocation——这个由 TemplateExpander 处理） | "TabBar 期望子元素全部是 <Tab>；发现 '{tag}'，会被 HorizontalLayoutGroup 照常排版但语义不正确。" | warning |
+| `PUI-TAB-CHILDREN` | `<Tab>` 自身包含子元素 | "Tab 是 leaf 控件，不接受子元素。用 text / icon 属性表达内容。" | error |
+| `PUI-TABBAR-DIRECTION` | `direction` 不在 `horizontal` / `vertical` | "TabBar.direction 合法值: horizontal, vertical。" | error |
+| `PUI-TAB-BIND-EMPTY` | `bind=""`（空字符串，非未设） | "Tab.bind 空字符串无意义；删除属性或填入 Frame id。" | warning |
+
+runtime 一律 `Debug.LogWarning`；CLI `UIXmlLint` 按 level 决定 exit code。
+
+> 注：`PUI-TAB-PARENT` / `PUI-TABBAR-CHILD` 用 warning 而非 error 是为了不阻断"父用 Template 间接展开成 TabBar"这种合法但 lint 静态看不出来的场景。
+
+---
+
+## 10. 实现要点
+
+### 10.1 `Runtime/Controls/Tab.cs`（新文件）
+
+骨架（详细 visual 布局逻辑放 plan）：
+
+```csharp
+using PromptUGUI.Application;
+using PromptUGUI.Controls.Internal;
+using PromptUGUI.Registry;
+using R3;
+using TMPro;
+using UnityEngine;
+using UnityImage = UnityEngine.UI.Image;
+using UnityToggle = UnityEngine.UI.Toggle;
+
+namespace PromptUGUI.Controls
+{
+    public sealed class Tab : Control
+    {
+        private UnityImage _bg;
+        private UnityImage _overlay;   // 可能为 null
+        private UnityImage _icon;      // 可能为 null
+        private TMP_Text _label;
+        private UnityToggle _toggle;
+        private string _fontType = "default";
+        private string _bindId;
+        private bool _bindResolved;
+        private Frame _boundFrame;
+        private readonly Subject<bool> _changed = new();
+        private readonly Subject<Unit> _selected = new();
+
+        public override void OnAttached()
+        {
+            _bg = GameObject.GetComponent<UnityImage>() ?? GameObject.AddComponent<UnityImage>();
+            _bg.color = ProceduralBuilders.DefaultBtnColor;
+            ProceduralBuilders.ApplyDefaultSlicedSprite(_bg);
+
+            _toggle = GameObject.GetComponent<UnityToggle>() ?? GameObject.AddComponent<UnityToggle>();
+            _toggle.targetGraphic = _bg;
+
+            _label = ProceduralBuilders.AddText(RectTransform, "Label");
+            _label.alignment = TextAlignmentOptions.Center;
+            _label.raycastTarget = false;
+            _label.fontSize = 24;
+            var lrt = _label.rectTransform;
+            lrt.anchorMin = Vector2.zero; lrt.anchorMax = Vector2.one;
+            lrt.offsetMin = Vector2.zero; lrt.offsetMax = Vector2.zero;
+            ApplyFont();
+
+            // overlay / icon 都是 lazy，由 TabBar.OnAfterApply 或 setter 触发
+            _toggle.onValueChanged.AddListener(OnIsOnChanged);
+            UI.Locale.Changed += ApplyFont;
+
+            // 找父 TabBar 的 ToggleGroup
+            var bar = FindAncestorTabBar();
+            if (bar != null) _toggle.group = bar.InternalToggleGroup;
+            else Debug.LogWarning($"Tab has no <TabBar> ancestor; mutex disabled.");
+        }
+
+        internal void EnsureOverlay(Sprite selectedSprite)
+        {
+            if (selectedSprite == null) return;
+            if (_overlay == null)
+            {
+                _overlay = ProceduralBuilders.AddImage(RectTransform, "Overlay", raycast: false);
+                var rt = _overlay.rectTransform;
+                rt.anchorMin = Vector2.zero; rt.anchorMax = Vector2.one;
+                rt.offsetMin = Vector2.zero; rt.offsetMax = Vector2.zero;
+                _toggle.graphic = _overlay;
+            }
+            _overlay.sprite = selectedSprite;
+            ProceduralBuilders.ApplyImageAutoSliced(_overlay);
+        }
+
+        internal void ApplyBgSprite(Sprite normalSprite)
+        {
+            if (normalSprite == null) return;
+            _bg.sprite = normalSprite;
+            ProceduralBuilders.ApplyImageAutoSliced(_bg);
+        }
+
+        // Text / IsOn / Bind / Font / FontSize / Icon attrs ... (同 Btn 风格)
+
+        private void OnIsOnChanged(bool isOn) { /* 7.3 流程 */ }
+        // ...
+    }
+}
+```
+
+> `ProceduralBuilders.ApplyImageAutoSliced(...)` 当前没这个 helper —— plan 阶段决定是抽出来还是 inline `img.type = img.sprite.border != Vector4.zero ? Sliced : Simple`。
+
+### 10.2 `Runtime/Controls/TabBar.cs`（新文件）
+
+```csharp
+public sealed class TabBar : Control
+{
+    private ToggleGroup _group;
+    private LayoutGroup _layout;
+    private string _direction = "horizontal";
+    private float _spacing;
+    private string _padding;
+    private string _itemTemplate;
+    private Sprite _sprite;
+    private Sprite _selectedSprite;
+    private Func<RectTransform, IControl> _factory;
+    private readonly List<Tab> _tabs = new();
+    private readonly Subject<Tab> _selectionChanged = new();
+    private IDisposable _activeBindSub;
+
+    internal ToggleGroup InternalToggleGroup => _group;
+
+    public override void OnAttached()
+    {
+        _group = GameObject.AddComponent<ToggleGroup>();
+        _group.allowSwitchOff = false;
+        ApplyDirection();
+    }
+
+    private void ApplyDirection() { /* 同 ScrollList.ApplyDirection 但无 viewport */ }
+
+    [UIAttr(IsSprite = true), Preserve]
+    public string Sprite { set { _sprite = UI.ResolveSprite(value); PushVisualToTabs(); } }
+
+    [UIAttr(IsSprite = true), Preserve]
+    public string SelectedSprite { set { _selectedSprite = UI.ResolveSprite(value); PushVisualToTabs(); } }
+
+    // direction / spacing / padding / itemTemplate setters
+
+    internal override void OnAfterApply()
+    {
+        // 收集子节点中的 Tab
+        CollectStaticTabs();
+        PushVisualToTabs();
+        SyncInitialSelection();
+        WireTabSubscriptions();
+    }
+
+    private void CollectStaticTabs() { /* 遍历 children, 找 Tab; 同时 hookup 到 ToggleGroup（若 Tab.OnAttached 没找到）*/ }
+    private void PushVisualToTabs() { foreach (var t in _tabs) { t.ApplyBgSprite(_sprite); t.EnsureOverlay(_selectedSprite); } }
+    private void SyncInitialSelection() { /* 7.2 */ }
+    private void WireTabSubscriptions()
+    {
+        _activeBindSub?.Dispose();
+        var d = new CompositeDisposable();
+        foreach (var t in _tabs)
+            t.OnValueChanged.Where(on => on).Subscribe(_ => _selectionChanged.OnNext(t)).AddTo(d);
+        _activeBindSub = d;
+    }
+
+    // BindItems / Count / SelectedIndex / SelectedTab / GetAt / OnSelectionChanged
+}
+```
+
+### 10.3 `Runtime/Application/BuiltinPrimitives.cs`
+
+```csharp
+reg.Register<TabBar>("TabBar", null);
+reg.Register<Tab>("Tab", null);
+```
+
+### 10.4 `Runtime/Application/ScreenInstantiator.cs`
+
+```csharp
+// L237 附近
+var selfIsLayoutGroup = node.Tag is "VStack" or "HStack" or "Grid" or "TabBar";
+```
+
+self-check 入口（创建 control 之前的 lint 同源块）追加 Tab / TabBar 分支调用 `TabRules`。
+
+### 10.5 `Runtime/Core/Lint/TabRules.cs`（新文件）
+
+跟 `MaskAttributeRules` 同模式：static class + `CheckTab(ElementNode)` / `CheckTabBar(ElementNode)` 返回 `IEnumerable<LintIssue>`。
+
+### 10.6 `Runtime/Core/Lint/IRWalker.cs`
+
+`WalkNode` 入口 self-check 追加：
+
+```csharp
+else if (node.Tag == "Tab")
+    foreach (var issue in TabRules.CheckTab(node)) yield return issue;
+else if (node.Tag == "TabBar")
+    foreach (var issue in TabRules.CheckTabBar(node)) yield return issue;
+```
+
+---
+
+## 11. 跟现有 spec / SKILL 的整合点
+
+### 11.1 主 spec `2026-05-07-promptugui-description-language-design.md`
+
+§5（控件表）追加两行：
+
+> `<TabBar>` | Tab 容器，私有 ToggleGroup + HorizontalLayoutGroup；共享 normal/selected sprite；支持 itemTemplate + BindItems | RectTransform + ToggleGroup + LayoutGroup（详见 [`2026-05-27-tabbar-design.md`](2026-05-27-tabbar-design.md)）
+>
+> `<Tab>` | TabBar 子项；UnityToggle + 居中 label + 可选 icon + 可选 selected overlay；`bind="frame_id"` 选中态联动 Frame 显隐 | RectTransform + UnityImage + UnityToggle |
+
+### 11.2 `authoring-promptugui-xml/SKILL.md`
+
+1. Built-in primitives 表追加两行（attrs 列见 §4）
+2. 新增 "Tabs" 小节，含：
+   - 静态用例（§3.1）
+   - button 模式（§3.2，需求 #4）
+   - 自定义 Template（§3.3）
+   - lint codes 列表（§9）
+   - "bind 不写 → 用户自己用 OnSelected 接业务"的一句话
+3. Quick reference 末尾加一行：
+   > `<TabBar sprite="..." selectedSprite="..."><Tab text="A" bind="frame_a" isOn="true"/>...</TabBar>` —— 私有互斥 group；bind 联动 Frame 显隐；动态走 BindItems
+
+### 11.3 `scripting-promptugui-csharp/SKILL.md`
+
+- `BindItems` 段补：TabBar 同 ScrollList 风格的两个重载；默认 `(Tab, T)` 简易重载免泛型
+- 新一句：`tabBar.OnSelectionChanged.Subscribe(tab => ...)` —— TabBar 级事件给动态场景；静态场景用 `tab.OnSelected` per-Tab 订阅
+- `tab.IsOn = true` 触发互斥 + bind 的 Frame 自动 SetActive，无需手写 `frame.GameObject.SetActive(...)`
+
+### 11.4 addressables skill 无关，不动。
+
+---
+
+## 12. Out of Scope
+
+- **per-Tab sprite override** —— TB-D4 留 v2；99% 用例 tabs 长得一样
+- **`allowSwitchOff=true`（无任何 tab 选中也合法）** —— TB-D7 砍掉；按钮模式靠"不写 selectedSprite"实现视觉退化
+- **垂直方向的"侧边栏 tab"完整视觉规范** —— TB-D15 允许 `direction="vertical"` 但 sprite 比例 / label 旋转之类由作者自己处理
+- **Fade transition** —— TB-D5 固定 UnityToggle.Transition.None；要 fade 后续在 TabBar 加 attr
+- **Tab 关闭按钮 / drag-reorder** —— v1 不做
+- **嵌套 TabBar（tab 里再开 tab）** —— 不阻拦，但 bind 一次只能联动一个 Frame；嵌套语义由 author 用 OnSelected 自定义
+- **动画过渡 frame 显隐** —— bind 是直接 SetActive；要淡入淡出用 `<Animation>` 控件或自己接 OnSelected 写
+- **Tab 内复杂内容（icon + 多行 + badge）** —— Tab 是 leaf，不接子。复杂内容用 itemTemplate + 用户 Template 把 Tab 包装在外层 Frame 里
+
+---
+
+## 13. 风险与回滚
+
+| 风险 | 缓解 |
+|---|---|
+| Tab.OnAttached 找父 TabBar 时父链还没建好 | OnAttached 是 DFS post-order，Tab 创建时父 TabBar 已 attach；如果遇到 nested 场景仍找不到 → LogWarning 不崩 |
+| 多 Tab 都 `isOn="true"` 时 attribute apply 顺序导致状态抖 | 由 `_toggle.group` 的 `allowSwitchOff=false` 兜底；setter 顺序最终只有一个 true；UnityToggle 自动处理 |
+| BindItems 重建期间旧 Tab Dispose 时它正在播 UnityToggle.PlayEffect | Dispose 先解订阅再销 GameObject，PlayEffect 协程被 GameObject Destroy 自动取消 |
+| `OnSelectionChanged` 在 BindItems 清空时是否要 fire null | 是，TB-D17 明确：清空后 SelectedTab=null + fire null；订阅者要 handle null |
+| TabBar 拖到 Scroll View 里 | 合法但 ToggleGroup 没问题；Tab.OnAttached 仍找得到 TabBar（ScrollList 是它祖先而非中间 ToggleGroup） |
+| 父 TabBar 被 Destroy 时 ToggleGroup 跟着没 | UnityToggle.group 引用悬挂 → Unity 内部按 null 处理（Selectable 健壮）；不影响 Player |
+| `<Tab>` 写 anchor="..." 想脱出 LayoutGroup | TB-D14 + lint 阻断；HorizontalLayoutGroup 仍会覆盖；author 看 lint 修 |
+| `bind` 指向的 Frame 在另一个 Variant 中被 SetActive | Tab 的 SetActive 与 Variant 的 SetActive 都直接写 GameObject.activeSelf，最后写的赢；author 需要意识到这种冲突（doc 一句提示） |
+| `OnAfterApply` 比单 attr setter 晚 → BindItems 在 attr apply 之前调用（很罕见，必须在 user code 手动调） | 文档说明：BindItems 应在 `screen.Get<TabBar>(...)` 拿到后调，那时 `OnAfterApply` 已跑完；Rebuild 内会再调 SyncInitialSelection 兜底 |
+| XSD 不自动更新 | 跟所有新 `[UIAttr]` 一样手动 `Tools → PromptUGUI → Schema → Generate XSD`；CLAUDE.md 已说明 |


### PR DESCRIPTION
## Summary

- New `<TabBar>` (container) + `<Tab>` (leaf) built-in controls per spec [`2026-05-27-tabbar-design.md`](docs~/superpowers/specs/2026-05-27-tabbar-design.md). Backed by `UnityEngine.UI.Toggle` + a private `ToggleGroup` (`allowSwitchOff=false`) on the TabBar GameObject; `Tab.OnAttached` walks transform ancestors to find the group.
- TabBar exposes `sprite` / `selectedSprite` once and pushes both to every child Tab — normal bg is `targetGraphic`, selected sprite becomes a child Overlay bound to `UnityToggle.graphic` (auto show/hide on `isOn`). Omitting `selectedSprite` degrades cleanly to a "button-list" with no selected visual feedback (req #4).
- `Tab.bind="frame_id"` resolves a sibling `<Frame>` lazily on first toggle and SetActive's it on subsequent isOn changes. `TabBar.SyncInitialSelection` reconciles non-selected bind frames on Open and auto-selects Tab[0] if no Tab declared `isOn="true"`.
- `TabBar.itemTemplate` + `BindItems<T>(source, Action<Tab,T>)` for dynamic content (default Tab) plus `BindItems<T,TSlot>` for custom-Template wrappers (FindTabIn walks ScopedIds → recursive Children). Static `<FileTab text=... icon=...>`-style Template wrappers inside `<TabBar>` get the same treatment via recursive `CollectStaticTabs`, so sprite push / SyncInitialSelection / OnSelectionChanged all apply to wrapped Tabs.
- 5 lint codes in `Runtime/Core/Lint/TabRules.cs` (PARENT / TABBAR-CHILD / TAB-CHILDREN / TABBAR-DIRECTION / TAB-BIND-EMPTY); dispatched from both `IRWalker` (CLI errors) and `ScreenInstantiator` (runtime warnings). PARENT + TABBAR-CHILD relax for Template-instance roots so the FileTab pattern doesn't false-positive.
- `TabBar` joins `ScreenInstantiator.selfIsLayoutGroup` so `<Tab>` direct children inherit existing `PUI-LAYOUTCHILD-*` rules.

## Test plan

- [x] EditMode: **947/947** pass — includes TabTests (14), TabBarTests (15), TabBarBindItemsTests (6), TabRulesTests (11)
- [x] PlayMode: **117/117** pass — includes TabBarPlayTests (2: direct + Template wrapper end-to-end)
- [x] EditorOnly: 164/165 pass — 1 pre-existing failure in `SpriteAtlasSyncerTests.Scan_skips_dynamic_icon_outside_template` unrelated to this branch (reproduces on `main`)
- [x] `dotnet format --verify-no-changes --severity warn` clean on `.lint/PromptUGUI.Lint.slnx`
- [x] `UIXmlLint` CLI on the smoke fixture fires `PUI-TABBAR-DIRECTION` + `PUI-TABBAR-CHILD` + `PUI-TAB-PARENT` with exit code 1
- [x] SKILL.md (`authoring-promptugui-xml` + `scripting-promptugui-csharp`) updated with TabBar/Tab rows, Tabs section, Custom-Template subsection, BindItems C# examples, lint code table
- [x] Main spec §5 control table adds two rows (count 12 → 14) linking to per-control spec

Spec, plan, and 26 implementation commits all on the branch. Spec was reviewed and approved before plan was written; plan was reviewed and approved before implementation began; each task was implemented TDD-style with red → impl → green → commit, then a final code review confirmed APPROVED FOR PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)