### PR TITLE
feat(color): 颜色引用值的 /alpha 不透明度后缀

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -549,6 +549,21 @@ If you register a token named `red`, then `color="red"` resolves to that token (
 
 `color.dark="..."` works as expected for variant overrides — value goes through the same token → literal resolution chain.
 
+### Alpha suffix (opacity)
+
+Append `/<0..1>` to any color **reference** to set its opacity. The suffix REPLACES the resolved color's alpha (Unity `Color.a` semantics, like Flutter `withOpacity`) — it does not multiply:
+
+```xml
+<Frame color="black/0.5"/>     <!-- black backdrop at 50% opacity -->
+<Image color="primary/0.8"/>   <!-- theme token's RGB, alpha forced to 0.8 -->
+<Text  color="#ff0000/0.3" text="faint"/>
+```
+
+- Works on **every** color-valued attribute (one resolution chokepoint): `color`, the state colors `hoverColor` / `pressedColor` / `selectedColor` / `disabledColor`, `*Modulate`, variant overrides (`color.dark="primary/0.5"`), and `<Animation char-color="primary/1:primary/0">` (fade out).
+- Replace, not multiply: a token whose own value carries alpha (e.g. `scrim = #00000080`) referenced as `scrim/1` comes out **fully opaque**.
+- Value is a `0..1` float. Out of range or malformed (`/1.5`, `/abc`, `/`, no color before `/`) → `ParseException` with node context.
+- Suffix is **reference-only**. Definition-side `<Color value="...">` does NOT take a suffix — bake alpha into the hex there (`value="#00000080"`) if you want a baked-alpha token.
+
 ### Error codes
 
 - `<Theme>: missing required attribute 'name'`
@@ -559,7 +574,8 @@ If you register a token named `red`, then `color="red"` resolves to that token (
 - `<Theme name="X" base="Y">: base theme 'Y' not found`
 - `<Theme> base cycle starting at 'X': ...`
 - (Runtime, when value can't resolve) `<Image id='X'> attribute color="Y": unknown color token "Y" (no entry in theme 'Z', not a valid hex/named literal)`
-- (Lint) `PUI-COLOR-LITERAL-INVALID` — static check: `color="#..."` literal that doesn't parse
+- (Runtime, bad alpha suffix) `color "black/1.5": alpha 1.5 is out of range — must be 0..1`
+- (Lint) `PUI-COLOR-LITERAL-INVALID` — static check: `color="#..."` literal that doesn't parse, or a hex literal with an out-of-range / malformed `/alpha` suffix
 
 ## Tint blend modes
 

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -437,6 +437,20 @@ namespace PromptUGUI.Application
             {
                 if (string.IsNullOrEmpty(value))
                     throw new System.Exception("empty color value");
+
+                // Reference-site alpha suffix: "black/0.5" → resolve "black", then set a = 0.5.
+                // The suffix REPLACES the resolved colour's own alpha (Color.a semantics),
+                // so a 50%-opaque token referenced as "scrim/1" comes out fully opaque.
+                if (!Parser.ColorParser.TrySplitAlpha(value, out var baseValue, out var alpha, out var err))
+                    throw new System.Exception(err);
+
+                var resolved = ResolveBase(baseValue);
+                if (alpha.HasValue) resolved.a = alpha.Value;
+                return resolved;
+            }
+
+            private static UnityEngine.Color ResolveBase(string value)
+            {
                 if (Current != null)
                 {
                     var hit = ThemeStore.Instance.LookupChained(Current, value);

--- a/Runtime/Core/Lint/ColorLiteralRules.cs
+++ b/Runtime/Core/Lint/ColorLiteralRules.cs
@@ -22,6 +22,18 @@ namespace PromptUGUI.Lint
             if (!node.Attributes.TryGetValue("color", out var value)) yield break;
             if (string.IsNullOrEmpty(value)) yield break;
 
+            // Reference-site /alpha suffix ("black/0.5"): strip it before the hex check.
+            // A malformed suffix on a hex literal is flagged at build time; on a bare word
+            // it's left to the runtime resolver (tokens aren't statically checked anyway).
+            if (!ColorParser.TrySplitAlpha(value, out var baseValue, out _, out var alphaErr))
+            {
+                if (value[0] == '#')
+                    yield return new LintIssue(ColorLiteralCode, node.Tag, node.Id,
+                        $"<{node.Tag} id='{node.Id}'>: {alphaErr}");
+                yield break;
+            }
+            value = baseValue;
+
             // Bare words (tokens) are not checked statically.
             if (value[0] != '#') yield break;
 

--- a/Runtime/Core/Parser/ColorParser.cs
+++ b/Runtime/Core/Parser/ColorParser.cs
@@ -39,6 +39,53 @@ namespace PromptUGUI.Parser
             return NamedColors.Contains(htmlString.ToLowerInvariant());
         }
 
+        /// <summary>
+        /// Splits an optional trailing alpha suffix off a colour <em>reference</em> value.
+        /// <c>"black/0.5"</c> → base <c>"black"</c>, alpha <c>0.5</c>; <c>"#ff0000/0.3"</c> →
+        /// base <c>"#ff0000"</c>, alpha <c>0.3</c>; <c>"primary"</c> → base <c>"primary"</c>,
+        /// alpha <c>null</c> (no suffix). The suffix is the text after the LAST '/'; colour
+        /// tokens are <c>[a-z0-9-]</c>, hex is <c>#...</c>, named colours are alphabetic —
+        /// none contain '/', so the split is unambiguous. Alpha is a 0..1 float and REPLACES
+        /// the resolved colour's own alpha (Unity <c>Color.a</c> semantics).
+        /// Returns false (with <paramref name="error"/> set) when a '/' is present but the
+        /// part before it is empty, or the suffix is empty / non-numeric / out of 0..1.
+        /// </summary>
+        public static bool TrySplitAlpha(string raw, out string baseValue, out float? alpha, out string error)
+        {
+            baseValue = raw;
+            alpha = null;
+            error = null;
+            if (string.IsNullOrEmpty(raw)) return true;   // empty handled by caller
+
+            var slash = raw.LastIndexOf('/');
+            if (slash < 0) return true;                   // no suffix → value unchanged
+
+            var head = raw.Substring(0, slash);
+            var tail = raw.Substring(slash + 1);
+
+            if (head.Length == 0)
+            {
+                error = $"color \"{raw}\": missing colour before the '/' alpha suffix";
+                return false;
+            }
+            if (tail.Length == 0
+                || !float.TryParse(tail, System.Globalization.NumberStyles.Float,
+                                   System.Globalization.CultureInfo.InvariantCulture, out var a))
+            {
+                error = $"color \"{raw}\": alpha after '/' must be a number in 0..1 (e.g. \"black/0.5\")";
+                return false;
+            }
+            if (a < 0f || a > 1f)
+            {
+                error = $"color \"{raw}\": alpha {tail} is out of range — must be 0..1";
+                return false;
+            }
+
+            baseValue = head;
+            alpha = a;
+            return true;
+        }
+
         private static bool IsHexDigit(char c)
         {
             return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');

--- a/Tests/EditMode/Application/ColorAlphaSuffixTests.cs
+++ b/Tests/EditMode/Application/ColorAlphaSuffixTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Application
+{
+    /// <summary>
+    /// Reference-site alpha suffix on color values: <c>color="black/0.5"</c>.
+    /// The <c>/&lt;0..1&gt;</c> tail REPLACES the resolved colour's alpha (matches
+    /// Unity <c>Color.a</c> / Flutter <c>withOpacity</c> semantics). Definition-side
+    /// <c>&lt;Color value="..."&gt;</c> stays pure (covered elsewhere).
+    /// </summary>
+    public class ColorAlphaSuffixTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static void Seed(string name, string baseName, params (string k, string v)[] entries)
+        {
+            var d = new Dictionary<string, Color>();
+            foreach (var (k, v) in entries) { ColorUtility.TryParseHtmlString(v, out var c); d[k] = c; }
+            ThemeStore.Instance.Register(name, baseName, d, src: "test");
+            ThemeStore.Instance.ResolveBases();
+        }
+
+        [Test]
+        public void NamedColor_With_Alpha_Suffix()
+        {
+            var c = UI.Theme.Resolve("black/0.5");
+            Assert.AreEqual(0f, c.r, 0.001f);
+            Assert.AreEqual(0f, c.g, 0.001f);
+            Assert.AreEqual(0f, c.b, 0.001f);
+            Assert.AreEqual(0.5f, c.a, 0.001f);
+        }
+
+        [Test]
+        public void Hex_With_Alpha_Suffix()
+        {
+            var c = UI.Theme.Resolve("#ff0000/0.3");
+            Assert.AreEqual(1f, c.r, 0.001f);
+            Assert.AreEqual(0f, c.g, 0.001f);
+            Assert.AreEqual(0.3f, c.a, 0.001f);
+        }
+
+        [Test]
+        public void Token_With_Alpha_Suffix()
+        {
+            Seed("light", null, ("primary", "#ff8800"));
+            UI.Theme.Set("light");
+            var c = UI.Theme.Resolve("primary/0.5");
+            Assert.AreEqual(1f, c.r, 0.005f);          // 0xff
+            Assert.AreEqual(0x88 / 255f, c.g, 0.005f); // 0x88
+            Assert.AreEqual(0f, c.b, 0.005f);
+            Assert.AreEqual(0.5f, c.a, 0.001f);
+        }
+
+        [Test]
+        public void Suffix_Replaces_Token_Baked_Alpha()
+        {
+            // scrim is itself 50% opaque (#..80). "/1" must REPLACE → fully opaque,
+            // not multiply (which would give ~0.5).
+            Seed("light", null, ("scrim", "#00000080"));
+            UI.Theme.Set("light");
+            Assert.AreEqual(1f, UI.Theme.Resolve("scrim/1").a, 0.001f);
+        }
+
+        [Test]
+        public void No_Suffix_Leaves_Baked_Alpha_Untouched()
+        {
+            // No '/' → behaviour identical to before this feature.
+            Assert.AreEqual(0x80 / 255f, UI.Theme.Resolve("#ff000080").a, 0.005f);
+        }
+
+        [Test]
+        public void Alpha_Out_Of_Range_Throws()
+        {
+            Assert.Throws<Exception>(() => UI.Theme.Resolve("black/1.5"));
+            Assert.Throws<Exception>(() => UI.Theme.Resolve("black/-0.1"));
+        }
+
+        [Test]
+        public void Alpha_Malformed_Throws()
+        {
+            Assert.Throws<Exception>(() => UI.Theme.Resolve("black/"));   // empty tail
+            Assert.Throws<Exception>(() => UI.Theme.Resolve("black/abc")); // non-numeric
+            Assert.Throws<Exception>(() => UI.Theme.Resolve("/0.5"));      // no base colour
+        }
+
+        [Test]
+        public void Suffix_On_Pending_Theme_SoftFails_To_White_Keeping_Alpha()
+        {
+            UI.Theme.Set("dark");  // intent recorded, theme not yet registered
+            var c = UI.Theme.Resolve("primary/0.5");
+            Assert.AreEqual(1f, c.r, 0.001f);   // white placeholder
+            Assert.AreEqual(0.5f, c.a, 0.001f); // alpha intent survives the placeholder
+        }
+    }
+}

--- a/Tests/EditMode/Application/ColorAlphaSuffixTests.cs.meta
+++ b/Tests/EditMode/Application/ColorAlphaSuffixTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bf05c926dce815e4b801a453cf439317

--- a/Tests/EditMode/Controls/ColorTokenIntegrationTests.cs
+++ b/Tests/EditMode/Controls/ColorTokenIntegrationTests.cs
@@ -60,6 +60,17 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
+        public void Image_Token_With_Alpha_Suffix_End_To_End()
+        {
+            SeedLight("#ff8800");
+            var s = Open("<Image id='x' color='primary/0.5'/>");
+            var img = s.Get<Image>("x").GameObject.GetComponent<UnityImage>();
+            Assert.AreEqual(1f, img.color.r, 0.005f);          // token RGB preserved
+            Assert.AreEqual(0x88 / 255f, img.color.g, 0.005f);
+            Assert.AreEqual(0.5f, img.color.a, 0.001f);        // alpha from suffix
+        }
+
+        [Test]
         public void Text_Token_Resolves()
         {
             SeedLight("#222222");

--- a/Tests/EditMode/Lint/ColorLiteralRulesTests.cs
+++ b/Tests/EditMode/Lint/ColorLiteralRulesTests.cs
@@ -120,6 +120,35 @@ namespace PromptUGUI.Tests.EditMode.Lint
         }
 
         [Test]
+        public void Hex_With_Alpha_Suffix_No_Issue()
+        {
+            // Reference-site /alpha suffix must be stripped before the hex check.
+            var n = new IR.ElementNode("Image") { Id = "test" };
+            n.Attributes["color"] = "#ff0000/0.3";
+            var issues = ColorLiteralRules.Check(n).ToList();
+            Assert.IsEmpty(issues);
+        }
+
+        [Test]
+        public void Token_With_Alpha_Suffix_No_Issue()
+        {
+            var n = new IR.ElementNode("Image") { Id = "test" };
+            n.Attributes["color"] = "primary/0.5";
+            var issues = ColorLiteralRules.Check(n).ToList();
+            Assert.IsEmpty(issues);
+        }
+
+        [Test]
+        public void Hex_With_OutOfRange_Alpha_Suffix_Flagged()
+        {
+            var n = new IR.ElementNode("Image") { Id = "bad" };
+            n.Attributes["color"] = "#ff0000/9";  // alpha must be 0..1
+            var issues = ColorLiteralRules.Check(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ColorLiteralRules.ColorLiteralCode, issues[0].Code);
+        }
+
+        [Test]
         public void IRWalker_Integration_TokenWord_NoDispatch()
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>


### PR DESCRIPTION
## 背景

`color` 现在多用主题 token（`red` / `black` / `primary`），但偶尔需要"同一个基色、单独压透明度"——典型场景是某个界面要一块**半透明黑底板**，为它单开一个 `<Color>` token 太重。

## 方案

任何颜色**引用**值可加 `/<0..1>` 后缀，**替换**（非相乘）解析后颜色的 alpha：

```xml
<Frame color="black/0.5"/>      <!-- 半透明黑底板 -->
<Image color="primary/0.8"/>    <!-- token 的 RGB，alpha 强制 0.8 -->
<Text  color="#ff0000/0.3" text="faint"/>
```

选后缀而非独立 `alpha=` 属性：所有颜色字符串本就汇到 `UI.Theme.Resolve` 单一解析点，把 alpha 放进字符串就对**每个** color 类属性自动生效，且避开独立属性的两个坑（只覆盖主 `color` → 会引出 `pressedAlpha` 之类；`color` 与 `alpha` 两个反射 setter 的应用顺序）。后缀也和现有 DSL 习惯一致（`stretch*2` / `2r` / `50%`）。`0–1` 小数对齐 Unity `Color.a` / `pivot`。

## 语义

- **替换，不相乘**：token 自带 alpha（`scrim = #00000080`）被 `scrim/1` 引用 → 全不透明。
- **作用范围**：`color`、状态色 `hover/pressed/selected/disabledColor`、`*Modulate`、Variant `color.dark="primary/0.5"`、`<Animation char-color="a/1:a/0">`（淡出）。
- **只在引用侧**：`<Color value="...">` 定义侧不收后缀（要烤 alpha 写进 hex）。
- 越界/畸形（`/1.5`、`/abc`、`/`、无底色）→ 运行时 `ParseException`；hex 字面上的坏后缀 build-time 报 `PUI-COLOR-LITERAL-INVALID`。

## 改动

| 文件 | 改动 |
|---|---|
| `Runtime/Core/Parser/ColorParser.cs` | 新增纯 C# `TrySplitAlpha`（按最后一个 `/` 拆，0..1 校验），运行时 + UIXmlLint CLI 共用 |
| `Runtime/Application/UI.cs` | `Theme.Resolve` 拆后缀 → 私有 `ResolveBase`（原逻辑）→ 覆写 `.a`；pending 软着陆保留 alpha |
| `Runtime/Core/Lint/ColorLiteralRules.cs` | 校验前剥后缀；hex 上越界后缀报错 |
| `.claude/skills/authoring-promptugui-xml/SKILL.md` | 新增 "Alpha suffix (opacity)" 子节 + 错误码 |
| `Tests/EditMode/...` | `ColorAlphaSuffixTests`（8）+ lint（3）+ 集成（1） |

## 测试

- EditMode **1342 / 1342**
- EditorOnly **175 / 175**
- `dotnet format --verify-no-changes --severity warn` exit 0
- UIXmlLint CLI 构建 0 错 + `Runtime/Resources/` 无 issue

无 XSD 改动（`color` 本就是自由字符串）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
