### PR TITLE
feat: scale="<r>r" canvas-relative pixel-snapped scale

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -233,7 +233,7 @@ Other notes:
 | `hidden="true"`            | bool                                               | Initial `SetActive(false)`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `interactable="false"`     | bool                                               | Initial `CanvasGroup.interactable=false` + `blocksRaycasts=false`. On `<Btn>` it **also** sets `Button.interactable=false` → the Btn enters its Disabled state (see **Btn state visuals**).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `stateReact="false"`       | bool (default `true`)                              | Opts this node **and its whole subtree** out of an ancestor `<Btn>` / `<Tab>` / `<Toggle>`'s state-colour tint fan-out (`hoverColor` / `pressedColor` / `selectedColor` / `disabledColor`). See **Btn state visuals**.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `scale="N"` / `scale="Nx"` / `scale="<r>R"` | positive float `N`; **or** `Nx` (N a positive integer); **or** `<r>R` (r a positive float, uppercase `R`) | `scale="N"` (float): `localScale=(N,N,1)`, **box-preserving** — declared `anchor`/`size`/`margin` stays the visual box, `N` only changes render density (`N<1` finer/crisper, `N>1` coarser), not on-screen size. `scale="Nx"` (device-density): `localScale = N / canvasFactor` → locks to **N physical pixels per design-unit** (constant size across factors, does **not** grow with the window). `scale="<r>R"` (canvas-relative snapped): `localScale = max(1, round(canvasFactor × r)) / canvasFactor` → scales to `r×` the canvas factor but **snaps the net to an integer**, so it **grows with the window yet stays pixel-aligned at any factor** (e.g. `0.5R` is net 1 px/unit at factor 2, net 2 at factor 3 _and_ 4, net 3 at factor 6). All three recompute on factor change; `Nx`/`<r>R` are crisp under a `scale-mode='pixel'` integer factor. `scale="2"` (coarse 2×) and `scale="2x"` (net 2 device-px) differ. See "Relative scale" / "Device-density" / "Canvas-relative snapped" below. |
+| `scale="N"` / `scale="Nx"` / `scale="<r>r"` | positive float `N`; **or** `Nx` (N a positive integer); **or** `<r>r` (r a positive float, lowercase `r`) | `scale="N"` (float): `localScale=(N,N,1)`, **box-preserving** — declared `anchor`/`size`/`margin` stays the visual box, `N` only changes render density (`N<1` finer/crisper, `N>1` coarser), not on-screen size. `scale="Nx"` (device-density): `localScale = N / canvasFactor` → locks to **N physical pixels per design-unit** (constant size across factors, does **not** grow with the window). `scale="<r>r"` (canvas-relative snapped): `localScale = max(1, round(canvasFactor × r)) / canvasFactor` → scales to `r×` the canvas factor but **snaps the net to an integer**, so it **grows with the window yet stays pixel-aligned at any factor** (e.g. `0.5r` is net 1 px/unit at factor 2, net 2 at factor 3 _and_ 4, net 3 at factor 6). All three recompute on factor change; `Nx`/`<r>r` are crisp under a `scale-mode='pixel'` integer factor. `scale="2"` (coarse 2×) and `scale="2x"` (net 2 device-px) differ. See "Relative scale" / "Device-density" / "Canvas-relative snapped" below. |
 
 `padding` and `spacing` are **NOT** universal — only on `<VStack>` / `<HStack>` / `<Grid>`.
 
@@ -634,17 +634,17 @@ Caveats:
 - `Nx` only locks density. The font must also be authored so 1 source pixel = 1 design-unit — i.e. set `fontSize` to the font's native pixel height. A `fontSize` that differs from native still misaligns.
 - Box-preserving behavior and the LayoutGroup-skip caveat below apply identically to `Nx` (the inflation uses `1 / localScale`).
 
-### Canvas-relative snapped (`scale="<r>R"`)
+### Canvas-relative snapped (`scale="<r>r"`)
 
-`scale="<r>R"` (r a **positive float**, uppercase `R`) scales the element to **r× the current canvas factor**, but snaps the result to the nearest integer net density so it stays pixel-aligned: `localScale = max(1, round(canvasFactor × r)) / canvasFactor`. The net physical-pixels-per-design-unit is `round(canvasFactor × r)` — an integer that **grows as the window grows** (unlike `Nx`, whose net is constant) while **never going off the pixel grid** (unlike a plain float, which blurs at odd factors). Recomputed on canvas resize / device rotation.
+`scale="<r>r"` (r a **positive float**, lowercase `r`) scales the element to **r× the current canvas factor**, but snaps the result to the nearest integer net density so it stays pixel-aligned: `localScale = max(1, round(canvasFactor × r)) / canvasFactor`. The net physical-pixels-per-design-unit is `round(canvasFactor × r)` — an integer that **grows as the window grows** (unlike `Nx`, whose net is constant) while **never going off the pixel grid** (unlike a plain float, which blurs at odd factors). Recomputed on canvas resize / device rotation.
 
-Why it exists: `scale="0.5"` follows the window but blurs at an odd factor (`3 × 0.5 = 1.5` px → off-grid); `scale="2x"` is always crisp but its size never grows with the window. `<r>R` gives the in-between: a smaller element that still responds to window size **and** stays crisp at every factor.
+Why it exists: `scale="0.5"` follows the window but blurs at an odd factor (`3 × 0.5 = 1.5` px → off-grid); `scale="2x"` is always crisp but its size never grows with the window. `<r>r` gives the in-between: a smaller element that still responds to window size **and** stays crisp at every factor.
 
 ```xml
 <!-- 12x12 CJK bitmap font: want it "about half" the chunky integer step, but crisp.
-     0.5R → factor 2: net 1 (12px); factor 3: net 2 (24px); factor 4: net 2; factor 6: net 3.
+     0.5r → factor 2: net 1 (12px); factor 3: net 2 (24px); factor 4: net 2; factor 6: net 3.
      Always an integer net → pixel-aligned, and it grows as the window grows. -->
-<Text fontSize="12" scale="0.5R" alignment="center">设置</Text>
+<Text fontSize="12" scale="0.5r" alignment="center">设置</Text>
 ```
 
 Choosing between the three forms:
@@ -653,15 +653,15 @@ Choosing between the three forms:
 |---|---|---|---|---|
 | `scale="N"` (float) | `N × factor` | yes | only if `N×factor` is integer | render-density tweaks on SDF/TMP text; not pixel-art |
 | `scale="Nx"` (N int) | `N` (constant) | no | yes (pixel mode) | UI text at a fixed physical size across devices |
-| `scale="<r>R"` (r float) | `round(factor × r)` | yes | yes (pixel mode) | small bitmap text/elements that scale with the window but must stay crisp |
+| `scale="<r>r"` (r float) | `round(factor × r)` | yes | yes (pixel mode) | small bitmap text/elements that scale with the window but must stay crisp |
 
 Caveats:
 
-- **Rounding is round-half-up**: `round(factor × r)` rounds `.5` up, so `0.5R` at factor 3 → net 2 (not 1), at factor 5 → net 3.
-- **Clamped to a minimum net of 1**: when `round(factor × r) < 1` (e.g. `0.25R` at factor 1), the net floors at 1 — you can't go below one physical pixel per design-unit and stay aligned.
-- **r may exceed 1** (`2R` grows twice as fast and stays aligned), and may be fractional (`0.25R`, `1.5R`). `r` must be positive; the suffix is uppercase `R` only (`0.5r` is a parse error).
+- **Rounding is round-half-up**: `round(factor × r)` rounds `.5` up, so `0.5r` at factor 3 → net 2 (not 1), at factor 5 → net 3.
+- **Clamped to a minimum net of 1**: when `round(factor × r) < 1` (e.g. `0.25r` at factor 1), the net floors at 1 — you can't go below one physical pixel per design-unit and stay aligned.
+- **r may exceed 1** (`2r` grows twice as fast and stays aligned), and may be fractional (`0.25r`, `1.5r`). `r` must be positive; the suffix is lowercase `r` only — matching device-density's lowercase `x` (`0.5R` is a parse error).
 - **Truly crisp only in `scale-mode="pixel"`** (integer factor + `Canvas.pixelPerfect`). In `auto` mode the net is still integer but position can land sub-pixel — same caveat as `Nx`.
-- **Composes with `UI.PixelScalePowerOfTwo` / `UI.MinPixelScale`**: `<r>R` reads the final effective factor, so it snaps relative to whatever factor those settings produce.
+- **Composes with `UI.PixelScalePowerOfTwo` / `UI.MinPixelScale`**: `<r>r` reads the final effective factor, so it snaps relative to whatever factor those settings produce.
 - Box-preserving behavior and the LayoutGroup-skip caveat below apply identically (the inflation uses `1 / localScale`).
 
 **Where to put `scale`**:

--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -233,7 +233,7 @@ Other notes:
 | `hidden="true"`            | bool                                               | Initial `SetActive(false)`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `interactable="false"`     | bool                                               | Initial `CanvasGroup.interactable=false` + `blocksRaycasts=false`. On `<Btn>` it **also** sets `Button.interactable=false` → the Btn enters its Disabled state (see **Btn state visuals**).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `stateReact="false"`       | bool (default `true`)                              | Opts this node **and its whole subtree** out of an ancestor `<Btn>` / `<Tab>` / `<Toggle>`'s state-colour tint fan-out (`hoverColor` / `pressedColor` / `selectedColor` / `disabledColor`). See **Btn state visuals**.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `scale="N"` / `scale="Nx"` | positive float, **or** `Nx` (N a positive integer) | `scale="N"` (float): `localScale=(N,N,1)`, **box-preserving** — declared `anchor`/`size`/`margin` stays the visual box, `N` only changes render density (`N<1` finer/crisper, `N>1` coarser), not on-screen size. `scale="Nx"` (device-density, N positive integer): `localScale = N / canvasFactor` → locks the element to **N physical pixels per design-unit**, recomputed when the factor changes. Use `Nx` for pixel-perfect bitmap text under a `scale-mode='pixel'` integer factor (e.g. a 12×12 CJK font: `scale="2x"` renders it 24×24 and crisp at factor 2, 3 _or_ 4). `scale="2"` (coarse 2×) and `scale="2x"` (net 2 device-px) differ. For a smaller element prefer a smaller `size`, not float `scale`. See "Relative scale" below. |
+| `scale="N"` / `scale="Nx"` / `scale="<r>R"` | positive float `N`; **or** `Nx` (N a positive integer); **or** `<r>R` (r a positive float, uppercase `R`) | `scale="N"` (float): `localScale=(N,N,1)`, **box-preserving** — declared `anchor`/`size`/`margin` stays the visual box, `N` only changes render density (`N<1` finer/crisper, `N>1` coarser), not on-screen size. `scale="Nx"` (device-density): `localScale = N / canvasFactor` → locks to **N physical pixels per design-unit** (constant size across factors, does **not** grow with the window). `scale="<r>R"` (canvas-relative snapped): `localScale = max(1, round(canvasFactor × r)) / canvasFactor` → scales to `r×` the canvas factor but **snaps the net to an integer**, so it **grows with the window yet stays pixel-aligned at any factor** (e.g. `0.5R` is net 1 px/unit at factor 2, net 2 at factor 3 _and_ 4, net 3 at factor 6). All three recompute on factor change; `Nx`/`<r>R` are crisp under a `scale-mode='pixel'` integer factor. `scale="2"` (coarse 2×) and `scale="2x"` (net 2 device-px) differ. See "Relative scale" / "Device-density" / "Canvas-relative snapped" below. |
 
 `padding` and `spacing` are **NOT** universal — only on `<VStack>` / `<HStack>` / `<Grid>`.
 
@@ -633,6 +633,36 @@ Caveats:
 - **`Nx` is truly crisp only in `scale-mode="pixel"`** (integer factor + `Canvas.pixelPerfect` snaps vertices). In `auto` mode the _size_ is still exactly N device-px per design-unit, but the element's position can land on a sub-pixel (auto mode does not snap), so text may be slightly soft.
 - `Nx` only locks density. The font must also be authored so 1 source pixel = 1 design-unit — i.e. set `fontSize` to the font's native pixel height. A `fontSize` that differs from native still misaligns.
 - Box-preserving behavior and the LayoutGroup-skip caveat below apply identically to `Nx` (the inflation uses `1 / localScale`).
+
+### Canvas-relative snapped (`scale="<r>R"`)
+
+`scale="<r>R"` (r a **positive float**, uppercase `R`) scales the element to **r× the current canvas factor**, but snaps the result to the nearest integer net density so it stays pixel-aligned: `localScale = max(1, round(canvasFactor × r)) / canvasFactor`. The net physical-pixels-per-design-unit is `round(canvasFactor × r)` — an integer that **grows as the window grows** (unlike `Nx`, whose net is constant) while **never going off the pixel grid** (unlike a plain float, which blurs at odd factors). Recomputed on canvas resize / device rotation.
+
+Why it exists: `scale="0.5"` follows the window but blurs at an odd factor (`3 × 0.5 = 1.5` px → off-grid); `scale="2x"` is always crisp but its size never grows with the window. `<r>R` gives the in-between: a smaller element that still responds to window size **and** stays crisp at every factor.
+
+```xml
+<!-- 12x12 CJK bitmap font: want it "about half" the chunky integer step, but crisp.
+     0.5R → factor 2: net 1 (12px); factor 3: net 2 (24px); factor 4: net 2; factor 6: net 3.
+     Always an integer net → pixel-aligned, and it grows as the window grows. -->
+<Text fontSize="12" scale="0.5R" alignment="center">设置</Text>
+```
+
+Choosing between the three forms:
+
+| Form | Net px/design-unit | Grows with window? | Pixel-aligned? | Use for |
+|---|---|---|---|---|
+| `scale="N"` (float) | `N × factor` | yes | only if `N×factor` is integer | render-density tweaks on SDF/TMP text; not pixel-art |
+| `scale="Nx"` (N int) | `N` (constant) | no | yes (pixel mode) | UI text at a fixed physical size across devices |
+| `scale="<r>R"` (r float) | `round(factor × r)` | yes | yes (pixel mode) | small bitmap text/elements that scale with the window but must stay crisp |
+
+Caveats:
+
+- **Rounding is round-half-up**: `round(factor × r)` rounds `.5` up, so `0.5R` at factor 3 → net 2 (not 1), at factor 5 → net 3.
+- **Clamped to a minimum net of 1**: when `round(factor × r) < 1` (e.g. `0.25R` at factor 1), the net floors at 1 — you can't go below one physical pixel per design-unit and stay aligned.
+- **r may exceed 1** (`2R` grows twice as fast and stays aligned), and may be fractional (`0.25R`, `1.5R`). `r` must be positive; the suffix is uppercase `R` only (`0.5r` is a parse error).
+- **Truly crisp only in `scale-mode="pixel"`** (integer factor + `Canvas.pixelPerfect`). In `auto` mode the net is still integer but position can land sub-pixel — same caveat as `Nx`.
+- **Composes with `UI.PixelScalePowerOfTwo` / `UI.MinPixelScale`**: `<r>R` reads the final effective factor, so it snaps relative to whatever factor those settings produce.
+- Box-preserving behavior and the LayoutGroup-skip caveat below apply identically (the inflation uses `1 / localScale`).
 
 **Where to put `scale`**:
 

--- a/Runtime/Application/Screen.cs
+++ b/Runtime/Application/Screen.cs
@@ -29,10 +29,11 @@ namespace PromptUGUI.Application
         private bool _isReapplyingScaler;
         // The pixel/auto factor that ApplyCanvasScaler last applied; 'Nx' scale divides by it.
         private float _canvasFactor = 1f;
-        // True if any node declares scale="Nx" (base or variant). Gates the resize path:
-        // such Screens re-run ReSolve (re-baseline + recompute) on canvas resize; others
-        // keep the lightweight ApplyCanvasScaler-only path (zero behavior change).
-        private bool _hasDeviceScale;
+        // True if any node declares a factor-dependent scale — scale="Nx" or scale="<r>R"
+        // (base or variant). Gates the resize path: such Screens re-run ReSolve (re-baseline +
+        // recompute) on canvas resize; others keep the lightweight ApplyCanvasScaler-only path
+        // (zero behavior change).
+        private bool _hasFactorScale;
 
         internal Controls.Internal.ToggleGroupRegistry ToggleGroups { get; private set; }
 
@@ -140,7 +141,7 @@ namespace PromptUGUI.Application
                                               _registry.Resolve(node.Tag), Variants);
             // scale must run after _nodeMap is populated and attributes have been applied
             // (so it doesn't fight ApplyCommon writes).
-            RecomputeHasDeviceScale();
+            RecomputeFactorScale();
             ApplyScales();
             _variantSub = Variants.Changed.Subscribe(_ => ReSolve());
             _themeHandler = _ => ReSolve();
@@ -236,7 +237,7 @@ namespace PromptUGUI.Application
         // Plain-multiplier 'scale="N"' has no dependence on canvas factor. The device-density
         // form 'scale="Nx"' and the canvas-relative form 'scale="<r>R"' both divide by
         // _canvasFactor, so a factor change (canvas resize) must re-run this — routed via
-        // ReSolve in OnCanvasDimensionsChanged when _hasDeviceScale.
+        // ReSolve in OnCanvasDimensionsChanged when _hasFactorScale.
         //
         // Walks every Control in _nodeMap so nodes that declared 'scale' only via a
         // variant override are still tracked (resolves to null → identity reset).
@@ -293,27 +294,28 @@ namespace PromptUGUI.Application
             }
         }
 
-        // Sets _hasDeviceScale if any currently-instantiated node uses scale="Nx".
-        // Called at Open and re-run in ReSolve: Add-block activation (Strategy C) can
-        // introduce device-scale nodes into _nodeMap after Open. Activated nodes stay in
-        // _nodeMap, so the flag is effectively sticky once any Nx node exists.
-        private void RecomputeHasDeviceScale()
+        // Sets _hasFactorScale if any currently-instantiated node uses a factor-dependent scale
+        // form (scale="Nx" or scale="<r>R"). Called at Open and re-run in ReSolve: Add-block
+        // activation (Strategy C) can introduce such nodes into _nodeMap after Open. Activated
+        // nodes stay in _nodeMap, so the flag is effectively sticky once any such node exists.
+        private void RecomputeFactorScale()
         {
-            _hasDeviceScale = false;
+            _hasFactorScale = false;
             foreach (var node in _nodeMap.Keys)
             {
-                if (DeclaresDeviceScale(node)) { _hasDeviceScale = true; break; }
+                if (DeclaresFactorScale(node)) { _hasFactorScale = true; break; }
             }
         }
 
-        // Whether a node declares scale="Nx" in its base attribute or any variant override.
-        private static bool DeclaresDeviceScale(ElementNode node)
+        // Whether a node declares a factor-dependent scale (Nx or <r>R) in its base attribute
+        // or any variant override.
+        private static bool DeclaresFactorScale(ElementNode node)
         {
             if (node.Attributes.TryGetValue("scale", out var baseVal)
-                && TryParseDeviceScale(baseVal, out _)) return true;
+                && (TryParseDeviceScale(baseVal, out _) || TryParseRelativeScale(baseVal, out _))) return true;
             if (node.VariantOverrides.TryGetValue("scale", out var list))
                 foreach (var (_, value) in list)
-                    if (TryParseDeviceScale(value, out _)) return true;
+                    if (TryParseDeviceScale(value, out _) || TryParseRelativeScale(value, out _)) return true;
             return false;
         }
 
@@ -400,7 +402,7 @@ namespace PromptUGUI.Application
             {
                 var scaler = RootGameObject.GetComponent<UnityEngine.UI.CanvasScaler>();
                 if (scaler == null) return;
-                if (_hasDeviceScale)
+                if (_hasFactorScale)
                     // 'Nx' localScale depends on the factor: re-baseline + recompute via the
                     // tested ReSolve path (ApplyCommon → ApplyCanvasScaler → ApplyScales) so the
                     // box-preserving inflation does not accumulate.
@@ -506,7 +508,7 @@ namespace PromptUGUI.Application
                 var entry = _registry.Resolve(node.Tag);
                 ControlAttributeApplier.Apply(node, control, entry, Variants, initial: false);
             }
-            RecomputeHasDeviceScale();
+            RecomputeFactorScale();
             ApplyCanvasScaler(RootGameObject.GetComponent<UnityEngine.UI.CanvasScaler>());
             ApplyScales();
         }

--- a/Runtime/Application/Screen.cs
+++ b/Runtime/Application/Screen.cs
@@ -234,8 +234,9 @@ namespace PromptUGUI.Application
         // to its margin-resolved baseline), so reading that baseline here is idempotent.
         //
         // Plain-multiplier 'scale="N"' has no dependence on canvas factor. The device-density
-        // form 'scale="Nx"' divides by _canvasFactor, so a factor change (canvas resize) must
-        // re-run this — routed via ReSolve in OnCanvasDimensionsChanged when _hasDeviceScale.
+        // form 'scale="Nx"' and the canvas-relative form 'scale="<r>R"' both divide by
+        // _canvasFactor, so a factor change (canvas resize) must re-run this — routed via
+        // ReSolve in OnCanvasDimensionsChanged when _hasDeviceScale.
         //
         // Walks every Control in _nodeMap so nodes that declared 'scale' only via a
         // variant override are still tracked (resolves to null → identity reset).
@@ -258,6 +259,19 @@ namespace PromptUGUI.Application
                 {
                     var f = _canvasFactor > 0f ? _canvasFactor : 1f;
                     var dv = devN / f;
+                    rt.localScale = new Vector3(dv, dv, 1f);
+                    ApplyBoxPreservingCompensation(rt, dv);
+                    continue;
+                }
+
+                if (TryParseRelativeScale(raw, out var relR))
+                {
+                    var f = _canvasFactor > 0f ? _canvasFactor : 1f;
+                    // round-half-up to the nearest integer effective (>= 1), then divide the
+                    // factor back out: net physical-px/unit = effective (integer → pixel-aligned),
+                    // and grows with f (responds to window size). See CRS-D3/D4/D5.
+                    var eff = Mathf.Max(1f, Mathf.Floor(f * relR + 0.5f));
+                    var dv = eff / f;
                     rt.localScale = new Vector3(dv, dv, 1f);
                     ApplyBoxPreservingCompensation(rt, dv);
                     continue;
@@ -313,6 +327,19 @@ namespace PromptUGUI.Application
             return int.TryParse(raw.Substring(0, raw.Length - 1),
                 System.Globalization.NumberStyles.None,
                 System.Globalization.CultureInfo.InvariantCulture, out n) && n >= 1;
+        }
+
+        // scale="<r>R" (r positive float): localScale = max(1, round(canvasFactor·r)) / canvasFactor
+        // → scales relative to the factor but snaps net physical-px/unit to the nearest integer
+        // so it stays pixel-aligned at any factor. Returns false for the 'Nx' and plain-multiplier
+        // forms (handled by TryParseDeviceScale / float.TryParse).
+        private static bool TryParseRelativeScale(string raw, out float r)
+        {
+            r = 0f;
+            if (string.IsNullOrEmpty(raw) || raw.Length < 2 || raw[raw.Length - 1] != 'R') return false;
+            return float.TryParse(raw.Substring(0, raw.Length - 1),
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out r) && r > 0f;
         }
 
         // Inflates a just-baselined RectTransform by 1/scale so that localScale=scale renders

--- a/Runtime/Application/Screen.cs
+++ b/Runtime/Application/Screen.cs
@@ -29,7 +29,7 @@ namespace PromptUGUI.Application
         private bool _isReapplyingScaler;
         // The pixel/auto factor that ApplyCanvasScaler last applied; 'Nx' scale divides by it.
         private float _canvasFactor = 1f;
-        // True if any node declares a factor-dependent scale — scale="Nx" or scale="<r>R"
+        // True if any node declares a factor-dependent scale — scale="Nx" or scale="<r>r"
         // (base or variant). Gates the resize path: such Screens re-run ReSolve (re-baseline +
         // recompute) on canvas resize; others keep the lightweight ApplyCanvasScaler-only path
         // (zero behavior change).
@@ -235,7 +235,7 @@ namespace PromptUGUI.Application
         // to its margin-resolved baseline), so reading that baseline here is idempotent.
         //
         // Plain-multiplier 'scale="N"' has no dependence on canvas factor. The device-density
-        // form 'scale="Nx"' and the canvas-relative form 'scale="<r>R"' both divide by
+        // form 'scale="Nx"' and the canvas-relative form 'scale="<r>r"' both divide by
         // _canvasFactor, so a factor change (canvas resize) must re-run this — routed via
         // ReSolve in OnCanvasDimensionsChanged when _hasFactorScale.
         //
@@ -295,7 +295,7 @@ namespace PromptUGUI.Application
         }
 
         // Sets _hasFactorScale if any currently-instantiated node uses a factor-dependent scale
-        // form (scale="Nx" or scale="<r>R"). Called at Open and re-run in ReSolve: Add-block
+        // form (scale="Nx" or scale="<r>r"). Called at Open and re-run in ReSolve: Add-block
         // activation (Strategy C) can introduce such nodes into _nodeMap after Open. Activated
         // nodes stay in _nodeMap, so the flag is effectively sticky once any such node exists.
         private void RecomputeFactorScale()
@@ -307,7 +307,7 @@ namespace PromptUGUI.Application
             }
         }
 
