### PR TITLE
feat(rawimage): <RawImage> 控件 — C# 设置动态 Texture

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -83,6 +83,7 @@ Pre-registered on `UI.Registry`. Use as XML tags by name. 速查目录如下；�
 | `<Frame>` | 空容器，可选 `mask="rect"` |
 | `<SafeArea>` | 撑满父级、按设备安全区内缩（见本节末 **Safe area** 小节） |
 | `<Image>` | uGUI Image：sprite + 等比适配 + mask |
+| `<RawImage>` | uGUI RawImage：C# 设 Texture（动态图）+ contain/cover 适配 + mask |
 | `<Text>` | TMP 文本：富对齐 + i18n |
 | `<VStack>` | 纵向布局组 |
 | `<HStack>` | 横向布局组 |
@@ -124,6 +125,22 @@ uGUI Image，从 `Resources` 加载 sprite；可选 `RectMask2D`（`mask="rect"`
 | `showMask` | bool | `true` | 仅 `mask="self"` |
 | `maskPadding` | `T,R,B,L` | — | 仅 `mask="rect"` |
 | `tint` | `multiply` / `linear` | — | 见 **Tint blend modes** |
+
+### `<RawImage>`
+
+uGUI `RawImage`，渲染**运行时动态加载的 `Texture`**（头像 / 下载图 / 截图 / `RenderTexture`）。图源**只能从 C# 设**——没有 `sprite` / SpriteSet、没有 XML 图源属性：`screen.Get<RawImage>("id").Texture = tex;`（见 scripting-promptugui-csharp）。
+
+| 属性 | 类型 / 取值 | 默认 | 说明 |
+|---|---|---|---|
+| `color` | hex / CSS named / theme token | `#ffffff` | 乘色；无 texture 时仍按 color 画纯色 quad（要初始隐形写 `color="#00000000"`） |
+| `type` | `contain` / `cover` | — | 等比适配，相对**父 rect**（同 `<Image>`）：`contain` 内嵌留边、`cover` 填满溢出；`cover` 裁切由父级 `mask="rect"` 负责。**仅这两个值**——`simple` / `sliced` / `tiled` / `filled` 是 sprite 专有，写了会 warning 并回退普通模式。适配模式下自身 `anchor` / `size` / `width` / `height` / `margin` 被 `AspectRatioFitter` 接管失效 |
+| `tint` | `multiply` / `linear` | `multiply` | 见 **Tint blend modes** |
+| `mask` | `rect` / `self` | — | 同 `<Image>` |
+| `showMask` | bool | `true` | 仅 `mask="self"` |
+| `maskPadding` | `T,R,B,L` | — | 仅 `mask="rect"` |
+
+- texture 由 C# 在 Open 后设置，故 `size="native"`（读 texture 像素宽高）仅在实例化前已同步赋 texture 时有值；常态请显式写 `size` 或用 `type="contain"/"cover"`。
+- 别在 `<VStack>` / `<HStack>` / `<Grid>` 直接子节点上用 fit 模式（`AspectRatioFitter` 与 LayoutGroup 抢布局）——套一层 `<Frame>`。
 
 ### `<Text>`
 
@@ -393,6 +410,7 @@ Other notes:
 | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `<Frame>`      | `RectTransform` 单独；可选 `RectMask2D`（写 `mask="rect"` 时挂）                                                                                                                                                                                               | —                                                                                                                                                                                                                                                                                      | —                                                                                                                           |
 | `<Image>`      | `Image` + (lazy) `PointerEventRelay`（被 hover/press trigger 引用为源时挂上）；可选 `RectMask2D`（`mask="rect"`）或 stencil `Mask`（`mask="self"`，用自身 sprite 作 mask 形状）                                                                                | —                                                                                                                                                                                                                                                                                      | `OnPointerEnter` / `OnPointerExit` / `OnPointerDown` ← Relay                                                                |
+| `<RawImage>`   | `RawImage` + (lazy) `PointerEventRelay`；可选 `AspectRatioFitter`（`type=contain/cover`）/ `RectMask2D`（`mask="rect"`）/ stencil `Mask`（`mask="self"`）；图源 = C# `Texture` 属性                                                                            | —                                                                                                                                                                                                                                                                                      | `OnPointerEnter` / `OnPointerExit` / `OnPointerDown` ← Relay                                                                |
 | `<Text>`       | `TextMeshProUGUI`                                                                                                                                                                                                                                              | —                                                                                                                                                                                                                                                                                      | —                                                                                                                           |
 | `<VStack>`     | `VerticalLayoutGroup`（硬编码 `childControlWidth/Height=true`、`childForceExpand*=false`）                                                                                                                                                                     | —                                                                                                                                                                                                                                                                                      | —                                                                                                                           |
 | `<HStack>`     | `HorizontalLayoutGroup`（同 VStack）                                                                                                                                                                                                                           | —                                                                                                                                                                                                                                                                                      | —                                                                                                                           |

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -177,6 +177,8 @@ screen.Get<InputField>("playerName").OnEndEdit
 
 **Progress** — `screen.Get<Progress>("hp").Value = 0.42f;` 或 R3 推送 `healthStream.Subscribe(v => p.Value = v).AddTo(screen)`。Progress 是只读显示控件，无 `OnValueChanged`。`Value` 被 `Mathf.Clamp01` 钳位。注意：`[Bind]` 在本项目里是把 child control 字段注入到 parent（见 `Runtime/Registry/BindAttribute.cs`），不是数据流绑定 —— 用直接 setter / R3 推。
 
