### PR TITLE
feat: warn on misnamed .xml PromptUGUI documents during sprite sync

### DIFF
--- a/Editor/SpriteAtlasSyncer.cs
+++ b/Editor/SpriteAtlasSyncer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Xml;
 using PromptUGUI.Application;
 using PromptUGUI.IR;
 using PromptUGUI.Parser;
@@ -37,7 +38,16 @@ namespace PromptUGUI.Editor
             {
                 var guid = guids[i];
                 var path = AssetDatabase.GUIDToAssetPath(guid);
-                if (!path.EndsWith(".ui.xml", StringComparison.Ordinal)) continue;
+                if (!path.EndsWith(".ui.xml", StringComparison.Ordinal))
+                {
+                    // Common foot-gun: PromptUGUI doc named `.xml` (single suffix)
+                    // is silently skipped by the .ui.xml filter, so any Template /
+                    // <Icon> in it never makes it into Pass A / Pass B. Sniff root
+                    // element; if it's <PromptUGUI>, warn so the author renames.
+                    if (path.EndsWith(".xml", StringComparison.Ordinal))
+                        WarnIfMisnamedPromptUGUIDoc(path);
+                    continue;
+                }
                 if (showProgress &&
                     EditorUtility.DisplayCancelableProgressBar(
                         ProgressTitle,
@@ -110,6 +120,41 @@ namespace PromptUGUI.Editor
                 }
             }
             return refs;
+        }
+
+        // XmlReaderSettings shared across calls — Closing it after each use is fine,
+        // settings are immutable. Comments / whitespace / processing instructions are
+        // skipped so we land on the first real Element node and stop.
+        private static readonly XmlReaderSettings MisnamedSniffSettings = new()
+        {
+            IgnoreComments = true,
+            IgnoreProcessingInstructions = true,
+            IgnoreWhitespace = true,
+            DtdProcessing = DtdProcessing.Ignore,
+        };
+
+        private static void WarnIfMisnamedPromptUGUIDoc(string path)
+        {
+            try
+            {
+                using var reader = XmlReader.Create(path, MisnamedSniffSettings);
+                while (reader.Read())
+                {
+                    if (reader.NodeType != XmlNodeType.Element) continue;
+                    if (reader.Name == "PromptUGUI")
+                    {
+                        Debug.LogWarning(
+                            $"[SpriteSync] '{path}' looks like a PromptUGUI document but is " +
+                            $"named '.xml' (single suffix). Sprite sync only scans '.ui.xml' " +
+                            $"files, so any <Icon>/sprite= refs in this file (including any " +
+                            $"Template body that's invoked elsewhere) will be missed. " +
+                            $"Rename to '.ui.xml'.");
+                    }
+                    return; // first element decides; stop reading either way
+                }
+            }
+            catch (XmlException) { /* not valid XML — silently ignore */ }
+            catch (IOException) { /* unreadable — silently ignore */ }
         }
 
         private readonly struct TemplateFlow

--- a/Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs
+++ b/Tests/EditMode/Editor/SpriteAtlasSyncerTests.cs
@@ -92,6 +92,49 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
+        public void Scan_warns_on_PromptUGUI_doc_with_misnamed_xml_extension()
+        {
+            // A common foot-gun: Template library file is named ".xml" instead of
+            // ".ui.xml". Scanner filters on .ui.xml so the file is silently skipped
+            // and any <Icon name="{{x}}"/> Param flow it would have contributed is
+            // missing — Template invocations in other files then look unanalyzable.
+            // Detect on file-content sniff (XmlReader root element) and warn so the
+            // user can rename to .ui.xml.
+            var path = $"{TestRoot}/MisnamedTemplate.xml";
+            File.WriteAllText(path,
+                @"<?xml version='1.0'?><PromptUGUI version='1'>
+                    <Template name='TestSyncerMisnamed'>
+                      <Param name='icon'/>
+                      <Icon name='{{icon}}'/>
+                    </Template>
+                  </PromptUGUI>");
+            AssetDatabase.ImportAsset(path);
+            _toCleanup.Add(path);
+
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("MisnamedTemplate\\.xml.*\\.ui\\.xml"));
+            SpriteAtlasSyncer.ScanXmlReferences();
+        }
+
+        [Test]
+        public void Scan_does_not_warn_on_non_PromptUGUI_xml_files()
+        {
+            // Other .xml files in the project (Unity .meta-adjacent configs, manifests,
+            // user data, etc.) must not trigger the misnamed-extension warning — the
+            // detector sniffs the root element, not just the filename.
+            var path = $"{TestRoot}/UnrelatedConfig.xml";
+            File.WriteAllText(path,
+                @"<?xml version='1.0'?><SomeOtherSchema>
+                    <value>not a PromptUGUI document</value>
+                  </SomeOtherSchema>");
+            AssetDatabase.ImportAsset(path);
+            _toCleanup.Add(path);
+
+            // LogAssert.NoUnexpectedReceived at TearDown enforces no stray warning.
+            SpriteAtlasSyncer.ScanXmlReferences();
+        }
+
+        [Test]
         public void Scan_follows_template_param_full_placeholder()
         {
             // <Icon name="{{iconName}}"/> — invocation arg is the full set:icon string.


### PR DESCRIPTION
## Summary
- `SpriteAtlasSyncer.ScanXmlReferences` previously filtered TextAssets by `.ui.xml` suffix and silently skipped any single-suffix `.xml` file — even ones whose root element is `<PromptUGUI>`. A Template library file misnamed `Foo.xml` (instead of `Foo.ui.xml`) was therefore invisible to sync: its Param flows weren't registered, so call-site `<Foo icon="ns:x"/>` invocations couldn't be resolved and the referenced sprites were missed.
- Add an Editor-only detection pass: for any `.xml`-not-`.ui.xml` TextAsset, sniff the root element with `XmlReader`; if it's `<PromptUGUI>`, `Debug.LogWarning` with rename guidance. No runtime / parser behavior changes — Addressables keys with `.xml` suffix keep working.

## Test plan
- [x] New test `Scan_warns_on_PromptUGUI_doc_with_misnamed_xml_extension` asserts the warning fires when a `.xml` doc with `<PromptUGUI>` root is present.
- [x] New test `Scan_does_not_warn_on_non_PromptUGUI_xml_files` asserts no false positive on unrelated `.xml` files (root element is `<SomeOtherSchema>`).
- [x] Full `SpriteAtlasSyncerTests` class: 44/44 pass — no regression on existing Template / variant / sprite-collection paths.
- [x] `dotnet format` whitespace / style / analyzers — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)