-        // Whether a node declares a factor-dependent scale (Nx or <r>R) in its base attribute
+        // Whether a node declares a factor-dependent scale (Nx or <r>r) in its base attribute
         // or any variant override.
         private static bool DeclaresFactorScale(ElementNode node)
         {
@@ -331,14 +331,14 @@ namespace PromptUGUI.Application
                 System.Globalization.CultureInfo.InvariantCulture, out n) && n >= 1;
         }
 
-        // scale="<r>R" (r positive float): localScale = max(1, round(canvasFactor·r)) / canvasFactor
+        // scale="<r>r" (r positive float): localScale = max(1, round(canvasFactor·r)) / canvasFactor
         // → scales relative to the factor but snaps net physical-px/unit to the nearest integer
         // so it stays pixel-aligned at any factor. Returns false for the 'Nx' and plain-multiplier
         // forms (handled by TryParseDeviceScale / float.TryParse).
         private static bool TryParseRelativeScale(string raw, out float r)
         {
             r = 0f;
-            if (string.IsNullOrEmpty(raw) || raw.Length < 2 || raw[raw.Length - 1] != 'R') return false;
+            if (string.IsNullOrEmpty(raw) || raw.Length < 2 || raw[raw.Length - 1] != 'r') return false;
             return float.TryParse(raw.Substring(0, raw.Length - 1),
                 System.Globalization.NumberStyles.Float,
                 System.Globalization.CultureInfo.InvariantCulture, out r) && r > 0f;

--- a/Runtime/Core/Parser/UIDocumentParser.cs
+++ b/Runtime/Core/Parser/UIDocumentParser.cs
@@ -531,7 +531,7 @@ namespace PromptUGUI.Parser
             // scale="Nx" (N positive integer) is the device-density form: localScale =
             // N / canvasFactor at runtime — locks the element to N physical pixels per
             // design-unit. See 2026-05-31-scale-device-density-design.md.
-            // scale="<r>R" (r positive float) is the canvas-relative snapped form: localScale =
+            // scale="<r>r" (r positive float) is the canvas-relative snapped form: localScale =
             // round(canvasFactor × r) / canvasFactor at runtime — scales with the factor but the
             // net physical-px/unit snaps to the nearest integer, keeping pixel alignment while
             // still responding to window size. See 2026-06-01-scale-canvas-relative-snap-design.md.
@@ -539,7 +539,7 @@ namespace PromptUGUI.Parser
                 throw new ParseException(
                     $"{contextLabel}: value cannot be empty " +
                     $"(expected a positive number like '0.5', a device-density like '2x', " +
-                    $"or a canvas-relative scale like '0.5R')");
+                    $"or a canvas-relative scale like '0.5r')");
 
             if (raw.Length >= 2 && raw[raw.Length - 1] == 'x')
             {
@@ -552,7 +552,7 @@ namespace PromptUGUI.Parser
                     $"(expected a positive integer before 'x', e.g. '1x' or '2x')");
             }
 
-            if (raw.Length >= 2 && raw[raw.Length - 1] == 'R')
+            if (raw.Length >= 2 && raw[raw.Length - 1] == 'r')
             {
                 var num = raw.Substring(0, raw.Length - 1);
                 if (float.TryParse(num, System.Globalization.NumberStyles.Float,
@@ -560,7 +560,7 @@ namespace PromptUGUI.Parser
                     return;
                 throw new ParseException(
                     $"{contextLabel}: invalid canvas-relative scale '{raw}' " +
-                    $"(expected a positive number before uppercase 'R', e.g. '0.5R' or '0.25R')");
+                    $"(expected a positive number before lowercase 'r', e.g. '0.5r' or '0.25r')");
             }
 
             if (!float.TryParse(raw, System.Globalization.NumberStyles.Float,
@@ -568,7 +568,7 @@ namespace PromptUGUI.Parser
                 throw new ParseException(
                     $"{contextLabel}: invalid value '{raw}' " +
                     $"(expected a positive number like '0.5', a device-density like '2x', " +
-                    $"or a canvas-relative scale like '0.5R')");
+                    $"or a canvas-relative scale like '0.5r')");
         }
 
         private static bool IsValidIconName(string name)

--- a/Runtime/Core/Parser/UIDocumentParser.cs
+++ b/Runtime/Core/Parser/UIDocumentParser.cs
@@ -531,10 +531,15 @@ namespace PromptUGUI.Parser
             // scale="Nx" (N positive integer) is the device-density form: localScale =
             // N / canvasFactor at runtime — locks the element to N physical pixels per
             // design-unit. See 2026-05-31-scale-device-density-design.md.
+            // scale="<r>R" (r positive float) is the canvas-relative snapped form: localScale =
+            // round(canvasFactor × r) / canvasFactor at runtime — scales with the factor but the
+            // net physical-px/unit snaps to the nearest integer, keeping pixel alignment while
+            // still responding to window size. See 2026-06-01-scale-canvas-relative-snap-design.md.
             if (string.IsNullOrEmpty(raw))
                 throw new ParseException(
                     $"{contextLabel}: value cannot be empty " +
-                    $"(expected a positive number like '0.5', or a device-density like '2x')");
+                    $"(expected a positive number like '0.5', a device-density like '2x', " +
+                    $"or a canvas-relative scale like '0.5R')");
 
             if (raw.Length >= 2 && raw[raw.Length - 1] == 'x')
             {
@@ -547,11 +552,23 @@ namespace PromptUGUI.Parser
                     $"(expected a positive integer before 'x', e.g. '1x' or '2x')");
             }
 
+            if (raw.Length >= 2 && raw[raw.Length - 1] == 'R')
+            {
+                var num = raw.Substring(0, raw.Length - 1);
+                if (float.TryParse(num, System.Globalization.NumberStyles.Float,
+                                   System.Globalization.CultureInfo.InvariantCulture, out var rr) && rr > 0f)
+                    return;
+                throw new ParseException(
+                    $"{contextLabel}: invalid canvas-relative scale '{raw}' " +
+                    $"(expected a positive number before uppercase 'R', e.g. '0.5R' or '0.25R')");
+            }
+
             if (!float.TryParse(raw, System.Globalization.NumberStyles.Float,
                                 System.Globalization.CultureInfo.InvariantCulture, out var v) || v <= 0f)
                 throw new ParseException(
                     $"{contextLabel}: invalid value '{raw}' " +
-                    $"(expected a positive number like '0.5', or a device-density like '2x')");
+                    $"(expected a positive number like '0.5', a device-density like '2x', " +
+                    $"or a canvas-relative scale like '0.5R')");
         }
 
         private static bool IsValidIconName(string name)

--- a/Tests/EditMode/Application/ScaleAttributeTests.cs
+++ b/Tests/EditMode/Application/ScaleAttributeTests.cs
@@ -914,7 +914,7 @@ namespace PromptUGUI.Tests.Application
             UnityEngine.Vector2 size = new(5760f, 3240f); // factor 3
             UI.CanvasSizeOverride = () => size;
             // Nx appears ONLY inside an initially-inactive Add block (variant 'extra'),
-            // so _hasDeviceScale must be (re)discovered when the block activates.
+            // so _hasFactorScale must be (re)discovered when the block activates.
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='1920x1080'>
@@ -932,7 +932,7 @@ namespace PromptUGUI.Tests.Application
             Assert.AreEqual(1f / 3f, rt.localScale.x, 1e-5f);
 
             // Resize to factor 2; must recompute even though Nx lived only in the
-            // (now-active) Add block — regression guard for the _hasDeviceScale gap.
+            // (now-active) Add block — regression guard for the _hasFactorScale gap.
             size = new UnityEngine.Vector2(3840f, 2160f); // factor 2
             var relay = screen.RootGameObject.GetComponent<PromptUGUI.Application.RectDimensionsRelay>();
             relay.OnDimensionsChanged?.Invoke();
@@ -963,6 +963,68 @@ namespace PromptUGUI.Tests.Application
 
             Assert.AreEqual(2f, scaler.scaleFactor, 1e-6f);
             Assert.AreEqual(0.5f, screen.Get("f").RectTransform.localScale.x, 1e-6f); // unchanged
+        }
+
+        // ---------- Canvas-relative recompute on resize + gate ----------
+
+        [Test]
+        public void RelativeScale_recomputes_localScale_on_resize()
+        {
+            // R-only Screen (no Nx): the resize gate must include the R form, else the
+            // lightweight path skips ApplyScales and localScale stays stale.
+            UnityEngine.Vector2 size = new(3840f, 2160f); // /1920x1080 = factor 2
+            UI.CanvasSizeOverride = () => size;
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Frame id='f' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(0.5f, rt.localScale.x, 1e-5f); // factor 2: round(1)=1 → 1/2
+
+            // Resize to factor 3; fire the relay.
+            size = new UnityEngine.Vector2(5760f, 3240f); // factor 3
+            var relay = screen.RootGameObject.GetComponent<PromptUGUI.Application.RectDimensionsRelay>();
+            relay.OnDimensionsChanged?.Invoke();
+            Assert.AreEqual(2f / 3f, rt.localScale.x, 1e-5f); // factor 3: round(1.5)=2 → 2/3
+        }
+
+        [Test]
+        public void RelativeScale_box_preserving_does_not_accumulate_across_resizes()
+        {
+            UnityEngine.Vector2 size = new(3840f, 2160f); // factor 2
+            UI.CanvasSizeOverride = () => size;
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Frame id='f' anchor='stretch' margin='10,10,10,10' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            var relay = screen.RootGameObject.GetComponent<PromptUGUI.Application.RectDimensionsRelay>();
+
+            // factor 2: round(1)=1 → localScale 1/2, inv 2 → span 2 about 0.5 → [-0.5, 1.5]; sizeDelta -20*2 = -40.
+            Assert.AreEqual(0.5f, rt.localScale.x, 1e-5f);
+            Assert.AreEqual(-0.5f, rt.anchorMin.x, 1e-4f);
+            Assert.AreEqual(1.5f, rt.anchorMax.x, 1e-4f);
+            Assert.AreEqual(-40f, rt.sizeDelta.x, 1e-3f);
+
+            // → factor 3: round(1.5)=2 → localScale 2/3, inv 1.5 → [-0.25, 1.25]; sizeDelta -30.
+            size = new UnityEngine.Vector2(5760f, 3240f);
+            relay.OnDimensionsChanged?.Invoke();
+            Assert.AreEqual(2f / 3f, rt.localScale.x, 1e-5f);
+            Assert.AreEqual(-0.25f, rt.anchorMin.x, 1e-4f);
+            Assert.AreEqual(1.25f, rt.anchorMax.x, 1e-4f);
+            Assert.AreEqual(-30f, rt.sizeDelta.x, 1e-3f);
+
+            // → back to factor 2: must equal first reading, NOT compounded.
+            size = new UnityEngine.Vector2(3840f, 2160f);
+            relay.OnDimensionsChanged?.Invoke();
+            Assert.AreEqual(0.5f, rt.localScale.x, 1e-5f);
+            Assert.AreEqual(-0.5f, rt.anchorMin.x, 1e-4f);
+            Assert.AreEqual(1.5f, rt.anchorMax.x, 1e-4f);
+            Assert.AreEqual(-40f, rt.sizeDelta.x, 1e-3f);
         }
     }
 }

--- a/Tests/EditMode/Application/ScaleAttributeTests.cs
+++ b/Tests/EditMode/Application/ScaleAttributeTests.cs
@@ -717,6 +717,139 @@ namespace PromptUGUI.Tests.Application
             Assert.GreaterOrEqual(rt.anchorMin.x, 0f);          // compensation skipped
         }
 
+        // ---------- Runtime canvas-relative: localScale = max(1, round(f·r)) / f ----------
+
+        [Test]
+        public void RelativeScale_half_in_pixel_factor2_is_half()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(3840f, 2160f); // /1920x1080 = factor 2
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Frame id='f' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(0.5f, rt.localScale.x, 1e-5f); // round(2*0.5)=1 → 1/2
+            Assert.AreEqual(0.5f, rt.localScale.y, 1e-5f);
+        }
+
+        [Test]
+        public void RelativeScale_half_in_pixel_factor3_is_two_thirds()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(5760f, 3240f); // factor 3
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Frame id='f' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(2f / 3f, rt.localScale.x, 1e-5f); // round(3*0.5)=round(1.5)=2 → 2/3
+        }
+
+        [Test]
+        public void RelativeScale_half_in_pixel_factor4_is_half()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(1920f, 1080f); // /480x270 = factor 4
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='480x270'>
+    <Frame id='f' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(0.5f, rt.localScale.x, 1e-5f); // round(4*0.5)=2 → 2/4
+        }
+
+        [Test]
+        public void RelativeScale_half_in_pixel_factor5_rounds_half_up()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(2400f, 1350f); // /480x270 = factor 5
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='480x270'>
+    <Frame id='f' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(3f / 5f, rt.localScale.x, 1e-5f); // round(5*0.5)=round(2.5)=3 (half-up) → 3/5
+        }
+
+        [Test]
+        public void RelativeScale_half_in_pixel_factor1_does_not_clamp()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(1920f, 1080f); // factor 1
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Frame id='f' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(1f, rt.localScale.x, 1e-5f); // round(1*0.5)=round(0.5)=1 → 1/1
+        }
+
+        [Test]
+        public void RelativeScale_quarter_in_pixel_factor1_clamps_to_one()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(1920f, 1080f); // factor 1
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Frame id='f' scale='0.25R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(1f, rt.localScale.x, 1e-5f); // round(0.25)=0 → max(1,0)=1 → 1/1
+        }
+
+        [Test]
+        public void RelativeScale_one_in_pixel_factor3_is_identity()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(5760f, 3240f); // factor 3
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Frame id='f' scale='1R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(1f, rt.localScale.x, 1e-5f); // round(3*1)=3 → 3/3
+        }
+
+        [Test]
+        public void RelativeScale_half_in_auto_factor2_is_half()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(3840f, 2160f); // /1920x1080 = factor 2
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='auto' reference='1920x1080'>
+    <Frame id='f' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(0.5f, rt.localScale.x, 1e-5f); // round(2*0.5)=1 → 1/2
+        }
+
+        [Test]
+        public void RelativeScale_box_preserving_stretch_in_factor3()
+        {
+            // localScale = round(3*0.5)/3 = 2/3; inv = 1.5. Same numbers as 2x@factor3 (net 2).
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(5760f, 3240f); // factor 3
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Frame id='f' anchor='stretch' margin='10,10,10,10' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(2f / 3f, rt.localScale.x, 1e-5f);
+            Assert.AreEqual(-0.25f, rt.anchorMin.x, 1e-4f);
+            Assert.AreEqual(1.25f, rt.anchorMax.x, 1e-4f);
+            Assert.AreEqual(-30f, rt.sizeDelta.x, 1e-3f);
+        }
+
         // ---------- Device-density recompute on canvas resize ----------
 
         [Test]

--- a/Tests/EditMode/Application/ScaleAttributeTests.cs
+++ b/Tests/EditMode/Application/ScaleAttributeTests.cs
@@ -204,6 +204,88 @@ namespace PromptUGUI.Tests.Application
             StringAssert.Contains("scale", ex.Message);
         }
 
+        // ---------- Parser validation: canvas-relative '<r>R' ----------
+
+        [Test]
+        public void Parser_accepts_relative_scale_half()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'><Frame id='f' scale='0.5R'/></Screen>
+</PromptUGUI>";
+            Assert.DoesNotThrow(() => UIDocumentParser.Parse(xml));
+        }
+
+        [Test]
+        public void Parser_accepts_relative_scale_fractional_and_integer_prefix()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <Frame id='a' scale='0.25R'/><Frame id='b' scale='1.5R'/>
+    <Frame id='c' scale='1R'/><Frame id='d' scale='2R'/>
+  </Screen>
+</PromptUGUI>";
+            Assert.DoesNotThrow(() => UIDocumentParser.Parse(xml));
+        }
+
+        [Test]
+        public void Parser_accepts_relative_scale_variant()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'><Frame id='f' scale='1' scale.portrait='0.5R'/></Screen>
+</PromptUGUI>";
+            Assert.DoesNotThrow(() => UIDocumentParser.Parse(xml));
+        }
+
+        [Test]
+        public void Parser_rejects_zero_relative_scale()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'><Frame id='f' scale='0R'/></Screen>
+</PromptUGUI>";
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+            StringAssert.Contains("canvas-relative", ex.Message);
+        }
+
+        [Test]
+        public void Parser_rejects_negative_relative_scale()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'><Frame id='f' scale='-0.5R'/></Screen>
+</PromptUGUI>";
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+            StringAssert.Contains("canvas-relative", ex.Message);
+        }
+
+        [Test]
+        public void Parser_rejects_bare_R()
+        {
+            // 'R' length<2 → not the R branch → falls to float check → still errors (msg contains 'scale').
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'><Frame id='f' scale='R'/></Screen>
+</PromptUGUI>";
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+            StringAssert.Contains("scale", ex.Message);
+        }
+
+        [Test]
+        public void Parser_rejects_lowercase_relative_scale()
+        {
+            // Canvas-relative suffix is uppercase 'R' only (CRS-D10). '0.5r' falls through to
+            // the float check and is rejected; the fallback message shows the '0.5R' form.
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'><Frame id='f' scale='0.5r'/></Screen>
+</PromptUGUI>";
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+            StringAssert.Contains("scale", ex.Message);
+        }
+
         // ---------- Runtime (relative semantic: localScale = N) ----------
 
         [Test]

--- a/Tests/EditMode/Application/ScaleAttributeTests.cs
+++ b/Tests/EditMode/Application/ScaleAttributeTests.cs
@@ -204,14 +204,14 @@ namespace PromptUGUI.Tests.Application
             StringAssert.Contains("scale", ex.Message);
         }
 
-        // ---------- Parser validation: canvas-relative '<r>R' ----------
+        // ---------- Parser validation: canvas-relative '<r>r' ----------
 
         [Test]
         public void Parser_accepts_relative_scale_half()
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
-  <Screen name='S'><Frame id='f' scale='0.5R'/></Screen>
+  <Screen name='S'><Frame id='f' scale='0.5r'/></Screen>
 </PromptUGUI>";
             Assert.DoesNotThrow(() => UIDocumentParser.Parse(xml));
         }
@@ -222,8 +222,8 @@ namespace PromptUGUI.Tests.Application
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S'>
-    <Frame id='a' scale='0.25R'/><Frame id='b' scale='1.5R'/>
-    <Frame id='c' scale='1R'/><Frame id='d' scale='2R'/>
+    <Frame id='a' scale='0.25r'/><Frame id='b' scale='1.5r'/>
+    <Frame id='c' scale='1r'/><Frame id='d' scale='2r'/>
   </Screen>
 </PromptUGUI>";
             Assert.DoesNotThrow(() => UIDocumentParser.Parse(xml));
@@ -234,7 +234,7 @@ namespace PromptUGUI.Tests.Application
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
-  <Screen name='S'><Frame id='f' scale='1' scale.portrait='0.5R'/></Screen>
+  <Screen name='S'><Frame id='f' scale='1' scale.portrait='0.5r'/></Screen>
 </PromptUGUI>";
             Assert.DoesNotThrow(() => UIDocumentParser.Parse(xml));
         }
@@ -244,7 +244,7 @@ namespace PromptUGUI.Tests.Application
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
-  <Screen name='S'><Frame id='f' scale='0R'/></Screen>
+  <Screen name='S'><Frame id='f' scale='0r'/></Screen>
 </PromptUGUI>";
             var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
             StringAssert.Contains("canvas-relative", ex.Message);
@@ -255,32 +255,33 @@ namespace PromptUGUI.Tests.Application
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
-  <Screen name='S'><Frame id='f' scale='-0.5R'/></Screen>
+  <Screen name='S'><Frame id='f' scale='-0.5r'/></Screen>
 </PromptUGUI>";
             var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
             StringAssert.Contains("canvas-relative", ex.Message);
         }
 
         [Test]
-        public void Parser_rejects_bare_R()
+        public void Parser_rejects_bare_r()
         {
-            // 'R' length<2 → not the R branch → falls to float check → still errors (msg contains 'scale').
+            // 'r' length<2 → not the r branch → falls to float check → still errors (msg contains 'scale').
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
-  <Screen name='S'><Frame id='f' scale='R'/></Screen>
+  <Screen name='S'><Frame id='f' scale='r'/></Screen>
 </PromptUGUI>";
             var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
             StringAssert.Contains("scale", ex.Message);
         }
 
         [Test]