+**RawImage** — 显示运行时加载的 `Texture`（不是 sprite）：`screen.Get<RawImage>("avatar").Texture = tex;`（`Texture2D` / `RenderTexture` 均可）。`Texture` 是普通 C# 属性（get/set），**不是** XML 属性 —— XML 端只声明位置 / `color` / `type=contain|cover` / `mask`。重新赋值会自动按新 texture 重算 `type=contain/cover` 的纵横比。典型用法是把异步加载结果推进去：`LoadAsync(url).Subscribe(t => raw.Texture = t).AddTo(screen)`。
+
 **`Btn.OnState` / `Tab.OnState` / `Toggle.OnState`** — each control broadcasts its uGUI interaction state as `Observable<InteractState>` (`InteractState { Normal, Hover, Pressed, Selected, Disabled }`). `Selected` = the active/`isOn` control at rest; transient Hover/Pressed/Disabled override it and revert on release; a momentary `<Btn>` never emits `Selected`. The observable replays the current value to new subscribers, so you can react in C# to press / hover / select / disable — complementing the XML-side `*Color` / `*Modulate` state colours and `<Show>` artwork swap (see authoring-promptugui-xml → "Btn state visuals"):
 
 ```csharp

--- a/Runtime/Application/BuiltinPrimitives.cs
+++ b/Runtime/Application/BuiltinPrimitives.cs
@@ -13,6 +13,7 @@ namespace PromptUGUI.Application
             reg.Register<Show>("Show", null);
             reg.Register<Animation>("Animation", null);
             reg.Register<Image>("Image", null);
+            reg.Register<RawImage>("RawImage", null);
             reg.Register<Icon>("Icon", null);
             reg.Register<Text>("Text", null, defaultTextAttr: "text");
             reg.Register<VStack>("VStack", null);

--- a/Runtime/Controls/Internal/ImageTint.cs
+++ b/Runtime/Controls/Internal/ImageTint.cs
@@ -1,21 +1,21 @@
 using UnityEngine;
-using UnityImage = UnityEngine.UI.Image;
+using UnityEngine.UI;
 
 namespace PromptUGUI.Controls.Internal
 {
     /// <summary>
-    /// Switches a <see cref="UnityImage"/> between Unity's default multiply tint
-    /// (material = null → Graphic falls back to UI/Default) and PromptUGUI's
+    /// Switches a <see cref="Graphic"/> (Image / RawImage / …) between Unity's default
+    /// multiply tint (material = null → Graphic falls back to UI/Default) and PromptUGUI's
     /// Linear Light tint material. The material asset is shared process-wide and
     /// lazy-loaded from Resources on first use; only the material setter is ever
-    /// touched (never the getter), so no per-Image material instance is created.
+    /// touched (never the getter), so no per-graphic material instance is created.
     /// </summary>
     internal static class ImageTint
     {
         private const string LinearLightTintResourcePath = "PromptUGUI/Material/UI-LinearLightTint";
         private static Material _linearLightTint;
 
-        public static void Apply(UnityImage img, string mode)
+        public static void Apply(Graphic img, string mode)
         {
             if (img == null) return;
             switch (mode)

--- a/Runtime/Controls/RawImage.cs
+++ b/Runtime/Controls/RawImage.cs
@@ -1,4 +1,5 @@
 using PromptUGUI.Application;
+using PromptUGUI.Controls.Internal;
 using PromptUGUI.Registry;
 using UnityEngine;
 using UnityEngine.UI;
@@ -30,6 +31,12 @@ namespace PromptUGUI.Controls
         public string Color
         {
             set => _raw.color = UI.Theme.Resolve(value);
+        }
+
+        [UIAttr, Preserve]
+        public string Tint
+        {
+            set => ImageTint.Apply(_raw, value);
         }
 
         private AspectRatioFitter _fitter;

--- a/Runtime/Controls/RawImage.cs
+++ b/Runtime/Controls/RawImage.cs
@@ -2,13 +2,14 @@ using PromptUGUI.Application;
 using PromptUGUI.Controls.Internal;
 using PromptUGUI.Layout;
 using PromptUGUI.Registry;
+using R3;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityRawImage = UnityEngine.UI.RawImage;
 
 namespace PromptUGUI.Controls
 {
-    public sealed class RawImage : Control
+    public sealed class RawImage : Control, IPointerEventSource
     {
         private UnityRawImage _raw;
         private RectMask2D _rectMask;
@@ -21,6 +22,15 @@ namespace PromptUGUI.Controls
             _raw = GameObject.GetComponent<UnityRawImage>()
                    ?? GameObject.AddComponent<UnityRawImage>();
         }
+
+        private PointerEventRelay _pointerRelay;
+
+        private PointerEventRelay EnsureRelay()
+            => _pointerRelay ??= GameObject.AddComponent<PointerEventRelay>();
+
+        public Observable<Unit> OnPointerEnter => EnsureRelay().OnPointerEnter;
+        public Observable<Unit> OnPointerExit => EnsureRelay().OnPointerExit;
+        public Observable<Unit> OnPointerDown => EnsureRelay().OnPointerDown;
 
         /// <summary>
         /// 显示的 texture。由 C# 设置（下载图 / RenderTexture 等），无对应 XML 属性。

--- a/Runtime/Controls/RawImage.cs
+++ b/Runtime/Controls/RawImage.cs
@@ -1,3 +1,5 @@
+using PromptUGUI.Application;
+using PromptUGUI.Registry;
 using UnityEngine;
 using UnityRawImage = UnityEngine.UI.RawImage;
 
@@ -21,6 +23,12 @@ namespace PromptUGUI.Controls
         {
             get => _raw.texture;
             set => _raw.texture = value;
+        }
+
+        [UIAttr(IsColor = true), Preserve]
+        public string Color
+        {
+            set => _raw.color = UI.Theme.Resolve(value);
         }
     }
 }

--- a/Runtime/Controls/RawImage.cs
+++ b/Runtime/Controls/RawImage.cs
@@ -139,5 +139,12 @@ namespace PromptUGUI.Controls
                     _rectMask.padding = MaskPaddingParser.Parse(value);
             }
         }
+
+        public override Vector2? GetNativeSize()
+        {
+            if (_raw == null || _raw.texture == null) return null;
+            // RawImage 无 pixelsPerUnit；texture 像素 1:1 映射 UI 单位（同 RawImage.SetNativeSize）。
+            return new Vector2(_raw.texture.width, _raw.texture.height);
+        }
     }
 }

--- a/Runtime/Controls/RawImage.cs
+++ b/Runtime/Controls/RawImage.cs
@@ -1,6 +1,7 @@
 using PromptUGUI.Application;
 using PromptUGUI.Registry;
 using UnityEngine;
+using UnityEngine.UI;
 using UnityRawImage = UnityEngine.UI.RawImage;
 
 namespace PromptUGUI.Controls
@@ -22,13 +23,56 @@ namespace PromptUGUI.Controls
         public UnityEngine.Texture Texture
         {
             get => _raw.texture;
-            set => _raw.texture = value;
+            set { _raw.texture = value; RecomputeAspect(); }
         }
 
         [UIAttr(IsColor = true), Preserve]
         public string Color
         {
             set => _raw.color = UI.Theme.Resolve(value);
+        }
+
+        private AspectRatioFitter _fitter;
+
+        private AspectRatioFitter EnsureFitter()
+            => _fitter ??= GameObject.AddComponent<AspectRatioFitter>();
+
+        // contain/cover 下按当前 texture 宽高刷新 ARF 比例；无 fitter / 无 texture 时 no-op。
+        private void RecomputeAspect()
+        {
+            if (_fitter != null && _fitter.enabled
+                && _raw.texture != null && _raw.texture.height > 0)
+                _fitter.aspectRatio = (float)_raw.texture.width / _raw.texture.height;
+        }
+
+        [UIAttr, Preserve]
+        public string Type
+        {
+            set
+            {
+                switch (value)
+                {
+                    case "contain":
+                    case "cover":
+                        var f = EnsureFitter();
+                        f.enabled = true;
+                        f.aspectMode = value == "cover"
+                            ? AspectRatioFitter.AspectMode.EnvelopeParent
+                            : AspectRatioFitter.AspectMode.FitInParent;
+                        RecomputeAspect();   // texture 已设（ReSolve 路径）则即时重算
+                        break;
+                    case null:
+                    case "":
+                        if (_fitter != null) _fitter.enabled = false;
+                        break;
+                    default:
+                        Debug.LogWarning(
+                            $"PromptUGUI: <RawImage type=\"{value}\"> only supports 'contain' / 'cover' " +
+                            "(simple/sliced/tiled/filled are sprite-only <Image> modes); ignoring.");
+                        if (_fitter != null) _fitter.enabled = false;
+                        break;
+                }
+            }
         }
     }
 }

--- a/Runtime/Controls/RawImage.cs
+++ b/Runtime/Controls/RawImage.cs
@@ -1,5 +1,6 @@
 using PromptUGUI.Application;
 using PromptUGUI.Controls.Internal;
+using PromptUGUI.Layout;
 using PromptUGUI.Registry;
 using UnityEngine;
 using UnityEngine.UI;
@@ -10,6 +11,10 @@ namespace PromptUGUI.Controls
     public sealed class RawImage : Control
     {
         private UnityRawImage _raw;
+        private RectMask2D _rectMask;
+        private Mask _stencilMask;
+        private string _pendingMaskPadding;
+        private bool? _pendingShowMask;
 
         public override void OnAttached()
         {
@@ -79,6 +84,49 @@ namespace PromptUGUI.Controls
                         if (_fitter != null) _fitter.enabled = false;
                         break;
                 }
+            }
+        }
+
+        [UIAttr, Preserve]
+        public string Mask
+        {
+            set
+            {
+                if (value == "rect")
+                {
+                    _rectMask ??= GameObject.AddComponent<RectMask2D>();
+                    if (!string.IsNullOrEmpty(_pendingMaskPadding))
+                        _rectMask.padding = MaskPaddingParser.Parse(_pendingMaskPadding);
+                }
+                else if (value == "self")
+                {
+                    _stencilMask ??= GameObject.AddComponent<Mask>();
+                    if (_pendingShowMask.HasValue)
+                        _stencilMask.showMaskGraphic = _pendingShowMask.Value;
+                }
+            }
+        }
+
+        [UIAttr, Preserve]
+        public string ShowMask
+        {
+            set
+            {
+                if (string.IsNullOrEmpty(value)) return;
+                _pendingShowMask = bool.Parse(value);
+                if (_stencilMask != null)
+                    _stencilMask.showMaskGraphic = _pendingShowMask.Value;
+            }
+        }
+
+        [UIAttr, Preserve]
+        public string MaskPadding
+        {
+            set
+            {
+                _pendingMaskPadding = value;
+                if (_rectMask != null)
+                    _rectMask.padding = MaskPaddingParser.Parse(value);
             }
         }
     }

--- a/Runtime/Controls/RawImage.cs
+++ b/Runtime/Controls/RawImage.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+using UnityRawImage = UnityEngine.UI.RawImage;
+
+namespace PromptUGUI.Controls
+{
+    public sealed class RawImage : Control
+    {
+        private UnityRawImage _raw;
+
+        public override void OnAttached()
+        {
+            _raw = GameObject.GetComponent<UnityRawImage>()
+                   ?? GameObject.AddComponent<UnityRawImage>();
+        }
+
+        /// <summary>
+        /// 显示的 texture。由 C# 设置（下载图 / RenderTexture 等），无对应 XML 属性。
+        /// 赋值时若已进入 contain/cover 适配模式会重算纵横比（Task 3 接上）。
+        /// </summary>
+        public UnityEngine.Texture Texture
+        {
+            get => _raw.texture;
+            set => _raw.texture = value;
+        }
+    }
+}

--- a/Runtime/Controls/RawImage.cs.meta
+++ b/Runtime/Controls/RawImage.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e654c635866cc6e42b0a060d1b851db0

--- a/Runtime/Core/Lint/BuiltinTags.cs
+++ b/Runtime/Core/Lint/BuiltinTags.cs
@@ -20,7 +20,7 @@ namespace PromptUGUI.Lint
         internal static readonly HashSet<string> All = new()
         {
             "Frame", "SafeArea", "Trigger", "Show", "Animation",
-            "Image", "Icon", "Text", "VStack", "HStack", "Grid",
+            "Image", "RawImage", "Icon", "Text", "VStack", "HStack", "Grid",
             "Btn", "Toggle", "Tab", "TabBar", "Slider", "Progress",
             "Dropdown", "ScrollList", "InputField", "Carousel",
         };

--- a/Tests/EditMode/Controls/RawImageMaskTests.cs
+++ b/Tests/EditMode/Controls/RawImageMaskTests.cs
@@ -1,0 +1,60 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using UnityEngine;
+using UnityEngine.UI;
+using PromptUGUIRawImage = PromptUGUI.Controls.RawImage;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class RawImageMaskTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static PromptUGUIRawImage Build(string attrs)
+        {
+            UI.LoadDocument("t",
+                "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>" +
+                $"<Screen name='S'><RawImage id='r' {attrs}/></Screen></PromptUGUI>");
+            return UI.Open("S").Get<PromptUGUIRawImage>("r");
+        }
+
+        [Test]
+        public void NoMaskAttr_NoMaskComponents()
+        {
+            var r = Build("");
+            Assert.IsNull(r.GameObject.GetComponent<RectMask2D>());
+            Assert.IsNull(r.GameObject.GetComponent<Mask>());
+        }
+
+        [Test]
+        public void MaskRect_AddsRectMask2D()
+        {
+            var r = Build("mask='rect'");
+            Assert.IsNotNull(r.GameObject.GetComponent<RectMask2D>());
+            Assert.IsNull(r.GameObject.GetComponent<Mask>());
+        }
+
+        [Test]
+        public void MaskRectWithPadding_AppliesPadding()
+        {
+            var rm = Build("mask='rect' maskPadding='1,2,3,4'").GameObject.GetComponent<RectMask2D>();
+            Assert.AreEqual(new Vector4(4f, 3f, 2f, 1f), rm.padding);
+        }
+
+        [Test]
+        public void MaskSelf_AddsStencilMask()
+        {
+            var r = Build("mask='self'");
+            Assert.IsNotNull(r.GameObject.GetComponent<Mask>());
+            Assert.IsNull(r.GameObject.GetComponent<RectMask2D>());
+        }
+
+        [Test]
+        public void MaskSelf_ShowMaskFalse_HidesGraphic()
+        {
+            var m = Build("mask='self' showMask='false'").GameObject.GetComponent<Mask>();
+            Assert.IsFalse(m.showMaskGraphic);
+        }
+    }
+}

--- a/Tests/EditMode/Controls/RawImageMaskTests.cs.meta
+++ b/Tests/EditMode/Controls/RawImageMaskTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 256b1507c6b924140bb5c248c38797e1

--- a/Tests/EditMode/Controls/RawImageTests.cs
+++ b/Tests/EditMode/Controls/RawImageTests.cs
@@ -6,8 +6,8 @@ using R3;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.UI;
-using UnityRawImage = UnityEngine.UI.RawImage;
 using PromptUGUIRawImage = PromptUGUI.Controls.RawImage;
+using UnityRawImage = UnityEngine.UI.RawImage;
 
 namespace PromptUGUI.Tests.EditMode.Controls
 {

--- a/Tests/EditMode/Controls/RawImageTests.cs
+++ b/Tests/EditMode/Controls/RawImageTests.cs
@@ -1,0 +1,39 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using UnityEngine;
+using UnityRawImage = UnityEngine.UI.RawImage;
+using PromptUGUIRawImage = PromptUGUI.Controls.RawImage;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class RawImageTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static PromptUGUIRawImage Build(string attrs = "")
+        {
+            UI.LoadDocument("t",
+                "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>" +
+                $"<Screen name='S'><RawImage id='r' {attrs}/></Screen></PromptUGUI>");
+            return UI.Open("S").Get<PromptUGUIRawImage>("r");
+        }
+
+        [Test]
+        public void Instantiates_With_UnityRawImage_Component()
+        {
+            var r = Build();
+            Assert.IsNotNull(r.GameObject.GetComponent<UnityRawImage>());
+        }
+
+        [Test]
+        public void Texture_Get_Set_Roundtrips()
+        {
+            var r = Build();
+            var tex = new Texture2D(8, 8);
+            r.Texture = tex;
+            Assert.AreSame(tex, r.Texture);
+            Assert.AreSame(tex, r.GameObject.GetComponent<UnityRawImage>().texture);
+        }
+    }
+}

--- a/Tests/EditMode/Controls/RawImageTests.cs
+++ b/Tests/EditMode/Controls/RawImageTests.cs
@@ -1,6 +1,8 @@
 using System.Text.RegularExpressions;
 using NUnit.Framework;
 using PromptUGUI.Application;
+using PromptUGUI.Controls.Internal;
+using R3;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.UI;
@@ -103,6 +105,15 @@ namespace PromptUGUI.Tests.EditMode.Controls
         {
             var raw = Build("tint='multiply'").GameObject.GetComponent<UnityRawImage>();
             Assert.AreEqual(raw.defaultMaterial, raw.material);
+        }
+
+        [Test]
+        public void OnPointerEnter_Subscription_AttachesRelay()
+        {
+            var r = Build();
+            Assert.IsNull(r.GameObject.GetComponent<PointerEventRelay>());
+            using var _ = r.OnPointerEnter.Subscribe(__ => { });
+            Assert.IsNotNull(r.GameObject.GetComponent<PointerEventRelay>());
         }
     }
 }

--- a/Tests/EditMode/Controls/RawImageTests.cs
+++ b/Tests/EditMode/Controls/RawImageTests.cs
@@ -1,6 +1,9 @@
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using PromptUGUI.Application;
 using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
 using UnityRawImage = UnityEngine.UI.RawImage;
 using PromptUGUIRawImage = PromptUGUI.Controls.RawImage;
 
@@ -41,6 +44,51 @@ namespace PromptUGUI.Tests.EditMode.Controls
         {
             var r = Build("color='#ff0000'");
             Assert.AreEqual(Color.red, r.GameObject.GetComponent<UnityRawImage>().color);
+        }
+
+        [Test]
+        public void TypeContain_AddsFitter_FitInParent()
+        {
+            var r = Build("type='contain'");
+            var arf = r.GameObject.GetComponent<AspectRatioFitter>();
+            Assert.IsNotNull(arf);
+            Assert.IsTrue(arf.enabled);
+            Assert.AreEqual(AspectRatioFitter.AspectMode.FitInParent, arf.aspectMode);
+        }
+
+        [Test]
+        public void TypeCover_AddsFitter_EnvelopeParent()
+        {
+            var r = Build("type='cover'");
+            var arf = r.GameObject.GetComponent<AspectRatioFitter>();
+            Assert.IsNotNull(arf);
+            Assert.IsTrue(arf.enabled);
+            Assert.AreEqual(AspectRatioFitter.AspectMode.EnvelopeParent, arf.aspectMode);
+        }
+
+        [Test]
+        public void Texture_With_FitMode_ComputesAspectRatio()
+        {
+            var r = Build("type='cover'");
+            var arf = r.GameObject.GetComponent<AspectRatioFitter>();
+            r.Texture = new Texture2D(4, 2);
+            Assert.AreEqual(2f, arf.aspectRatio, 0.001f);
+            r.Texture = new Texture2D(2, 4);
+            Assert.AreEqual(0.5f, arf.aspectRatio, 0.001f);
+        }
+
+        [Test]
+        public void NoType_NoFitter()
+        {
+            Assert.IsNull(Build().GameObject.GetComponent<AspectRatioFitter>());
+        }
+
+        [Test]
+        public void TypeSimple_Warns_NoFitter()
+        {
+            LogAssert.Expect(LogType.Warning, new Regex("type"));
+            var r = Build("type='simple'");
+            Assert.IsNull(r.GameObject.GetComponent<AspectRatioFitter>());
         }
     }
 }

--- a/Tests/EditMode/Controls/RawImageTests.cs
+++ b/Tests/EditMode/Controls/RawImageTests.cs
@@ -115,5 +115,19 @@ namespace PromptUGUI.Tests.EditMode.Controls
             using var _ = r.OnPointerEnter.Subscribe(__ => { });
             Assert.IsNotNull(r.GameObject.GetComponent<PointerEventRelay>());
         }
+
+        [Test]
+        public void GetNativeSize_NullWhenNoTexture()
+        {
+            Assert.IsFalse(Build().GetNativeSize().HasValue);
+        }
+
+        [Test]
+        public void GetNativeSize_ReturnsTextureDimensions()
+        {
+            var r = Build();
+            r.Texture = new Texture2D(120, 60);
+            Assert.AreEqual(new Vector2(120f, 60f), r.GetNativeSize().Value);
+        }
     }
 }

--- a/Tests/EditMode/Controls/RawImageTests.cs
+++ b/Tests/EditMode/Controls/RawImageTests.cs
@@ -35,5 +35,12 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.AreSame(tex, r.Texture);
             Assert.AreSame(tex, r.GameObject.GetComponent<UnityRawImage>().texture);
         }
+
+        [Test]
+        public void Color_Applies_To_RawImage()
+        {
+            var r = Build("color='#ff0000'");
+            Assert.AreEqual(Color.red, r.GameObject.GetComponent<UnityRawImage>().color);
+        }
     }
 }

--- a/Tests/EditMode/Controls/RawImageTests.cs
+++ b/Tests/EditMode/Controls/RawImageTests.cs
@@ -90,5 +90,19 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var r = Build("type='simple'");
             Assert.IsNull(r.GameObject.GetComponent<AspectRatioFitter>());
         }
+
+        [Test]
+        public void TintLinear_UsesLinearLightTintMaterial()
+        {
+            var raw = Build("tint='linear'").GameObject.GetComponent<UnityRawImage>();
+            Assert.AreEqual("UI/LinearLightTint", raw.material.shader.name);
+        }
+
+        [Test]
+        public void TintMultiply_UsesDefaultMaterial()
+        {
+            var raw = Build("tint='multiply'").GameObject.GetComponent<UnityRawImage>();
+            Assert.AreEqual(raw.defaultMaterial, raw.material);
+        }
     }
 }

--- a/Tests/EditMode/Controls/RawImageTests.cs.meta
+++ b/Tests/EditMode/Controls/RawImageTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3e5901ddfb2d53842afd3ce4e3bd5ebe

--- a/Tests/EditMode/Editor/XsdGeneratorTests.cs
+++ b/Tests/EditMode/Editor/XsdGeneratorTests.cs
@@ -32,6 +32,18 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
+        public void RawImage_element_appears_with_reflected_attrs()
+        {
+            // RawImage isn't a hardcoded primitive — it flows through the reflected
+            // `customs` path, so its element + [UIAttr] attrs appear automatically.
+            var r = new ControlRegistry();
+            r.Register<RawImage>("RawImage", null);
+            var xsd = XsdGenerator.Generate(r);
+            StringAssert.Contains("name=\"RawImage\"", xsd);   // element emitted
+            StringAssert.Contains("name=\"showMask\"", xsd);   // [UIAttr] reflected (camelCase ShowMask)
+        }
+
+        [Test]
         public void Generate_to_file_produces_readable_file()
         {
             var r = new ControlRegistry();

--- a/docs~/superpowers/plans/2026-06-06-raw-image.md
+++ b/docs~/superpowers/plans/2026-06-06-raw-image.md
@@ -1,0 +1,877 @@
+# `<RawImage>` 控件实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增 `<RawImage>` 控件——底层 `UnityEngine.UI.RawImage`，由 C# 端 `Texture` 属性推送运行时动态加载的 texture（头像 / 下载图 / RenderTexture），不走 sprite/SpriteSet；外观能力镜像 `<Image>`（color / tint / type=contain·cover / mask / pointer / native-size）。
+
+**Architecture:** 仿 `Runtime/Controls/Image.cs` 写一个 `sealed class RawImage : Control`。图源是非 `[UIAttr]` 的纯 C# 属性 `Texture`；`type=contain|cover` 复用 `AspectRatioFitter`（相对父级），比例在 `Texture` setter / `Type` setter 里按 `texture.width/height` 重算（texture 是 Open 后才到的，比 Image 在 `OnAfterApply` 算更靠后）。`tint` 复用内部 `ImageTint`，需把其形参从 `UnityEngine.UI.Image` 放宽到 `Graphic`（实现只碰 `.material`，现有调用方零改动）。
+
+**Tech Stack:** Unity 6 uGUI（`RawImage` / `AspectRatioFitter` / `RectMask2D` / `Mask`）、R3（`Observable<Unit>` pointer 事件）、NUnit EditMode 测试、Unity MCP 跑测试。
+
+**约定（所有任务通用）：**
+- 每次改完源码，先 `mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)`，再 `mcp__UnityMCP__read_console(action="get", types=["error"])` 确认无编译错误，最后才 `run_tests`。
+- MCP 工具是 deferred，先 `ToolSearch(query="select:refresh_unity,run_tests,read_console", max_results=3)` 载入 schema。
+- 单类过滤：`run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RawImageTests")`。
+- 运行期 `Debug.LogWarning` 用**英文**（与 `ImageTint` 一致）；代码注释可中文。
+- 不在 main 提交；当前分支 `feat/raw-image`。
+
+---
+
+### Task 1: 控件骨架 + 注册 + `Texture` get/set
+
+**Files:**
+- Create: `Runtime/Controls/RawImage.cs`
+- Modify: `Runtime/Application/BuiltinPrimitives.cs:15`（在 `Image` 行后加一行）
+- Create: `Tests/EditMode/Controls/RawImageTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+`Tests/EditMode/Controls/RawImageTests.cs`：
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application;
+using UnityEngine;
+using UnityRawImage = UnityEngine.UI.RawImage;
+using PromptUGUIRawImage = PromptUGUI.Controls.RawImage;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class RawImageTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static PromptUGUIRawImage Build(string attrs = "")
+        {
+            UI.LoadDocument("t",
+                "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>" +
+                $"<Screen name='S'><RawImage id='r' {attrs}/></Screen></PromptUGUI>");
+            return UI.Open("S").Get<PromptUGUIRawImage>("r");
+        }
+
+        [Test]
+        public void Instantiates_With_UnityRawImage_Component()
+        {
+            var r = Build();
+            Assert.IsNotNull(r.GameObject.GetComponent<UnityRawImage>());
+        }
+
+        [Test]
+        public void Texture_Get_Set_Roundtrips()
+        {
+            var r = Build();
+            var tex = new Texture2D(8, 8);
+            r.Texture = tex;
+            Assert.AreSame(tex, r.Texture);
+            Assert.AreSame(tex, r.GameObject.GetComponent<UnityRawImage>().texture);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认红**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: 编译错误 `The type or namespace name 'RawImage' does not exist in namespace 'PromptUGUI.Controls'`（红：类型未定义）。
+
+- [ ] **Step 3: 写最小实现**
+
+`Runtime/Controls/RawImage.cs`：
+
+```csharp
+using UnityEngine;
+using UnityRawImage = UnityEngine.UI.RawImage;
+
+namespace PromptUGUI.Controls
+{
+    public sealed class RawImage : Control
+    {
+        private UnityRawImage _raw;
+
+        public override void OnAttached()
+        {
+            _raw = GameObject.GetComponent<UnityRawImage>()
+                   ?? GameObject.AddComponent<UnityRawImage>();
+        }
+
+        /// <summary>
+        /// 显示的 texture。由 C# 设置（下载图 / RenderTexture 等），无对应 XML 属性。
+        /// 赋值时若已进入 contain/cover 适配模式会重算纵横比（Task 3 接上）。
+        /// </summary>
+        public UnityEngine.Texture Texture
+        {
+            get => _raw.texture;
+            set => _raw.texture = value;
+        }
+    }
+}
+```
+
+`Runtime/Application/BuiltinPrimitives.cs` 在 `reg.Register<Image>("Image", null);` 之后加一行：
+
+```csharp
+            reg.Register<RawImage>("RawImage", null);
+```
+
+- [ ] **Step 4: 跑测试确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RawImageTests")
+```
+Expected: 2 passed。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Controls/RawImage.cs Runtime/Controls/RawImage.cs.meta \
+        Runtime/Application/BuiltinPrimitives.cs \
+        Tests/EditMode/Controls/RawImageTests.cs Tests/EditMode/Controls/RawImageTests.cs.meta
+git commit -m "feat(rawimage): <RawImage> 骨架 + 注册 + C# Texture get/set"
+```
+> `.meta` 文件由 Unity refresh 生成；若尚未生成则先 refresh 再 `git add`。
+
+---
+
+### Task 2: `color` 属性
+
+**Files:**
+- Modify: `Runtime/Controls/RawImage.cs`
+- Modify: `Tests/EditMode/Controls/RawImageTests.cs`
+
+- [ ] **Step 1: 写失败测试**（加到 `RawImageTests`）
+
+```csharp
+        [Test]
+        public void Color_Applies_To_RawImage()
+        {
+            var r = Build("color='#ff0000'");
+            Assert.AreEqual(Color.red, r.GameObject.GetComponent<UnityRawImage>().color);
+        }
+```
+
+- [ ] **Step 2: 跑测试确认红**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RawImageTests")
+```
+Expected: `Color_Applies_To_RawImage` FAIL（无 `Color` setter，`color` 属性被忽略 → 仍是默认白色，`Color.white != Color.red`）。
+
+- [ ] **Step 3: 写实现**
+
+`RawImage.cs` 顶部加 `using`：
+
+```csharp
+using PromptUGUI.Application;
+using PromptUGUI.Registry;
+```
+
+在 `Texture` 属性后加：
+
+```csharp
+        [UIAttr(IsColor = true), Preserve]
+        public string Color
+        {
+            set => _raw.color = UI.Theme.Resolve(value);
+        }
+```
+
+- [ ] **Step 4: 跑测试确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RawImageTests")
+```
+Expected: 3 passed。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Controls/RawImage.cs Tests/EditMode/Controls/RawImageTests.cs
+git commit -m "feat(rawimage): color 乘色属性"
+```
+
+---
+
+### Task 3: `type=contain|cover` 等比适配 + 比例重算
+
+**Files:**
+- Modify: `Runtime/Controls/RawImage.cs`
+- Modify: `Tests/EditMode/Controls/RawImageTests.cs`
+
+- [ ] **Step 1: 写失败测试**（加到 `RawImageTests`；文件顶部补 `using System.Text.RegularExpressions;`、`using UnityEngine.TestTools;` 和 `using UnityEngine.UI;`）
+
+```csharp
+        [Test]
+        public void TypeContain_AddsFitter_FitInParent()
+        {
+            var r = Build("type='contain'");
+            var arf = r.GameObject.GetComponent<AspectRatioFitter>();
+            Assert.IsNotNull(arf);
+            Assert.IsTrue(arf.enabled);
+            Assert.AreEqual(AspectRatioFitter.AspectMode.FitInParent, arf.aspectMode);
+        }
+
+        [Test]
+        public void TypeCover_AddsFitter_EnvelopeParent()
+        {
+            var r = Build("type='cover'");
+            var arf = r.GameObject.GetComponent<AspectRatioFitter>();
+            Assert.IsNotNull(arf);
+            Assert.IsTrue(arf.enabled);
+            Assert.AreEqual(AspectRatioFitter.AspectMode.EnvelopeParent, arf.aspectMode);
+        }
+
+        [Test]
+        public void Texture_With_FitMode_ComputesAspectRatio()
+        {
+            var r = Build("type='cover'");
+            var arf = r.GameObject.GetComponent<AspectRatioFitter>();
+            r.Texture = new Texture2D(4, 2);
+            Assert.AreEqual(2f, arf.aspectRatio, 0.001f);
+            r.Texture = new Texture2D(2, 4);
+            Assert.AreEqual(0.5f, arf.aspectRatio, 0.001f);
+        }
+
+        [Test]
+        public void NoType_NoFitter()
+        {
+            Assert.IsNull(Build().GameObject.GetComponent<AspectRatioFitter>());
+        }
+
+        [Test]
+        public void TypeSimple_Warns_NoFitter()
+        {
+            LogAssert.Expect(LogType.Warning, new Regex("type"));
+            var r = Build("type='simple'");
+            Assert.IsNull(r.GameObject.GetComponent<AspectRatioFitter>());
+        }
+```
+
+- [ ] **Step 2: 跑测试确认红**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RawImageTests")
+```
+Expected: 5 个新测试 FAIL（无 `Type` setter / 无 fitter / 无 warning）。
+
+- [ ] **Step 3: 写实现**
+
+`RawImage.cs` 顶部加 `using UnityEngine.UI;`（取 `AspectRatioFitter`；本文件类名 `RawImage` 会遮蔽 `UnityEngine.UI.RawImage`，与 `Image.cs` 同款写法，编译正常）。
+
+加字段 + helper（放在 `Color` 之后）：
+
+```csharp
+        private AspectRatioFitter _fitter;
+
+        private AspectRatioFitter EnsureFitter()
+            => _fitter ??= GameObject.AddComponent<AspectRatioFitter>();
+
+        // contain/cover 下按当前 texture 宽高刷新 ARF 比例；无 fitter / 无 texture 时 no-op。
+        private void RecomputeAspect()
+        {
+            if (_fitter != null && _fitter.enabled
+                && _raw.texture != null && _raw.texture.height > 0)
+                _fitter.aspectRatio = (float)_raw.texture.width / _raw.texture.height;
+        }
+
+        [UIAttr, Preserve]
+        public string Type
+        {
+            set
+            {
+                switch (value)
+                {
+                    case "contain":
+                    case "cover":
+                        var f = EnsureFitter();
+                        f.enabled = true;
+                        f.aspectMode = value == "cover"
+                            ? AspectRatioFitter.AspectMode.EnvelopeParent
+                            : AspectRatioFitter.AspectMode.FitInParent;
+                        RecomputeAspect();   // texture 已设（ReSolve 路径）则即时重算
+                        break;
+                    case null:
+                    case "":
+                        if (_fitter != null) _fitter.enabled = false;
+                        break;
+                    default:
+                        Debug.LogWarning(
+                            $"PromptUGUI: <RawImage type=\"{value}\"> only supports 'contain' / 'cover' " +
+                            "(simple/sliced/tiled/filled are sprite-only <Image> modes); ignoring.");
+                        if (_fitter != null) _fitter.enabled = false;
+                        break;
+                }
+            }
+        }
+```
+
+修改 `Texture` setter，赋值后重算：
+
+```csharp
+        public UnityEngine.Texture Texture
+        {
+            get => _raw.texture;
+            set { _raw.texture = value; RecomputeAspect(); }
+        }
+```
+
+- [ ] **Step 4: 跑测试确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RawImageTests")
+```
+Expected: 8 passed。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Controls/RawImage.cs Tests/EditMode/Controls/RawImageTests.cs
+git commit -m "feat(rawimage): type=contain|cover 等比适配 + texture 换图重算比例"
+```
+
+---
+
+### Task 4: `tint` + 把 `ImageTint.Apply` 放宽到 `Graphic`
+
+**Files:**
+- Modify: `Runtime/Controls/Internal/ImageTint.cs:1-30`
+- Modify: `Runtime/Controls/RawImage.cs`
+- Modify: `Tests/EditMode/Controls/RawImageTests.cs`
+
+- [ ] **Step 1: 写失败测试**（加到 `RawImageTests`）
+
+```csharp
+        [Test]
+        public void TintLinear_UsesLinearLightTintMaterial()
+        {
+            var raw = Build("tint='linear'").GameObject.GetComponent<UnityRawImage>();
+            Assert.AreEqual("UI/LinearLightTint", raw.material.shader.name);
+        }
+
+        [Test]
+        public void TintMultiply_UsesDefaultMaterial()
+        {
+            var raw = Build("tint='multiply'").GameObject.GetComponent<UnityRawImage>();
+            Assert.AreEqual(raw.defaultMaterial, raw.material);
+        }
+```
+
+- [ ] **Step 2: 跑测试确认红**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RawImageTests")
+```
+Expected: `TintLinear_*` FAIL（无 `Tint` setter，`tint` 被忽略 → material 是默认，shader 名不是 `UI/LinearLightTint`）。
+
+- [ ] **Step 3: 写实现**
+
+(a) `Runtime/Controls/Internal/ImageTint.cs`：把第 2 行 `using UnityImage = UnityEngine.UI.Image;` 改成 `using UnityEngine.UI;`，并把方法签名 `public static void Apply(UnityImage img, string mode)` 改成 `public static void Apply(Graphic img, string mode)`。方法体一字不动（只用到 `img.material`）。改完文件顶部为：
+
+```csharp
+using UnityEngine;
+using UnityEngine.UI;
+```
+
+`Image : Graphic`，现有 `Image`/`Btn`/`Progress`/`Tab` 调用方传 `Image` 实参隐式上转，零改动编译通过。
+
+(b) `RawImage.cs` 顶部加 `using PromptUGUI.Controls.Internal;`，在 `Color` setter 后加：
+
+```csharp
+        [UIAttr, Preserve]
+        public string Tint
+        {
+            set => ImageTint.Apply(_raw, value);
+        }
+```
+
+- [ ] **Step 4: 跑测试确认绿（含 tint 回归）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RawImageTests")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ImageTintTests")
+```
+Expected: RawImageTests 10 passed；ImageTintTests 全绿（`Image`/`Btn`/`Toggle`/`Tab`/`Progress` 的 tint 不受签名放宽影响 = 回归保护）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Controls/Internal/ImageTint.cs Runtime/Controls/RawImage.cs Tests/EditMode/Controls/RawImageTests.cs
+git commit -m "feat(rawimage): tint（放宽 ImageTint.Apply 到 Graphic 以复用）"
+```
+
+---
+
+### Task 5: `mask` / `showMask` / `maskPadding`
+
+**Files:**
+- Modify: `Runtime/Controls/RawImage.cs`
+- Create: `Tests/EditMode/Controls/RawImageMaskTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+`Tests/EditMode/Controls/RawImageMaskTests.cs`：
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application;
+using UnityEngine;
+using UnityEngine.UI;
+using PromptUGUIRawImage = PromptUGUI.Controls.RawImage;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class RawImageMaskTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static PromptUGUIRawImage Build(string attrs)
+        {
+            UI.LoadDocument("t",
+                "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>" +
+                $"<Screen name='S'><RawImage id='r' {attrs}/></Screen></PromptUGUI>");
+            return UI.Open("S").Get<PromptUGUIRawImage>("r");
+        }
+
+        [Test]
+        public void NoMaskAttr_NoMaskComponents()
+        {
+            var r = Build("");
+            Assert.IsNull(r.GameObject.GetComponent<RectMask2D>());
+            Assert.IsNull(r.GameObject.GetComponent<Mask>());
+        }
+
+        [Test]
+        public void MaskRect_AddsRectMask2D()
+        {
+            var r = Build("mask='rect'");
+            Assert.IsNotNull(r.GameObject.GetComponent<RectMask2D>());
+            Assert.IsNull(r.GameObject.GetComponent<Mask>());
+        }
+
+        [Test]
+        public void MaskRectWithPadding_AppliesPadding()
+        {
+            var rm = Build("mask='rect' maskPadding='1,2,3,4'").GameObject.GetComponent<RectMask2D>();
+            Assert.AreEqual(new Vector4(4f, 3f, 2f, 1f), rm.padding);
+        }
+
+        [Test]
+        public void MaskSelf_AddsStencilMask()
+        {
+            var r = Build("mask='self'");
+            Assert.IsNotNull(r.GameObject.GetComponent<Mask>());
+            Assert.IsNull(r.GameObject.GetComponent<RectMask2D>());
+        }
+
+        [Test]
+        public void MaskSelf_ShowMaskFalse_HidesGraphic()
+        {
+            var m = Build("mask='self' showMask='false'").GameObject.GetComponent<Mask>();
+            Assert.IsFalse(m.showMaskGraphic);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认红**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RawImageMaskTests")
+```
+Expected: `MaskRect_*` / `MaskSelf_*` / padding FAIL（无 mask setter）；`NoMaskAttr_*` 可能已绿。
+
+- [ ] **Step 3: 写实现**
+
+`RawImage.cs` 顶部加 `using PromptUGUI.Layout;`（取 `MaskPaddingParser`）。加字段（放在 `_fitter` 附近）：
+
+```csharp
+        private RectMask2D _rectMask;
+        private Mask _stencilMask;
+        private string _pendingMaskPadding;
+        private bool? _pendingShowMask;
+```
+
+加 setter（放在 `Tint` 之后，仿 `Image.cs:90-131`）：
+
+```csharp
+        [UIAttr, Preserve]
+        public string Mask
+        {
+            set
+            {
+                if (value == "rect")
+                {
+                    _rectMask ??= GameObject.AddComponent<RectMask2D>();
+                    if (!string.IsNullOrEmpty(_pendingMaskPadding))
+                        _rectMask.padding = MaskPaddingParser.Parse(_pendingMaskPadding);
+                }
+                else if (value == "self")
+                {
+                    _stencilMask ??= GameObject.AddComponent<Mask>();
+                    if (_pendingShowMask.HasValue)
+                        _stencilMask.showMaskGraphic = _pendingShowMask.Value;
+                }
+            }
+        }
+
+        [UIAttr, Preserve]
+        public string ShowMask
+        {
+            set
+            {
+                if (string.IsNullOrEmpty(value)) return;
+                _pendingShowMask = bool.Parse(value);
+                if (_stencilMask != null)
+                    _stencilMask.showMaskGraphic = _pendingShowMask.Value;
+            }
+        }
+
+        [UIAttr, Preserve]
+        public string MaskPadding
+        {
+            set
+            {
+                _pendingMaskPadding = value;
+                if (_rectMask != null)
+                    _rectMask.padding = MaskPaddingParser.Parse(value);
+            }
+        }
+```
+
+- [ ] **Step 4: 跑测试确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RawImageMaskTests")
+```
+Expected: 5 passed。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Controls/RawImage.cs \
+        Tests/EditMode/Controls/RawImageMaskTests.cs Tests/EditMode/Controls/RawImageMaskTests.cs.meta
+git commit -m "feat(rawimage): mask/showMask/maskPadding（同 Image）"
+```
+
+---
+
+### Task 6: pointer 事件（`IPointerEventSource`）
+
+**Files:**
+- Modify: `Runtime/Controls/RawImage.cs`
+- Modify: `Tests/EditMode/Controls/RawImageTests.cs`
+
+- [ ] **Step 1: 写失败测试**（加到 `RawImageTests`；文件顶部补 `using R3;` 和 `using PromptUGUI.Controls.Internal;`）
+
+```csharp
+        [Test]
+        public void OnPointerEnter_Subscription_AttachesRelay()
+        {
+            var r = Build();
+            Assert.IsNull(r.GameObject.GetComponent<PointerEventRelay>());
+            using var _ = r.OnPointerEnter.Subscribe(__ => { });
+            Assert.IsNotNull(r.GameObject.GetComponent<PointerEventRelay>());
+        }
+```
+
+- [ ] **Step 2: 跑测试确认红**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RawImageTests")
+```
+Expected: 编译错误（`RawImage` 无 `OnPointerEnter`）= 红。
+
+- [ ] **Step 3: 写实现**
+
+`RawImage.cs` 顶部加 `using R3;`。把类声明改成实现接口：
+
+```csharp
+    public sealed class RawImage : Control, IPointerEventSource
+```
+
+加字段 + 事件（仿 `Image.cs:15,29-37`，放在 `OnAttached` 之后）：
+
+```csharp
+        private PointerEventRelay _pointerRelay;
+
+        private PointerEventRelay EnsureRelay()
+            => _pointerRelay ??= GameObject.AddComponent<PointerEventRelay>();
+
+        public Observable<Unit> OnPointerEnter => EnsureRelay().OnPointerEnter;
+        public Observable<Unit> OnPointerExit => EnsureRelay().OnPointerExit;
+        public Observable<Unit> OnPointerDown => EnsureRelay().OnPointerDown;
+```
+
+- [ ] **Step 4: 跑测试确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RawImageTests")
+```
+Expected: 11 passed。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Controls/RawImage.cs Tests/EditMode/Controls/RawImageTests.cs
+git commit -m "feat(rawimage): IPointerEventSource（OnPointerEnter/Exit/Down，供 Trigger）"
+```
+
+---
+
+### Task 7: `GetNativeSize`（读 texture 像素尺寸）
+
+**Files:**
+- Modify: `Runtime/Controls/RawImage.cs`
+- Modify: `Tests/EditMode/Controls/RawImageTests.cs`
+
+- [ ] **Step 1: 写失败测试**（加到 `RawImageTests`）
+
+```csharp
+        [Test]
+        public void GetNativeSize_NullWhenNoTexture()
+        {
+            Assert.IsFalse(Build().GetNativeSize().HasValue);
+        }
+
+        [Test]
+        public void GetNativeSize_ReturnsTextureDimensions()
+        {
+            var r = Build();
+            r.Texture = new Texture2D(120, 60);
+            Assert.AreEqual(new Vector2(120f, 60f), r.GetNativeSize().Value);
+        }
+```
+
+- [ ] **Step 2: 跑测试确认红**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RawImageTests")
+```
+Expected: `GetNativeSize_ReturnsTextureDimensions` FAIL（基类默认 `GetNativeSize` 返回 `null` → `.Value` 抛 `InvalidOperationException`）。`GetNativeSize_NullWhenNoTexture` 已绿（基类默认 null）。
+
+- [ ] **Step 3: 写实现**（加到 `RawImage.cs`，放在 `Mask` 相关 setter 之后）
+
+```csharp
+        public override Vector2? GetNativeSize()
+        {
+            if (_raw == null || _raw.texture == null) return null;
+            // RawImage 无 pixelsPerUnit；texture 像素 1:1 映射 UI 单位（同 RawImage.SetNativeSize）。
+            return new Vector2(_raw.texture.width, _raw.texture.height);
+        }
+```
+
+- [ ] **Step 4: 跑测试确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RawImageTests")
+```
+Expected: 13 passed。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Controls/RawImage.cs Tests/EditMode/Controls/RawImageTests.cs
+git commit -m "feat(rawimage): GetNativeSize 读 texture 像素尺寸"
+```
+
+---
+
+### Task 8: XSD — 锁住 `<RawImage>` element（EditorOnly 测试）
+
+> `RawImage` 不在 `XsdGenerator` 硬编码 primitives（仅 `Frame/Image/Icon/Text/VStack/HStack/Grid/Btn`），走 `customs` 反射路径自动产出 element + `[UIAttr]` 属性，**无需改 `XsdGenerator.cs`**。本任务只加回归测试。
+
+**Files:**
+- Modify: `Tests/EditMode/Editor/XsdGeneratorTests.cs`
+
+- [ ] **Step 1: 写测试**（加到 `XsdGeneratorTests`，仿 `Custom_control_appears_with_UIAttr_attributes`）
+
+```csharp
+        [Test]
+        public void RawImage_element_appears_with_reflected_attrs()
+        {
+            var r = new ControlRegistry();
+            r.Register<PromptUGUI.Controls.RawImage>("RawImage", null);
+            var xsd = XsdGenerator.Generate(r);
+            StringAssert.Contains("name=\"RawImage\"", xsd);   // element 产出
+            StringAssert.Contains("name=\"showMask\"", xsd);   // [UIAttr] 反射（camelCase ShowMask）
+        }
+```
+
+- [ ] **Step 2: 跑测试确认绿**（实现已在 Task 1-7 完成；这是锁定行为的回归测试，直接绿）
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"], filter="XsdGeneratorTests")
+```
+Expected: 全绿（含新增 1 个）。若新测试意外失败，说明反射路径假设有误——回到 `XsdGenerator.cs` 排查，勿改测试将就。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add Tests/EditMode/Editor/XsdGeneratorTests.cs
+git commit -m "test(rawimage): 锁定 XSD 产出 <RawImage> element + 反射属性"
+```
+
+---
+
+### Task 9: 文档（XML SKILL + C# SKILL + 主 spec）
+
+> CLAUDE.md：任何功能新增必须在同 PR 反映到相关 SKILL（英文）。
+
+**Files:**
+- Modify: `.claude/skills/authoring-promptugui-xml/SKILL.md`
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md`
+- Modify: `docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md`
+
+- [ ] **Step 1: XML SKILL — 控件目录行**
+
+在内置控件目录表里 `| <Image> | uGUI Image：sprite + 等比适配 + mask |` 这一行**之后**插入：
+
+```markdown
+| `<RawImage>` | uGUI RawImage：C# 设 Texture（动态图）+ contain/cover 适配 + mask |
+```
+
+- [ ] **Step 2: XML SKILL — 新增 `### <RawImage>` 小节**
+
+紧跟 `### <Image>` 小节之后插入（英文）：
+
+```markdown
+### `<RawImage>`
+
+uGUI `RawImage`, renders an arbitrary runtime `Texture` (downloaded image / avatar / screenshot / `RenderTexture`). The image source is **set from C# only** — there is no `sprite` / SpriteSet and no XML image attribute: `screen.Get<RawImage>("id").Texture = tex;` (see the C# SKILL).
+
+| attr | values | default | notes |
+|---|---|---|---|
+| `color` | color ref | `#ffffff` | multiply tint; with no texture a RawImage still draws a solid `color` quad (write `color="#00000000"` to start invisible) |
+| `type` | `contain` / `cover` | — | aspect-fit relative to the **parent** rect (same as `<Image>`): `contain` letterboxes, `cover` fills + overflows; clip `cover` overflow with `mask="rect"` on the parent. **Only these two values** — `simple`/`sliced`/`tiled`/`filled` are sprite-only; writing them logs a warning and falls back to plain. In fit mode the RawImage's own `anchor`/`size`/`margin` are taken over by `AspectRatioFitter` |
+| `tint` | `multiply` / `linear` | `multiply` | blend material, same as `<Image>` |
+| `mask` / `showMask` / `maskPadding` | same as `<Image>` | — | `rect`=RectMask2D, `self`=stencil Mask |
+
+- The texture is assigned from C# after Open, so `size="native"` only has a value when a texture was assigned synchronously before instantiation; normally set an explicit `size` or use `type="contain"/"cover"`.
+- Don't use fit mode as a direct `<VStack>`/`<HStack>`/`<Grid>` child (AspectRatioFitter fights the LayoutGroup) — wrap in a `<Frame>`.
+```
+
+并在「实现映射」大表里 `<Image>` 行之后加一行（英文，仿 Image 行）：
+
+```markdown
+| `<RawImage>`   | `RawImage` + (lazy) `PointerEventRelay`; optional `AspectRatioFitter` (`type=contain/cover`) / `RectMask2D` / stencil `Mask` | — | `OnPointerEnter` / `OnPointerExit` / `OnPointerDown` ← Relay |
+```
+
+- [ ] **Step 3: C# SKILL — `RawImage.Texture` 用法**
+
+在控件 C# API 示例区追加（英文）：
+
+```markdown
+### `<RawImage>` — assigning a dynamic Texture
+
+`<RawImage>` displays a runtime-loaded `Texture` (not a sprite). Grab the control and assign `Texture`:
+
+```csharp
+var raw = screen.Get<RawImage>("avatar");
+raw.Texture = await LoadAvatarTextureAsync(userId);   // Texture2D or RenderTexture
+```
+
+`Texture` is a plain C# property (get/set), **not** an XML attribute — XML only declares position / `color` / `type=contain|cover` / `mask`. Re-assigning recomputes the `type=contain/cover` aspect ratio from the new texture.
+```
+
+- [ ] **Step 4: 主 spec — 控件目录行**
+
+在主 spec 里 `<Image>` 的目录/表格条目之后加一行（先 `grep -n "Image" docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md` 定位 Image 那行，按同格式插入）：
+
+```markdown
+| `<RawImage>` | uGUI RawImage；C# 设 `Texture`（动态加载图，非 sprite）+ `type=contain|cover` 等比适配 + mask；图源仅 C# |
+```
+
+- [ ] **Step 5: 跑 markdown 一致性自检 + 提交**
+
+确认三处文件无格式破损（表格列对齐、代码块闭合）。
+
+```bash
+git add .claude/skills/authoring-promptugui-xml/SKILL.md \
+        .claude/skills/scripting-promptugui-csharp/SKILL.md \
+        "docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md"
+git commit -m "docs(rawimage): XML/C# SKILL + 主 spec 增补 <RawImage>"
+```
+
+---
+
+### Task 10: 全量回归 + lint 收尾
+
+**Files:** 无新增（验证 + 视情况 lint 修复）
+
+- [ ] **Step 1: 全 EditMode + EditorOnly 套件**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+```
+Expected: 全绿（基线 EditMode 1342 / EditorOnly 175 之上新增本控件用例；无回归）。
+> PlayMode 不涉本控件行为（无逐帧逻辑），按 `project_unity_mcp_test_gotchas` 易 flaky，跳过；如需保险可单跑一次 `run_tests(mode="PlayMode", ...)` 确认与改动无关。
+
+- [ ] **Step 2: lint（C#）**
+
+```bash
+cd .lint && dotnet restore PromptUGUI.Lint.slnx
+dotnet format whitespace PromptUGUI.Lint.slnx
+dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+Expected: 无 diff、退出码 0。若 `RawImage.cs` 有空白/风格问题，`dotnet format whitespace` 会修；修后 `git add` + `git commit -m "style(rawimage): dotnet format"`。
+> 不要跑 `dotnet format analyzers --severity info`（CLAUDE.md 列的 fixer 会炸 Unity 编译）。
+
+- [ ] **Step 3: 确认无 .ui.xml 改动**
+
+本控件未新增/修改任何 `.ui.xml`，跳过 `UIXmlLint` CLI。（若实现期顺手加了示例 `.ui.xml`，则 `dotnet run --project .lint/UIXmlLint -- <file>` 并确保退出码 0。）
+
+- [ ] **Step 4: 最终核对**
+
+```bash
+git log --oneline feat/raw-image ^main
+git status
+```
+Expected: 干净工作树；提交序列覆盖 Task 1-9（+ 视情况 lint）。准备好后按 finishing-a-development-branch 走 PR。
+
+---
+
+## Self-Review
+
+**1. Spec coverage（对照设计文档逐节）：**
+- §2.1 tag + 注册 + 别名 → Task 1 ✅
+- §2.2 C# `Texture` get/set → Task 1（+ Task 3 接 RecomputeAspect）✅
+- §2.3 / §4 `type=contain|cover` + warn + 重算时序 → Task 3 ✅
+- §2.4 `color` → Task 2 ✅；`tint`（+ ImageTint 放宽）→ Task 4 ✅；`mask` 系列 → Task 5 ✅；pointer → Task 6 ✅
+- §5 ImageTint 放宽 Graphic → Task 4 ✅
+- §6 GetNativeSize → Task 7 ✅
+- §8 测试（控件行为 1-10 / tint 回归 / XSD）→ Task 1-8 ✅
+- §9 文档（XML/C# SKILL + 主 spec）→ Task 9 ✅
+- §7 非目标（uvRect / XML src / lint）→ 不实现，计划无对应任务（正确）✅
+
+**2. Placeholder 扫描：** 无 TBD/TODO；每个改码步骤都给了完整代码或精确 Edit 内容。✅
+
+**3. 类型/命名一致性：** `_raw`(`UnityRawImage`)、`_fitter`(`AspectRatioFitter`)、`RecomputeAspect()`、`EnsureFitter()`、`EnsureRelay()`、`_pointerRelay`、`_rectMask`/`_stencilMask`/`_pendingMaskPadding`/`_pendingShowMask`、`Texture`/`Color`/`Type`/`Tint`/`Mask`/`ShowMask`/`MaskPadding` —— 各任务用法一致；`ImageTint.Apply(Graphic, string)` 在 Task 4 定义并即用。✅

--- a/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
+++ b/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
@@ -146,6 +146,7 @@ Template 同名（含 commons 与各 Import 的任意组合）→ 报错；`as="
 |---|---|---|
 | `<Frame>` | 纯定位容器，无视觉；可选 `mask="rect"` 启用 RectMask2D | RectTransform（+ 可选 RectMask2D） |
 | `<Image>` | 图像 / 9-slice / 纯色块 | Image |
