### PR TITLE
feat(text): <Text overflow="ellipsis|truncate"> 文字溢出收尾

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -152,12 +152,15 @@ TMP_Text。文本简写：`<Text>Hello</Text>` ≡ `<Text text="Hello"/>`。
 | `fontSize` | int | — | |
 | `color` | hex / CSS named / theme token | — | 见 **Color Tokens** |
 | `align` | TMP 对齐 | `left`+`middle` | 一个水平 token `left` / `center` / `right` / `justified` / `flush` / `geo`，和/或一个垂直 token `top` / `middle` / `bottom` / `baseline` / `midline` / `capline`，连字符或空格连接、顺序无关（`bottom-right` / `top-center` / `capline-flush`）；只给水平保持垂直 `middle`，只给垂直保持水平 `left`；未知 token = parse error |
-| `wrap` | bool | — | |
+| `wrap` | bool | `true` | `false`=不换行（NoWrap）；常配 `overflow="ellipsis"` 做单行省略号 |
+| `overflow` | `overflow` / `ellipsis` / `truncate` | `overflow` | 文字塞不下框后的收尾：`overflow`=溢出框外（TMP 默认）、`ellipsis`=尾部 `…`、`truncate`=硬裁切无 `…`；未知值 = parse error |
 | `raycastTarget` | bool | — | |
 | `font` | string | `default` | Settings 里的 font type |
 | `autosize` | bool | `false` | 开 TMP auto-size（仅 WD% 形式——字宽最多压 50%，字号不变） |
 | `tr` | bool | `true` | `false`=跳过 i18n 提取 |
 | `ctx` | string | — | msgctxt 消歧同 msgid |
+
+**`autosize` / `overflow` 是两层，会叠加（不是二选一）**：TMP 先用 `autosize`「努力塞进去」（压字宽），塞不下再由 `overflow` 决定怎么收尾。单行省略号的标准写法：`<Text wrap="false" overflow="ellipsis"/>`；想先压扁再省略：`<Text wrap="false" autosize="true" overflow="ellipsis"/>`。**坑**：`ellipsis` / `truncate` 只在文本框「定宽」时才触发——若这个 `<Text>` 靠 native-size 撑开（框跟着文字变宽，如 Frame 里不写 `width`、或挂了 ContentSizeFitter），就永远不溢出、省略号也不出现；用 `anchor="stretch"`+`margin` 或显式 `width` 把宽度钉死。
 
 ### `<VStack>`
 

--- a/Runtime/Controls/Text.cs
+++ b/Runtime/Controls/Text.cs
@@ -146,6 +146,28 @@ namespace PromptUGUI.Controls
             set => _tmp.textWrappingMode = value ? TextWrappingModes.Normal : TextWrappingModes.NoWrap;
         }
 
+        // What to do once auto-sizing (if any) has done its best and the text still doesn't fit the
+        // rect. Orthogonal to `wrap` and `autosize`. Omitting the attribute leaves TMP's default
+        // (Overflow) untouched, so existing UIs are unaffected.
+        [UIAttr, Preserve]
+        public string Overflow
+        {
+            set => _tmp.overflowMode = ParseOverflow(value);
+        }
+
+        internal static TextOverflowModes ParseOverflow(string value)
+        {
+            switch ((value ?? "").Trim().ToLowerInvariant())
+            {
+                case "overflow": return TextOverflowModes.Overflow;
+                case "ellipsis": return TextOverflowModes.Ellipsis;
+                case "truncate": return TextOverflowModes.Truncate;
+                default:
+                    throw new ArgumentException(
+                        $"overflow value '{value}' is not one of overflow|ellipsis|truncate");
+            }
+        }
+
         [UIAttr, Preserve]
         public bool RaycastTarget
         {

--- a/Tests/EditMode/Controls/TextTests.cs
+++ b/Tests/EditMode/Controls/TextTests.cs
@@ -75,6 +75,32 @@ namespace PromptUGUI.Tests.EditMode.Controls
             StringAssert.Contains("bottm", ex.Message);
         }
 