-        public void Parser_rejects_lowercase_relative_scale()
+        public void Parser_rejects_uppercase_relative_scale()
         {
-            // Canvas-relative suffix is uppercase 'R' only (CRS-D10). '0.5r' falls through to
-            // the float check and is rejected; the fallback message shows the '0.5R' form.
+            // Canvas-relative suffix is lowercase 'r' only (CRS-D10), matching device-density's
+            // lowercase 'x'. '0.5R' falls through to the float check and is rejected; the
+            // fallback message shows the '0.5r' form.
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
-  <Screen name='S'><Frame id='f' scale='0.5r'/></Screen>
+  <Screen name='S'><Frame id='f' scale='0.5R'/></Screen>
 </PromptUGUI>";
             var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
             StringAssert.Contains("scale", ex.Message);
@@ -726,7 +727,7 @@ namespace PromptUGUI.Tests.Application
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='1920x1080'>
-    <Frame id='f' scale='0.5R'/>
+    <Frame id='f' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -741,7 +742,7 @@ namespace PromptUGUI.Tests.Application
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='1920x1080'>
-    <Frame id='f' scale='0.5R'/>
+    <Frame id='f' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -755,7 +756,7 @@ namespace PromptUGUI.Tests.Application
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='480x270'>
-    <Frame id='f' scale='0.5R'/>
+    <Frame id='f' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -769,7 +770,7 @@ namespace PromptUGUI.Tests.Application
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='480x270'>
-    <Frame id='f' scale='0.5R'/>
+    <Frame id='f' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -783,7 +784,7 @@ namespace PromptUGUI.Tests.Application
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='1920x1080'>
-    <Frame id='f' scale='0.5R'/>
+    <Frame id='f' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -797,7 +798,7 @@ namespace PromptUGUI.Tests.Application
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='1920x1080'>
-    <Frame id='f' scale='0.25R'/>
+    <Frame id='f' scale='0.25r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -811,7 +812,7 @@ namespace PromptUGUI.Tests.Application
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='1920x1080'>
-    <Frame id='f' scale='1R'/>
+    <Frame id='f' scale='1r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -825,7 +826,7 @@ namespace PromptUGUI.Tests.Application
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='auto' reference='1920x1080'>
-    <Frame id='f' scale='0.5R'/>
+    <Frame id='f' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -840,7 +841,7 @@ namespace PromptUGUI.Tests.Application
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='1920x1080'>
-    <Frame id='f' anchor='stretch' margin='10,10,10,10' scale='0.5R'/>
+    <Frame id='f' anchor='stretch' margin='10,10,10,10' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -977,7 +978,7 @@ namespace PromptUGUI.Tests.Application
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='1920x1080'>
-    <Frame id='f' scale='0.5R'/>
+    <Frame id='f' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -998,7 +999,7 @@ namespace PromptUGUI.Tests.Application
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='1920x1080'>
-    <Frame id='f' anchor='stretch' margin='10,10,10,10' scale='0.5R'/>
+    <Frame id='f' anchor='stretch' margin='10,10,10,10' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;

--- a/docs~/superpowers/plans/2026-06-01-scale-canvas-relative-snap.md
+++ b/docs~/superpowers/plans/2026-06-01-scale-canvas-relative-snap.md
@@ -1,0 +1,803 @@
+# `scale="<r>R"` 画布相对像素吸附缩放 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 给 `scale` 属性新增取值形态 `<r>R`（r 正浮点），运行期解析为 `localScale = max(1, round(canvasFactor × r)) / canvasFactor`——随 canvas factor 响应窗口、净尺寸吸附整数保持像素对齐。
+
+**Architecture:** 复用已合并的 device-density（`Nx`）全部基础设施：同一个 `_canvasFactor` 缓存、同一条 `OnCanvasDimensionsChanged → ReSolve` 重算路径。新增一个 `TryParseRelativeScale` helper 与 `ApplyScales` 分支；把原本只认 `Nx` 的 resize 门控（`_hasDeviceScale`）泛化为"含 factor 依赖型 scale"（`_hasFactorScale`），让 `<r>R` 也触发 resize 重算。parser 加 `R` 后缀校验。无 C# 公开 API 变化。
+
+**Tech Stack:** C# (Unity 6, `Awaitable`/uGUI), NUnit EditMode tests via Unity MCP, `dotnet format`（`.lint/`）。
+
+**规范来源:** `docs~/superpowers/specs/2026-06-01-scale-canvas-relative-snap-design.md`（决策编号 CRS-D1…D18）。
+
+---
+
+## 文件结构
+
+| 文件 | 职责 | 改动 |
+|---|---|---|
+| `Runtime/Core/Parser/UIDocumentParser.cs` | XML→IR 解析 + 属性校验 | 改 `ValidateScale`：加 `R` 后缀分支 + 错误信息补 `0.5R` 示例 |
+| `Runtime/Application/Screen.cs` | 运行期 layout / scale 应用 / resize 重算 | 加 `TryParseRelativeScale` helper；`ApplyScales` 加 `R` 分支；门控 `_hasDeviceScale`→`_hasFactorScale` 泛化 + 检测扩到 `R`；更新注释 |
+| `Tests/EditMode/Application/ScaleAttributeTests.cs` | EditMode 测试 | 加 parser / runtime / box-preserving / resize / 门控 用例 |
+| `.claude/skills/authoring-promptugui-xml/SKILL.md` | XML 作者文档 | `scale` 表行 + 新增 "Canvas-relative snapped" 子节 + 三形态对照 + caveat |
+| `docs~/superpowers/specs/2026-05-07-...-design.md` | master spec | §6 `scale` 行旁追加 `<r>R` 一行 + 引用 |
+| （核实）XSD generator | `scale` 是否被 XSD 约束 | 大概率 anyAttribute → 无需改；Task 4 核实 |
+
+**测试执行方式（Unity MCP）：** 每次改 C# 后先
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+确认无编译错误，再
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ScaleAttributeTests")
+```
+
+（先加载工具：`ToolSearch(query="select:refresh_unity,read_console,run_tests", max_results=3)`。MCP 不可用时尝试重连或告知用户重启 MCP。）
+
+---
+
+## Task 1: Parser — `<r>R` 校验
+
+**Files:**
+- Modify: `Runtime/Core/Parser/UIDocumentParser.cs`（`ValidateScale`，约 line 527-555）
+- Test: `Tests/EditMode/Application/ScaleAttributeTests.cs`
+
+- [ ] **Step 1: 写失败的 parser 测试**
+
+在 `ScaleAttributeTests.cs` 的 device-density parser 段（约 line 205 `Parser_rejects_uppercase_device_scale` 之后）插入：
+
+```csharp
+        // ---------- Parser validation: canvas-relative '<r>R' ----------
+
+        [Test]
+        public void Parser_accepts_relative_scale_half()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'><Frame id='f' scale='0.5R'/></Screen>
+</PromptUGUI>";
+            Assert.DoesNotThrow(() => UIDocumentParser.Parse(xml));
+        }
+
+        [Test]
+        public void Parser_accepts_relative_scale_fractional_and_integer_prefix()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <Frame id='a' scale='0.25R'/><Frame id='b' scale='1.5R'/>
+    <Frame id='c' scale='1R'/><Frame id='d' scale='2R'/>
+  </Screen>
+</PromptUGUI>";
+            Assert.DoesNotThrow(() => UIDocumentParser.Parse(xml));
+        }
+
+        [Test]
+        public void Parser_accepts_relative_scale_variant()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'><Frame id='f' scale='1' scale.portrait='0.5R'/></Screen>
+</PromptUGUI>";
+            Assert.DoesNotThrow(() => UIDocumentParser.Parse(xml));
+        }
+
+        [Test]
+        public void Parser_rejects_zero_relative_scale()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'><Frame id='f' scale='0R'/></Screen>
+</PromptUGUI>";
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+            StringAssert.Contains("canvas-relative", ex.Message);
+        }
+
+        [Test]
+        public void Parser_rejects_negative_relative_scale()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'><Frame id='f' scale='-0.5R'/></Screen>
+</PromptUGUI>";
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+            StringAssert.Contains("canvas-relative", ex.Message);
+        }
+
+        [Test]
+        public void Parser_rejects_bare_R()
+        {
+            // 'R' length<2 → not the R branch → falls to float check → still errors (msg contains 'scale').
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'><Frame id='f' scale='R'/></Screen>
+</PromptUGUI>";
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+            StringAssert.Contains("scale", ex.Message);
+        }
+
+        [Test]
+        public void Parser_rejects_lowercase_relative_scale()
+        {
+            // Canvas-relative suffix is uppercase 'R' only (CRS-D10). '0.5r' falls through to
+            // the float check and is rejected; the fallback message shows the '0.5R' form.
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'><Frame id='f' scale='0.5r'/></Screen>
+</PromptUGUI>";
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
+            StringAssert.Contains("scale", ex.Message);
+        }
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```
+ToolSearch(query="select:refresh_unity,read_console,run_tests", max_results=3)
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ScaleAttributeTests")
+```
+
+Expected: `Parser_accepts_relative_scale_*` 失败（`0.5R` 当前走 float 校验 → `float.TryParse("0.5R")` fail → ParseException）；`Parser_rejects_zero/negative_relative_scale` 失败（断言找 `canvas-relative` 子串，但当前 fallback msg 无此词）。
+
+- [ ] **Step 3: 实现 `ValidateScale` 的 `R` 分支**
+
+在 `Runtime/Core/Parser/UIDocumentParser.cs` 的 `ValidateScale` 里，把 `x` 分支（`if (raw.Length >= 2 && raw[raw.Length - 1] == 'x')` ... 那段）之后、最后的 float fallback 之前，插入 `R` 分支，并把两处 fallback 错误信息补上 `0.5R` 示例。改完后整个方法体为：
+
+```csharp
+        private static void ValidateScale(string raw, string contextLabel)
+        {
+            // scale="N" sets RectTransform.localScale = N (relative to layout box; works in
+            // any scale-mode). Must be a positive float. N=1 is the no-op identity.
+            // scale="Nx" (N positive integer) is the device-density form: localScale =
+            // N / canvasFactor at runtime — locks the element to N physical pixels per
+            // design-unit. See 2026-05-31-scale-device-density-design.md.
+            // scale="<r>R" (r positive float) is the canvas-relative snapped form: localScale =
+            // round(canvasFactor × r) / canvasFactor at runtime — scales with the factor but the
+            // net physical-px/unit snaps to the nearest integer, keeping pixel alignment while
+            // still responding to window size. See 2026-06-01-scale-canvas-relative-snap-design.md.
+            if (string.IsNullOrEmpty(raw))
+                throw new ParseException(
+                    $"{contextLabel}: value cannot be empty " +
+                    $"(expected a positive number like '0.5', a device-density like '2x', " +
+                    $"or a canvas-relative scale like '0.5R')");
+
+            if (raw.Length >= 2 && raw[raw.Length - 1] == 'x')
+            {
+                var num = raw.Substring(0, raw.Length - 1);
+                if (int.TryParse(num, System.Globalization.NumberStyles.None,
+                                 System.Globalization.CultureInfo.InvariantCulture, out var n) && n >= 1)
+                    return;
+                throw new ParseException(
+                    $"{contextLabel}: invalid device-density '{raw}' " +
+                    $"(expected a positive integer before 'x', e.g. '1x' or '2x')");
+            }
+
+            if (raw.Length >= 2 && raw[raw.Length - 1] == 'R')
+            {
+                var num = raw.Substring(0, raw.Length - 1);
+                if (float.TryParse(num, System.Globalization.NumberStyles.Float,
+                                   System.Globalization.CultureInfo.InvariantCulture, out var rr) && rr > 0f)
+                    return;
+                throw new ParseException(
+                    $"{contextLabel}: invalid canvas-relative scale '{raw}' " +
+                    $"(expected a positive number before uppercase 'R', e.g. '0.5R' or '0.25R')");
+            }
+
+            if (!float.TryParse(raw, System.Globalization.NumberStyles.Float,
+                                System.Globalization.CultureInfo.InvariantCulture, out var v) || v <= 0f)
+                throw new ParseException(
+                    $"{contextLabel}: invalid value '{raw}' " +
+                    $"(expected a positive number like '0.5', a device-density like '2x', " +
+                    $"or a canvas-relative scale like '0.5R')");
+        }
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ScaleAttributeTests")
+```
+
+Expected: 新增 8 个 parser 测试全绿；原有 parser/runtime 测试不回归。
+
+- [ ] **Step 5: Lint**
+
+```bash
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx && dotnet format style PromptUGUI.Lint.slnx
+dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+Expected: 无 diff、无 warn。（**不要**用 `dotnet format analyzers --severity info`。）
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Runtime/Core/Parser/UIDocumentParser.cs Tests/EditMode/Application/ScaleAttributeTests.cs
+git commit -m "feat: parse scale=\"<r>R\" canvas-relative scale form
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Screen — `TryParseRelativeScale` + `ApplyScales` 分支（Open 期）
+
+**Files:**
+- Modify: `Runtime/Application/Screen.cs`（`ApplyScales` 约 line 242；`TryParseDeviceScale` 旁约 line 309；`ApplyScales` 上方注释约 line 236）
+- Test: `Tests/EditMode/Application/ScaleAttributeTests.cs`
+
+> 本任务只覆盖 **Open 期固定 factor** 的 localScale + box-preserving。resize 重算依赖门控（Task 3），故 resize 用例放 Task 3。
+
+- [ ] **Step 1: 写失败的 runtime 测试**
+
+在 `ScaleAttributeTests.cs` device-density runtime 段（约 line 636，`DeviceScale_under_layout_group...` 之后）插入：
+
+```csharp
+        // ---------- Runtime canvas-relative: localScale = max(1, round(f·r)) / f ----------
+
+        [Test]
+        public void RelativeScale_half_in_pixel_factor2_is_half()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(3840f, 2160f); // /1920x1080 = factor 2
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Frame id='f' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(0.5f, rt.localScale.x, 1e-5f); // round(2*0.5)=1 → 1/2
+            Assert.AreEqual(0.5f, rt.localScale.y, 1e-5f);
+        }
+
+        [Test]
+        public void RelativeScale_half_in_pixel_factor3_is_two_thirds()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(5760f, 3240f); // factor 3
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Frame id='f' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(2f / 3f, rt.localScale.x, 1e-5f); // round(3*0.5)=round(1.5)=2 → 2/3
+        }
+
+        [Test]
+        public void RelativeScale_half_in_pixel_factor4_is_half()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(1920f, 1080f); // /480x270 = factor 4
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='480x270'>
+    <Frame id='f' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(0.5f, rt.localScale.x, 1e-5f); // round(4*0.5)=2 → 2/4
+        }
+
+        [Test]
+        public void RelativeScale_half_in_pixel_factor5_rounds_half_up()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(2400f, 1350f); // /480x270 = factor 5
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='480x270'>
+    <Frame id='f' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(3f / 5f, rt.localScale.x, 1e-5f); // round(5*0.5)=round(2.5)=3 (half-up) → 3/5
+        }
+
+        [Test]
+        public void RelativeScale_half_in_pixel_factor1_does_not_clamp()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(1920f, 1080f); // factor 1
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Frame id='f' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(1f, rt.localScale.x, 1e-5f); // round(1*0.5)=round(0.5)=1 → 1/1
+        }
+
+        [Test]
+        public void RelativeScale_quarter_in_pixel_factor1_clamps_to_one()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(1920f, 1080f); // factor 1
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Frame id='f' scale='0.25R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(1f, rt.localScale.x, 1e-5f); // round(0.25)=0 → max(1,0)=1 → 1/1
+        }
+
+        [Test]
+        public void RelativeScale_one_in_pixel_factor3_is_identity()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(5760f, 3240f); // factor 3
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Frame id='f' scale='1R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(1f, rt.localScale.x, 1e-5f); // round(3*1)=3 → 3/3
+        }
+
+        [Test]
+        public void RelativeScale_half_in_auto_factor2_is_half()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(3840f, 2160f); // /1920x1080 = factor 2
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='auto' reference='1920x1080'>
+    <Frame id='f' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(0.5f, rt.localScale.x, 1e-5f); // round(2*0.5)=1 → 1/2
+        }
+
+        [Test]
+        public void RelativeScale_box_preserving_stretch_in_factor3()
+        {
+            // localScale = round(3*0.5)/3 = 2/3; inv = 1.5. Same numbers as 2x@factor3 (net 2).
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(5760f, 3240f); // factor 3
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Frame id='f' anchor='stretch' margin='10,10,10,10' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(2f / 3f, rt.localScale.x, 1e-5f);
+            Assert.AreEqual(-0.25f, rt.anchorMin.x, 1e-4f);
+            Assert.AreEqual(1.25f, rt.anchorMax.x, 1e-4f);
+            Assert.AreEqual(-30f, rt.sizeDelta.x, 1e-3f);
+        }
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ScaleAttributeTests")
+```
+
+Expected: 9 个 `RelativeScale_*` 全失败——当前 `ApplyScales` 不识别 `R`，`float.TryParse("0.5R")` fail → localScale 落到 identity 1（断言 0.5/0.6667 等 → 失败）。
+
+- [ ] **Step 3: 实现 helper + `ApplyScales` 分支**
+
+`Runtime/Application/Screen.cs`：在 `TryParseDeviceScale`（约 line 309）下方新增 helper：
+
+```csharp
+        // scale="<r>R" (r positive float): localScale = max(1, round(canvasFactor·r)) / canvasFactor
+        // → scales relative to the factor but snaps net physical-px/unit to the nearest integer
+        // so it stays pixel-aligned at any factor. Returns false for the 'Nx' and plain-multiplier
+        // forms (handled by TryParseDeviceScale / float.TryParse).
+        private static bool TryParseRelativeScale(string raw, out float r)
+        {
+            r = 0f;
+            if (string.IsNullOrEmpty(raw) || raw.Length < 2 || raw[raw.Length - 1] != 'R') return false;
+            return float.TryParse(raw.Substring(0, raw.Length - 1),
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out r) && r > 0f;
+        }
+```
+
+在 `ApplyScales`（约 line 242）的 device-scale 分支（`if (TryParseDeviceScale(raw, out var devN)) { ... continue; }`，约 line 257-264）**之后**、`if (string.IsNullOrEmpty(raw) || !float.TryParse...` 之前插入：
+
+```csharp
+                if (TryParseRelativeScale(raw, out var relR))
+                {
+                    var f = _canvasFactor > 0f ? _canvasFactor : 1f;
+                    // round-half-up to nearest integer effective (≥1), then divide the factor
+                    // back out: net physical-px/unit = effective (integer → pixel-aligned),
+                    // and grows with f (responds to window size). See CRS-D3/D4/D5.
+                    var eff = UnityEngine.Mathf.Max(1f, UnityEngine.Mathf.Floor(f * relR + 0.5f));
+                    var dv = eff / f;
+                    rt.localScale = new UnityEngine.Vector3(dv, dv, 1f);
+                    ApplyBoxPreservingCompensation(rt, dv);
+                    continue;
+                }
+```
+
+同时更新 `ApplyScales` 上方注释（约 line 236-238）的 "Plain-multiplier has no dependence... The device-density form 'Nx' divides by _canvasFactor" 段，改为同时提及 `<r>R`：
+
+```csharp
+        // Plain-multiplier 'scale="N"' has no dependence on canvas factor. The device-density
+        // form 'scale="Nx"' and the canvas-relative form 'scale="<r>R"' both divide by
+        // _canvasFactor, so a factor change (canvas resize) must re-run this — routed via
+        // ReSolve in OnCanvasDimensionsChanged when _hasFactorScale.
+```
+
+> 注：`_hasFactorScale` 在 Task 3 才重命名出现；本任务先按计划写注释，编译以 Task 3 落地后为准——若想本任务独立编译通过，可暂时写 `_hasDeviceScale`，Task 3 再随重命名一并改。推荐合并 Task 2/3 一起 refresh 编译，避免中间态注释引用未定义符号（注释不影响编译，安全）。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ScaleAttributeTests")
+```
+
+Expected: 9 个 `RelativeScale_*`（含 box-preserving）全绿；原有用例不回归。
+
+- [ ] **Step 5: Lint**
+
+```bash
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx && dotnet format style PromptUGUI.Lint.slnx
+dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Runtime/Application/Screen.cs Tests/EditMode/Application/ScaleAttributeTests.cs
+git commit -m "feat: apply scale=\"<r>R\" at Open (localScale = round(f*r)/f)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Screen — resize 门控泛化（`_hasDeviceScale`→`_hasFactorScale`，检测扩到 `R`）
+
+**Files:**
+- Modify: `Runtime/Application/Screen.cs`（字段约 line 35；`RecomputeHasDeviceScale` 约 line 286；`DeclaresDeviceScale` 约 line 296；调用点：`Open` 约 line 143、`OnCanvasDimensionsChanged` 约 line 376、`ReSolve` 约 line 482）
+- Test: `Tests/EditMode/Application/ScaleAttributeTests.cs`
+
+- [ ] **Step 1: 写失败的 resize 测试**
+
+在 `ScaleAttributeTests.cs` device-density resize 段（约 line 748，`Resize_without_device_scale_still_recomputes_factor` 之后）插入：
+
+```csharp
+        // ---------- Canvas-relative recompute on resize + gate ----------
+
+        [Test]
+        public void RelativeScale_recomputes_localScale_on_resize()
+        {
+            // R-only Screen (no Nx): the resize gate must include the R form, else the
+            // lightweight path skips ApplyScales and localScale stays stale.
+            UnityEngine.Vector2 size = new(3840f, 2160f); // /1920x1080 = factor 2
+            UI.CanvasSizeOverride = () => size;
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Frame id='f' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(0.5f, rt.localScale.x, 1e-5f); // factor 2: round(1)=1 → 1/2
+
+            // Resize to factor 3; fire the relay.
+            size = new UnityEngine.Vector2(5760f, 3240f); // factor 3
+            var relay = screen.RootGameObject.GetComponent<PromptUGUI.Application.RectDimensionsRelay>();
+            relay.OnDimensionsChanged?.Invoke();
+            Assert.AreEqual(2f / 3f, rt.localScale.x, 1e-5f); // factor 3: round(1.5)=2 → 2/3
+        }
+
+        [Test]
+        public void RelativeScale_box_preserving_does_not_accumulate_across_resizes()
+        {
+            UnityEngine.Vector2 size = new(3840f, 2160f); // factor 2
+            UI.CanvasSizeOverride = () => size;
+            var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Frame id='f' anchor='stretch' margin='10,10,10,10' scale='0.5R'/>
+  </Screen>
+</PromptUGUI>");
+            var rt = screen.Get("f").RectTransform;
+            var relay = screen.RootGameObject.GetComponent<PromptUGUI.Application.RectDimensionsRelay>();
+
+            // factor 2: round(1)=1 → localScale 1/2, inv 2 → span 2 about 0.5 → [-0.5, 1.5]; sizeDelta -20*2 = -40.
+            Assert.AreEqual(0.5f, rt.localScale.x, 1e-5f);
+            Assert.AreEqual(-0.5f, rt.anchorMin.x, 1e-4f);
+            Assert.AreEqual(1.5f, rt.anchorMax.x, 1e-4f);
+            Assert.AreEqual(-40f, rt.sizeDelta.x, 1e-3f);
+
+            // → factor 3: round(1.5)=2 → localScale 2/3, inv 1.5 → [-0.25, 1.25]; sizeDelta -30.
+            size = new UnityEngine.Vector2(5760f, 3240f);
+            relay.OnDimensionsChanged?.Invoke();
+            Assert.AreEqual(2f / 3f, rt.localScale.x, 1e-5f);
+            Assert.AreEqual(-0.25f, rt.anchorMin.x, 1e-4f);
+            Assert.AreEqual(1.25f, rt.anchorMax.x, 1e-4f);
+            Assert.AreEqual(-30f, rt.sizeDelta.x, 1e-3f);
+
+            // → back to factor 2: must equal first reading, NOT compounded.
+            size = new UnityEngine.Vector2(3840f, 2160f);
+            relay.OnDimensionsChanged?.Invoke();
+            Assert.AreEqual(0.5f, rt.localScale.x, 1e-5f);
+            Assert.AreEqual(-0.5f, rt.anchorMin.x, 1e-4f);
+            Assert.AreEqual(1.5f, rt.anchorMax.x, 1e-4f);
+            Assert.AreEqual(-40f, rt.sizeDelta.x, 1e-3f);
+        }
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ScaleAttributeTests")
+```
+
+Expected: 两个测试在 resize 后断言失败——`_hasDeviceScale` 当前只认 `Nx`，R-only Screen 走轻量 `ApplyCanvasScaler`（更新 `_canvasFactor` 但不跑 `ApplyScales`），localScale 停留在 Open 时的 0.5。
+
+- [ ] **Step 3: 泛化门控（重命名 + 扩检测）**
+
+`Runtime/Application/Screen.cs`，做 4 处机械改名 + 1 处检测扩展：
+
+(a) 字段（约 line 35）：
+
+```csharp
+        private bool _hasFactorScale;      // 任一节点用了 scale="Nx" 或 "<r>R"（依赖 _canvasFactor）→ resize 走 ReSolve
+```
+
+(b) `RecomputeHasDeviceScale`（约 line 286）→ 重命名为 `RecomputeFactorScale`，注释同步：
+
+```csharp
+        // Sets _hasFactorScale if any currently-instantiated node uses a factor-dependent
+        // scale form (scale="Nx" or scale="<r>R"). Called at Open and re-run in ReSolve:
+        // Add-block activation (Strategy C) can introduce such nodes into _nodeMap after Open.
+        private void RecomputeFactorScale()
+        {
+            _hasFactorScale = false;
+            foreach (var node in _nodeMap.Keys)
+            {
+                if (DeclaresFactorScale(node)) { _hasFactorScale = true; break; }
+            }
+        }
+```
+
+(c) `DeclaresDeviceScale`（约 line 296）→ 重命名为 `DeclaresFactorScale`，检测加 `TryParseRelativeScale`：
+
+```csharp
+        // Whether a node declares a factor-dependent scale (Nx or <r>R) in its base attribute
+        // or any variant override.
+        private static bool DeclaresFactorScale(ElementNode node)
+        {
+            if (node.Attributes.TryGetValue("scale", out var baseVal)
+                && (TryParseDeviceScale(baseVal, out _) || TryParseRelativeScale(baseVal, out _))) return true;
+            if (node.VariantOverrides.TryGetValue("scale", out var list))
+                foreach (var (_, value) in list)
+                    if (TryParseDeviceScale(value, out _) || TryParseRelativeScale(value, out _)) return true;
+            return false;
+        }
+```
+
+(d) 调用点改名：
+- `Open`（约 line 143）：`RecomputeHasDeviceScale();` → `RecomputeFactorScale();`
+- `ReSolve`（约 line 482）：`RecomputeHasDeviceScale();` → `RecomputeFactorScale();`
+- `OnCanvasDimensionsChanged`（约 line 376）：`if (_hasDeviceScale)` → `if (_hasFactorScale)`
+
+用 grep 兜底确认无遗漏：
+
+```bash
+grep -rn "_hasDeviceScale\|DeclaresDeviceScale\|RecomputeHasDeviceScale" Runtime/
+```
+
+Expected: 无输出（全部改完）。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ScaleAttributeTests")
+```
+
+Expected: 两个新 resize 测试转绿；**所有** `DeviceScale_*` / `RelativeScale_*` / 裸乘数 / variant 用例全绿（重命名未改行为）。特别确认 `Resize_without_device_scale_still_recomputes_factor` 仍绿（无 Nx 无 R → 仍走轻量路径）。
+
+- [ ] **Step 5: Lint**
+
+```bash
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx && dotnet format style PromptUGUI.Lint.slnx
+dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+- [ ] **Step 6: 全量 EditMode 回归**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+```
+
+Expected: 全绿（确认重命名没碰到 Screen 其他路径）。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Runtime/Application/Screen.cs Tests/EditMode/Application/ScaleAttributeTests.cs
+git commit -m "feat: gate resize-recompute on any factor-dependent scale (Nx or <r>R)
+
+Generalize _hasDeviceScale → _hasFactorScale so scale=\"<r>R\" also re-runs
+ReSolve on canvas resize. Internal rename, no behavior change for Nx.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: 核实 XSD generator 对 `scale` 的约束
+
+**Files:**
+- 核实（必要时 Modify）：XSD generator（Editor 下；grep 定位）
+
+- [ ] **Step 1: 定位 `scale` 在 XSD 的处理方式**
+
+```bash
+grep -rn "scale\|anyAttribute\|xs:string\|AddAttribute" Editor/ Runtime/ --include=*.cs | grep -i "xsd\|schema\|anyAttribute" | head
+grep -rln "anyAttribute\|XmlSchema\|xsd" Editor/ Runtime/ --include=*.cs
+```
+
+定位生成 `scale` 属性声明的代码处，判断它是：
+- (A) `xs:anyAttribute` / `xs:string` 无 pattern/enum 约束 → **无需改**（`<r>R` 天然被接受）。
+- (B) 有 pattern/enum 限定 `scale` 取值 → 需放开以接受 `<r>R`（如 pattern 加 `|[0-9]*\.?[0-9]+R` 分支）。
+
+- [ ] **Step 2: 处置**
+
+- 若 (A)：在本计划勾选记录"XSD 无 `scale` 约束，无需改"，跳到 Task 5。
+- 若 (B)：改 generator 放开 `scale`；若有 XSD generator 测试（`StringAssert.Contains` 风格），加一条覆盖 `<r>R` 被接受；跑 `PromptUGUI.Tests.EditorOnly` 转绿。
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+```
+
+- [ ] **Step 3: Commit（仅当 (B) 改了代码）**
+
+```bash
+git add Editor/
+git commit -m "feat: XSD accepts scale=\"<r>R\" canvas-relative form
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: XML SKILL 同步
+
+**Files:**
+- Modify: `.claude/skills/authoring-promptugui-xml/SKILL.md`（`scale` 表行 line 236；Device-density 子节末尾约 line 635 后插入新子节）
+
+- [ ] **Step 1: 改 `scale` 速查表行（line 236）**
+
+把现有 `scale="N"` / `scale="Nx"` 行整行替换为同时含 `<r>R` 的版本：
+
+```markdown
+| `scale="N"` / `scale="Nx"` / `scale="<r>R"` | positive float `N`; **or** `Nx` (N positive integer); **or** `<r>R` (r positive float, uppercase `R`) | `scale="N"` (float): `localScale=(N,N,1)`, **box-preserving** — declared box stays, `N` only changes render density. `scale="Nx"` (device-density): `localScale = N / canvasFactor` → locks to **N physical pixels per design-unit** (constant size across factors, does **not** grow with window). `scale="<r>R"` (canvas-relative snapped): `localScale = max(1, round(canvasFactor × r)) / canvasFactor` → scales to `r×` the canvas factor but **snaps the net to an integer**, so it **grows with the window yet stays pixel-aligned at any factor** (e.g. `0.5R` is net 1 px/unit at factor 2, net 2 at factor 3 _and_ 4, net 3 at factor 6). All three recompute on factor change. See "Relative scale" / "Device-density" / "Canvas-relative snapped" below. |
+```
+
+- [ ] **Step 2: 在 "Device-density (`scale="Nx"`)" 子节之后（约 line 635 的 LayoutGroup caveat 项之后）新增子节**
+
+```markdown
+### Canvas-relative snapped (`scale="<r>R"`)
+
+`scale="<r>R"` (r a **positive float**, uppercase `R`) scales the element to **r× the current canvas factor**, but snaps the result to the nearest integer net density so it stays pixel-aligned: `localScale = max(1, round(canvasFactor × r)) / canvasFactor`. The net physical-pixels-per-design-unit is `round(canvasFactor × r)` — an integer that **grows as the window grows** (unlike `Nx`, whose net is constant) while **never going off the pixel grid** (unlike a plain float, which blurs at odd factors). Recomputed on canvas resize / device rotation.
+
+Why it exists: `scale="0.5"` follows the window but blurs at an odd factor (`3 × 0.5 = 1.5` px → off-grid); `scale="2x"` is always crisp but its size never grows with the window. `<r>R` gives the in-between: a smaller element that still responds to window size **and** stays crisp at every factor.
+
+```xml
+<!-- 12x12 CJK bitmap font: want it "about half" the chunky integer step, but crisp.
+     0.5R → factor 2: net 1 (12px); factor 3: net 2 (24px); factor 4: net 2; factor 6: net 3.
+     Always an integer net → pixel-aligned, and it grows as the window grows. -->
+<Text fontSize="12" scale="0.5R" alignment="center">设置</Text>
+```
+
+Choosing between the three forms:
+
+| Form | Net px/design-unit | Grows with window? | Pixel-aligned? | Use for |
+|---|---|---|---|---|
+| `scale="N"` (float) | `N × factor` | yes | only if `N×factor` is integer | render-density tweaks on SDF/TMP text; not pixel-art |
+| `scale="Nx"` (N int) | `N` (constant) | no | yes (pixel mode) | UI text at a fixed physical size across devices |
+| `scale="<r>R"` (r float) | `round(factor × r)` | yes | yes (pixel mode) | small bitmap text/elements that scale with the window but must stay crisp |
+
+- **Rounding is round-half-up**: `round(factor × r)` rounds `.5` up, so `0.5R` at factor 3 → net 2 (not 1), at factor 5 → net 3.
+- **Clamped to a minimum net of 1**: when `round(factor × r) < 1` (e.g. `0.25R` at factor 1), the net floors at 1 — you can't go below one physical pixel per design-unit and stay aligned.
+- **r may exceed 1** (`2R` grows twice as fast and stays aligned), and may be fractional (`0.25R`, `1.5R`). `r` must be positive; the suffix is uppercase `R` only (`0.5r` is a parse error).
+- **Truly crisp only in `scale-mode="pixel"`** (integer factor + `Canvas.pixelPerfect`). In `auto` mode the net is still integer but position can land sub-pixel — same caveat as `Nx`.
+- **Composes with `UI.PixelScalePowerOfTwo` / `UI.MinPixelScale`**: `<r>R` reads the final effective factor, so it snaps relative to whatever factor those settings produce.
+- Box-preserving behavior and the LayoutGroup-skip caveat (below) apply identically (inflation uses `1 / localScale`).
+```
+
+- [ ] **Step 3: 校验 SKILL 无破坏 + 文内一致**
+
+通读改动两处，确认表格列对齐、示例 XML 合法、与 spec 数值一致（factor 3 → net 2）。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/authoring-promptugui-xml/SKILL.md
+git commit -m "docs(skill): document scale=\"<r>R\" canvas-relative snapped form
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: master spec 同步
+
+**Files:**
+- Modify: `docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md`（约 line 235，`scale="Nx"` 那一行）
+
+- [ ] **Step 1: 在 `scale="Nx"` 行之后追加 `<r>R` 一行**
+
+在 master spec 现有 `- 元素级 \`scale="Nx"\`（...）...详见 2026-05-31-scale-device-density-design.md。普通 \`scale="N"\`...` 那一条之后，追加：
+
+```markdown
+- 元素级 `scale="<r>R"`（r 正浮点，大写 `R`，支持 `.variant`）：画布相对吸附形态，`localScale = max(1, round(canvasFactor × r)) / canvasFactor`——缩放跟随 factor（随窗口长大），但净物理像素/设计单位吸附到整数保持像素对齐，填补 `scale="N"`（响应但奇数 factor 糊）与 `scale="Nx"`（恒定不长大）之间。详见 [`2026-06-01-scale-canvas-relative-snap-design.md`](2026-06-01-scale-canvas-relative-snap-design.md)。
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add "docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md"
+git commit -m "doc: reference scale=\"<r>R\" spec from master design
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: host Unity 肉眼验收
+
+**Files:** 无（手动验证）
+
+- [ ] **Step 1: pixel 模式多 factor 目测**
+
+在 host 工程 `C:\xsoft\PromptUGUIDev` 摆一个 `scale-mode="pixel"` Screen，放 `<Text fontSize="12" scale="0.5R">设置文字 ABC</Text>`，调窗口大小使 factor 落在 2 / 3 / 4 / 5：
+- 每个 factor 下中文位图字**清晰不糊**（无半像素跨格）。
+- factor 越大字越大（net 1→2→2→3），即随窗口响应。
+
+- [ ] **Step 2: resize 实时重算**
+
+拖动窗口跨越 factor 边界（如从 factor 2 区间拖到 factor 3 区间），确认字体尺寸**实时跳变并保持清晰**（resize→ReSolve 路径生效），无累积变形（来回拖动回到原 factor 字体精确复原）。
+
+- [ ] **Step 3: 与 `0.5` / `2x` 对照**
+
+同屏并列 `scale="0.5"`、`scale="2x"`、`scale="0.5R"` 三个 `<Text>`，在 factor 3 下确认：`0.5` 糊、`2x` 清晰但偏小固定、`0.5R` 清晰且尺寸介于两者并随窗口变化。
+
+- [ ] **Step 4: 记录结论**
+
+把目测结论（通过/问题）记到 PR 描述。
+
+---
+
+## 自检（spec 覆盖）
+
+| spec 要点 | 对应任务 |
+|---|---|
+| CRS-D1/D2 语法 `<r>R` 正浮点 | Task 1 |
+| CRS-D3/D4/D5 语义 + round-half-up + ≥1 钳制 | Task 2（Step 3 公式 `Max(1, Floor(f·r+0.5))`） |
+| CRS-D6/D7 不分支 scale-mode + 读最终 `_canvasFactor` | Task 2（复用既有 `_canvasFactor`） |
+| CRS-D8 门控泛化 `_hasFactorScale` | Task 3 |
+| CRS-D9/D10 parse 校验 + 大写 R | Task 1 |
+| CRS-D11 r>1 允许 | Task 1（`2R` 用例）+ Task 2（identity/放大隐含） |
+| CRS-D12 ApplyScales 解析顺序 | Task 2（R 分支在 Nx 后、float 前） |
+| CRS-D13 `_canvasFactor≤0` 兜底 | Task 2（`f = _canvasFactor>0 ? : 1`） |
+| CRS-D14 LayoutGroup 子节点 | 复用 `ApplyBoxPreservingCompensation`（无新代码）；SKILL caveat（Task 5） |
+| CRS-D15 XSD | Task 4 |
+| CRS-D16 SKILL | Task 5 |
+| CRS-D17 master spec | Task 6 |
+| CRS-D18 测试位置 | Task 1/2/3（全部 `ScaleAttributeTests.cs`） |
+| 风险：auto 模式 caveat / 三形态混淆 | Task 5 SKILL caveat + 对照表 |
+| 验收：肉眼脆度 + resize | Task 7 |
+
+**Placeholder 扫描：** 无 TBD/TODO；每个 code step 含完整代码。
+**类型一致性：** `TryParseRelativeScale(string, out float)` / `_hasFactorScale` / `DeclaresFactorScale` / `RecomputeFactorScale` 在 Task 2/3 跨任务命名一致；`ApplyBoxPreservingCompensation(rt, dv)` 沿用既有签名。

--- a/docs~/superpowers/plans/2026-06-01-scale-canvas-relative-snap.md
+++ b/docs~/superpowers/plans/2026-06-01-scale-canvas-relative-snap.md
@@ -1,10 +1,10 @@
-# `scale="<r>R"` 画布相对像素吸附缩放 实施计划
+# `scale="<r>r"` 画布相对像素吸附缩放 实施计划
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** 给 `scale` 属性新增取值形态 `<r>R`（r 正浮点），运行期解析为 `localScale = max(1, round(canvasFactor × r)) / canvasFactor`——随 canvas factor 响应窗口、净尺寸吸附整数保持像素对齐。
+**Goal:** 给 `scale` 属性新增取值形态 `<r>r`（r 正浮点），运行期解析为 `localScale = max(1, round(canvasFactor × r)) / canvasFactor`——随 canvas factor 响应窗口、净尺寸吸附整数保持像素对齐。
 
-**Architecture:** 复用已合并的 device-density（`Nx`）全部基础设施：同一个 `_canvasFactor` 缓存、同一条 `OnCanvasDimensionsChanged → ReSolve` 重算路径。新增一个 `TryParseRelativeScale` helper 与 `ApplyScales` 分支；把原本只认 `Nx` 的 resize 门控（`_hasDeviceScale`）泛化为"含 factor 依赖型 scale"（`_hasFactorScale`），让 `<r>R` 也触发 resize 重算。parser 加 `R` 后缀校验。无 C# 公开 API 变化。
+**Architecture:** 复用已合并的 device-density（`Nx`）全部基础设施：同一个 `_canvasFactor` 缓存、同一条 `OnCanvasDimensionsChanged → ReSolve` 重算路径。新增一个 `TryParseRelativeScale` helper 与 `ApplyScales` 分支；把原本只认 `Nx` 的 resize 门控（`_hasDeviceScale`）泛化为"含 factor 依赖型 scale"（`_hasFactorScale`），让 `<r>r` 也触发 resize 重算。parser 加 `R` 后缀校验。无 C# 公开 API 变化。
 
 **Tech Stack:** C# (Unity 6, `Awaitable`/uGUI), NUnit EditMode tests via Unity MCP, `dotnet format`（`.lint/`）。
 
@@ -16,11 +16,11 @@
 
 | 文件 | 职责 | 改动 |
 |---|---|---|
-| `Runtime/Core/Parser/UIDocumentParser.cs` | XML→IR 解析 + 属性校验 | 改 `ValidateScale`：加 `R` 后缀分支 + 错误信息补 `0.5R` 示例 |
+| `Runtime/Core/Parser/UIDocumentParser.cs` | XML→IR 解析 + 属性校验 | 改 `ValidateScale`：加 `R` 后缀分支 + 错误信息补 `0.5r` 示例 |
 | `Runtime/Application/Screen.cs` | 运行期 layout / scale 应用 / resize 重算 | 加 `TryParseRelativeScale` helper；`ApplyScales` 加 `R` 分支；门控 `_hasDeviceScale`→`_hasFactorScale` 泛化 + 检测扩到 `R`；更新注释 |
 | `Tests/EditMode/Application/ScaleAttributeTests.cs` | EditMode 测试 | 加 parser / runtime / box-preserving / resize / 门控 用例 |
 | `.claude/skills/authoring-promptugui-xml/SKILL.md` | XML 作者文档 | `scale` 表行 + 新增 "Canvas-relative snapped" 子节 + 三形态对照 + caveat |
-| `docs~/superpowers/specs/2026-05-07-...-design.md` | master spec | §6 `scale` 行旁追加 `<r>R` 一行 + 引用 |
+| `docs~/superpowers/specs/2026-05-07-...-design.md` | master spec | §6 `scale` 行旁追加 `<r>r` 一行 + 引用 |
 | （核实）XSD generator | `scale` 是否被 XSD 约束 | 大概率 anyAttribute → 无需改；Task 4 核实 |
 
 **测试执行方式（Unity MCP）：** 每次改 C# 后先
@@ -40,7 +40,7 @@ mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.Edit
 
 ---
 
-## Task 1: Parser — `<r>R` 校验
+## Task 1: Parser — `<r>r` 校验
 
 **Files:**
 - Modify: `Runtime/Core/Parser/UIDocumentParser.cs`（`ValidateScale`，约 line 527-555）
@@ -51,14 +51,14 @@ mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.Edit
 在 `ScaleAttributeTests.cs` 的 device-density parser 段（约 line 205 `Parser_rejects_uppercase_device_scale` 之后）插入：
 
 ```csharp
-        // ---------- Parser validation: canvas-relative '<r>R' ----------
+        // ---------- Parser validation: canvas-relative '<r>r' ----------
 
         [Test]
         public void Parser_accepts_relative_scale_half()
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
-  <Screen name='S'><Frame id='f' scale='0.5R'/></Screen>
+  <Screen name='S'><Frame id='f' scale='0.5r'/></Screen>
 </PromptUGUI>";
             Assert.DoesNotThrow(() => UIDocumentParser.Parse(xml));
         }