+| `<RawImage>` | 运行时动态 `Texture`（头像 / 下载图 / RenderTexture）；图源仅 C# `Texture` 属性，非 sprite；`type=contain\|cover` 等比适配 + mask（详见 [`2026-06-06-rawimage-control-design.md`](2026-06-06-rawimage-control-design.md)） | RawImage |
 | `<Text>` | 文本 | TMP_Text |
 | `<VStack>` | 纵向自动排布 | RectTransform + VerticalLayoutGroup |
 | `<HStack>` | 横向自动排布 | RectTransform + HorizontalLayoutGroup |

--- a/docs~/superpowers/specs/2026-06-06-rawimage-control-design.md
+++ b/docs~/superpowers/specs/2026-06-06-rawimage-control-design.md
@@ -1,0 +1,166 @@
+# `<RawImage>` 控件设计（C# 设置动态 Texture）
+
+- **日期**: 2026-06-06
+- **状态**: 设计已与用户敲定，待落 plan
+- **分支**: `feat/raw-image`
+- **关联**: 主 spec `2026-05-07-promptugui-description-language-design.md`（新增控件行）；复用 `2026-06-05-image-fit-cover-contain-design.md` 的 `AspectRatioFitter` 适配方案
+
+## 1. 背景与动机
+
+现有 `<Image>` 走 sprite / SpriteSet 通道（`UI.ResolveSprite`），面向作者预先准备好的静态资源。但有一类需求是**运行时动态加载的 `Texture`**——头像、下载的图片、截图、`RenderTexture` 等——由 C# 代码加载后直接赋到界面上，既不是 sprite 也不进 SpriteSet/atlas。
+
+uGUI 对此有专门组件 `UnityEngine.UI.RawImage`（直接渲染任意 `Texture`，不需要 `Sprite` 包装）。本设计新增 `<RawImage>` 控件，把它接入 PromptUGUI：XML 端声明位置与外观、C# 端用一个 `Texture` 属性把动态 texture 推进去。
+
+## 2. 设计决策（已敲定）
+
+1. **新增 tag `<RawImage>`**，`sealed class RawImage : Control, IPointerEventSource`，底层 `GetComponent/AddComponent<UnityEngine.UI.RawImage>`。在 `BuiltinPrimitives.Register` 注册 `reg.Register<RawImage>("RawImage", null);`。
+   - 控件类名 `PromptUGUI.Controls.RawImage` 与 Unity 类型 `UnityEngine.UI.RawImage` **重名**，控件文件内用别名 `using UnityRawImage = UnityEngine.UI.RawImage;`（仿 `Image.cs` 的 `using UnityImage = ...`）。`BuiltinPrimitives.cs` 不 import `UnityEngine.UI`，`RawImage` 在那里解析为控件类，无冲突。
+
+2. **Texture 一律 C# 设置，无 XML texture/src 属性**。控件暴露公开属性：
+   ```csharp
+   public UnityEngine.Texture Texture { get; set; }   // 非 [UIAttr]，纯 C# API
+   ```
+   用法：`screen.Get<RawImage>("preview").Texture = myTexture;`（`Texture2D` / `RenderTexture` 均可）。getter→`_raw.texture`；setter→赋值 `_raw.texture` 并触发 `RecomputeAspect()`（见 §4）。
+
+3. **沿用 `type=`，只支持 `contain` / `cover` 两个值**（与 `<Image>` 命名一致）。
+   - `contain` → `AspectRatioFitter`，`FitInParent`（等比塞进父框、留边）；
+   - `cover` → `AspectRatioFitter`，`EnvelopeParent`（等比撑满父框、溢出）；
+   - 框 = **直接父级 rect**；裁切由作者在父级 `mask="rect"` 负责（与 Image fit 完全一致的语义）。
+   - `simple` / `sliced` / `tiled` / `filled` 是 sprite 专有渲染模式，RawImage **不支持**。作者误写这些值时发一条 `Debug.LogWarning`（仿 `ImageTint` 对未知 `tint` 的处理）并回退普通模式（关掉 fitter），不静默吞掉。
+   - 空 / 不写 `type` → 普通模式（不创建/关闭 fitter），texture 直接按 rect 拉伸铺满（RawImage 默认 `uvRect=(0,0,1,1)`）。
+
+4. **镜像 `<Image>` 的外观 / 交互能力**（用户确认 parity 全留）：
+   - `color`（`IsColor`）→ `_raw.color` 乘色。
+   - `tint`（`multiply` / `linear`）→ 复用 `ImageTint`（需把其参数从 `UnityEngine.UI.Image` 放宽到 `Graphic`，见 §5）。
+   - `mask` / `showMask` / `maskPadding` → 与 Image 同（`RectMask2D` / stencil `Mask` + `MaskPaddingParser`）。
+   - `IPointerEventSource`（懒挂 `PointerEventRelay`）→ `OnPointerEnter/Exit/Down`，可作 `<Trigger>` 的 hover/press 源。
+   - `GetNativeSize()` → 读 texture 像素尺寸（见 §6）。
+
+## 3. uGUI 映射（属性表）
+
+| 属性          | 落到 uGUI                                | 备注                                                                 |
+| ------------- | ---------------------------------------- | -------------------------------------------------------------------- |
+| (C#) `Texture`| `_raw.texture`                           | 唯一图源；无 XML 对应                                                 |
+| `color`       | `_raw.color`                             | 乘色；无 texture 时 RawImage 仍按 color 画纯色 quad（uGUI null→白图） |
+| `type`        | `AspectRatioFitter`（仅 contain/cover）  | 见 §2.3；其余值 warn + 关 fitter                                     |
+| `tint`        | `_raw.material`（经 `ImageTint`）         | `multiply`→null 材质；`linear`→LinearLightTint                       |
+| `mask`        | `RectMask2D`（`rect`）/ `Mask`（`self`） | 与 Image 同                                                          |
+| `showMask`    | `Mask.showMaskGraphic`                   | 与 Image 同                                                          |
+| `maskPadding` | `RectMask2D.padding`                     | 与 Image 同                                                          |
+
+> `StateReact`（来自 `Control` 基类）自动可用，无需额外处理。
+
+## 4. `Texture` setter 与 `AspectRatioFitter` 重算时序
+
+Image 在 `OnAfterApply` 里按 `sprite.rect` 算 `aspectRatio`，因为 sprite 在属性循环里就到位了。RawImage 的 texture **是 Open 之后才由 C# 赋值**，属性循环跑完时 texture 还是 null。所以把重算下沉到一个共享方法，由 **`Texture` setter** 与 **`type` setter** 两处触发：
+
+```csharp
+private AspectRatioFitter _fitter;
+private AspectRatioFitter EnsureFitter() => _fitter ??= GameObject.AddComponent<AspectRatioFitter>();
+
+private void RecomputeAspect()
+{
+    if (_fitter != null && _fitter.enabled && _raw.texture != null && _raw.texture.height > 0)
+        _fitter.aspectRatio = (float)_raw.texture.width / _raw.texture.height;
+}
+
+public UnityEngine.Texture Texture
+{
+    get => _raw.texture;
+    set { _raw.texture = value; RecomputeAspect(); }
+}
+
+[UIAttr, Preserve]
+public string Type
+{
+    set
+    {
+        switch (value)
+        {
+            case "contain":
+            case "cover":
+                var f = EnsureFitter();
+                f.enabled = true;
+                f.aspectMode = value == "cover"
+                    ? AspectRatioFitter.AspectMode.EnvelopeParent
+                    : AspectRatioFitter.AspectMode.FitInParent;
+                RecomputeAspect();   // 若 texture 已由 C# 设过（ReSolve 路径）则即时重算
+                break;
+            case null:
+            case "":
+                if (_fitter != null) _fitter.enabled = false;
+                break;
+            default:
+                Debug.LogWarning($"PromptUGUI: <RawImage type=\"{value}\"> 仅支持 'contain' / 'cover'；" +
+                    "simple/sliced/tiled/filled 是 <Image> 的 sprite 专有模式，已忽略。");
+                if (_fitter != null) _fitter.enabled = false;
+                break;
+        }
+    }
+}
+```
+
+- **时序**：初次实例化时 texture 恒为 null（C# 只能在 Open 后 `Get<>` 拿到控件再赋值）→ `type` setter 里的 `RecomputeAspect` 是 no-op；真正的比例计算发生在之后 C# 赋 `Texture` 时。换图（再次赋 `Texture`）自动重算。
+- **不需要 override `OnAfterApply`**：两个 setter 已覆盖「初次 + 换图 + ReSolve 重应用 `type`」全部路径，比 Image 更精简。
+- **`AspectRatioFitter` 生命周期**：懒创建、靠 `enabled` 开关复用、绝不 `Destroy`（同 Image）。它是 `ILayoutSelfController`，父级 resize 自动重排。
+- **fit 模式下 RawImage 自身 `anchor`/`size`/`margin` 被 ARF 接管失效**（同 Image §2.4）：框由父级决定。
+
+## 5. `ImageTint` 参数放宽到 `Graphic`
+
+当前 `ImageTint.Apply(UnityEngine.UI.Image img, string mode)` 形参是 `Image`，但实现只读写 `img.material`（`Graphic` 成员）。把签名改为 `Apply(UnityEngine.UI.Graphic img, string mode)`：
+
+- 实现一字不改；
+- `Image : MaskableGraphic : Graphic`，现有调用方（`Image`/`Btn`/`Progress`/`Tab` 等）传 `Image` 实参隐式上转，**零改动编译通过**；
+- `RawImage : MaskableGraphic : Graphic`，可直接复用。
+- `ImageTint.cs` 顶部补 `using UnityEngine.UI;`（取 `Graphic`）。
+
+`internal` 类型，影响面受控。
+
+## 6. `GetNativeSize`
+
+```csharp
+public override Vector2? GetNativeSize()
+{
+    if (_raw == null || _raw.texture == null) return null;
+    return new Vector2(_raw.texture.width, _raw.texture.height);   // 像素 1:1，RawImage 无 PPU
+}
+```
+
+- RawImage 无 `pixelsPerUnit`（那是 sprite 概念），texture 像素直接 1:1 映射 UI 单位（对齐 `RawImage.SetNativeSize()`）。
+- **注意时序**：texture 是 Open 后才赋值，所以 `size="native"` 仅在「实例化前已同步赋 texture」的特殊场景才有值；常态请显式写 `size` 或用 `type="contain"/"cover"`。文档需提示。
+
+## 7. 边界 / 非目标（YAGNI）
+
+- **`uvRect`（子区域 / 平铺）**：RawImage 的特色能力，但非本次需求，v1 不暴露。
+- **XML 端从 Resources 加载 texture 的 `src`**：texture 一律 C# 设置，不引入 texture 资源解析通道。
+- **`type` 的 lint 规则**：Image 有 `PUI-IMAGE-FIT-VARIANT` / `PUI-IMAGE-FIT-GEOMETRY`。RawImage 的 `type=contain/cover` 同样不宜进变体、fit 下几何失效——但为收敛范围，v1 **暂不**为 RawImage 加这两条 lint，仅在 XML SKILL 文档提示。后续可作 parity follow-up（规则实现在 `Runtime/Core/Lint/`，到时按 tag 泛化）。
+- **LayoutGroup 直接子级**：fit 模式 RawImage 直接做 `<VStack>`/`<HStack>`/`<Grid>` 子级时 ARF 与 LayoutGroup 抢布局，行为未定义；仅文档提示「套一层 `<Frame>`」（同 Image）。
+- **`raycastTarget`**：保持 uGUI 默认 `true`（同 Image，无新属性暴露）。
+
+## 8. 测试（EditMode，TDD：先红后绿）
+
+控件行为（`PromptUGUI.Tests.EditMode`）：
+
+1. `<RawImage>` 实例化后 GameObject 上有 `UnityEngine.UI.RawImage`。
+2. `Texture` get/set：C# 赋值后 `_raw.texture` 等于所赋 texture，getter 取回同值。
+3. `color="#RRGGBB"` → `_raw.color` 应用。
+4. `tint="linear"` → `_raw.material` 为 LinearLightTint（非 null）；`tint="multiply"`/不写 → null。
+5. `type="contain"` → 有 `AspectRatioFitter`、`enabled`、`FitInParent`；`type="cover"` → `EnvelopeParent`。
+6. 赋 `Texture`（已知比例，如 4×2）后 `_fitter.aspectRatio == 2.0`；换一张（如 2×4）后重算为 0.5。
+7. `type="simple"`（或其它 sprite 模式）→ 不创建/关闭 fitter（行为退化为普通），且不抛异常。
+8. 不写 `type` → 无 `AspectRatioFitter`。
+9. `GetNativeSize()`：无 texture→null；赋 W×H texture→`(W, H)`。
+10. `mask="rect"` → 有 `RectMask2D`；`mask="self"` → 有 stencil `Mask`。
+
+回归（确保 `ImageTint` 放宽签名不破坏现有控件）：`<Image>` / `<Btn>` 的 `tint="linear"` 测试仍绿（现有测试覆盖即可，无需新增）。
+
+XSD（`PromptUGUI.Tests.EditorOnly`）：确认 `XsdGenerator` 自 registry 自动产出 `<RawImage>` element（新 tag 应自动出现）；若 EditorOnly 有「全 tag 枚举」类断言按需补 `StringAssert.Contains("RawImage")`。
+
+## 9. 文档更新（同 PR）
+
+- **主 spec** `2026-05-07-...-design.md`：控件目录加 `<RawImage>` 行（uGUI RawImage：C# 设 Texture + 等比适配 + mask）。
+- **XML SKILL** `.claude/skills/authoring-promptugui-xml/SKILL.md`（英文）：
+  - 内置控件目录加 `<RawImage>` 行；
+  - 新增 `<RawImage>` 小节：属性表（`color`/`type=contain|cover`/`tint`/`mask`…）、「texture 由 C# 设置、无 sprite」说明、`type` 仅 contain/cover + 父级框 + 作者负责裁切、native-size 时序提示、LayoutGroup 套 Frame 提示。
+- **C# SKILL** `.claude/skills/scripting-promptugui-csharp/SKILL.md`（英文）：加 `RawImage.Texture` get/set 用法（`screen.Get<RawImage>("id").Texture = tex;`）。
+- **Addressables SKILL**：无 `PROMPTUGUI_HAS_ADDRESSABLES` 相关变更，不动。


### PR DESCRIPTION
## Summary
- 新增 `<RawImage>` 控件：底层 `UnityEngine.UI.RawImage`，由 C# 端 `Texture` get/set 推送运行时动态加载的 texture（头像 / 下载图 / 截图 / `RenderTexture`），**不走 sprite/SpriteSet、无 XML 图源属性**：`screen.Get<RawImage>("id").Texture = tex;`
- `type=contain|cover` 等比适配（`AspectRatioFitter`，相对父级，同 `<Image>`）；比例在 `Texture` setter / `Type` setter 重算（解决 texture 在 Open 之后才到的时序）；`simple/sliced/tiled/filled` 等 sprite 专有值 warning 回退普通模式。
- 镜像 `<Image>`：`color` / `tint` / `mask`·`showMask`·`maskPadding` / `IPointerEventSource`（供 `<Trigger>`）/ `GetNativeSize`（texture 像素 1:1）。
- 复用内部 `ImageTint` → 把 `Apply` 形参从 `Image` 放宽到 `Graphic`（实现只碰 `.material`，现有 Image/Btn/Progress/Tab 调用方零改动）。
- 同步 `Runtime/Core/Lint/BuiltinTags.cs`（lint 注册表镜像）；文档同步 XML SKILL + C# SKILL + 主 spec。

设计 / 计划：`docs~/superpowers/specs/2026-06-06-rawimage-control-design.md`、`docs~/superpowers/plans/2026-06-06-raw-image.md`

## Test Plan
- [x] EditMode 全量 **1360/1360**（新增 RawImageTests ×13 + RawImageMaskTests ×5）
- [x] EditorOnly 全量 **176/176**（新增 XSD `<RawImage>` element + 反射属性回归）
- [x] tint 放宽 `ImageTint` 的回归保护：ImageTintTests（Image/Btn/Toggle/Tab/Progress）全绿
- [x] lint `dotnet format --verify-no-changes --severity warn` 退出 0
- [ ] 视觉 QA（用户）：动态 texture 显示 + contain/cover 适配（PC 宽屏 / 手机竖屏）

🤖 Generated with [Claude Code](https://claude.com/claude-code)