+        // --- overflow: maps onto TMP's overflowMode (the "what to do once text still doesn't fit"
+        // layer). Orthogonal to wrap (line-wrapping) and autosize (the "try to squeeze it in" layer).
+        [TestCase("overflow", TextOverflowModes.Overflow)]
+        [TestCase("ellipsis", TextOverflowModes.Ellipsis)]
+        [TestCase("truncate", TextOverflowModes.Truncate)]
+        public void Overflow_MapsToTmpOverflowMode(string token, TextOverflowModes mode)
+        {
+            var t = OpenText($"overflow='{token}'");
+            Assert.AreEqual(mode, t.TmpComponent.overflowMode);
+        }
+
+        // Tokens are case-insensitive, mirroring align.
+        [Test]
+        public void Overflow_IsCaseInsensitive()
+        {
+            var t = OpenText("overflow='Ellipsis'");
+            Assert.AreEqual(TextOverflowModes.Ellipsis, t.TmpComponent.overflowMode);
+        }
+
+        [Test]
+        public void Overflow_UnknownToken_Throws()
+        {
+            var ex = Assert.Throws<ParseException>(() => OpenText("overflow='clip'"));
+            StringAssert.Contains("clip", ex.Message);
+        }
+
         [Test]
         public void Visual_ColorDefaultsToDarkGrey()
         {


### PR DESCRIPTION
## 背景

作者需求：让 `<Text>` 在文字超出框时**不换行、尾部显示省略号 `…`**。Unity 里只有 TMP 能原生做（`overflowMode = Ellipsis`），旧版 `UI.Text` 不行。本项目 `<Text>` 底层就是 TMP，但 `overflowMode` 此前没有暴露为 XML 属性。

## 改动

新增 `<Text overflow="overflow|ellipsis|truncate">`，映射 `TMP_Text.overflowMode`。解析法照搬 `Text.ParseAlign`（小写 token、未知值抛 `ArgumentException` → `ApplyOne` 包成 `ParseException`）。

| 值 | 行为 |
|---|---|
| `overflow` | 溢出框外（TMP 默认） |
| `ellipsis` | 尾部 `…` |
| `truncate` | 硬裁切，无 `…` |

**不写属性 → setter 不触发 → 保持 TMP 默认 `Overflow`，对现有所有 UI 零行为变化。**

单行省略号：
\`\`\`xml
<Text wrap="false" overflow="ellipsis" text="一段很长的文字" />
\`\`\`

## 设计决策：`overflow` 与 `autosize` 保持独立（不合并）

讨论过是否把现有 `autosize`（横向压字宽最多 50%）折进 `overflow` 枚举统一掉。结论是**不合并**：TMP 里 `enableAutoSizing`（努力塞进去）和 `overflowMode`（塞不下怎么收尾）是**正交两层、会叠加**，折成一个枚举会逼出假互斥、且废弃 `autosize` 是破坏性改动、实现也不对等。两者独立后白捡一个组合：`wrap="false" autosize="true" overflow="ellipsis"` = 先压扁再省略。

## 坑（已写进 SKILL）

`ellipsis`/`truncate` 只在文本框**定宽**时触发。若 `<Text>` 靠 native-size 撑开（Frame 里不写 `width`、或挂 `ContentSizeFitter`），框跟着文字变宽 → 永不溢出 → 省略号不出现。用 `anchor="stretch"`+`margin` 或显式 `width` 钉死宽度。

## 文件

- `Runtime/Controls/Text.cs` — `Overflow` 属性 + `ParseOverflow`
- `Tests/EditMode/Controls/TextTests.cs` — 5 新用例（3 映射 + 大小写不敏感 + 未知值抛错）
- `.claude/skills/authoring-promptugui-xml/SKILL.md` — `<Text>` 表新增 `overflow` 行 + 两层模型说明 + 定宽坑提示

## 验证

- TDD：RED（4 项失败，原因正确）→ GREEN
- **EditMode 1365/1365 通过**（+5 新），无回归
- **lint `--verify-no-changes` exit=0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)