@@ -69,8 +69,8 @@ mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.Edit
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S'>
-    <Frame id='a' scale='0.25R'/><Frame id='b' scale='1.5R'/>
-    <Frame id='c' scale='1R'/><Frame id='d' scale='2R'/>
+    <Frame id='a' scale='0.25r'/><Frame id='b' scale='1.5r'/>
+    <Frame id='c' scale='1r'/><Frame id='d' scale='2r'/>
   </Screen>
 </PromptUGUI>";
             Assert.DoesNotThrow(() => UIDocumentParser.Parse(xml));
@@ -81,7 +81,7 @@ mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.Edit
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
-  <Screen name='S'><Frame id='f' scale='1' scale.portrait='0.5R'/></Screen>
+  <Screen name='S'><Frame id='f' scale='1' scale.portrait='0.5r'/></Screen>
 </PromptUGUI>";
             Assert.DoesNotThrow(() => UIDocumentParser.Parse(xml));
         }
@@ -91,7 +91,7 @@ mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.Edit
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
-  <Screen name='S'><Frame id='f' scale='0R'/></Screen>
+  <Screen name='S'><Frame id='f' scale='0r'/></Screen>
 </PromptUGUI>";
             var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
             StringAssert.Contains("canvas-relative", ex.Message);
@@ -102,32 +102,32 @@ mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.Edit
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
-  <Screen name='S'><Frame id='f' scale='-0.5R'/></Screen>
+  <Screen name='S'><Frame id='f' scale='-0.5r'/></Screen>
 </PromptUGUI>";
             var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
             StringAssert.Contains("canvas-relative", ex.Message);
         }
 
         [Test]
-        public void Parser_rejects_bare_R()
+        public void Parser_rejects_bare_r()
         {
-            // 'R' length<2 → not the R branch → falls to float check → still errors (msg contains 'scale').
+            // 'r' length<2 → not the r branch → falls to float check → still errors (msg contains 'scale').
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
-  <Screen name='S'><Frame id='f' scale='R'/></Screen>
+  <Screen name='S'><Frame id='f' scale='r'/></Screen>
 </PromptUGUI>";
             var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
             StringAssert.Contains("scale", ex.Message);
         }
 
         [Test]
-        public void Parser_rejects_lowercase_relative_scale()
+        public void Parser_rejects_uppercase_relative_scale()
         {
-            // Canvas-relative suffix is uppercase 'R' only (CRS-D10). '0.5r' falls through to
-            // the float check and is rejected; the fallback message shows the '0.5R' form.
+            // Canvas-relative suffix is lowercase 'r' only (CRS-D10), matching device-density's
+            // lowercase 'x'. '0.5R' falls through to the float check and is rejected.
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
-  <Screen name='S'><Frame id='f' scale='0.5r'/></Screen>
+  <Screen name='S'><Frame id='f' scale='0.5R'/></Screen>
 </PromptUGUI>";
             var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(xml));
             StringAssert.Contains("scale", ex.Message);
@@ -142,11 +142,11 @@ mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_
 mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ScaleAttributeTests")
 ```
 
-Expected: `Parser_accepts_relative_scale_*` 失败（`0.5R` 当前走 float 校验 → `float.TryParse("0.5R")` fail → ParseException）；`Parser_rejects_zero/negative_relative_scale` 失败（断言找 `canvas-relative` 子串，但当前 fallback msg 无此词）。
+Expected: `Parser_accepts_relative_scale_*` 失败（`0.5r` 当前走 float 校验 → `float.TryParse("0.5r")` fail → ParseException）；`Parser_rejects_zero/negative_relative_scale` 失败（断言找 `canvas-relative` 子串，但当前 fallback msg 无此词）。
 
 - [ ] **Step 3: 实现 `ValidateScale` 的 `R` 分支**
 
-在 `Runtime/Core/Parser/UIDocumentParser.cs` 的 `ValidateScale` 里，把 `x` 分支（`if (raw.Length >= 2 && raw[raw.Length - 1] == 'x')` ... 那段）之后、最后的 float fallback 之前，插入 `R` 分支，并把两处 fallback 错误信息补上 `0.5R` 示例。改完后整个方法体为：
+在 `Runtime/Core/Parser/UIDocumentParser.cs` 的 `ValidateScale` 里，把 `x` 分支（`if (raw.Length >= 2 && raw[raw.Length - 1] == 'x')` ... 那段）之后、最后的 float fallback 之前，插入 `R` 分支，并把两处 fallback 错误信息补上 `0.5r` 示例。改完后整个方法体为：
 
 ```csharp
         private static void ValidateScale(string raw, string contextLabel)
@@ -156,7 +156,7 @@ Expected: `Parser_accepts_relative_scale_*` 失败（`0.5R` 当前走 float 校�
             // scale="Nx" (N positive integer) is the device-density form: localScale =
             // N / canvasFactor at runtime — locks the element to N physical pixels per
             // design-unit. See 2026-05-31-scale-device-density-design.md.
-            // scale="<r>R" (r positive float) is the canvas-relative snapped form: localScale =
+            // scale="<r>r" (r positive float) is the canvas-relative snapped form: localScale =
             // round(canvasFactor × r) / canvasFactor at runtime — scales with the factor but the
             // net physical-px/unit snaps to the nearest integer, keeping pixel alignment while
             // still responding to window size. See 2026-06-01-scale-canvas-relative-snap-design.md.
@@ -164,7 +164,7 @@ Expected: `Parser_accepts_relative_scale_*` 失败（`0.5R` 当前走 float 校�
                 throw new ParseException(
                     $"{contextLabel}: value cannot be empty " +
                     $"(expected a positive number like '0.5', a device-density like '2x', " +
-                    $"or a canvas-relative scale like '0.5R')");
+                    $"or a canvas-relative scale like '0.5r')");
 
             if (raw.Length >= 2 && raw[raw.Length - 1] == 'x')
             {
@@ -177,7 +177,7 @@ Expected: `Parser_accepts_relative_scale_*` 失败（`0.5R` 当前走 float 校�
                     $"(expected a positive integer before 'x', e.g. '1x' or '2x')");
             }
 
-            if (raw.Length >= 2 && raw[raw.Length - 1] == 'R')
+            if (raw.Length >= 2 && raw[raw.Length - 1] == 'r')
             {
                 var num = raw.Substring(0, raw.Length - 1);
                 if (float.TryParse(num, System.Globalization.NumberStyles.Float,
@@ -185,7 +185,7 @@ Expected: `Parser_accepts_relative_scale_*` 失败（`0.5R` 当前走 float 校�
                     return;
                 throw new ParseException(
                     $"{contextLabel}: invalid canvas-relative scale '{raw}' " +
-                    $"(expected a positive number before uppercase 'R', e.g. '0.5R' or '0.25R')");
+                    $"(expected a positive number before lowercase 'r', e.g. '0.5r' or '0.25r')");
             }
 
             if (!float.TryParse(raw, System.Globalization.NumberStyles.Float,
@@ -193,7 +193,7 @@ Expected: `Parser_accepts_relative_scale_*` 失败（`0.5R` 当前走 float 校�
                 throw new ParseException(
                     $"{contextLabel}: invalid value '{raw}' " +
                     $"(expected a positive number like '0.5', a device-density like '2x', " +
-                    $"or a canvas-relative scale like '0.5R')");
+                    $"or a canvas-relative scale like '0.5r')");
         }
 ```
 
@@ -220,7 +220,7 @@ Expected: 无 diff、无 warn。（**不要**用 `dotnet format analyzers --seve
 
 ```bash
 git add Runtime/Core/Parser/UIDocumentParser.cs Tests/EditMode/Application/ScaleAttributeTests.cs
-git commit -m "feat: parse scale=\"<r>R\" canvas-relative scale form
+git commit -m "feat: parse scale=\"<r>r\" canvas-relative scale form
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 ```
@@ -249,7 +249,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='1920x1080'>
-    <Frame id='f' scale='0.5R'/>
+    <Frame id='f' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -264,7 +264,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='1920x1080'>
-    <Frame id='f' scale='0.5R'/>
+    <Frame id='f' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -278,7 +278,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='480x270'>
-    <Frame id='f' scale='0.5R'/>
+    <Frame id='f' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -292,7 +292,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='480x270'>
-    <Frame id='f' scale='0.5R'/>
+    <Frame id='f' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -306,7 +306,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='1920x1080'>
-    <Frame id='f' scale='0.5R'/>
+    <Frame id='f' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -320,7 +320,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='1920x1080'>
-    <Frame id='f' scale='0.25R'/>
+    <Frame id='f' scale='0.25r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -334,7 +334,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='1920x1080'>
-    <Frame id='f' scale='1R'/>
+    <Frame id='f' scale='1r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -348,7 +348,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='auto' reference='1920x1080'>
-    <Frame id='f' scale='0.5R'/>
+    <Frame id='f' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -363,7 +363,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='1920x1080'>
-    <Frame id='f' anchor='stretch' margin='10,10,10,10' scale='0.5R'/>
+    <Frame id='f' anchor='stretch' margin='10,10,10,10' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -381,21 +381,21 @@ mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_
 mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ScaleAttributeTests")
 ```
 
-Expected: 9 个 `RelativeScale_*` 全失败——当前 `ApplyScales` 不识别 `R`，`float.TryParse("0.5R")` fail → localScale 落到 identity 1（断言 0.5/0.6667 等 → 失败）。
+Expected: 9 个 `RelativeScale_*` 全失败——当前 `ApplyScales` 不识别 `R`，`float.TryParse("0.5r")` fail → localScale 落到 identity 1（断言 0.5/0.6667 等 → 失败）。
 
 - [ ] **Step 3: 实现 helper + `ApplyScales` 分支**
 
 `Runtime/Application/Screen.cs`：在 `TryParseDeviceScale`（约 line 309）下方新增 helper：
 
 ```csharp
-        // scale="<r>R" (r positive float): localScale = max(1, round(canvasFactor·r)) / canvasFactor
+        // scale="<r>r" (r positive float): localScale = max(1, round(canvasFactor·r)) / canvasFactor
         // → scales relative to the factor but snaps net physical-px/unit to the nearest integer
         // so it stays pixel-aligned at any factor. Returns false for the 'Nx' and plain-multiplier
         // forms (handled by TryParseDeviceScale / float.TryParse).
         private static bool TryParseRelativeScale(string raw, out float r)
         {
             r = 0f;
-            if (string.IsNullOrEmpty(raw) || raw.Length < 2 || raw[raw.Length - 1] != 'R') return false;
+            if (string.IsNullOrEmpty(raw) || raw.Length < 2 || raw[raw.Length - 1] != 'r') return false;
             return float.TryParse(raw.Substring(0, raw.Length - 1),
                 System.Globalization.NumberStyles.Float,
                 System.Globalization.CultureInfo.InvariantCulture, out r) && r > 0f;
@@ -419,11 +419,11 @@ Expected: 9 个 `RelativeScale_*` 全失败——当前 `ApplyScales` 不识别 
                 }
 ```
 
-同时更新 `ApplyScales` 上方注释（约 line 236-238）的 "Plain-multiplier has no dependence... The device-density form 'Nx' divides by _canvasFactor" 段，改为同时提及 `<r>R`：
+同时更新 `ApplyScales` 上方注释（约 line 236-238）的 "Plain-multiplier has no dependence... The device-density form 'Nx' divides by _canvasFactor" 段，改为同时提及 `<r>r`：
 
 ```csharp
         // Plain-multiplier 'scale="N"' has no dependence on canvas factor. The device-density
-        // form 'scale="Nx"' and the canvas-relative form 'scale="<r>R"' both divide by
+        // form 'scale="Nx"' and the canvas-relative form 'scale="<r>r"' both divide by
         // _canvasFactor, so a factor change (canvas resize) must re-run this — routed via
         // ReSolve in OnCanvasDimensionsChanged when _hasFactorScale.
 ```
@@ -451,7 +451,7 @@ dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
 
 ```bash
 git add Runtime/Application/Screen.cs Tests/EditMode/Application/ScaleAttributeTests.cs
-git commit -m "feat: apply scale=\"<r>R\" at Open (localScale = round(f*r)/f)
+git commit -m "feat: apply scale=\"<r>r\" at Open (localScale = round(f*r)/f)
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 ```
@@ -481,7 +481,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='1920x1080'>
-    <Frame id='f' scale='0.5R'/>
+    <Frame id='f' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -502,7 +502,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
             var screen = OpenScreen(@"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S' scale-mode='pixel' reference='1920x1080'>
-    <Frame id='f' anchor='stretch' margin='10,10,10,10' scale='0.5R'/>
+    <Frame id='f' anchor='stretch' margin='10,10,10,10' scale='0.5r'/>
   </Screen>
 </PromptUGUI>");
             var rt = screen.Get("f").RectTransform;
@@ -548,14 +548,14 @@ Expected: 两个测试在 resize 后断言失败——`_hasDeviceScale` 当前�
 (a) 字段（约 line 35）：
 
 ```csharp
-        private bool _hasFactorScale;      // 任一节点用了 scale="Nx" 或 "<r>R"（依赖 _canvasFactor）→ resize 走 ReSolve
+        private bool _hasFactorScale;      // 任一节点用了 scale="Nx" 或 "<r>r"（依赖 _canvasFactor）→ resize 走 ReSolve
 ```
 
 (b) `RecomputeHasDeviceScale`（约 line 286）→ 重命名为 `RecomputeFactorScale`，注释同步：
 
 ```csharp
         // Sets _hasFactorScale if any currently-instantiated node uses a factor-dependent
-        // scale form (scale="Nx" or scale="<r>R"). Called at Open and re-run in ReSolve:
+        // scale form (scale="Nx" or scale="<r>r"). Called at Open and re-run in ReSolve:
         // Add-block activation (Strategy C) can introduce such nodes into _nodeMap after Open.
         private void RecomputeFactorScale()
         {
@@ -570,7 +570,7 @@ Expected: 两个测试在 resize 后断言失败——`_hasDeviceScale` 当前�
 (c) `DeclaresDeviceScale`（约 line 296）→ 重命名为 `DeclaresFactorScale`，检测加 `TryParseRelativeScale`：
 
 ```csharp
-        // Whether a node declares a factor-dependent scale (Nx or <r>R) in its base attribute
+        // Whether a node declares a factor-dependent scale (Nx or <r>r) in its base attribute
         // or any variant override.
         private static bool DeclaresFactorScale(ElementNode node)
         {
@@ -625,9 +625,9 @@ Expected: 全绿（确认重命名没碰到 Screen 其他路径）。
 
 ```bash
 git add Runtime/Application/Screen.cs Tests/EditMode/Application/ScaleAttributeTests.cs
-git commit -m "feat: gate resize-recompute on any factor-dependent scale (Nx or <r>R)
+git commit -m "feat: gate resize-recompute on any factor-dependent scale (Nx or <r>r)
 
-Generalize _hasDeviceScale → _hasFactorScale so scale=\"<r>R\" also re-runs
+Generalize _hasDeviceScale → _hasFactorScale so scale=\"<r>r\" also re-runs
 ReSolve on canvas resize. Internal rename, no behavior change for Nx.
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
@@ -648,13 +648,13 @@ grep -rln "anyAttribute\|XmlSchema\|xsd" Editor/ Runtime/ --include=*.cs
 ```
 
 定位生成 `scale` 属性声明的代码处，判断它是：
-- (A) `xs:anyAttribute` / `xs:string` 无 pattern/enum 约束 → **无需改**（`<r>R` 天然被接受）。
-- (B) 有 pattern/enum 限定 `scale` 取值 → 需放开以接受 `<r>R`（如 pattern 加 `|[0-9]*\.?[0-9]+R` 分支）。
+- (A) `xs:anyAttribute` / `xs:string` 无 pattern/enum 约束 → **无需改**（`<r>r` 天然被接受）。
+- (B) 有 pattern/enum 限定 `scale` 取值 → 需放开以接受 `<r>r`（如 pattern 加 `|[0-9]*\.?[0-9]+R` 分支）。
 
 - [ ] **Step 2: 处置**
 
 - 若 (A)：在本计划勾选记录"XSD 无 `scale` 约束，无需改"，跳到 Task 5。
-- 若 (B)：改 generator 放开 `scale`；若有 XSD generator 测试（`StringAssert.Contains` 风格），加一条覆盖 `<r>R` 被接受；跑 `PromptUGUI.Tests.EditorOnly` 转绿。
+- 若 (B)：改 generator 放开 `scale`；若有 XSD generator 测试（`StringAssert.Contains` 风格），加一条覆盖 `<r>r` 被接受；跑 `PromptUGUI.Tests.EditorOnly` 转绿。
 
 ```
 mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
@@ -664,7 +664,7 @@ mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.Edit
 
 ```bash
 git add Editor/
-git commit -m "feat: XSD accepts scale=\"<r>R\" canvas-relative form
+git commit -m "feat: XSD accepts scale=\"<r>r\" canvas-relative form
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 ```
@@ -678,26 +678,26 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 - [ ] **Step 1: 改 `scale` 速查表行（line 236）**
 
-把现有 `scale="N"` / `scale="Nx"` 行整行替换为同时含 `<r>R` 的版本：
+把现有 `scale="N"` / `scale="Nx"` 行整行替换为同时含 `<r>r` 的版本：
 
 ```markdown
-| `scale="N"` / `scale="Nx"` / `scale="<r>R"` | positive float `N`; **or** `Nx` (N positive integer); **or** `<r>R` (r positive float, uppercase `R`) | `scale="N"` (float): `localScale=(N,N,1)`, **box-preserving** — declared box stays, `N` only changes render density. `scale="Nx"` (device-density): `localScale = N / canvasFactor` → locks to **N physical pixels per design-unit** (constant size across factors, does **not** grow with window). `scale="<r>R"` (canvas-relative snapped): `localScale = max(1, round(canvasFactor × r)) / canvasFactor` → scales to `r×` the canvas factor but **snaps the net to an integer**, so it **grows with the window yet stays pixel-aligned at any factor** (e.g. `0.5R` is net 1 px/unit at factor 2, net 2 at factor 3 _and_ 4, net 3 at factor 6). All three recompute on factor change. See "Relative scale" / "Device-density" / "Canvas-relative snapped" below. |
+| `scale="N"` / `scale="Nx"` / `scale="<r>r"` | positive float `N`; **or** `Nx` (N positive integer); **or** `<r>r` (r positive float, lowercase `r`) | `scale="N"` (float): `localScale=(N,N,1)`, **box-preserving** — declared box stays, `N` only changes render density. `scale="Nx"` (device-density): `localScale = N / canvasFactor` → locks to **N physical pixels per design-unit** (constant size across factors, does **not** grow with window). `scale="<r>r"` (canvas-relative snapped): `localScale = max(1, round(canvasFactor × r)) / canvasFactor` → scales to `r×` the canvas factor but **snaps the net to an integer**, so it **grows with the window yet stays pixel-aligned at any factor** (e.g. `0.5r` is net 1 px/unit at factor 2, net 2 at factor 3 _and_ 4, net 3 at factor 6). All three recompute on factor change. See "Relative scale" / "Device-density" / "Canvas-relative snapped" below. |
 ```
 
 - [ ] **Step 2: 在 "Device-density (`scale="Nx"`)" 子节之后（约 line 635 的 LayoutGroup caveat 项之后）新增子节**
 
 ```markdown
-### Canvas-relative snapped (`scale="<r>R"`)
+### Canvas-relative snapped (`scale="<r>r"`)
 
-`scale="<r>R"` (r a **positive float**, uppercase `R`) scales the element to **r× the current canvas factor**, but snaps the result to the nearest integer net density so it stays pixel-aligned: `localScale = max(1, round(canvasFactor × r)) / canvasFactor`. The net physical-pixels-per-design-unit is `round(canvasFactor × r)` — an integer that **grows as the window grows** (unlike `Nx`, whose net is constant) while **never going off the pixel grid** (unlike a plain float, which blurs at odd factors). Recomputed on canvas resize / device rotation.
+`scale="<r>r"` (r a **positive float**, lowercase `r`) scales the element to **r× the current canvas factor**, but snaps the result to the nearest integer net density so it stays pixel-aligned: `localScale = max(1, round(canvasFactor × r)) / canvasFactor`. The net physical-pixels-per-design-unit is `round(canvasFactor × r)` — an integer that **grows as the window grows** (unlike `Nx`, whose net is constant) while **never going off the pixel grid** (unlike a plain float, which blurs at odd factors). Recomputed on canvas resize / device rotation.
 
-Why it exists: `scale="0.5"` follows the window but blurs at an odd factor (`3 × 0.5 = 1.5` px → off-grid); `scale="2x"` is always crisp but its size never grows with the window. `<r>R` gives the in-between: a smaller element that still responds to window size **and** stays crisp at every factor.
+Why it exists: `scale="0.5"` follows the window but blurs at an odd factor (`3 × 0.5 = 1.5` px → off-grid); `scale="2x"` is always crisp but its size never grows with the window. `<r>r` gives the in-between: a smaller element that still responds to window size **and** stays crisp at every factor.
 
 ```xml
 <!-- 12x12 CJK bitmap font: want it "about half" the chunky integer step, but crisp.
-     0.5R → factor 2: net 1 (12px); factor 3: net 2 (24px); factor 4: net 2; factor 6: net 3.
+     0.5r → factor 2: net 1 (12px); factor 3: net 2 (24px); factor 4: net 2; factor 6: net 3.
      Always an integer net → pixel-aligned, and it grows as the window grows. -->
-<Text fontSize="12" scale="0.5R" alignment="center">设置</Text>
+<Text fontSize="12" scale="0.5r" alignment="center">设置</Text>
 ```
 
 Choosing between the three forms:
@@ -706,13 +706,13 @@ Choosing between the three forms:
 |---|---|---|---|---|
 | `scale="N"` (float) | `N × factor` | yes | only if `N×factor` is integer | render-density tweaks on SDF/TMP text; not pixel-art |
 | `scale="Nx"` (N int) | `N` (constant) | no | yes (pixel mode) | UI text at a fixed physical size across devices |
-| `scale="<r>R"` (r float) | `round(factor × r)` | yes | yes (pixel mode) | small bitmap text/elements that scale with the window but must stay crisp |
+| `scale="<r>r"` (r float) | `round(factor × r)` | yes | yes (pixel mode) | small bitmap text/elements that scale with the window but must stay crisp |
 
-- **Rounding is round-half-up**: `round(factor × r)` rounds `.5` up, so `0.5R` at factor 3 → net 2 (not 1), at factor 5 → net 3.
-- **Clamped to a minimum net of 1**: when `round(factor × r) < 1` (e.g. `0.25R` at factor 1), the net floors at 1 — you can't go below one physical pixel per design-unit and stay aligned.
-- **r may exceed 1** (`2R` grows twice as fast and stays aligned), and may be fractional (`0.25R`, `1.5R`). `r` must be positive; the suffix is uppercase `R` only (`0.5r` is a parse error).
+- **Rounding is round-half-up**: `round(factor × r)` rounds `.5` up, so `0.5r` at factor 3 → net 2 (not 1), at factor 5 → net 3.
+- **Clamped to a minimum net of 1**: when `round(factor × r) < 1` (e.g. `0.25r` at factor 1), the net floors at 1 — you can't go below one physical pixel per design-unit and stay aligned.
+- **r may exceed 1** (`2r` grows twice as fast and stays aligned), and may be fractional (`0.25r`, `1.5r`). `r` must be positive; the suffix is lowercase `r` only — matching device-density's lowercase `x` (`0.5R` is a parse error).
 - **Truly crisp only in `scale-mode="pixel"`** (integer factor + `Canvas.pixelPerfect`). In `auto` mode the net is still integer but position can land sub-pixel — same caveat as `Nx`.
-- **Composes with `UI.PixelScalePowerOfTwo` / `UI.MinPixelScale`**: `<r>R` reads the final effective factor, so it snaps relative to whatever factor those settings produce.
+- **Composes with `UI.PixelScalePowerOfTwo` / `UI.MinPixelScale`**: `<r>r` reads the final effective factor, so it snaps relative to whatever factor those settings produce.
 - Box-preserving behavior and the LayoutGroup-skip caveat (below) apply identically (inflation uses `1 / localScale`).
 ```
 
@@ -724,7 +724,7 @@ Choosing between the three forms:
 
 ```bash
 git add .claude/skills/authoring-promptugui-xml/SKILL.md
-git commit -m "docs(skill): document scale=\"<r>R\" canvas-relative snapped form
+git commit -m "docs(skill): document scale=\"<r>r\" canvas-relative snapped form
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 ```
@@ -736,19 +736,19 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 **Files:**
 - Modify: `docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md`（约 line 235，`scale="Nx"` 那一行）
 
-- [ ] **Step 1: 在 `scale="Nx"` 行之后追加 `<r>R` 一行**
+- [ ] **Step 1: 在 `scale="Nx"` 行之后追加 `<r>r` 一行**
 
 在 master spec 现有 `- 元素级 \`scale="Nx"\`（...）...详见 2026-05-31-scale-device-density-design.md。普通 \`scale="N"\`...` 那一条之后，追加：
 
 ```markdown
-- 元素级 `scale="<r>R"`（r 正浮点，大写 `R`，支持 `.variant`）：画布相对吸附形态，`localScale = max(1, round(canvasFactor × r)) / canvasFactor`——缩放跟随 factor（随窗口长大），但净物理像素/设计单位吸附到整数保持像素对齐，填补 `scale="N"`（响应但奇数 factor 糊）与 `scale="Nx"`（恒定不长大）之间。详见 [`2026-06-01-scale-canvas-relative-snap-design.md`](2026-06-01-scale-canvas-relative-snap-design.md)。
+- 元素级 `scale="<r>r"`（r 正浮点，小写 `r`，支持 `.variant`）：画布相对吸附形态，`localScale = max(1, round(canvasFactor × r)) / canvasFactor`——缩放跟随 factor（随窗口长大），但净物理像素/设计单位吸附到整数保持像素对齐，填补 `scale="N"`（响应但奇数 factor 糊）与 `scale="Nx"`（恒定不长大）之间。详见 [`2026-06-01-scale-canvas-relative-snap-design.md`](2026-06-01-scale-canvas-relative-snap-design.md)。
 ```
 
 - [ ] **Step 2: Commit**
 
 ```bash
 git add "docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md"
-git commit -m "doc: reference scale=\"<r>R\" spec from master design
+git commit -m "doc: reference scale=\"<r>r\" spec from master design
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 ```
@@ -761,7 +761,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 - [ ] **Step 1: pixel 模式多 factor 目测**
 
-在 host 工程 `C:\xsoft\PromptUGUIDev` 摆一个 `scale-mode="pixel"` Screen，放 `<Text fontSize="12" scale="0.5R">设置文字 ABC</Text>`，调窗口大小使 factor 落在 2 / 3 / 4 / 5：
+在 host 工程 `C:\xsoft\PromptUGUIDev` 摆一个 `scale-mode="pixel"` Screen，放 `<Text fontSize="12" scale="0.5r">设置文字 ABC</Text>`，调窗口大小使 factor 落在 2 / 3 / 4 / 5：
 - 每个 factor 下中文位图字**清晰不糊**（无半像素跨格）。
 - factor 越大字越大（net 1→2→2→3），即随窗口响应。
 
@@ -771,7 +771,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 - [ ] **Step 3: 与 `0.5` / `2x` 对照**
 
-同屏并列 `scale="0.5"`、`scale="2x"`、`scale="0.5R"` 三个 `<Text>`，在 factor 3 下确认：`0.5` 糊、`2x` 清晰但偏小固定、`0.5R` 清晰且尺寸介于两者并随窗口变化。
+同屏并列 `scale="0.5"`、`scale="2x"`、`scale="0.5r"` 三个 `<Text>`，在 factor 3 下确认：`0.5` 糊、`2x` 清晰但偏小固定、`0.5r` 清晰且尺寸介于两者并随窗口变化。
 
 - [ ] **Step 4: 记录结论**
 
@@ -783,12 +783,12 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 | spec 要点 | 对应任务 |
 |---|---|
-| CRS-D1/D2 语法 `<r>R` 正浮点 | Task 1 |
+| CRS-D1/D2 语法 `<r>r` 正浮点 | Task 1 |
 | CRS-D3/D4/D5 语义 + round-half-up + ≥1 钳制 | Task 2（Step 3 公式 `Max(1, Floor(f·r+0.5))`） |
 | CRS-D6/D7 不分支 scale-mode + 读最终 `_canvasFactor` | Task 2（复用既有 `_canvasFactor`） |
 | CRS-D8 门控泛化 `_hasFactorScale` | Task 3 |
-| CRS-D9/D10 parse 校验 + 大写 R | Task 1 |
-| CRS-D11 r>1 允许 | Task 1（`2R` 用例）+ Task 2（identity/放大隐含） |
+| CRS-D9/D10 parse 校验 + 小写 r | Task 1 |
+| CRS-D11 r>1 允许 | Task 1（`2r` 用例）+ Task 2（identity/放大隐含） |
 | CRS-D12 ApplyScales 解析顺序 | Task 2（R 分支在 Nx 后、float 前） |
 | CRS-D13 `_canvasFactor≤0` 兜底 | Task 2（`f = _canvasFactor>0 ? : 1`） |
 | CRS-D14 LayoutGroup 子节点 | 复用 `ApplyBoxPreservingCompensation`（无新代码）；SKILL caveat（Task 5） |

--- a/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
+++ b/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
@@ -233,6 +233,7 @@ Template 同名（含 commons 与各 Import 的任意组合）→ 报错；`as="
 
 - `scale-mode="auto|pixel"`（可选，支持 `.variant`）：`pixel` 切 CanvasScaler 到 `ConstantPixelSize` + 整数倍 `scaleFactor`（用于像素艺术）。详见 [`2026-05-25-pixel-perfect-scaling-design.md`](2026-05-25-pixel-perfect-scaling-design.md)。
 - 元素级 `scale="Nx"`（N 正整数，支持 `.variant`）：设备像素密度形态，`localScale = N / canvasFactor`（每个设计单位渲染 N 个物理像素，canvas factor 变化时重算），用于 `scale-mode="pixel"` 下位图字的像素对齐。普通 `scale="N"`（正浮点）仍是 factor-independent 的 box-preserving 渲染密度乘数。详见 [`2026-05-31-scale-device-density-design.md`](2026-05-31-scale-device-density-design.md)。
+- 元素级 `scale="<r>R"`（r 正浮点，大写 `R`，支持 `.variant`）：画布相对吸附形态，`localScale = max(1, round(canvasFactor × r)) / canvasFactor`——缩放跟随 factor（随窗口长大），但净物理像素/设计单位吸附到整数保持像素对齐，填补 `scale="N"`（响应但奇数 factor 糊）与 `scale="Nx"`（恒定不长大）之间。详见 [`2026-06-01-scale-canvas-relative-snap-design.md`](2026-06-01-scale-canvas-relative-snap-design.md)。
 
 ### 5.7 `<Trigger>` / `<Animation>`（事件订阅 + LitMotion 动画，since 2026-05-14）
 

--- a/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
+++ b/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
@@ -233,7 +233,7 @@ Template 同名（含 commons 与各 Import 的任意组合）→ 报错；`as="
 
 - `scale-mode="auto|pixel"`（可选，支持 `.variant`）：`pixel` 切 CanvasScaler 到 `ConstantPixelSize` + 整数倍 `scaleFactor`（用于像素艺术）。详见 [`2026-05-25-pixel-perfect-scaling-design.md`](2026-05-25-pixel-perfect-scaling-design.md)。
 - 元素级 `scale="Nx"`（N 正整数，支持 `.variant`）：设备像素密度形态，`localScale = N / canvasFactor`（每个设计单位渲染 N 个物理像素，canvas factor 变化时重算），用于 `scale-mode="pixel"` 下位图字的像素对齐。普通 `scale="N"`（正浮点）仍是 factor-independent 的 box-preserving 渲染密度乘数。详见 [`2026-05-31-scale-device-density-design.md`](2026-05-31-scale-device-density-design.md)。
-- 元素级 `scale="<r>R"`（r 正浮点，大写 `R`，支持 `.variant`）：画布相对吸附形态，`localScale = max(1, round(canvasFactor × r)) / canvasFactor`——缩放跟随 factor（随窗口长大），但净物理像素/设计单位吸附到整数保持像素对齐，填补 `scale="N"`（响应但奇数 factor 糊）与 `scale="Nx"`（恒定不长大）之间。详见 [`2026-06-01-scale-canvas-relative-snap-design.md`](2026-06-01-scale-canvas-relative-snap-design.md)。
+- 元素级 `scale="<r>r"`（r 正浮点，小写 `r`，支持 `.variant`）：画布相对吸附形态，`localScale = max(1, round(canvasFactor × r)) / canvasFactor`——缩放跟随 factor（随窗口长大），但净物理像素/设计单位吸附到整数保持像素对齐，填补 `scale="N"`（响应但奇数 factor 糊）与 `scale="Nx"`（恒定不长大）之间。详见 [`2026-06-01-scale-canvas-relative-snap-design.md`](2026-06-01-scale-canvas-relative-snap-design.md)。
 
 ### 5.7 `<Trigger>` / `<Animation>`（事件订阅 + LitMotion 动画，since 2026-05-14）
 

--- a/docs~/superpowers/specs/2026-06-01-scale-canvas-relative-snap-design.md
+++ b/docs~/superpowers/specs/2026-06-01-scale-canvas-relative-snap-design.md
@@ -1,8 +1,8 @@
-# `scale="<r>R"` factor 相对像素吸附缩放设计
+# `scale="<r>r"` factor 相对像素吸附缩放设计
 
 **日期**：2026-06-01
 **状态**：设计阶段（待 review，未进入实施）
-**作用域**：给已有的 `scale` 属性再新增一种取值形态 `<r>R`（r 为正浮点），语义 = "把这个元素缩放到当前 canvas factor 的 r 倍，但实效缩放吸附到最近的整数"，即 `localScale = round(canvasFactor × r) / canvasFactor`，并在 canvas factor 变化时重算。让作者能写出"比满屏小、但在任意整数 factor（2/3/4…）下都保持像素对齐、且随窗口响应"的字体/元素——填补现有 `scale="N"`（响应但奇数 factor 糊）与 `scale="Nx"`（永远对齐但不随窗口长大）之间的空档。
+**作用域**：给已有的 `scale` 属性再新增一种取值形态 `<r>r`（r 为正浮点），语义 = "把这个元素缩放到当前 canvas factor 的 r 倍，但实效缩放吸附到最近的整数"，即 `localScale = round(canvasFactor × r) / canvasFactor`，并在 canvas factor 变化时重算。让作者能写出"比满屏小、但在任意整数 factor（2/3/4…）下都保持像素对齐、且随窗口响应"的字体/元素——填补现有 `scale="N"`（响应但奇数 factor 糊）与 `scale="Nx"`（永远对齐但不随窗口长大）之间的空档。
 **依赖**：
 - [`2026-05-31-scale-device-density-design.md`](2026-05-31-scale-device-density-design.md)（已合并：`scale="Nx"`、`_canvasFactor` 缓存、`_hasDeviceScale` 门控的 resize→ReSolve 重算路径、`ApplyBoxPreservingCompensation`）
 - [`2026-05-25-pixel-perfect-scaling-design.md`](2026-05-25-pixel-perfect-scaling-design.md)（`scale-mode="pixel"` + `PixelScaleSolver` 整数 factor；`PixelScalePowerOfTwo` / `MinPixelScale`）
@@ -40,12 +40,12 @@ localScale = effective / canvasFactor          // 把 factor 约回去
 净物理像素/设计单位 = canvasFactor × localScale = effective = 整数      ← 与 f 是否整数无关
 ```
 
-- factor 2 + `0.5R` → effective round(1)=1 → localScale 0.5 → 净 1（12 字 → 12 物理像素）
-- factor 3 + `0.5R` → effective round(1.5)=**2** → localScale 2/3 → 净 2（12 字 → 24 物理像素）
-- factor 4 + `0.5R` → effective round(2)=2 → localScale 0.5 → 净 2
-- factor 6 + `0.5R` → effective round(3)=3 → localScale 0.5 → 净 3
+- factor 2 + `0.5r` → effective round(1)=1 → localScale 0.5 → 净 1（12 字 → 12 物理像素）
+- factor 3 + `0.5r` → effective round(1.5)=**2** → localScale 2/3 → 净 2（12 字 → 24 物理像素）
+- factor 4 + `0.5r` → effective round(2)=2 → localScale 0.5 → 净 2
+- factor 6 + `0.5r` → effective round(3)=3 → localScale 0.5 → 净 3
 
-净尺寸 = `round(f × r)` **随 factor 单调增长（响应窗口）**，又**永远是整数（像素对齐）**——正好是 §1.1 表里缺的那一格。同一句 `scale="0.5R"` 在所有 factor 下都对齐，且窗口越大字越大。`scale="Nx"` 解的"奇数 factor 落到整数实效"在这里自动达成，而且不丢响应性。
+净尺寸 = `round(f × r)` **随 factor 单调增长（响应窗口）**，又**永远是整数（像素对齐）**——正好是 §1.1 表里缺的那一格。同一句 `scale="0.5r"` 在所有 factor 下都对齐，且窗口越大字越大。`scale="Nx"` 解的"奇数 factor 落到整数实效"在这里自动达成，而且不丢响应性。
 
 ### 1.3 与 `Nx` 的关系（净尺寸对比）
 
@@ -53,29 +53,29 @@ localScale = effective / canvasFactor          // 把 factor 约回去
 |---|---|---|---|---|---|
 | `scale="N"`（裸乘数） | N（字面） | N×f | 是 | 仅当 N×f 整数 | 渲染密度乘数，非像素契约 |
 | `scale="Nx"`（device-density） | N/f | N（恒定） | **否** | 是（pixel 模式真脆） | 跨设备物理尺寸恒定的 UI 文字 |
-| `scale="<r>R"`（本特性） | round(f·r)/f | round(f·r)（增长） | **是** | 是（pixel 模式真脆） | 随窗口缩放但保持对齐的小字/元素 |
+| `scale="<r>r"`（本特性） | round(f·r)/f | round(f·r)（增长） | **是** | 是（pixel 模式真脆） | 随窗口缩放但保持对齐的小字/元素 |
 
-三者都产出 localScale + 复用同一套 box-preserving 补偿；区别只在 localScale 怎么从 r 和 f 推导。`R` 与 `Nx` 同样依赖 `_canvasFactor`、同样需要 resize 重算——因此**复用 `Nx` 已落地的全部基础设施**（§3）。
+三者都产出 localScale + 复用同一套 box-preserving 补偿；区别只在 localScale 怎么从 r 和 f 推导。`r` 与 `Nx` 同样依赖 `_canvasFactor`、同样需要 resize 重算——因此**复用 `Nx` 已落地的全部基础设施**（§3）。
 
 ### 1.4 为什么不分支 scale-mode（与 `Nx` 同理）
 
 `localScale = round(f·r) / f` 在三种 canvas 配置下都成立，`ApplyScales` 里这条路只除以缓存好的 `_canvasFactor`，不看模式：
 
-| canvas 配置 | `_canvasFactor` 来源 | `<r>R` 行为 |
+| canvas 配置 | `_canvasFactor` 来源 | `<r>r` 行为 |
 |---|---|---|
 | pixel（ConstantPixelSize + 整数 factor） | `PixelScaleSolver.Solve` 算出的整数（已含 `PixelScalePowerOfTwo` 吸附 + `MinPixelScale` 钳制） | 净 `round(f·r)` 物理像素/单位，**真脆**（整数 factor + pixelPerfect 顶点吸附） |
 | auto + `reference`（ScaleWithScreenSize） | 连续 factor（如 2.733） | effective=round(2.733·r) 仍整数；净尺寸 = effective（整数）；但位置受小数父链推到半像素、auto 不开 pixelPerfect → **清晰度尽力而为** |
-| auto 无 `reference`（ConstantPixelSize=1） | 1 | effective=round(r)；`0.5R`→round(0.5)=1→ localScale 1；`0.25R`→round(0.25)=0→钳到 1→ localScale 1 |
+| auto 无 `reference`（ConstantPixelSize=1） | 1 | effective=round(r)；`0.5r`→round(0.5)=1→ localScale 1；`0.25r`→round(0.25)=0→钳到 1→ localScale 1 |
 
 模式分支只在"算 factor"那层（已有的 `ApplyPixel` / `ApplyAuto`，且 `_canvasFactor` 缓存的就是钳制/吸附后的最终值）。auto 模式"清晰度尽力而为"是优雅降级，不报错、不分支——与 `Nx` 完全一致。
 
 ### 1.5 目标
 
-1. `scale` 属性新增取值形态 `<r>R`（r 正浮点），与裸乘数 `N`、device-density `Nx` 三者并存。
-2. 运行期 `<r>R` → `localScale = max(1, round(canvasFactor × r)) / canvasFactor`，复用 `ApplyBoxPreservingCompensation`。
-3. canvas factor 变化（resize / 旋转）时重算 `<r>R` 的 localScale，且不让 box 补偿累积——复用 `Nx` 的 resize→ReSolve 门控路径。
-4. parse 期校验 `<r>R`：r 必须正浮点；`0R`/`-0.5R`/`R` 等早失败。
-5. variant 可覆盖（`scale.portrait="0.5R"`），沿用现有基础设施。
+1. `scale` 属性新增取值形态 `<r>r`（r 正浮点），与裸乘数 `N`、device-density `Nx` 三者并存。
+2. 运行期 `<r>r` → `localScale = max(1, round(canvasFactor × r)) / canvasFactor`，复用 `ApplyBoxPreservingCompensation`。
+3. canvas factor 变化（resize / 旋转）时重算 `<r>r` 的 localScale，且不让 box 补偿累积——复用 `Nx` 的 resize→ReSolve 门控路径。
+4. parse 期校验 `<r>r`：r 必须正浮点；`0r`/`-0.5r`/`r` 等早失败。
+5. variant 可覆盖（`scale.portrait="0.5r"`），沿用现有基础设施。
 
 ### 1.6 显式不做
 
@@ -92,23 +92,23 @@ localScale = effective / canvasFactor          // 把 factor 约回去
 
 | # | 决策 | 选择 | 理由 |
 |---|---|---|---|
-| CRS-D1 | 语法 | 复用 `scale` 属性，新增 `<r>R` 取值（如 `scale="0.5R"`），与 `N` / `Nx` 并存 | 同样产出 localScale + box 补偿，只是乘数从 `round(f·r)/f` 推导；后缀字母区分语义（裸数=字面、`x`=密度、`R`=相对吸附），沿用作者已习得的"后缀决定数字含义"规律，零新属性 |
-| CRS-D2 | r 取值类型 | **正浮点**（>0，可小数：`0.5R`/`0.25R`/`1.5R`） | r 是 factor 的倍率，分数缩小正是本特性目的；与 `Nx` 的"正整数 N"形成对比（`Nx` 的 N 必整数因为它直接是净像素数） |
+| CRS-D1 | 语法 | 复用 `scale` 属性，新增 `<r>r` 取值（如 `scale="0.5r"`），与 `N` / `Nx` 并存 | 同样产出 localScale + box 补偿，只是乘数从 `round(f·r)/f` 推导；后缀字母区分语义（裸数=字面、`x`=密度、`r`=相对吸附），沿用作者已习得的"后缀决定数字含义"规律，零新属性 |
+| CRS-D2 | r 取值类型 | **正浮点**（>0，可小数：`0.5r`/`0.25r`/`1.5r`） | r 是 factor 的倍率，分数缩小正是本特性目的；与 `Nx` 的"正整数 N"形成对比（`Nx` 的 N 必整数因为它直接是净像素数） |
 | CRS-D3 | 语义 | `effective = round(canvasFactor × r)`；`localScale = effective / canvasFactor`；box 补偿照旧（inv = `1/localScale`） | 净 = effective = 整数 → 像素对齐；effective 随 f 增长 → 响应窗口（§1.2） |
 | CRS-D4 | 取整方式 | **round-half-away-from-zero**：`Mathf.Floor(f·r + 0.5f)` | 用户已确认 factor3×0.5=1.5 应取 **2**；`Mathf.Floor(x+0.5)` 保证 .5 一律向上（1.5→2、2.5→3），避开 `Mathf.Round` 的银行家舍入（Round(2.5)=2）反直觉。r=0.5 时每个奇数 factor 都落在 .5，取整规则影响最大，必须确定 |
-| CRS-D5 | effective 下限 | `Mathf.Max(1f, …)` 钳到 ≥1 | 当 f·r < 0.5（如 factor 1 + `0.25R` → round(0.25)=0）净 0 无意义。最小可对齐净尺寸是 1 物理像素/单位 → effective 钳到 1 → localScale=1/f。防 localScale=0（注：round-half-up 下 round(0.5)=1，恰好 0.5 不触发钳制） |
+| CRS-D5 | effective 下限 | `Mathf.Max(1f, …)` 钳到 ≥1 | 当 f·r < 0.5（如 factor 1 + `0.25r` → round(0.25)=0）净 0 无意义。最小可对齐净尺寸是 1 物理像素/单位 → effective 钳到 1 → localScale=1/f。防 localScale=0（注：round-half-up 下 round(0.5)=1，恰好 0.5 不触发钳制） |
 | CRS-D6 | 是否按 scale-mode 分支 | **不分支**；`ApplyScales` 统一除以缓存的 `_canvasFactor` | 公式在 pixel/auto/无-reference 三配置都成立（§1.4）；与 `Nx` 同一条路 |
-| CRS-D7 | factor 来源 | 复用 `Nx` 已有的 `_canvasFactor`（`ApplyPixel`/`ApplyAuto` 末尾缓存的最终生效 factor，已含 `PixelScalePowerOfTwo` 吸附 + `MinPixelScale` 钳制） | `R` 读"实际生效"的 factor → 与 pow2/min 钳制自动组合，无需额外处理 |
-| CRS-D8 | factor 变化重算门控 | 把 `Nx` 的 `_hasDeviceScale` 门控**泛化为"含 factor 依赖型 scale"**：重命名内部 `_hasDeviceScale`→`_hasFactorScale`、`DeclaresDeviceScale`→`DeclaresFactorScale`、`RecomputeHasDeviceScale`→`RecomputeFactorScale`；检测同时认 `Nx` 和 `<r>R` | `R` 与 `Nx` 都依赖 `_canvasFactor`、resize 都须 ReSolve；门控语义本就该是"localScale 依赖 factor 吗"。纯内部字段/方法名，无公开面变化。（若 reviewer 偏好最小 diff，可保留旧名仅扩检测——但名字会失真） |
-| CRS-D9 | 解析期校验 | `ValidateScale` 在现有"`x`→整数 / 否则浮点"基础上，先识别 `R` 后缀（前缀须正浮点）；`<Animation>` 豁免不变 | `0R`/`-0.5R`/`R`/`1e2R` 之外的非法早失败；`R` 与 `x` 后缀互斥（末字符不同），分支顺序无关 |
-| CRS-D10 | 大小写 | `R` 严格大写（镜像 `x` 严格小写）；`0.5r` 小写 → ParseException，提示用大写 `R` | 两后缀各自唯一大小写，`2x` vs `2R` 视觉差异大反而防混淆；与 `Nx` 开放问题"只接受小写 x"对称。（若 reviewer 想大小写不敏感，plan 阶段再放开） |
-| CRS-D11 | r>1 是否允许 | 允许（`2R` → 净 round(2f) 比满屏更大、仍对齐）；无上限 | 公式对 r>1 同样成立；放大型对齐缩放有合法用途，作者自负 |
-| CRS-D12 | ApplyScales 解析顺序 | `TryParseDeviceScale`(x) → `TryParseRelativeScale`(R) → 现有 `float.TryParse`（裸乘数）→ 否则 identity | 三分支后缀互斥；`R` 必须在裸 float 之前拦截（`float.TryParse("0.5R")` 会 fail → 否则落到 identity） |
+| CRS-D7 | factor 来源 | 复用 `Nx` 已有的 `_canvasFactor`（`ApplyPixel`/`ApplyAuto` 末尾缓存的最终生效 factor，已含 `PixelScalePowerOfTwo` 吸附 + `MinPixelScale` 钳制） | `r` 读"实际生效"的 factor → 与 pow2/min 钳制自动组合，无需额外处理 |
+| CRS-D8 | factor 变化重算门控 | 把 `Nx` 的 `_hasDeviceScale` 门控**泛化为"含 factor 依赖型 scale"**：重命名内部 `_hasDeviceScale`→`_hasFactorScale`、`DeclaresDeviceScale`→`DeclaresFactorScale`、`RecomputeHasDeviceScale`→`RecomputeFactorScale`；检测同时认 `Nx` 和 `<r>r` | `r` 与 `Nx` 都依赖 `_canvasFactor`、resize 都须 ReSolve；门控语义本就该是"localScale 依赖 factor 吗"。纯内部字段/方法名，无公开面变化。（若 reviewer 偏好最小 diff，可保留旧名仅扩检测——但名字会失真） |
+| CRS-D9 | 解析期校验 | `ValidateScale` 在现有"`x`→整数 / 否则浮点"基础上，先识别 `r` 后缀（前缀须正浮点）；`<Animation>` 豁免不变 | `0r`/`-0.5r`/`r`/`1e2r` 之外的非法早失败；`r` 与 `x` 后缀互斥（末字符不同），分支顺序无关 |
+| CRS-D10 | 大小写 | `r` 严格小写（与 device-density `x` 严格小写一致）；`0.5R` 大写 → ParseException，提示用小写 `r` | user 选择：同一 `scale` 属性里后缀一律小写（`x`/`r`），作者只需记"后缀小写"，比大小写混用一致；与 `Nx` 开放问题"只接受小写 x"对称。（若 reviewer 想大小写不敏感，plan 阶段再放开） |
+| CRS-D11 | r>1 是否允许 | 允许（`2r` → 净 round(2f) 比满屏更大、仍对齐）；无上限 | 公式对 r>1 同样成立；放大型对齐缩放有合法用途，作者自负 |
+| CRS-D12 | ApplyScales 解析顺序 | `TryParseDeviceScale`(x) → `TryParseRelativeScale`(R) → 现有 `float.TryParse`（裸乘数）→ 否则 identity | 三分支后缀互斥；`r` 必须在裸 float 之前拦截（`float.TryParse("0.5r")` 会 fail → 否则落到 identity） |
 | CRS-D13 | `_canvasFactor ≤ 0` 兜底 | 视作 1（复用 `Nx` 既有 `f = _canvasFactor>0 ? _canvasFactor : 1` 写法） | 防御性；正常 factor 恒为正 |
-| CRS-D14 | LayoutGroup 子节点 | 与 `N`/`Nx` 一致：localScale 应用，box 补偿在 LayoutGroup 下跳过 | `ApplyBoxPreservingCompensation` 已有 LayoutGroup 分支，`R` 自动继承 |
+| CRS-D14 | LayoutGroup 子节点 | 与 `N`/`Nx` 一致：localScale 应用，box 补偿在 LayoutGroup 下跳过 | `ApplyBoxPreservingCompensation` 已有 LayoutGroup 分支，`r` 自动继承 |
 | CRS-D15 | XSD generator | 核对 `scale` 在 XSD 是否被 pattern/enum 约束；多数通用属性走 anyAttribute → 大概率无需改；plan 阶段核实 | 与 `Nx`（SDD-D13）同样处置 |
-| CRS-D16 | SKILL 更新范围 | XML skill：`scale` 属性行 + "Relative scale" 段加 `<r>R` 形态说明 + 三形态对照表 + 中文小字例子 + auto 模式 caveat；**C# skill 不动** | 属性取值新增 → XML skill（CLAUDE.md 规则）；无 C# API 变化 |
-| CRS-D17 | master spec 同步 | 在 master spec §6 `scale="Nx"` 那一行旁追加 `<r>R` 形态一行 + 引用本文档 | 维持 spec workflow（参照 SDD-D15） |
+| CRS-D16 | SKILL 更新范围 | XML skill：`scale` 属性行 + "Relative scale" 段加 `<r>r` 形态说明 + 三形态对照表 + 中文小字例子 + auto 模式 caveat；**C# skill 不动** | 属性取值新增 → XML skill（CLAUDE.md 规则）；无 C# API 变化 |
+| CRS-D17 | master spec 同步 | 在 master spec §6 `scale="Nx"` 那一行旁追加 `<r>r` 形态一行 + 引用本文档 | 维持 spec workflow（参照 SDD-D15） |
 | CRS-D18 | 测试位置 | 扩 `Tests/EditMode/Application/ScaleAttributeTests.cs`（共用 `OpenScreen` + `CanvasSizeOverride` 模式） | 与 `N`/`Nx` box-preserving / resize 测试同文件 |
 
 ---
@@ -119,14 +119,14 @@ localScale = effective / canvasFactor          // 把 factor 约回去
 
 ### 3.1 `Runtime/Core/Parser/UIDocumentParser.cs` — `ValidateScale`（line 527）
 
-在现有 `x` 分支与 float 分支之间插入 `R` 分支（注释同步补充 `R` 形态）：
+在现有 `x` 分支与 float 分支之间插入 `r` 分支（注释同步补充 `r` 形态）：
 
 ```csharp
-// scale="<r>R" (r positive float) is the canvas-relative snapped form: localScale =
+// scale="<r>r" (r positive float) is the canvas-relative snapped form: localScale =
 // round(canvasFactor × r) / canvasFactor at runtime — scales with the factor but the
 // effective (net physical px/unit) snaps to the nearest integer, keeping pixel alignment
 // while still responding to window size. See 2026-06-01-scale-canvas-relative-snap-design.md.
-if (raw.Length >= 2 && raw[raw.Length - 1] == 'R')
+if (raw.Length >= 2 && raw[raw.Length - 1] == 'r')
 {
     var num = raw.Substring(0, raw.Length - 1);
     if (float.TryParse(num, System.Globalization.NumberStyles.Float,
@@ -134,13 +134,13 @@ if (raw.Length >= 2 && raw[raw.Length - 1] == 'R')
         return;
     throw new ParseException(
         $"{contextLabel}: invalid canvas-relative scale '{raw}' " +
-        $"(expected a positive number before uppercase 'R', e.g. '0.5R' or '0.25R')");
+        $"(expected a positive number before lowercase 'r', e.g. '0.5r' or '0.25r')");
 }
 ```
 
-错误信息（`x` 分支与末尾兜底）补上 `, or a canvas-relative scale like '0.5R'`，让作者三种形态一眼齐全。`<Animation>` 豁免（line 503）不变。
+错误信息（`x` 分支与末尾兜底）补上 `, or a canvas-relative scale like '0.5r'`，让作者三种形态一眼齐全。`<Animation>` 豁免（line 503）不变。
 
-### 3.2 `Runtime/Application/Screen.cs` — `ApplyScales`（line 242）插入 `R` 分支
+### 3.2 `Runtime/Application/Screen.cs` — `ApplyScales`（line 242）插入 `r` 分支
 
 在 `TryParseDeviceScale`（line 257-264）分支之后、裸 float 分支（line 266）之前插入：
 
@@ -161,28 +161,28 @@ if (TryParseRelativeScale(raw, out var relR))
 helper（紧邻 `TryParseDeviceScale`，line 309 旁）：
 
 ```csharp
-// scale="<r>R" (r positive float): localScale = round(canvasFactor·r) / canvasFactor →
+// scale="<r>r" (r positive float): localScale = round(canvasFactor·r) / canvasFactor →
 // scales relative to the factor but snaps the net physical-px/unit to the nearest integer
 // so it stays pixel-aligned at any factor. Returns false for the 'Nx' and plain-multiplier
 // forms (handled by TryParseDeviceScale / float.TryParse).
 private static bool TryParseRelativeScale(string raw, out float r)
 {
     r = 0f;
-    if (string.IsNullOrEmpty(raw) || raw.Length < 2 || raw[raw.Length - 1] != 'R') return false;
+    if (string.IsNullOrEmpty(raw) || raw.Length < 2 || raw[raw.Length - 1] != 'r') return false;
     return float.TryParse(raw.Substring(0, raw.Length - 1),
         System.Globalization.NumberStyles.Float,
         System.Globalization.CultureInfo.InvariantCulture, out r) && r > 0f;
 }
 ```
 
-同时更新 `ApplyScales` 上方注释（line 236-238）：把"Plain-multiplier 无 factor 依赖、Nx 依赖 factor"改为"`Nx` 与 `<r>R` 两种形态依赖 `_canvasFactor`，resize 须经 ReSolve 重算"。
+同时更新 `ApplyScales` 上方注释（line 236-238）：把"Plain-multiplier 无 factor 依赖、Nx 依赖 factor"改为"`Nx` 与 `<r>r` 两种形态依赖 `_canvasFactor`，resize 须经 ReSolve 重算"。
 
 ### 3.3 `Runtime/Application/Screen.cs` — 门控泛化（CRS-D8）
 
 把 `Nx` 专用的门控泛化为"含 factor 依赖型 scale"。**仅内部重命名 + 扩检测**：
 
 ```csharp
-private bool _hasFactorScale;   // 原 _hasDeviceScale（line 35）：任一节点用了 scale="Nx" 或 "<r>R"
+private bool _hasFactorScale;   // 原 _hasDeviceScale（line 35）：任一节点用了 scale="Nx" 或 "<r>r"
 
 // 原 RecomputeHasDeviceScale（line 286）
 private void RecomputeFactorScale()
@@ -192,7 +192,7 @@ private void RecomputeFactorScale()
         if (DeclaresFactorScale(node)) { _hasFactorScale = true; break; }
 }
 
-// 原 DeclaresDeviceScale（line 296）：base 或 variant 值匹配 Nx 或 <r>R
+// 原 DeclaresDeviceScale（line 296）：base 或 variant 值匹配 Nx 或 <r>r
 private static bool DeclaresFactorScale(ElementNode node)
 {
     if (node.Attributes.TryGetValue("scale", out var baseVal)
@@ -204,20 +204,20 @@ private static bool DeclaresFactorScale(ElementNode node)
 }
 ```
 
-调用点同步改名：`Open`（line 143）、`ReSolve`（line 482）、`OnCanvasDimensionsChanged`（line 376 的 `if (_hasDeviceScale)`）。逻辑路径完全不变——只是门控现在对 `<r>R` 也开。无 factor 依赖型 scale 的 Screen 仍走轻量 `ApplyCanvasScaler`，零行为变化。
+调用点同步改名：`Open`（line 143）、`ReSolve`（line 482）、`OnCanvasDimensionsChanged`（line 376 的 `if (_hasDeviceScale)`）。逻辑路径完全不变——只是门控现在对 `<r>r` 也开。无 factor 依赖型 scale 的 Screen 仍走轻量 `ApplyCanvasScaler`，零行为变化。
 
 ### 3.4 触发与重算流（与 `Nx` 同一条路）
 
 ```
 Parse:
-  <Text scale="0.5R"> → ValidateScale: 末尾 'R' + 前缀 float 0.5>0 → 通过；raw "0.5R" 存入 Attributes["scale"]
+  <Text scale="0.5r"> → ValidateScale: 末尾 'r' + 前缀 float 0.5>0 → 通过；raw "0.5r" 存入 Attributes["scale"]
 
 Open:
   ApplyCanvasScaler → ApplyPixel: scaleFactor = 3（含 pow2/min 钳制）→ _canvasFactor = 3
   ...instantiate, attributes applied...
-  RecomputeFactorScale → 扫描 (任一 scale 为 Nx 或 <r>R) → _hasFactorScale = true
+  RecomputeFactorScale → 扫描 (任一 scale 为 Nx 或 <r>r) → _hasFactorScale = true
   ApplyScales:
-        raw "0.5R" → TryParseRelativeScale → r=0.5
+        raw "0.5r" → TryParseRelativeScale → r=0.5
         eff = max(1, floor(3×0.5 + 0.5)) = floor(2.0) = 2
         localScale = 2 / 3 = 0.6667
         ApplyBoxPreservingCompensation(rt, 0.6667)   ← inv = 1.5
@@ -230,8 +230,8 @@ Window resize / 旋转 (factor 3 → 4):
               └─ ApplyScales: eff = floor(4×0.5+0.5)=2；localScale = 2/4 = 0.5；box inv = 2.0
         (无 factor 依赖型 scale 的 Screen 仍只跑 ApplyCanvasScaler)
 
-Variant flip (scale.portrait="0.25R" 生效):
-  Variants.Changed → ReSolve → ApplyCanvasScaler + ApplyScales（resolve 出 "0.25R"，按当前 factor 重算）
+Variant flip (scale.portrait="0.25r" 生效):
+  Variants.Changed → ReSolve → ApplyCanvasScaler + ApplyScales（resolve 出 "0.25r"，按当前 factor 重算）
 ```
 
 再入保护复用既有 `_isReapplyingScaler`（line 362 区）；`ReadCanvasRectSize` 读 `pixelRect` 切断反馈环（既有）。
@@ -242,13 +242,13 @@ Variant flip (scale.portrait="0.25R" 生效):
 
 | 状态 | 形态 / 行为 | 说明 |
 |---|---|---|
-| 新 XML 取值 | `scale="<r>R"`（r 正浮点，+ `scale.<variant>="<r>R"`） | `localScale = max(1, round(canvasFactor×r)) / canvasFactor`；净 = round(f·r) 物理像素/单位，随 factor 增长且整数对齐；factor 变化时重算 |
+| 新 XML 取值 | `scale="<r>r"`（r 正浮点，+ `scale.<variant>="<r>r"`） | `localScale = max(1, round(canvasFactor×r)) / canvasFactor`；净 = round(f·r) 物理像素/单位，随 factor 增长且整数对齐；factor 变化时重算 |
 | 不变 | `scale="Nx"`（device-density，N 正整数） | 仍 `localScale = N/canvasFactor`，净恒 N，不随窗口长大 |
 | 不变 | `scale="N"`（正浮点裸乘数） | 仍 `localScale = N`，factor-independent，不重算 |
-| 新解析期错误 | `scale="0R"` / `scale="-0.5R"` / `scale="R"` / `scale="0.5r"`(小写) → `ParseException`，msg 含 `canvas-relative scale` + `positive number before uppercase 'R'` | r 须正浮点、后缀须大写 `R` |
-| 行为变化（含 `Nx` **或** `<r>R` 的 Screen） | resize/旋转时走 `ReSolve` 而非轻量 `ApplyCanvasScaler` | 门控从 `_hasDeviceScale` 泛化为 `_hasFactorScale`；无 factor 依赖型 scale 的 Screen 零变化 |
-| caveat | auto 模式下 `<r>R` 净尺寸正确、清晰度尽力而为 | 同 `Nx`：pixel 模式才有整数 factor + pixelPerfect 顶点吸附保证真脆（§1.4） |
-| 组合 | `<r>R` 读最终 `_canvasFactor`（已含 `PixelScalePowerOfTwo` 吸附 + `MinPixelScale` 钳制） | 自动与这两个全局设置组合，无需特殊处理 |
+| 新解析期错误 | `scale="0r"` / `scale="-0.5r"` / `scale="r"` / `scale="0.5R"`(大写) → `ParseException`，msg 含 `canvas-relative scale` + `positive number before lowercase 'r'` | r 须正浮点、后缀须小写 `r` |
+| 行为变化（含 `Nx` **或** `<r>r` 的 Screen） | resize/旋转时走 `ReSolve` 而非轻量 `ApplyCanvasScaler` | 门控从 `_hasDeviceScale` 泛化为 `_hasFactorScale`；无 factor 依赖型 scale 的 Screen 零变化 |
+| caveat | auto 模式下 `<r>r` 净尺寸正确、清晰度尽力而为 | 同 `Nx`：pixel 模式才有整数 factor + pixelPerfect 顶点吸附保证真脆（§1.4） |
+| 组合 | `<r>r` 读最终 `_canvasFactor`（已含 `PixelScalePowerOfTwo` 吸附 + `MinPixelScale` 钳制） | 自动与这两个全局设置组合，无需特殊处理 |
 | 不变 | C# API（`UI.*` / `IScreen` / 等） | 本特性无 C# 公开面变化 |
 | 不变 | `PixelScaleSolver` / canvas factor / sprite 缩放 / `<Animation scale="1:0.5">` | 完全不碰 |
 
@@ -262,49 +262,49 @@ Variant flip (scale.portrait="0.25R" 生效):
 
 | 用例 | 期望 |
 |---|---|
-| `scale="0.5R"` / `scale="0.25R"` / `scale="1R"` / `scale="2R"` | DoesNotThrow |
-| `scale="1.5R"`（r 允许小数） | DoesNotThrow |
-| `scale="0R"` | ParseException，msg 含 `canvas-relative scale` |
-| `scale="-0.5R"` | ParseException |
-| `scale="R"` | ParseException |
-| `scale="0.5r"`（小写） | ParseException，msg 提示大写 `R` |
-| `scale.mobile="0.5R"`（variant） | DoesNotThrow |
+| `scale="0.5r"` / `scale="0.25r"` / `scale="1r"` / `scale="2r"` | DoesNotThrow |
+| `scale="1.5r"`（r 允许小数） | DoesNotThrow |
+| `scale="0r"` | ParseException，msg 含 `canvas-relative scale` |
+| `scale="-0.5r"` | ParseException |
+| `scale="r"` | ParseException |
+| `scale="0.5R"`（大写） | ParseException，msg 提示小写 `r` |
+| `scale.mobile="0.5r"`（variant） | DoesNotThrow |
 | 既有 `scale="2x"` / `scale="0.5"` / `<Animation scale="1:0.5">` | 仍各自 DoesNotThrow（三形态共存，豁免不变） |
 
 ### Runtime（localScale = max(1, round(f·r)) / f）
 
 | 场景（`scale-mode`, reference, CanvasSizeOverride → factor） | scale | 期望 localScale | 净 |
 |---|---|---|---|
-| pixel, 1920x1080, factor 2 | `0.5R` | 0.5 | 1 |
-| pixel, 1920x1080, factor 3 | `0.5R` | 2/3 (≈0.6667) | 2 |
-| pixel, 1920x1080, factor 4 | `0.5R` | 0.5 | 2 |
-| pixel, 1920x1080, factor 5 | `0.5R` | 3/5 (0.6)（round-half-up：2.5→3） | 3 |
-| pixel, 1920x1080, factor 6 | `0.5R` | 0.5 | 3 |
-| pixel, factor 1 | `0.5R` | 1.0（round(0.5)=1，未触发钳制） | 1 |
-| pixel, factor 1 | `0.25R` | 1.0（round(0.25)=0→钳到 1，验证下限） | 1 |
-| pixel, factor 3 | `0.25R` | 1/3（round(0.75)=1） | 1 |
-| pixel, factor 4 | `0.25R` | 0.25（round(1)=1） | 1 |
-| pixel, factor 8 | `0.25R` | 0.25（round(2)=2） | 2 |
+| pixel, 1920x1080, factor 2 | `0.5r` | 0.5 | 1 |
+| pixel, 1920x1080, factor 3 | `0.5r` | 2/3 (≈0.6667) | 2 |
+| pixel, 1920x1080, factor 4 | `0.5r` | 0.5 | 2 |
+| pixel, 1920x1080, factor 5 | `0.5r` | 3/5 (0.6)（round-half-up：2.5→3） | 3 |
+| pixel, 1920x1080, factor 6 | `0.5r` | 0.5 | 3 |
+| pixel, factor 1 | `0.5r` | 1.0（round(0.5)=1，未触发钳制） | 1 |
+| pixel, factor 1 | `0.25r` | 1.0（round(0.25)=0→钳到 1，验证下限） | 1 |
+| pixel, factor 3 | `0.25r` | 1/3（round(0.75)=1） | 1 |
+| pixel, factor 4 | `0.25r` | 0.25（round(1)=1） | 1 |
+| pixel, factor 8 | `0.25r` | 0.25（round(2)=2） | 2 |
 | pixel, factor 3 | `1R` | 1.0（round(3)=3，identity） | 3 |
-| pixel, factor 2 | `2R` | 2.0（round(4)=4，放大对齐） | 4 |
-| auto, reference 1920x1080, factor 2 | `0.5R` | 0.5（round(1)=1） | 1 |
-| auto, 无 reference（factor 1） | `0.5R` | 1.0（round(0.5)=1） | 1 |
+| pixel, factor 2 | `2r` | 2.0（round(4)=4，放大对齐） | 4 |
+| auto, reference 1920x1080, factor 2 | `0.5r` | 0.5（round(1)=1） | 1 |
+| auto, 无 reference（factor 1） | `0.5r` | 1.0（round(0.5)=1） | 1 |
 
-### Box-preserving（`<r>R` 复用 `ApplyBoxPreservingCompensation`）
+### Box-preserving（`<r>r` 复用 `ApplyBoxPreservingCompensation`）
 
 | 用例 | 期望 |
 |---|---|
-| pixel factor 3 + `<Frame anchor='stretch' margin='10,10,10,10' scale='0.5R'>` | localScale 0.6667（eff 2）；anchors 按 inv=1.5 居中加宽 [-0.25,1.25]；sizeDelta = -20×1.5 = -30（与 `scale="2x"` @factor3 数值一致，可对照） |
-| LayoutGroup 子节点 `scale='0.5R'` | localScale 应用；anchors 不加宽（补偿跳过）；LE.preferredWidth = 未缩放声明值 |
+| pixel factor 3 + `<Frame anchor='stretch' margin='10,10,10,10' scale='0.5r'>` | localScale 0.6667（eff 2）；anchors 按 inv=1.5 居中加宽 [-0.25,1.25]；sizeDelta = -20×1.5 = -30（与 `scale="2x"` @factor3 数值一致，可对照） |
+| LayoutGroup 子节点 `scale='0.5r'` | localScale 应用；anchors 不加宽（补偿跳过）；LE.preferredWidth = 未缩放声明值 |
 
 ### Resize 重算 + 不累积 + 门控
 
 | 用例 | 期望 |
 |---|---|
-| Open pixel `0.5R` @ factor 2 (localScale 0.5)，改 `CanvasSizeOverride` 到 factor 3，触发 dimension-changed | localScale = 2/3（eff 2）；box 补偿按 inv=1.5 重算，**不在上次基础上累积** |
+| Open pixel `0.5r` @ factor 2 (localScale 0.5)，改 `CanvasSizeOverride` 到 factor 3，触发 dimension-changed | localScale = 2/3（eff 2）；box 补偿按 inv=1.5 重算，**不在上次基础上累积** |
 | 同上来回切 factor 2→3→2 | 回到 factor 2 时 localScale 精确回 0.5、几何回 inv=2 基线（参照现有 `Nx`/variant 不累积测试） |
-| Screen 只含 `<r>R`（无 `Nx`） resize | `_hasFactorScale` 为 true → 走 ReSolve 重算（验证门控泛化生效） |
-| Screen 既无 `Nx` 也无 `<r>R` resize | 仍只跑 `ApplyCanvasScaler`（不进 ReSolve）；现有 pixel-scale 测试全绿 |
+| Screen 只含 `<r>r`（无 `Nx`） resize | `_hasFactorScale` 为 true → 走 ReSolve 重算（验证门控泛化生效） |
+| Screen 既无 `Nx` 也无 `<r>r` resize | 仍只跑 `ApplyCanvasScaler`（不进 ReSolve）；现有 pixel-scale 测试全绿 |
 
 ### 兼容回归
 
@@ -318,27 +318,27 @@ Variant flip (scale.portrait="0.25R" 生效):
 | 风险 | 影响 | 缓解 |
 |---|---|---|
 | 重命名 `_hasDeviceScale`→`_hasFactorScale` 等触及多处调用点 | 编译/回归风险 | 纯内部、机械改名；调用点固定 3 处（Open/ReSolve/OnCanvasDimensionsChanged）；改完先 compile-check 再跑测试 |
-| 作者混淆 `0.5`（糊）/ `2x`（不长大）/ `0.5R`（长大+对齐）三形态 | 用错形态 | XML skill 三形态对照表 + 净尺寸列 + "什么时候用哪个"一句话指引 |
-| auto 模式作者以为 `<r>R` 一定脆，实际位置半像素发糊 | 期望落差 | XML skill 明示"真脆只在 `scale-mode='pixel'`；auto 模式尺寸/净对、清晰度尽力"（与 `Nx` 同款 caveat） |
+| 作者混淆 `0.5`（糊）/ `2x`（不长大）/ `0.5r`（长大+对齐）三形态 | 用错形态 | XML skill 三形态对照表 + 净尺寸列 + "什么时候用哪个"一句话指引 |
+| auto 模式作者以为 `<r>r` 一定脆，实际位置半像素发糊 | 期望落差 | XML skill 明示"真脆只在 `scale-mode='pixel'`；auto 模式尺寸/净对、清晰度尽力"（与 `Nx` 同款 caveat） |
 | round-half 行为（factor5×0.5=2.5→3）作者预期不一致 | 个别 factor 净尺寸差 1 | spec/skill 写明取整规则（round-half-away-from-zero），例子覆盖奇数 factor |
-| 含 `<r>R` 的 Screen 每次 resize 走整套 ReSolve | resize 期 O(nodes) 重算 | resize/旋转低频；ReSolve 已被测试覆盖；无 factor 依赖型 scale 的 Screen 不受影响（门控） |
-| `_canvasFactor` 在 auto 模式与 Unity 实际值偏差 | `<r>R` 净尺寸略偏（同 `Nx`） | auto 公式精确复刻 Unity match∈{0,1} 端点输出（既有）；pixel 模式用整数 factor 无偏差 |
+| 含 `<r>r` 的 Screen 每次 resize 走整套 ReSolve | resize 期 O(nodes) 重算 | resize/旋转低频；ReSolve 已被测试覆盖；无 factor 依赖型 scale 的 Screen 不受影响（门控） |
+| `_canvasFactor` 在 auto 模式与 Unity 实际值偏差 | `<r>r` 净尺寸略偏（同 `Nx`） | auto 公式精确复刻 Unity match∈{0,1} 端点输出（既有）；pixel 模式用整数 factor 无偏差 |
 
 ---
 
 ## 7. 实施顺序（plan 时细化）
 
-1. EditMode red 测：parser `<r>R` 接受/拒绝表 + 各 factor 下 localScale 表（先红）
-2. `UIDocumentParser.ValidateScale` 加 `R` 分支 + 错误信息补 `0.5R` 提示
-3. `Screen.cs`：加 `TryParseRelativeScale` helper；`ApplyScales` 插入 `R` 分支（在 `Nx` 后、裸 float 前）；更新 `ApplyScales` 上方注释
+1. EditMode red 测：parser `<r>r` 接受/拒绝表 + 各 factor 下 localScale 表（先红）
+2. `UIDocumentParser.ValidateScale` 加 `r` 分支 + 错误信息补 `0.5r` 提示
+3. `Screen.cs`：加 `TryParseRelativeScale` helper；`ApplyScales` 插入 `r` 分支（在 `Nx` 后、裸 float 前）；更新 `ApplyScales` 上方注释
 4. `Screen.cs`：门控泛化——重命名 `_hasDeviceScale`/`DeclaresDeviceScale`/`RecomputeHasDeviceScale` 为 `_hasFactorScale`/`DeclaresFactorScale`/`RecomputeFactorScale`，检测加 `TryParseRelativeScale`；同步 3 处调用点
 5. compile-check（read_console error）→ 跑 `ScaleAttributeTests` 转绿
 6. EditMode 补 box-preserving + resize 不累积 + 门控用例 → 全绿
 7. 全量 EditMode 回归（裸乘数 / `Nx` / pixel-scale / variant 全绿）
-8. 核实 XSD `scale` 约束（CRS-D15）；必要时放开接受 `<r>R`
+8. 核实 XSD `scale` 约束（CRS-D15）；必要时放开接受 `<r>r`
 9. XML SKILL 同步（`scale` 行 + Relative scale 段 + 三形态对照表 + 中文小字例子 + caveat）
-10. master spec §6 追加 `<r>R` 一行 + 引用本文档
-11. host Unity：pixel 模式多 factor（2/3/4/5）下肉眼验 `0.5R` 中文位图字脆度 + resize 实时随窗口长大重算
+10. master spec §6 追加 `<r>r` 一行 + 引用本文档
+11. host Unity：pixel 模式多 factor（2/3/4/5）下肉眼验 `0.5r` 中文位图字脆度 + resize 实时随窗口长大重算
 
 ---
 
@@ -347,6 +347,6 @@ Variant flip (scale.portrait="0.25R" 生效):
 | 问题 | 处置 |
 |---|---|
 | 是否要 `floor`/`ceil` 变体（`0.5F`/`0.5C`） | 不本 PR；round 先落地，确有"永不超过/不低于请求倍率"需求再加后缀，公式天然可扩展 |
-| 是否允许小写 `0.5r` / 大小写不敏感 | 默认严格大写 `R`（CRS-D10）；reviewer 如倾向不敏感，plan 阶段放开（只影响 parser 一处 + helper 一处） |
-| `<r>R` 与 Screen 级 / 项目级"默认文字密度"如何配合 | 与 `Nx` 开放问题合并；per-element 原语先落地 |
+| 是否允许大写 `0.5R` / 大小写不敏感 | 默认严格小写 `r`（CRS-D10）；reviewer 如倾向不敏感，plan 阶段放开（只影响 parser 一处 + helper 一处） |
+| `<r>r` 与 Screen 级 / 项目级"默认文字密度"如何配合 | 与 `Nx` 开放问题合并；per-element 原语先落地 |
 | r 上限 | 不设硬上限（CRS-D11）；r 很大只是放大对齐，作者自负 |

--- a/docs~/superpowers/specs/2026-06-01-scale-canvas-relative-snap-design.md
+++ b/docs~/superpowers/specs/2026-06-01-scale-canvas-relative-snap-design.md
@@ -1,0 +1,352 @@
+# `scale="<r>R"` factor 相对像素吸附缩放设计
+
+**日期**：2026-06-01
+**状态**：设计阶段（待 review，未进入实施）
+**作用域**：给已有的 `scale` 属性再新增一种取值形态 `<r>R`（r 为正浮点），语义 = "把这个元素缩放到当前 canvas factor 的 r 倍，但实效缩放吸附到最近的整数"，即 `localScale = round(canvasFactor × r) / canvasFactor`，并在 canvas factor 变化时重算。让作者能写出"比满屏小、但在任意整数 factor（2/3/4…）下都保持像素对齐、且随窗口响应"的字体/元素——填补现有 `scale="N"`（响应但奇数 factor 糊）与 `scale="Nx"`（永远对齐但不随窗口长大）之间的空档。
+**依赖**：
+- [`2026-05-31-scale-device-density-design.md`](2026-05-31-scale-device-density-design.md)（已合并：`scale="Nx"`、`_canvasFactor` 缓存、`_hasDeviceScale` 门控的 resize→ReSolve 重算路径、`ApplyBoxPreservingCompensation`）
+- [`2026-05-25-pixel-perfect-scaling-design.md`](2026-05-25-pixel-perfect-scaling-design.md)（`scale-mode="pixel"` + `PixelScaleSolver` 整数 factor；`PixelScalePowerOfTwo` / `MinPixelScale`）
+- [`2026-05-07-promptugui-description-language-design.md`](2026-05-07-promptugui-description-language-design.md) §6（layout）
+
+---
+
+## 1. 背景与目标
+
+### 1.1 问题
+
+像素美术项目里，位图字最小可读尺寸已固定（如 12×12 中文）。`scale-mode="pixel"` 下 CanvasScaler 走 ConstantPixelSize + 整数 factor（`PixelScaleSolver.Solve` fit-inside 取小），factor 随屏幕自动算出，常见 2/3/4。作者想让文字**比满屏渲染更小**，于是用 `scale="0.5"`，但这是**固定乘数**：
+
+```
+净物理像素/设计单位 = canvasFactor × localScale = 3 × 0.5 = 1.5   ← 非整数 → 字格跨像素 → 糊
+```
+
+现有两种写法都不能同时满足"更小 + 随窗口长大 + 任意 factor 都对齐"：
+
+| 写法 | localScale | factor=2 净 | factor=3 净 | factor=4 净 | 随窗口长大？ | 对齐？ |
+|---|---|---|---|---|---|---|
+| `scale="0.5"`（正浮点裸乘数） | 0.5 固定 | 1 ✓ | **1.5 ✗ 糊** | 2 ✓ | 是 | 仅当 0.5×f 为整数 |
+| `scale="2x"`（device-density） | 2/f | 2 ✓ | 2 ✓ | 2 ✓ | **否（净恒为 2）** | 是 |
+
+`scale="Nx"` 把 factor 完全约掉，净尺寸跨 factor 恒定——文字不随窗口长大；`scale="N"` 随窗口长大但奇数 factor 必糊。作者真正想要的是"**随 factor 成比例、但实效落在整数上**"。
+
+### 1.2 关键洞察
+
+把"相对 factor 的倍率"和"吸附到整数"两件事合到一个公式里，用已经在手的 `_canvasFactor` 一步算出，无需新增 variant 维度、无需 driver、无反馈环：
+
+```
+令 r = 作者写的相对倍率（正浮点，如 0.5）
+effective = round(canvasFactor × r)          // 吸附到最近整数 → 必然像素对齐
+localScale = effective / canvasFactor          // 把 factor 约回去
+净物理像素/设计单位 = canvasFactor × localScale = effective = 整数      ← 与 f 是否整数无关
+```
+
+- factor 2 + `0.5R` → effective round(1)=1 → localScale 0.5 → 净 1（12 字 → 12 物理像素）
+- factor 3 + `0.5R` → effective round(1.5)=**2** → localScale 2/3 → 净 2（12 字 → 24 物理像素）
+- factor 4 + `0.5R` → effective round(2)=2 → localScale 0.5 → 净 2
+- factor 6 + `0.5R` → effective round(3)=3 → localScale 0.5 → 净 3
+
+净尺寸 = `round(f × r)` **随 factor 单调增长（响应窗口）**，又**永远是整数（像素对齐）**——正好是 §1.1 表里缺的那一格。同一句 `scale="0.5R"` 在所有 factor 下都对齐，且窗口越大字越大。`scale="Nx"` 解的"奇数 factor 落到整数实效"在这里自动达成，而且不丢响应性。
+
+### 1.3 与 `Nx` 的关系（净尺寸对比）
+
+| 形态 | localScale | 净物理像素/单位 | 随窗口长大 | 像素对齐 | 定位 |
+|---|---|---|---|---|---|
+| `scale="N"`（裸乘数） | N（字面） | N×f | 是 | 仅当 N×f 整数 | 渲染密度乘数，非像素契约 |
+| `scale="Nx"`（device-density） | N/f | N（恒定） | **否** | 是（pixel 模式真脆） | 跨设备物理尺寸恒定的 UI 文字 |
+| `scale="<r>R"`（本特性） | round(f·r)/f | round(f·r)（增长） | **是** | 是（pixel 模式真脆） | 随窗口缩放但保持对齐的小字/元素 |
+
+三者都产出 localScale + 复用同一套 box-preserving 补偿；区别只在 localScale 怎么从 r 和 f 推导。`R` 与 `Nx` 同样依赖 `_canvasFactor`、同样需要 resize 重算——因此**复用 `Nx` 已落地的全部基础设施**（§3）。
+
+### 1.4 为什么不分支 scale-mode（与 `Nx` 同理）
+
+`localScale = round(f·r) / f` 在三种 canvas 配置下都成立，`ApplyScales` 里这条路只除以缓存好的 `_canvasFactor`，不看模式：
+
+| canvas 配置 | `_canvasFactor` 来源 | `<r>R` 行为 |
+|---|---|---|
+| pixel（ConstantPixelSize + 整数 factor） | `PixelScaleSolver.Solve` 算出的整数（已含 `PixelScalePowerOfTwo` 吸附 + `MinPixelScale` 钳制） | 净 `round(f·r)` 物理像素/单位，**真脆**（整数 factor + pixelPerfect 顶点吸附） |
+| auto + `reference`（ScaleWithScreenSize） | 连续 factor（如 2.733） | effective=round(2.733·r) 仍整数；净尺寸 = effective（整数）；但位置受小数父链推到半像素、auto 不开 pixelPerfect → **清晰度尽力而为** |
+| auto 无 `reference`（ConstantPixelSize=1） | 1 | effective=round(r)；`0.5R`→round(0.5)=1→ localScale 1；`0.25R`→round(0.25)=0→钳到 1→ localScale 1 |
+
+模式分支只在"算 factor"那层（已有的 `ApplyPixel` / `ApplyAuto`，且 `_canvasFactor` 缓存的就是钳制/吸附后的最终值）。auto 模式"清晰度尽力而为"是优雅降级，不报错、不分支——与 `Nx` 完全一致。
+
+### 1.5 目标
+
+1. `scale` 属性新增取值形态 `<r>R`（r 正浮点），与裸乘数 `N`、device-density `Nx` 三者并存。
+2. 运行期 `<r>R` → `localScale = max(1, round(canvasFactor × r)) / canvasFactor`，复用 `ApplyBoxPreservingCompensation`。
+3. canvas factor 变化（resize / 旋转）时重算 `<r>R` 的 localScale，且不让 box 补偿累积——复用 `Nx` 的 resize→ReSolve 门控路径。
+4. parse 期校验 `<r>R`：r 必须正浮点；`0R`/`-0.5R`/`R` 等早失败。
+5. variant 可覆盖（`scale.portrait="0.5R"`），沿用现有基础设施。
+
+### 1.6 显式不做
+
+- ❌ `floor` / `ceil` 变体（`<r>F` / `<r>C`）——用户只要 round；如需"永不超过请求倍率"的 floor 语义后续再立项。
+- ❌ 改 `scale="Nx"` / 裸乘数 `scale="N"` 的语义——三种形态各自独立，文档讲清对照。
+- ❌ 改 `PixelScaleSolver` / factor 计算 / `PixelScalePowerOfTwo` / `MinPixelScale`——本特性完全不碰 canvas factor，只读最终缓存的 `_canvasFactor`。
+- ❌ Screen 级 / 项目级"默认文字密度"——仍是 per-element 原语（与 `Nx` 开放问题 Q1 一致）。
+- ❌ 引入 canvas-pixel-factor 维度的内置 variant（如 `scale.pixel3x`）——经评估其需要 per-Screen factor 驱动全局 store、求值顺序反馈环、端数命名等结构性问题；本公式方案在 `ApplyScales` 内纯函数求解，无这些代价（详见本次 brainstorming 结论）。
+- ❌ 新 C# 公开 API（无 `UI.*` 变化）。
+
+---
+
+## 2. 决策一览（CRS = Canvas-Relative Scale）
+
+| # | 决策 | 选择 | 理由 |
+|---|---|---|---|
+| CRS-D1 | 语法 | 复用 `scale` 属性，新增 `<r>R` 取值（如 `scale="0.5R"`），与 `N` / `Nx` 并存 | 同样产出 localScale + box 补偿，只是乘数从 `round(f·r)/f` 推导；后缀字母区分语义（裸数=字面、`x`=密度、`R`=相对吸附），沿用作者已习得的"后缀决定数字含义"规律，零新属性 |
+| CRS-D2 | r 取值类型 | **正浮点**（>0，可小数：`0.5R`/`0.25R`/`1.5R`） | r 是 factor 的倍率，分数缩小正是本特性目的；与 `Nx` 的"正整数 N"形成对比（`Nx` 的 N 必整数因为它直接是净像素数） |
+| CRS-D3 | 语义 | `effective = round(canvasFactor × r)`；`localScale = effective / canvasFactor`；box 补偿照旧（inv = `1/localScale`） | 净 = effective = 整数 → 像素对齐；effective 随 f 增长 → 响应窗口（§1.2） |
+| CRS-D4 | 取整方式 | **round-half-away-from-zero**：`Mathf.Floor(f·r + 0.5f)` | 用户已确认 factor3×0.5=1.5 应取 **2**；`Mathf.Floor(x+0.5)` 保证 .5 一律向上（1.5→2、2.5→3），避开 `Mathf.Round` 的银行家舍入（Round(2.5)=2）反直觉。r=0.5 时每个奇数 factor 都落在 .5，取整规则影响最大，必须确定 |
+| CRS-D5 | effective 下限 | `Mathf.Max(1f, …)` 钳到 ≥1 | 当 f·r < 0.5（如 factor 1 + `0.25R` → round(0.25)=0）净 0 无意义。最小可对齐净尺寸是 1 物理像素/单位 → effective 钳到 1 → localScale=1/f。防 localScale=0（注：round-half-up 下 round(0.5)=1，恰好 0.5 不触发钳制） |
+| CRS-D6 | 是否按 scale-mode 分支 | **不分支**；`ApplyScales` 统一除以缓存的 `_canvasFactor` | 公式在 pixel/auto/无-reference 三配置都成立（§1.4）；与 `Nx` 同一条路 |
+| CRS-D7 | factor 来源 | 复用 `Nx` 已有的 `_canvasFactor`（`ApplyPixel`/`ApplyAuto` 末尾缓存的最终生效 factor，已含 `PixelScalePowerOfTwo` 吸附 + `MinPixelScale` 钳制） | `R` 读"实际生效"的 factor → 与 pow2/min 钳制自动组合，无需额外处理 |
+| CRS-D8 | factor 变化重算门控 | 把 `Nx` 的 `_hasDeviceScale` 门控**泛化为"含 factor 依赖型 scale"**：重命名内部 `_hasDeviceScale`→`_hasFactorScale`、`DeclaresDeviceScale`→`DeclaresFactorScale`、`RecomputeHasDeviceScale`→`RecomputeFactorScale`；检测同时认 `Nx` 和 `<r>R` | `R` 与 `Nx` 都依赖 `_canvasFactor`、resize 都须 ReSolve；门控语义本就该是"localScale 依赖 factor 吗"。纯内部字段/方法名，无公开面变化。（若 reviewer 偏好最小 diff，可保留旧名仅扩检测——但名字会失真） |
+| CRS-D9 | 解析期校验 | `ValidateScale` 在现有"`x`→整数 / 否则浮点"基础上，先识别 `R` 后缀（前缀须正浮点）；`<Animation>` 豁免不变 | `0R`/`-0.5R`/`R`/`1e2R` 之外的非法早失败；`R` 与 `x` 后缀互斥（末字符不同），分支顺序无关 |
+| CRS-D10 | 大小写 | `R` 严格大写（镜像 `x` 严格小写）；`0.5r` 小写 → ParseException，提示用大写 `R` | 两后缀各自唯一大小写，`2x` vs `2R` 视觉差异大反而防混淆；与 `Nx` 开放问题"只接受小写 x"对称。（若 reviewer 想大小写不敏感，plan 阶段再放开） |
+| CRS-D11 | r>1 是否允许 | 允许（`2R` → 净 round(2f) 比满屏更大、仍对齐）；无上限 | 公式对 r>1 同样成立；放大型对齐缩放有合法用途，作者自负 |
+| CRS-D12 | ApplyScales 解析顺序 | `TryParseDeviceScale`(x) → `TryParseRelativeScale`(R) → 现有 `float.TryParse`（裸乘数）→ 否则 identity | 三分支后缀互斥；`R` 必须在裸 float 之前拦截（`float.TryParse("0.5R")` 会 fail → 否则落到 identity） |
+| CRS-D13 | `_canvasFactor ≤ 0` 兜底 | 视作 1（复用 `Nx` 既有 `f = _canvasFactor>0 ? _canvasFactor : 1` 写法） | 防御性；正常 factor 恒为正 |
+| CRS-D14 | LayoutGroup 子节点 | 与 `N`/`Nx` 一致：localScale 应用，box 补偿在 LayoutGroup 下跳过 | `ApplyBoxPreservingCompensation` 已有 LayoutGroup 分支，`R` 自动继承 |
+| CRS-D15 | XSD generator | 核对 `scale` 在 XSD 是否被 pattern/enum 约束；多数通用属性走 anyAttribute → 大概率无需改；plan 阶段核实 | 与 `Nx`（SDD-D13）同样处置 |
+| CRS-D16 | SKILL 更新范围 | XML skill：`scale` 属性行 + "Relative scale" 段加 `<r>R` 形态说明 + 三形态对照表 + 中文小字例子 + auto 模式 caveat；**C# skill 不动** | 属性取值新增 → XML skill（CLAUDE.md 规则）；无 C# API 变化 |
+| CRS-D17 | master spec 同步 | 在 master spec §6 `scale="Nx"` 那一行旁追加 `<r>R` 形态一行 + 引用本文档 | 维持 spec workflow（参照 SDD-D15） |
+| CRS-D18 | 测试位置 | 扩 `Tests/EditMode/Application/ScaleAttributeTests.cs`（共用 `OpenScreen` + `CanvasSizeOverride` 模式） | 与 `N`/`Nx` box-preserving / resize 测试同文件 |
+
+---
+
+## 3. 改动面
+
+> 全部建立在已合并的 device-density（`Nx`）实现之上；下面行号以当前主干为准。
+
+### 3.1 `Runtime/Core/Parser/UIDocumentParser.cs` — `ValidateScale`（line 527）
+
+在现有 `x` 分支与 float 分支之间插入 `R` 分支（注释同步补充 `R` 形态）：
+
+```csharp
+// scale="<r>R" (r positive float) is the canvas-relative snapped form: localScale =
+// round(canvasFactor × r) / canvasFactor at runtime — scales with the factor but the
+// effective (net physical px/unit) snaps to the nearest integer, keeping pixel alignment
+// while still responding to window size. See 2026-06-01-scale-canvas-relative-snap-design.md.
+if (raw.Length >= 2 && raw[raw.Length - 1] == 'R')
+{
+    var num = raw.Substring(0, raw.Length - 1);
+    if (float.TryParse(num, System.Globalization.NumberStyles.Float,
+                       System.Globalization.CultureInfo.InvariantCulture, out var rr) && rr > 0f)
+        return;
+    throw new ParseException(
+        $"{contextLabel}: invalid canvas-relative scale '{raw}' " +
+        $"(expected a positive number before uppercase 'R', e.g. '0.5R' or '0.25R')");
+}
+```
+
+错误信息（`x` 分支与末尾兜底）补上 `, or a canvas-relative scale like '0.5R'`，让作者三种形态一眼齐全。`<Animation>` 豁免（line 503）不变。
+
+### 3.2 `Runtime/Application/Screen.cs` — `ApplyScales`（line 242）插入 `R` 分支
+
+在 `TryParseDeviceScale`（line 257-264）分支之后、裸 float 分支（line 266）之前插入：
+
+```csharp
+if (TryParseRelativeScale(raw, out var relR))
+{
+    var f = _canvasFactor > 0f ? _canvasFactor : 1f;
+    // round-half-up to nearest integer effective (≥1), then divide the factor back out:
+    // net physical px/unit = effective (integer → pixel-aligned), grows with f (responsive).
+    var eff = Mathf.Max(1f, Mathf.Floor(f * relR + 0.5f));
+    var dv = eff / f;
+    rt.localScale = new Vector3(dv, dv, 1f);
+    ApplyBoxPreservingCompensation(rt, dv);
+    continue;
+}
+```
+
+helper（紧邻 `TryParseDeviceScale`，line 309 旁）：
+
+```csharp
+// scale="<r>R" (r positive float): localScale = round(canvasFactor·r) / canvasFactor →
+// scales relative to the factor but snaps the net physical-px/unit to the nearest integer
+// so it stays pixel-aligned at any factor. Returns false for the 'Nx' and plain-multiplier
+// forms (handled by TryParseDeviceScale / float.TryParse).
+private static bool TryParseRelativeScale(string raw, out float r)
+{
+    r = 0f;
+    if (string.IsNullOrEmpty(raw) || raw.Length < 2 || raw[raw.Length - 1] != 'R') return false;
+    return float.TryParse(raw.Substring(0, raw.Length - 1),
+        System.Globalization.NumberStyles.Float,
+        System.Globalization.CultureInfo.InvariantCulture, out r) && r > 0f;
+}
+```
+
+同时更新 `ApplyScales` 上方注释（line 236-238）：把"Plain-multiplier 无 factor 依赖、Nx 依赖 factor"改为"`Nx` 与 `<r>R` 两种形态依赖 `_canvasFactor`，resize 须经 ReSolve 重算"。
+
+### 3.3 `Runtime/Application/Screen.cs` — 门控泛化（CRS-D8）
+
+把 `Nx` 专用的门控泛化为"含 factor 依赖型 scale"。**仅内部重命名 + 扩检测**：
+
+```csharp
+private bool _hasFactorScale;   // 原 _hasDeviceScale（line 35）：任一节点用了 scale="Nx" 或 "<r>R"
+
+// 原 RecomputeHasDeviceScale（line 286）
+private void RecomputeFactorScale()
+{
+    _hasFactorScale = false;
+    foreach (var node in _nodeMap.Keys)
+        if (DeclaresFactorScale(node)) { _hasFactorScale = true; break; }
+}
+
+// 原 DeclaresDeviceScale（line 296）：base 或 variant 值匹配 Nx 或 <r>R
+private static bool DeclaresFactorScale(ElementNode node)
+{
+    if (node.Attributes.TryGetValue("scale", out var baseVal)
+        && (TryParseDeviceScale(baseVal, out _) || TryParseRelativeScale(baseVal, out _))) return true;
+    if (node.VariantOverrides.TryGetValue("scale", out var list))
+        foreach (var (_, value) in list)
+            if (TryParseDeviceScale(value, out _) || TryParseRelativeScale(value, out _)) return true;
+    return false;
+}
+```
+
+调用点同步改名：`Open`（line 143）、`ReSolve`（line 482）、`OnCanvasDimensionsChanged`（line 376 的 `if (_hasDeviceScale)`）。逻辑路径完全不变——只是门控现在对 `<r>R` 也开。无 factor 依赖型 scale 的 Screen 仍走轻量 `ApplyCanvasScaler`，零行为变化。
+
+### 3.4 触发与重算流（与 `Nx` 同一条路）
+
+```
+Parse:
+  <Text scale="0.5R"> → ValidateScale: 末尾 'R' + 前缀 float 0.5>0 → 通过；raw "0.5R" 存入 Attributes["scale"]
+
+Open:
+  ApplyCanvasScaler → ApplyPixel: scaleFactor = 3（含 pow2/min 钳制）→ _canvasFactor = 3
+  ...instantiate, attributes applied...
+  RecomputeFactorScale → 扫描 (任一 scale 为 Nx 或 <r>R) → _hasFactorScale = true
+  ApplyScales:
+        raw "0.5R" → TryParseRelativeScale → r=0.5
+        eff = max(1, floor(3×0.5 + 0.5)) = floor(2.0) = 2
+        localScale = 2 / 3 = 0.6667
+        ApplyBoxPreservingCompensation(rt, 0.6667)   ← inv = 1.5
+
+Window resize / 旋转 (factor 3 → 4):
+  Canvas RectTransform 变 → RectDimensionsRelay → OnCanvasDimensionsChanged
+        └─ _hasFactorScale → ReSolve()
+              ├─ ControlAttributeApplier.Apply(每节点)  ← RT 重置回 margin 基线（消除上次 inv=1.5 膨胀）
+              ├─ ApplyCanvasScaler → _canvasFactor = 4
+              └─ ApplyScales: eff = floor(4×0.5+0.5)=2；localScale = 2/4 = 0.5；box inv = 2.0
+        (无 factor 依赖型 scale 的 Screen 仍只跑 ApplyCanvasScaler)
+
+Variant flip (scale.portrait="0.25R" 生效):
+  Variants.Changed → ReSolve → ApplyCanvasScaler + ApplyScales（resolve 出 "0.25R"，按当前 factor 重算）
+```
+
+再入保护复用既有 `_isReapplyingScaler`（line 362 区）；`ReadCanvasRectSize` 读 `pixelRect` 切断反馈环（既有）。
+
+---
+
+## 4. 公开行为表
+
+| 状态 | 形态 / 行为 | 说明 |
+|---|---|---|
+| 新 XML 取值 | `scale="<r>R"`（r 正浮点，+ `scale.<variant>="<r>R"`） | `localScale = max(1, round(canvasFactor×r)) / canvasFactor`；净 = round(f·r) 物理像素/单位，随 factor 增长且整数对齐；factor 变化时重算 |
+| 不变 | `scale="Nx"`（device-density，N 正整数） | 仍 `localScale = N/canvasFactor`，净恒 N，不随窗口长大 |
+| 不变 | `scale="N"`（正浮点裸乘数） | 仍 `localScale = N`，factor-independent，不重算 |
+| 新解析期错误 | `scale="0R"` / `scale="-0.5R"` / `scale="R"` / `scale="0.5r"`(小写) → `ParseException`，msg 含 `canvas-relative scale` + `positive number before uppercase 'R'` | r 须正浮点、后缀须大写 `R` |
+| 行为变化（含 `Nx` **或** `<r>R` 的 Screen） | resize/旋转时走 `ReSolve` 而非轻量 `ApplyCanvasScaler` | 门控从 `_hasDeviceScale` 泛化为 `_hasFactorScale`；无 factor 依赖型 scale 的 Screen 零变化 |
+| caveat | auto 模式下 `<r>R` 净尺寸正确、清晰度尽力而为 | 同 `Nx`：pixel 模式才有整数 factor + pixelPerfect 顶点吸附保证真脆（§1.4） |
+| 组合 | `<r>R` 读最终 `_canvasFactor`（已含 `PixelScalePowerOfTwo` 吸附 + `MinPixelScale` 钳制） | 自动与这两个全局设置组合，无需特殊处理 |
+| 不变 | C# API（`UI.*` / `IScreen` / 等） | 本特性无 C# 公开面变化 |
+| 不变 | `PixelScaleSolver` / canvas factor / sprite 缩放 / `<Animation scale="1:0.5">` | 完全不碰 |
+
+---
+
+## 5. 测试矩阵
+
+扩 `Tests/EditMode/Application/ScaleAttributeTests.cs`（共用现有 `OpenScreen` + `CanvasSizeOverride` 模式）：
+
+### Parser
+
+| 用例 | 期望 |
+|---|---|
+| `scale="0.5R"` / `scale="0.25R"` / `scale="1R"` / `scale="2R"` | DoesNotThrow |
+| `scale="1.5R"`（r 允许小数） | DoesNotThrow |
+| `scale="0R"` | ParseException，msg 含 `canvas-relative scale` |
+| `scale="-0.5R"` | ParseException |
+| `scale="R"` | ParseException |
+| `scale="0.5r"`（小写） | ParseException，msg 提示大写 `R` |
+| `scale.mobile="0.5R"`（variant） | DoesNotThrow |
+| 既有 `scale="2x"` / `scale="0.5"` / `<Animation scale="1:0.5">` | 仍各自 DoesNotThrow（三形态共存，豁免不变） |
+
+### Runtime（localScale = max(1, round(f·r)) / f）
+
+| 场景（`scale-mode`, reference, CanvasSizeOverride → factor） | scale | 期望 localScale | 净 |
+|---|---|---|---|
+| pixel, 1920x1080, factor 2 | `0.5R` | 0.5 | 1 |
+| pixel, 1920x1080, factor 3 | `0.5R` | 2/3 (≈0.6667) | 2 |
+| pixel, 1920x1080, factor 4 | `0.5R` | 0.5 | 2 |
+| pixel, 1920x1080, factor 5 | `0.5R` | 3/5 (0.6)（round-half-up：2.5→3） | 3 |
+| pixel, 1920x1080, factor 6 | `0.5R` | 0.5 | 3 |
+| pixel, factor 1 | `0.5R` | 1.0（round(0.5)=1，未触发钳制） | 1 |
+| pixel, factor 1 | `0.25R` | 1.0（round(0.25)=0→钳到 1，验证下限） | 1 |
+| pixel, factor 3 | `0.25R` | 1/3（round(0.75)=1） | 1 |
+| pixel, factor 4 | `0.25R` | 0.25（round(1)=1） | 1 |
+| pixel, factor 8 | `0.25R` | 0.25（round(2)=2） | 2 |
+| pixel, factor 3 | `1R` | 1.0（round(3)=3，identity） | 3 |
+| pixel, factor 2 | `2R` | 2.0（round(4)=4，放大对齐） | 4 |
+| auto, reference 1920x1080, factor 2 | `0.5R` | 0.5（round(1)=1） | 1 |
+| auto, 无 reference（factor 1） | `0.5R` | 1.0（round(0.5)=1） | 1 |
+
+### Box-preserving（`<r>R` 复用 `ApplyBoxPreservingCompensation`）
+
+| 用例 | 期望 |
+|---|---|
+| pixel factor 3 + `<Frame anchor='stretch' margin='10,10,10,10' scale='0.5R'>` | localScale 0.6667（eff 2）；anchors 按 inv=1.5 居中加宽 [-0.25,1.25]；sizeDelta = -20×1.5 = -30（与 `scale="2x"` @factor3 数值一致，可对照） |
+| LayoutGroup 子节点 `scale='0.5R'` | localScale 应用；anchors 不加宽（补偿跳过）；LE.preferredWidth = 未缩放声明值 |
+
+### Resize 重算 + 不累积 + 门控
+
+| 用例 | 期望 |
+|---|---|
+| Open pixel `0.5R` @ factor 2 (localScale 0.5)，改 `CanvasSizeOverride` 到 factor 3，触发 dimension-changed | localScale = 2/3（eff 2）；box 补偿按 inv=1.5 重算，**不在上次基础上累积** |
+| 同上来回切 factor 2→3→2 | 回到 factor 2 时 localScale 精确回 0.5、几何回 inv=2 基线（参照现有 `Nx`/variant 不累积测试） |
+| Screen 只含 `<r>R`（无 `Nx`） resize | `_hasFactorScale` 为 true → 走 ReSolve 重算（验证门控泛化生效） |
+| Screen 既无 `Nx` 也无 `<r>R` resize | 仍只跑 `ApplyCanvasScaler`（不进 ReSolve）；现有 pixel-scale 测试全绿 |
+
+### 兼容回归
+
+- 现有 `ScaleAttributeTests` 全部用例（裸乘数 + `Nx`）→ 全绿
+- 现有 pixel-mode / `PixelScalePowerOfTwo` / `MinPixelScale` / variant / box-preserving 测试 → 全绿
+
+---
+
+## 6. 风险
+
+| 风险 | 影响 | 缓解 |
+|---|---|---|
+| 重命名 `_hasDeviceScale`→`_hasFactorScale` 等触及多处调用点 | 编译/回归风险 | 纯内部、机械改名；调用点固定 3 处（Open/ReSolve/OnCanvasDimensionsChanged）；改完先 compile-check 再跑测试 |
+| 作者混淆 `0.5`（糊）/ `2x`（不长大）/ `0.5R`（长大+对齐）三形态 | 用错形态 | XML skill 三形态对照表 + 净尺寸列 + "什么时候用哪个"一句话指引 |
+| auto 模式作者以为 `<r>R` 一定脆，实际位置半像素发糊 | 期望落差 | XML skill 明示"真脆只在 `scale-mode='pixel'`；auto 模式尺寸/净对、清晰度尽力"（与 `Nx` 同款 caveat） |
+| round-half 行为（factor5×0.5=2.5→3）作者预期不一致 | 个别 factor 净尺寸差 1 | spec/skill 写明取整规则（round-half-away-from-zero），例子覆盖奇数 factor |
+| 含 `<r>R` 的 Screen 每次 resize 走整套 ReSolve | resize 期 O(nodes) 重算 | resize/旋转低频；ReSolve 已被测试覆盖；无 factor 依赖型 scale 的 Screen 不受影响（门控） |
+| `_canvasFactor` 在 auto 模式与 Unity 实际值偏差 | `<r>R` 净尺寸略偏（同 `Nx`） | auto 公式精确复刻 Unity match∈{0,1} 端点输出（既有）；pixel 模式用整数 factor 无偏差 |
+
+---
+
+## 7. 实施顺序（plan 时细化）
+
+1. EditMode red 测：parser `<r>R` 接受/拒绝表 + 各 factor 下 localScale 表（先红）
+2. `UIDocumentParser.ValidateScale` 加 `R` 分支 + 错误信息补 `0.5R` 提示
+3. `Screen.cs`：加 `TryParseRelativeScale` helper；`ApplyScales` 插入 `R` 分支（在 `Nx` 后、裸 float 前）；更新 `ApplyScales` 上方注释
+4. `Screen.cs`：门控泛化——重命名 `_hasDeviceScale`/`DeclaresDeviceScale`/`RecomputeHasDeviceScale` 为 `_hasFactorScale`/`DeclaresFactorScale`/`RecomputeFactorScale`，检测加 `TryParseRelativeScale`；同步 3 处调用点
+5. compile-check（read_console error）→ 跑 `ScaleAttributeTests` 转绿
+6. EditMode 补 box-preserving + resize 不累积 + 门控用例 → 全绿
+7. 全量 EditMode 回归（裸乘数 / `Nx` / pixel-scale / variant 全绿）
+8. 核实 XSD `scale` 约束（CRS-D15）；必要时放开接受 `<r>R`
+9. XML SKILL 同步（`scale` 行 + Relative scale 段 + 三形态对照表 + 中文小字例子 + caveat）
+10. master spec §6 追加 `<r>R` 一行 + 引用本文档
+11. host Unity：pixel 模式多 factor（2/3/4/5）下肉眼验 `0.5R` 中文位图字脆度 + resize 实时随窗口长大重算
+
+---
+
+## 8. 开放问题
+
+| 问题 | 处置 |
+|---|---|
+| 是否要 `floor`/`ceil` 变体（`0.5F`/`0.5C`） | 不本 PR；round 先落地，确有"永不超过/不低于请求倍率"需求再加后缀，公式天然可扩展 |
+| 是否允许小写 `0.5r` / 大小写不敏感 | 默认严格大写 `R`（CRS-D10）；reviewer 如倾向不敏感，plan 阶段放开（只影响 parser 一处 + helper 一处） |
+| `<r>R` 与 Screen 级 / 项目级"默认文字密度"如何配合 | 与 `Nx` 开放问题合并；per-element 原语先落地 |
+| r 上限 | 不设硬上限（CRS-D11）；r 很大只是放大对齐，作者自负 |


### PR DESCRIPTION
## Summary

新增 `scale` 取值形态 `<r>r`（r 正浮点，小写 `r`，与 device-density 的小写 `x` 一致）：`localScale = max(1, round(canvasFactor × r)) / canvasFactor`。

净物理像素/设计单位 = `round(factor × r)` —— **整数（像素对齐）且随窗口长大（响应）**，填补现有两种形态之间的空档：
- `scale="N"`（浮点）：随窗口长大，但奇数 factor 发糊（`3×0.5=1.5`）。
- `scale="Nx"`（device-density）：永远对齐，但尺寸恒定、不随窗口长大。
- `scale="<r>r"`（本 PR）：两者兼得。

例：`0.5r` 在 factor 2→净1、factor 3→净2、factor 4→净2、factor 6→净3。

### 实现要点
- 取整 round-half-up（`Mathf.Floor(f·r+0.5)`，factor3×0.5→net 2）；净下限钳到 1。
- 复用已合并的 `Nx`（device-density）基础设施：同一 `_canvasFactor`、同一 resize→ReSolve 重算路径。
- 门控泛化：`_hasDeviceScale`→`_hasFactorScale`（+`DeclaresFactorScale`/`RecomputeFactorScale`），对 `Nx` 与 `<r>r` 都触发 resize 重算（纯内部重命名，`Nx` 行为不变）。
- Parser：`ValidateScale` 加 `r` 分支，严格小写 `r`（`0.5R` 报错）。
- 自动与 `UI.PixelScalePowerOfTwo` / `UI.MinPixelScale` 组合（读最终生效 factor）。
- 无 C# 公开 API 变化；XSD 不变（`scale` 为 `xs:string` 无约束）。

Spec: `docs~/superpowers/specs/2026-06-01-scale-canvas-relative-snap-design.md`（CRS-D1…D18）
Plan: `docs~/superpowers/plans/2026-06-01-scale-canvas-relative-snap.md`

## Test Plan

- [x] EditMode `PromptUGUI.Tests.EditMode` 全量 **1188/1188** 绿
- [x] EditMode `PromptUGUI.Tests.EditorOnly` **174/174** 绿（XSD 无回归）
- [x] `ScaleAttributeTests` **62/62**（新增 19：8 parser + 9 open-time runtime/box-preserving + 2 resize/门控不累积）
- [x] `dotnet format` lint 干净
- [ ] **host Unity 肉眼验收（待 reviewer）**：pixel 模式 factor 2/3/4/5 下 `0.5r` 中文位图字清晰不糊 + 拖窗跨 factor 边界实时重算、来回拖动不累积变形 + 与 `0.5`/`2x` 同屏对照

🤖 Generated with [Claude Code](https://claude.com/claude-code)