### PR TITLE
feat(modal): 内置 InputBox 文本输入模态

### DIFF
--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -501,6 +501,9 @@ CUSTOM         class X : Control { override OnAttached() { ... } }
 MODAL          var r = await MessageBox.Open(text, MsgBtn.OK|MsgBtn.Cancel, icon, title)
                MessageBox.Open(text, [(label,key),...], icon, title, mode)  custom labels
                MessageBox.Open(text, ..., mode: ModalMode.Queued)  排队,不叠加
+               var s = await InputBox.Open(title, message, initial, placeholder,
+                                           contentType, okLabel, cancelLabel, mode)
+                       // confirm → text ("" if empty); cancel/ESC → null
                ESC priority   Cancel > No > Close   (OK-only → no-op)
                override XML   MessageBox.XmlSrc = "MyUI/Modals/Foo.ui"   (keep .ui suffix)
                               prereq #1  resolver registered + (Addressables) address pre-registered
@@ -521,8 +524,9 @@ LOADING        var h = Loading.Open(text); h.Close()        idempotent; h.IsClos
 
 ## Modal dialogs
 
-PromptUGUI ships a generic modal stack in `PromptUGUI.Application.Modals` plus two
-builtin overlays: a `MessageBox` dialog and a `Loading` spinner. **Every modal IS a real
+PromptUGUI ships a generic modal stack in `PromptUGUI.Application.Modals` plus three
+builtin overlays: a `MessageBox` dialog, an `InputBox` text prompt, and a `Loading`
+spinner. **Every modal IS a real
 `Screen` instantiated from `.ui.xml`** — anchor / margin / Variant / locale / `<Icon>`
 all work normally. The modal subsystem only adds: stack management, ESC handling, and a
 sortingOrder band above regular Screens.
@@ -544,6 +548,15 @@ var r2 = await MessageBox.Open(UI.Tr("File not found."),
 // Optional icon and title; ModalMode.Queued waits behind any current dialog
 await MessageBox.Open("Saved.", MsgBtn.OK,
     icon: "ui:check", title: "Done", mode: ModalMode.Queued);
+
+// InputBox: text prompt. Returns the text on confirm/Enter, null on cancel/ESC.
+// "" (empty) is distinct from null — empty submit vs cancelled.
+string name = await InputBox.Open(UI.Tr("Your name?"), placeholder: UI.Tr("e.g. Link"));
+if (name != null) game.PlayerName = name;
+
+// password prompt with a sub-message line
+string pw = await InputBox.Open(UI.Tr("Enter password"),
+    message: UI.Tr("at least 8 chars"), contentType: "password");
 ```
 
 ### API surface (`PromptUGUI.Application.Modals`)
@@ -562,6 +575,21 @@ public static class MessageBox {
         IEnumerable<(string label, MsgBtn key)> buttons,   // also sets the .Buttons mask
         string icon = null, string title = null,
         ModalMode mode = ModalMode.Popup);
+}
+
+public static class InputBox {
+    public static string XmlSrc { get; set; } = "PromptUGUI/Modals/InputBox.ui";
+
+    // confirm/Enter → entered text ("" if empty); cancel/ESC → null
+    public static Awaitable<string> Open(
+        string title,
+        string message     = null,   // optional line under the title
+        string initial     = null,   // prefill text
+        string placeholder = null,
+        string contentType = null,   // InputField.contentType, e.g. "password" / "email"
+        string okLabel     = null,
+        string cancelLabel = null,
+        ModalMode mode     = ModalMode.Popup);
 }
 
 [Flags] public enum MsgBtn { None=0, OK=1, Cancel=2, Yes=4, No=8, Close=16 }
@@ -640,7 +668,7 @@ public sealed class NamePickerRequest : ModalRequest<string> {
     public override string XmlSrc => "MyUI/Modals/NamePicker.ui";
     public override void Bind(IScreen screen, Action<string> close) {
         screen.Get<Btn>("ok").OnClick.Subscribe(_ =>
-            close(screen.Get<InputField>("input").Text)).AddTo(screen);
+            close(screen.Get<InputField>("input").TextValue)).AddTo(screen);
         screen.Get<Btn>("cancel").OnClick.Subscribe(_ => close(null)).AddTo(screen);
     }
     public override bool TryEscape(out string r) { r = null; return true; }  // ESC → null
@@ -648,6 +676,10 @@ public sealed class NamePickerRequest : ModalRequest<string> {
 
 var name = await UI.Modal.OpenAsync(new NamePickerRequest());
 ```
+
+> `InputField.TextValue` is the read/write current-text property (the same one bound by
+> the XML `text=` attribute). For the common "prompt the user for a string" case, prefer
+> the builtin `InputBox.Open(...)` over hand-rolling a `ModalRequest<string>`.
 
 Custom modal `XmlSrc` keys go through the caller's `UI.SourceResolver` like any other
 Screen (the `PromptUGUI/` prefix is reserved — those keys load synchronously from the

--- a/Runtime/Application/Modals/InputBoxRequest.cs
+++ b/Runtime/Application/Modals/InputBoxRequest.cs
@@ -1,0 +1,82 @@
+using System;
+using R3;
+
+namespace PromptUGUI.Application.Modals
+{
+    public sealed class InputBoxRequest : ModalRequest<string>
+    {
+        public string Title;
+        public string Message;
+        public string Initial;
+        public string Placeholder;
+        public string ContentType;
+        public string OkLabel;
+        public string CancelLabel;
+
+        public override string XmlSrc => InputBox.XmlSrc;
+
+        public override void Bind(IScreen screen, Action<string> close)
+        {
+            var titleCtl = screen.Get<PromptUGUI.Controls.Text>("title");
+            if (string.IsNullOrEmpty(Title)) titleCtl.GameObject.SetActive(false);
+            else titleCtl.TextValue = Title;
+
+            // message 节点可选（覆盖 XML 可能删掉）
+            try
+            {
+                var msgCtl = screen.Get<PromptUGUI.Controls.Text>("message");
+                if (string.IsNullOrEmpty(Message)) msgCtl.GameObject.SetActive(false);
+                else msgCtl.TextValue = Message;
+            }
+            catch (System.Collections.Generic.KeyNotFoundException) { /* message element is optional */ }
+
+            var field = screen.Get<PromptUGUI.Controls.InputField>("field");
+            if (!string.IsNullOrEmpty(ContentType)) field.ContentType = ContentType;
+            if (Placeholder != null) field.Placeholder = Placeholder;
+            field.TextValue = Initial ?? "";
+
+            // 回车 = 确定；OnSubmit 直接给出当前文本。
+            field.OnSubmit.Subscribe(v => close(v)).AddTo(screen);
+
+            var ok = screen.Get<PromptUGUI.Controls.Btn>("ok");
+            if (!string.IsNullOrEmpty(OkLabel)) ok.Text = OkLabel;
+            ok.OnClick.Subscribe(_ => close(field.TextValue)).AddTo(screen);
+
+            var cancel = screen.Get<PromptUGUI.Controls.Btn>("cancel");
+            if (!string.IsNullOrEmpty(CancelLabel)) cancel.Text = CancelLabel;
+            cancel.OnClick.Subscribe(_ => close(null)).AddTo(screen);
+        }
+
+        public override bool TryEscape(out string result)
+        {
+            result = null;   // ESC → 取消
+            return true;
+        }
+    }
+
+    public static class InputBox
+    {
+        // 必须带 .ui 后缀：Unity 只剥离 .ui.xml 文件名的最后 .xml。
+        public static string XmlSrc { get; set; } = "PromptUGUI/Modals/InputBox.ui";
+
+        public static UnityEngine.Awaitable<string> Open(
+            string title,
+            string message = null,
+            string initial = null,
+            string placeholder = null,
+            string contentType = null,
+            string okLabel = null,
+            string cancelLabel = null,
+            ModalMode mode = ModalMode.Popup)
+            => UI.Modal.OpenAsync(new InputBoxRequest
+            {
+                Title = title,
+                Message = message,
+                Initial = initial,
+                Placeholder = placeholder,
+                ContentType = contentType,
+                OkLabel = okLabel,
+                CancelLabel = cancelLabel,
+            }, mode);
+    }
+}

--- a/Runtime/Application/Modals/InputBoxRequest.cs.meta
+++ b/Runtime/Application/Modals/InputBoxRequest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1b62cf9d2fbfbaf4fb78b257f8884019

--- a/Runtime/Controls/InputField.cs
+++ b/Runtime/Controls/InputField.cs
@@ -139,6 +139,7 @@ namespace PromptUGUI.Controls
         [UIAttr("text"), Preserve]
         public string TextValue
         {
+            get => _input != null ? _input.text : null;
             set => _input.text = value ?? string.Empty;
         }
 

--- a/Runtime/Resources/PromptUGUI/Modals/InputBox.ui.xml
+++ b/Runtime/Resources/PromptUGUI/Modals/InputBox.ui.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PromptUGUI version="1">
+  <Screen name="PromptUGUI/Modals/InputBox.ui" reference="1920x1080" reference.portrait="1080x1920" >
+    <Image id="backdrop" anchor="stretch" color="#000000FE"/>
+
+    <Image id="dialog" sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round"
+           anchor="center" size="640x280">
+      <VStack anchor="stretch" margin="24" spacing="12">
+        <Text id="title" fontSize="24" height="40"/>
+        <Text id="message" width="stretch" height="stretch" fontSize="18"/>
+        <InputField id="field" height="44"/>
+        <HStack height="44" spacing="8">
+          <Btn id="ok">OK</Btn>
+          <Btn id="cancel">Cancel</Btn>
+        </HStack>
+      </VStack>
+    </Image>
+  </Screen>
+</PromptUGUI>

--- a/Runtime/Resources/PromptUGUI/Modals/InputBox.ui.xml.meta
+++ b/Runtime/Resources/PromptUGUI/Modals/InputBox.ui.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a18de0b2d9673cf42b95eaf08b8801bf
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Controls/InputFieldTests.cs
+++ b/Tests/EditMode/Controls/InputFieldTests.cs
@@ -463,5 +463,28 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var f = UI.Open("S").Get<PInputField>("f");
             Assert.IsTrue(f.GameObject.GetComponent<TMP_InputField>().interactable);
         }
+
+        // --- TextValue getter ---------------------------------------------------
+
+        [Test]
+        public void TextValue_Getter_RoundtripsSetValue()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <InputField id='f'/>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var f = UI.Open("S").Get<PInputField>("f");
+            f.TextValue = "abc";
+            Assert.AreEqual("abc", f.TextValue);
+        }
+
+        [Test]
+        public void TextValue_Getter_BeforeAttach_ReturnsNull()
+        {
+            // _input is null before OnAttached → getter must defend, not NRE.
+            var f = new PInputField();
+            Assert.IsNull(f.TextValue);
+        }
     }
 }

--- a/Tests/EditMode/Modals/InputBoxTests.cs
+++ b/Tests/EditMode/Modals/InputBoxTests.cs
@@ -1,0 +1,201 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using TMPro;
+using PBtn = PromptUGUI.Controls.Btn;
+using PInputField = PromptUGUI.Controls.InputField;
+using PText = PromptUGUI.Controls.Text;
+
+namespace PromptUGUI.Tests.Modals
+{
+    public class InputBoxTests
+    {
+        private const string InputBoxXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/InputBox1'>
+    <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+    <Frame id='dialog' anchor='center' size='400x220'>
+      <VStack anchor='stretch' margin='16' spacing='8'>
+        <Text id='title' fontSize='20'/>
+        <Text id='message' fontSize='14'/>
+        <InputField id='field' height='44'/>
+        <Btn id='ok'>OK</Btn>
+        <Btn id='cancel'>Cancel</Btn>
+      </VStack>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+
+        // Same dialog but WITHOUT the message node — covers an override XML that drops it.
+        private const string InputBoxNoMessageXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/InputBoxNoMsg'>
+    <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+    <Frame id='dialog' anchor='center' size='400x200'>
+      <VStack anchor='stretch' margin='16' spacing='8'>
+        <Text id='title' fontSize='20'/>
+        <InputField id='field' height='44'/>
+        <Btn id='ok'>OK</Btn>
+        <Btn id='cancel'>Cancel</Btn>
+      </VStack>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+
+        private Dictionary<string, string> _files;
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            _files = new Dictionary<string, string>
+            {
+                ["test/InputBox1"] = InputBoxXml,
+                ["test/InputBoxNoMsg"] = InputBoxNoMessageXml,
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(_files.TryGetValue(src, out var v) ? v : null);
+            InputBox.XmlSrc = "test/InputBox1";
+        }
+
+        [TearDown]
+        public void TearDown() => UI.ResetForTests();
+
+        private static PInputField Field()
+            => UI.Modal.TopScreen.Get<PInputField>("field");
+
+        private static string Label(string id)
+            => UI.Modal.TopScreen.Get<PBtn>(id).GameObject
+                .GetComponentInChildren<TMP_Text>().text;
+
+        [Test]
+        public void Click_OK_returns_current_field_text()
+        {
+            var task = UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?" });
+            Field().TextValue = "Link";
+            UI.Modal.TopScreen.Get<PBtn>("ok").SimulateClick();
+            Assert.AreEqual("Link", task.GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public void Click_Cancel_returns_null()
+        {
+            var task = UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?" });
+            UI.Modal.TopScreen.Get<PBtn>("cancel").SimulateClick();
+            Assert.IsNull(task.GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public void Submit_resolves_with_submitted_text()
+        {
+            var task = UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?" });
+            Field().GameObject.GetComponent<TMP_InputField>().onSubmit.Invoke("typed");
+            Assert.AreEqual("typed", task.GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public void Empty_input_then_OK_returns_empty_string_not_null()
+        {
+            var task = UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?" });
+            UI.Modal.TopScreen.Get<PBtn>("ok").SimulateClick();
+            var result = task.GetAwaiter().GetResult();
+            Assert.IsNotNull(result);
+            Assert.AreEqual("", result);
+        }
+
+        [Test]
+        public void Initial_prefills_field()
+        {
+            UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?", Initial = "preset" });
+            Assert.AreEqual("preset",
+                Field().GameObject.GetComponent<TMP_InputField>().text);
+        }
+
+        [Test]
+        public void ContentType_password_applied_to_field()
+        {
+            UI.Modal.OpenAsync(new InputBoxRequest { Title = "Pw", ContentType = "password" });
+            Assert.AreEqual(TMP_InputField.ContentType.Password,
+                Field().GameObject.GetComponent<TMP_InputField>().contentType);
+        }
+
+        [Test]
+        public void Custom_ok_cancel_labels_override_default()
+        {
+            UI.Modal.OpenAsync(new InputBoxRequest
+            {
+                Title = "Name?",
+                OkLabel = "Save",
+                CancelLabel = "Later",
+            });
+            Assert.AreEqual("Save", Label("ok"));
+            Assert.AreEqual("Later", Label("cancel"));
+        }
+
+        [Test]
+        public void Null_message_hides_message_node()
+        {
+            UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?", Message = null });
+            Assert.IsFalse(UI.Modal.TopScreen.Get<PText>("message").GameObject.activeSelf);
+        }
+
+        [Test]
+        public void Message_present_shows_message_node_with_text()
+        {
+            UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?", Message = "details" });
+            var msg = UI.Modal.TopScreen.Get<PText>("message");
+            Assert.IsTrue(msg.GameObject.activeSelf);
+            Assert.AreEqual("details", msg.TmpComponent.text);
+        }
+
+        [Test]
+        public void Missing_message_node_in_xml_is_tolerated()
+        {
+            InputBox.XmlSrc = "test/InputBoxNoMsg";
+            var task = UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?", Message = "ignored" });
+            // Bind must not throw even though there is no 'message' id.
+            Field().TextValue = "ok";
+            UI.Modal.TopScreen.Get<PBtn>("ok").SimulateClick();
+            Assert.AreEqual("ok", task.GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public void TryEscape_returns_null_and_true()
+        {
+            var req = new InputBoxRequest { Title = "Name?" };
+            Assert.IsTrue(req.TryEscape(out var r));
+            Assert.IsNull(r);
+        }
+
+        // ESC must route through the real pump → ModalEscapeListener → TryEscape → close,
+        // not just the unit-level TryEscape. Mirrors MessageBoxRequestTests.Escape_via_listener_*.
+        [Test]
+        public void Escape_via_listener_returns_null_and_closes()
+        {
+            var task = UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?" });
+            var listener = UI.Modal.TopScreen
+                .RootGameObject.GetComponent<ModalEscapeListener>();
+            Assert.IsNotNull(listener, "Pump must attach ModalEscapeListener to the modal Screen root");
+            listener.FireForTests();
+            Assert.IsNull(task.GetAwaiter().GetResult());
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+
+        [Test]
+        public void Null_title_hides_title_node()
+        {
+            UI.Modal.OpenAsync(new InputBoxRequest { Title = null });
+            Assert.IsFalse(UI.Modal.TopScreen.Get<PText>("title").GameObject.activeSelf);
+        }
+
+        [Test]
+        public void Placeholder_applied_to_field()
+        {
+            UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?", Placeholder = "type here" });
+            var ph = Field().GameObject.transform.Find("Text Area/Placeholder")
+                .GetComponent<TMP_Text>();
+            Assert.AreEqual("type here", ph.text);
+        }
+    }
+}

--- a/Tests/EditMode/Modals/InputBoxTests.cs.meta
+++ b/Tests/EditMode/Modals/InputBoxTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 74f8e7481e9f13149b2522f5eea5c8b1

--- a/docs~/superpowers/plans/2026-06-07-input-box-modal.md
+++ b/docs~/superpowers/plans/2026-06-07-input-box-modal.md
@@ -1,0 +1,681 @@
+# InputBox 内置模态 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在既有模态体系里新增第三个内置 overlay `InputBox`：一个返回用户输入文本的强模态对话框（`InputBox.Open(...) → Awaitable<string>`，确定返回文本、取消/ESC 返回 `null`）。
+
+**Architecture:** 复用既有 `ModalRequest<TResult>` + `UI.Modal` + `ModalDocCache` 机制（队列 / ESC / sortingOrder / teardown 全部不动）。新增 `InputBoxRequest : ModalRequest<string>` + 静态 wrapper `InputBox`，与 `MessageBoxRequest` / `MessageBox` 完全平级；配套给 `InputField` 补一个公开 `TextValue` getter 以便 Bind 读回输入。内置 `.ui.xml` 走包内 Resources，可被 `InputBox.XmlSrc` 整体覆盖。
+
+**Tech Stack:** C# (Unity 6, LangVersion 9)、uGUI、TMP_InputField、R3（Cysharp）、NUnit EditMode 测试、UnityMCP 跑测试、`dotnet format` + UIXmlLint 做 lint。
+
+参考 spec：`docs~/superpowers/specs/2026-06-07-input-box-modal-design.md`
+
+---
+
+## File Structure
+
+| 文件 | 动作 | 责任 |
+|---|---|---|
+| `Runtime/Controls/InputField.cs` | 修改 | 给 `TextValue` 属性补 getter（读 `_input.text`） |
+| `Runtime/Application/Modals/InputBoxRequest.cs` | 新建 | `InputBoxRequest`（Bind/TryEscape）+ 静态 `InputBox`（XmlSrc/Open），与 `MessageBoxRequest.cs` 同构 |
+| `Runtime/Resources/PromptUGUI/Modals/InputBox.ui.xml` | 新建 | 内置默认皮肤：backdrop + dialog(title + message + InputField + OK/Cancel) |
+| `Tests/EditMode/Controls/InputFieldTests.cs` | 修改 | 2 条 getter 单测 |
+| `Tests/EditMode/Modals/InputBoxTests.cs` | 新建 | Bind / 提交 / 取消 / label / message 节点等 11 条 EditMode 测试（fake-resolver 内联 XML） |
+| `.claude/skills/scripting-promptugui-csharp/SKILL.md` | 修改 | overlay 计数 2→3、新增 InputBox 节、修 `NamePickerRequest` 的 `.Text`→`.TextValue` |
+
+**约定**：每次改源码后先 `refresh_unity`，再 `read_console` 看编译错误，再 `run_tests`。EditMode 测试不存在的类型/成员会表现为**编译错误**（即本计划的 "红"），而非 NUnit 失败——这是 Unity/C# 的正常 TDD 形态。
+
+---
+
+## Task 1: `InputField.TextValue` getter
+
+**Files:**
+- Modify: `Runtime/Controls/InputField.cs:139-143`（`TextValue` 属性）
+- Test: `Tests/EditMode/Controls/InputFieldTests.cs`（追加 2 条）
+
+- [ ] **Step 1: 写失败测试**
+
+在 `Tests/EditMode/Controls/InputFieldTests.cs` 的 `InputFieldTests` 类末尾（最后一个 `}` 之前）追加：
+
+```csharp
+        // --- TextValue getter ---------------------------------------------------
+
+        [Test]
+        public void TextValue_Getter_RoundtripsSetValue()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <InputField id='f'/>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var f = UI.Open("S").Get<PInputField>("f");
+            f.TextValue = "abc";
+            Assert.AreEqual("abc", f.TextValue);
+        }
+
+        [Test]
+        public void TextValue_Getter_BeforeAttach_ReturnsNull()
+        {
+            // _input is null before OnAttached → getter must defend, not NRE.
+            var f = new PInputField();
+            Assert.IsNull(f.TextValue);
+        }
+```
+
+- [ ] **Step 2: 刷新并确认红（编译错误）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: 编译错误 `CS0154: The property or indexer 'InputField.TextValue' cannot be used in this context because it lacks the get accessor`（来自 `TextValue_Getter_RoundtripsSetValue` 和 `..._BeforeAttach_...`）。
+
+- [ ] **Step 3: 实现 getter**
+
+把 `Runtime/Controls/InputField.cs` 的：
+
+```csharp
+        [UIAttr("text"), Preserve]
+        public string TextValue
+        {
+            set => _input.text = value ?? string.Empty;
+        }
+```
+
+改为：
+
+```csharp
+        [UIAttr("text"), Preserve]
+        public string TextValue
+        {
+            get => _input != null ? _input.text : null;
+            set => _input.text = value ?? string.Empty;
+        }
+```
+
+- [ ] **Step 4: 刷新并确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="InputFieldTests")
+```
+Expected: 无编译错误；`InputFieldTests` 全绿（含新增 2 条）。
+
+- [ ] **Step 5: Lint**
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+Expected: 退出码 0（若有 `Local.props` 缺失导致的 CS0246 噪音可忽略，但 whitespace/style 不应报 InputField.cs 的改动）。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Runtime/Controls/InputField.cs Tests/EditMode/Controls/InputFieldTests.cs
+git commit -m "$(cat <<'EOF'
+feat(inputfield): TextValue 补 getter
+
+读 _input.text（未 attach 时返回 null）。InputBox 模态 Bind 需要读回
+当前输入；也修正 C# skill NamePicker 示例引用的 .Text（下一步统一改 skill）。
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `InputBoxRequest` + 静态 `InputBox`
+
+**Files:**
+- Create: `Runtime/Application/Modals/InputBoxRequest.cs`
+- Test: `Tests/EditMode/Modals/InputBoxTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `Tests/EditMode/Modals/InputBoxTests.cs`：
+
+```csharp
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using TMPro;
+using PBtn = PromptUGUI.Controls.Btn;
+using PInputField = PromptUGUI.Controls.InputField;
+using PText = PromptUGUI.Controls.Text;
+
+namespace PromptUGUI.Tests.Modals
+{
+    public class InputBoxTests
+    {
+        private const string InputBoxXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/InputBox1'>
+    <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+    <Frame id='dialog' anchor='center' size='400x220'>
+      <VStack anchor='stretch' margin='16' spacing='8'>
+        <Text id='title' fontSize='20'/>
+        <Text id='message' fontSize='14'/>
+        <InputField id='field' height='44'/>
+        <Btn id='ok'>OK</Btn>
+        <Btn id='cancel'>Cancel</Btn>
+      </VStack>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+
+        // Same dialog but WITHOUT the message node — covers an override XML that drops it.
+        private const string InputBoxNoMessageXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/InputBoxNoMsg'>
+    <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+    <Frame id='dialog' anchor='center' size='400x200'>
+      <VStack anchor='stretch' margin='16' spacing='8'>
+        <Text id='title' fontSize='20'/>
+        <InputField id='field' height='44'/>
+        <Btn id='ok'>OK</Btn>
+        <Btn id='cancel'>Cancel</Btn>
+      </VStack>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+
+        private Dictionary<string, string> _files;
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            _files = new Dictionary<string, string>
+            {
+                ["test/InputBox1"] = InputBoxXml,
+                ["test/InputBoxNoMsg"] = InputBoxNoMessageXml,
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(_files.TryGetValue(src, out var v) ? v : null);
+            InputBox.XmlSrc = "test/InputBox1";
+        }
+
+        [TearDown]
+        public void TearDown() => UI.ResetForTests();
+
+        private static PInputField Field()
+            => UI.Modal.TopScreen.Get<PInputField>("field");
+
+        private static string Label(string id)
+            => UI.Modal.TopScreen.Get<PBtn>(id).GameObject
+                .GetComponentInChildren<TMP_Text>().text;
+
+        [Test]
+        public void Click_OK_returns_current_field_text()
+        {
+            var task = UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?" });
+            Field().TextValue = "Link";
+            UI.Modal.TopScreen.Get<PBtn>("ok").SimulateClick();
+            Assert.AreEqual("Link", task.GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public void Click_Cancel_returns_null()
+        {
+            var task = UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?" });
+            UI.Modal.TopScreen.Get<PBtn>("cancel").SimulateClick();
+            Assert.IsNull(task.GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public void Submit_resolves_with_submitted_text()
+        {
+            var task = UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?" });
+            Field().GameObject.GetComponent<TMP_InputField>().onSubmit.Invoke("typed");
+            Assert.AreEqual("typed", task.GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public void Empty_input_then_OK_returns_empty_string_not_null()
+        {
+            var task = UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?" });
+            UI.Modal.TopScreen.Get<PBtn>("ok").SimulateClick();
+            var result = task.GetAwaiter().GetResult();
+            Assert.IsNotNull(result);
+            Assert.AreEqual("", result);
+        }
+
+        [Test]
+        public void Initial_prefills_field()
+        {
+            UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?", Initial = "preset" });
+            Assert.AreEqual("preset",
+                Field().GameObject.GetComponent<TMP_InputField>().text);
+        }
+
+        [Test]
+        public void ContentType_password_applied_to_field()
+        {
+            UI.Modal.OpenAsync(new InputBoxRequest { Title = "Pw", ContentType = "password" });
+            Assert.AreEqual(TMP_InputField.ContentType.Password,
+                Field().GameObject.GetComponent<TMP_InputField>().contentType);
+        }
+
+        [Test]
+        public void Custom_ok_cancel_labels_override_default()
+        {
+            UI.Modal.OpenAsync(new InputBoxRequest
+            {
+                Title = "Name?",
+                OkLabel = "Save",
+                CancelLabel = "Later",
+            });
+            Assert.AreEqual("Save", Label("ok"));
+            Assert.AreEqual("Later", Label("cancel"));
+        }
+
+        [Test]
+        public void Null_message_hides_message_node()
+        {
+            UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?", Message = null });
+            Assert.IsFalse(UI.Modal.TopScreen.Get<PText>("message").GameObject.activeSelf);
+        }
+
+        [Test]
+        public void Message_present_shows_message_node_with_text()
+        {
+            UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?", Message = "details" });
+            var msg = UI.Modal.TopScreen.Get<PText>("message");
+            Assert.IsTrue(msg.GameObject.activeSelf);
+            Assert.AreEqual("details", msg.TmpComponent.text);
+        }
+
+        [Test]
+        public void Missing_message_node_in_xml_is_tolerated()
+        {
+            InputBox.XmlSrc = "test/InputBoxNoMsg";
+            var task = UI.Modal.OpenAsync(new InputBoxRequest { Title = "Name?", Message = "ignored" });
+            // Bind must not throw even though there is no 'message' id.
+            Field().TextValue = "ok";
+            UI.Modal.TopScreen.Get<PBtn>("ok").SimulateClick();
+            Assert.AreEqual("ok", task.GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public void TryEscape_returns_null_and_true()
+        {
+            var req = new InputBoxRequest { Title = "Name?" };
+            Assert.IsTrue(req.TryEscape(out var r));
+            Assert.IsNull(r);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 刷新并确认红（编译错误）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: 编译错误 `CS0246: The type or namespace name 'InputBoxRequest' could not be found` 及 `'InputBox' does not exist`。
+
+- [ ] **Step 3: 实现 `InputBoxRequest` + `InputBox`**
+
+新建 `Runtime/Application/Modals/InputBoxRequest.cs`：
+
+```csharp
+using System;
+using R3;
+
+namespace PromptUGUI.Application.Modals
+{
+    public sealed class InputBoxRequest : ModalRequest<string>
+    {
+        public string Title;
+        public string Message;
+        public string Initial;
+        public string Placeholder;
+        public string ContentType;
+        public string OkLabel;
+        public string CancelLabel;
+
+        public override string XmlSrc => InputBox.XmlSrc;
+
+        public override void Bind(IScreen screen, Action<string> close)
+        {
+            var titleCtl = screen.Get<PromptUGUI.Controls.Text>("title");
+            if (string.IsNullOrEmpty(Title)) titleCtl.GameObject.SetActive(false);
+            else titleCtl.TextValue = Title;
+
+            // message 节点可选（覆盖 XML 可能删掉）
+            try
+            {
+                var msgCtl = screen.Get<PromptUGUI.Controls.Text>("message");
+                if (string.IsNullOrEmpty(Message)) msgCtl.GameObject.SetActive(false);
+                else msgCtl.TextValue = Message;
+            }
+            catch (System.Collections.Generic.KeyNotFoundException) { /* message element is optional */ }
+
+            var field = screen.Get<PromptUGUI.Controls.InputField>("field");
+            if (!string.IsNullOrEmpty(ContentType)) field.ContentType = ContentType;
+            if (Placeholder != null) field.Placeholder = Placeholder;
+            field.TextValue = Initial ?? "";
+
+            // 回车 = 确定；OnSubmit 直接给出当前文本。
+            field.OnSubmit.Subscribe(v => close(v)).AddTo(screen);
+
+            var ok = screen.Get<PromptUGUI.Controls.Btn>("ok");
+            if (!string.IsNullOrEmpty(OkLabel)) ok.Text = OkLabel;
+            ok.OnClick.Subscribe(_ => close(field.TextValue)).AddTo(screen);
+
+            var cancel = screen.Get<PromptUGUI.Controls.Btn>("cancel");
+            if (!string.IsNullOrEmpty(CancelLabel)) cancel.Text = CancelLabel;
+            cancel.OnClick.Subscribe(_ => close(null)).AddTo(screen);
+        }
+
+        public override bool TryEscape(out string result)
+        {
+            result = null;   // ESC → 取消
+            return true;
+        }
+    }
+
+    public static class InputBox
+    {
+        // 必须带 .ui 后缀：Unity 只剥离 .ui.xml 文件名的最后 .xml。
+        public static string XmlSrc { get; set; } = "PromptUGUI/Modals/InputBox.ui";
+
+        public static UnityEngine.Awaitable<string> Open(
+            string title,
+            string message = null,
+            string initial = null,
+            string placeholder = null,
+            string contentType = null,
+            string okLabel = null,
+            string cancelLabel = null,
+            ModalMode mode = ModalMode.Popup)
+            => UI.Modal.OpenAsync(new InputBoxRequest
+            {
+                Title = title,
+                Message = message,
+                Initial = initial,
+                Placeholder = placeholder,
+                ContentType = contentType,
+                OkLabel = okLabel,
+                CancelLabel = cancelLabel,
+            }, mode);
+    }
+}
+```
+
+- [ ] **Step 4: 刷新并确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="InputBoxTests")
+```
+Expected: 无编译错误；`InputBoxTests` 11 条全绿。
+
+- [ ] **Step 5: Lint**
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+Expected: 退出码 0。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Runtime/Application/Modals/InputBoxRequest.cs Tests/EditMode/Modals/InputBoxTests.cs
+git commit -m "$(cat <<'EOF'
+feat(modal): InputBoxRequest + 静态 InputBox
+
+第三个内置 modal overlay：InputBox.Open(title, message, initial,
+placeholder, contentType, okLabel, cancelLabel, mode) → Awaitable<string>。
+确定/回车返回文本，取消/ESC 返回 null（区分于空串）。复用既有
+ModalRequest<T> + UI.Modal，不碰队列/ESC/sortingOrder。
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: 内置 `InputBox.ui.xml`
+
+**Files:**
+- Create: `Runtime/Resources/PromptUGUI/Modals/InputBox.ui.xml`
+
+> 本任务产出一份静态资源（无 NUnit 单测——Bind 契约已由 Task 2 的 fake-resolver 测试覆盖同一套 id）。验证靠 UIXmlLint（结构）+ Screen-name byte-equal 校验 + 后续 visual QA。
+
+- [ ] **Step 1: 创建内置 XML**
+
+新建 `Runtime/Resources/PromptUGUI/Modals/InputBox.ui.xml`，与 `MessageBox.ui.xml` 同皮肤：
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<PromptUGUI version="1">
+  <Screen name="PromptUGUI/Modals/InputBox.ui" reference="1920x1080" reference.portrait="1080x1920" >
+    <Image id="backdrop" anchor="stretch" color="#000000FE"/>
+
+    <Image id="dialog" sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round"
+           anchor="center" size="640x280">
+      <VStack anchor="stretch" margin="24" spacing="12">
+        <Text id="title" fontSize="24" height="40"/>
+        <Text id="message" width="stretch" height="stretch" fontSize="18"/>
+        <InputField id="field" height="44"/>
+        <HStack height="44" spacing="8">
+          <Btn id="ok">OK</Btn>
+          <Btn id="cancel">Cancel</Btn>
+        </HStack>
+      </VStack>
+    </Image>
+  </Screen>
+</PromptUGUI>
+```
+
+- [ ] **Step 2: 校验 `<Screen name>` 与默认 `InputBox.XmlSrc` byte-equal**
+
+```bash
+grep -q 'name="PromptUGUI/Modals/InputBox.ui"' Runtime/Resources/PromptUGUI/Modals/InputBox.ui.xml && echo "screen-name OK"
+```
+Expected: 打印 `screen-name OK`（与 `InputBox.XmlSrc` 默认值逐字相等——`ModalDocCache.EnsureLoaded` 的硬约束）。
+
+- [ ] **Step 3: UIXmlLint**
+
+```bash
+dotnet run --project .lint/UIXmlLint -- Runtime/Resources/PromptUGUI/Modals/InputBox.ui.xml
+```
+Expected: 退出码 0，无 error（layout-group 子节点上没有非法 anchor/margin）。
+
+- [ ] **Step 4: 刷新让 Unity 导入资源（生成 .meta）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: 无 error（资源导入成功）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Resources/PromptUGUI/Modals/InputBox.ui.xml Runtime/Resources/PromptUGUI/Modals/InputBox.ui.xml.meta
+git commit -m "$(cat <<'EOF'
+feat(modal): 内置 InputBox.ui.xml 默认皮肤
+
+backdrop + dialog(title + message + InputField + OK/Cancel)，复用
+MessageBox 的九宫格皮肤；Screen name byte-equal InputBox.XmlSrc 默认值。
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: C# SKILL.md 更新
+
+**Files:**
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md`
+
+- [ ] **Step 1: overlay 计数 2→3 + 索引行**
+
+把 `## Modal dialogs` 段开头（`SKILL.md:524-528` 附近）的：
+
+```
+builtin overlays: a `MessageBox` dialog and a `Loading` spinner.
+```
+
+改为：
+
+```
+builtin overlays: a `MessageBox` dialog, an `InputBox` text prompt, and a `Loading`
+spinner.
+```
+
+并在 `MODAL` 速查表区块（`SKILL.md:501-517` 附近）`MessageBox.Open(...)` 行之后补一行：
+
+```
+               var s = await InputBox.Open(title, message, initial, placeholder,
+                                           contentType, okLabel, cancelLabel, mode)
+                       // ↑ confirm → text ("" if empty); cancel/ESC → null
+```
+
+- [ ] **Step 2: Quick usage 补 InputBox 例子**
+
+在 `### Quick usage` 代码块（`SKILL.md:532-547`）末尾、闭合 ``` 之前追加：
+
+```csharp
+
+// InputBox: text prompt. Returns the text on confirm/Enter, null on cancel/ESC.
+// "" (empty) is distinct from null — empty submit vs cancelled.
+string name = await InputBox.Open(UI.Tr("Your name?"), placeholder: UI.Tr("e.g. Link"));
+if (name != null) game.PlayerName = name;
+
+// password prompt with a sub-message line
+string pw = await InputBox.Open(UI.Tr("Enter password"),
+    message: UI.Tr("at least 8 chars"), contentType: "password");
+```
+
+- [ ] **Step 3: API surface 补 InputBox 块**
+
+在 `### API surface` 代码块里，`MessageBox` 块之后、`[Flags] public enum MsgBtn ...` 之前插入：
+
+```csharp
+public static class InputBox {
+    public static string XmlSrc { get; set; } = "PromptUGUI/Modals/InputBox.ui";
+
+    // confirm/Enter → entered text ("" if empty); cancel/ESC → null
+    public static Awaitable<string> Open(
+        string title,
+        string message     = null,   // optional line under the title
+        string initial     = null,   // prefill text
+        string placeholder = null,
+        string contentType = null,   // InputField.contentType, e.g. "password" / "email"
+        string okLabel     = null,
+        string cancelLabel = null,
+        ModalMode mode     = ModalMode.Popup);
+}
+```
+
+- [ ] **Step 4: 修 `NamePickerRequest` 示例 `.Text` → `.TextValue`**
+
+把 `### Custom modal types` 里（`SKILL.md:643` 附近）：
+
+```csharp
+        screen.Get<Btn>("ok").OnClick.Subscribe(_ =>
+            close(screen.Get<InputField>("input").Text)).AddTo(screen);
+```
+
+改为：
+
+```csharp
+        screen.Get<Btn>("ok").OnClick.Subscribe(_ =>
+            close(screen.Get<InputField>("input").TextValue)).AddTo(screen);
+```
+
+并在该示例下方补一句注解：
+
+```markdown
+> `InputField.TextValue` is the read/write current-text property (the same one bound by
+> the XML `text=` attribute). For the common "prompt the user for a string" case, prefer
+> the builtin `InputBox.Open(...)` over hand-rolling a `ModalRequest<string>`.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/skills/scripting-promptugui-csharp/SKILL.md
+git commit -m "$(cat <<'EOF'
+docs(skill): InputBox 内置模态 + InputField.TextValue getter
+
+C# skill：overlay 计数 2→3、新增 InputBox Quick usage + API surface，
+修正 NamePicker 示例 .Text→.TextValue（旧示例引用了不存在的 getter）。
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: 全量回归 + 收尾
+
+**Files:** 无（验证 + 收尾提交）
+
+- [ ] **Step 1: 全量 EditMode**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+```
+Expected: 无编译错误；EditMode 全绿（既有 + 新增 13 条），无回归。
+
+- [ ] **Step 2: 全量 lint**
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+dotnet run --project UIXmlLint -- ../Runtime/Resources/
+```
+Expected: `dotnet format` 退出码 0；UIXmlLint 整个 Resources 目录退出码 0。
+
+- [ ] **Step 3: （可选）PlayMode 冒烟**
+
+模态机制本身已被既有 MessageBox PlayMode 测试覆盖、InputBox 无新机制，仅在改动接触了共享路径时跑：
+
+```
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], filter="Modal")
+```
+Expected: 既有 Modal PlayMode 测试无回归。
+
+- [ ] **Step 4: 人工 visual QA（交给 user）**
+
+在 host 工程跑一句 `await InputBox.Open("Your name?", placeholder: "e.g. Link")`，确认：弹窗居中、输入框可聚焦输入、回车=OK、ESC/Cancel 返回 null、password 走掩码。默认皮肤丑可由 user 覆盖 `InputBox.XmlSrc`。
+
+- [ ] **Step 5: 推分支 + 开 PR（待 user 确认后）**
+
+```bash
+git push -u origin feat/input-box-modal
+gh pr create --title "feat(modal): 内置 InputBox 文本输入模态" --body "..."
+```
+（DO NOT 合并 main；PR 描述含 spec/plan 链接 + 验收点。）
+
+---
+
+## Self-Review
+
+**Spec coverage（逐节核对 spec → task）：**
+- spec §2.1 `InputBox.Open` 7 参数 + XmlSrc → Task 2 Step 3 ✓
+- spec §2.2 `InputBoxRequest`（字段 + Bind + TryEscape→null/true）→ Task 2 Step 3；TryEscape 测试 Task 2 Step 1 ✓
+- spec §3 内置 XML（id: title/message/field/ok/cancel，Screen name byte-equal）→ Task 3 ✓
+- spec §4 Bind（getter 读 OK、OnSubmit→close、message 可选 catch）→ Task 2 Step 3 + 测试 `Submit_*` / `Missing_message_node_*` ✓
+- spec §5 `InputField.TextValue` getter（`_input!=null` 防御）→ Task 1 ✓
+- spec §6 边界（空串≠null、message 隐藏/缺失、label 覆盖、ContentType）→ Task 2 测试 `Empty_input_*` / `Null_message_*` / `Custom_*` / `ContentType_*` ✓
+- spec §7 测试（EditMode 11 + getter 2）→ Task 1 + Task 2 ✓
+- spec §8 SKILL（计数 + InputBox 节 + 修 `.Text`）→ Task 4 ✓
+
+**Placeholder 扫描：** 无 TBD/TODO；每个代码步骤都给了完整代码。Task 5 Step 5 的 PR body `"..."` 是占位但属交付动作（待 user 确认后填），非实现缺口。
+
+**类型一致性：** `TextValue`（get/set）在 Task 1 定义、Task 2 Bind（`field.TextValue` 读写）+ Task 1/2 测试一致；`InputBox.XmlSrc` 默认 `"PromptUGUI/Modals/InputBox.ui"` 在 Task 2 Step 3 与 Task 3 Screen name 一致；`InputBoxRequest` 字段名（Title/Message/Initial/Placeholder/ContentType/OkLabel/CancelLabel）在 Step 3 定义与测试构造一致；`Btn.Text` / `Text.TmpComponent` / `Btn.SimulateClick` / `InputField.OnSubmit` 均为既有 API（已核对源码）。

--- a/docs~/superpowers/specs/2026-06-07-input-box-modal-design.md
+++ b/docs~/superpowers/specs/2026-06-07-input-box-modal-design.md
@@ -1,0 +1,301 @@
+# 内置 InputBox 模态设计
+
+**日期**：2026-06-07
+**状态**：设计阶段（待 review，未进入实施）
+**作用域**：在既有 `PromptUGUI.Application.Modals` 模态体系里新增**第三个内置 overlay**——`InputBox`：一个返回用户输入文本的强模态对话框。包含 (1) 静态便捷 wrapper `InputBox.Open(...)` → `Awaitable<string>`；(2) 内置子类 `InputBoxRequest : ModalRequest<string>`；(3) 内置 `.ui.xml` 模板（title + 可选 message + `<InputField>` + OK/Cancel）；(4) 给 `InputField` 补一个公开的 `TextValue` getter（当前只有 setter），以便 Bind 时读取最终文本。
+**依赖**：[`2026-05-14-messagebox-modal-design.md`](2026-05-14-messagebox-modal-design.md)（通用模态系统 + `ModalRequest<T>` + `UI.Modal` + `ModalDocCache` + ESC/sortingOrder/队列，已实现并合并）；`Runtime/Application/Modals/MessageBoxRequest.cs`（结构原型）；`Runtime/Controls/InputField.cs`（被复用的输入控件）；`Runtime/Application/Modals/ModalMode.cs`
+
+---
+
+## 1. 背景与目标
+
+模态系统在 MessageBox PR 里已建好——队列、ESC 监听、sortingOrder 叠加、`ModalDocCache` 加载分流、teardown 取消都是现成的。`ModalRequest<TResult>` 从 day 1 就是开放扩展点，`MessageBox` / `Loading` 只是其上的两个内置实例。
+
+当前缺口：**没有内置的「让用户输入一段文本」对话框**。这是仅次于 MessageBox 的高频需求：
+
+```csharp
+string name = await InputBox.Open(UI.Tr("Your name?"), placeholder: UI.Tr("e.g. Link"));
+if (name != null) game.PlayerName = name;
+```
+
+调用方今天能自己写 `ModalRequest<string>` 子类做到（C# skill 里的 `NamePickerRequest` 示例正是如此），但：
+
+1. 每个项目都要重抄一遍 Bind + 一份 XML；
+2. skill 示例引用了 `screen.Get<InputField>("input").Text`，而 `InputField` **没有这个 getter**——示例无法编译。说明「读回输入值」这一步缺一个公开入口。
+
+目标：把这套封装成开箱即用的内置 overlay，与 `MessageBox.Open` 对称。
+
+### 设计原则
+
+1. **复用既有模态机制**：InputBox 不碰 `UI.Modal` / `ModalDocCache` / ESC / sortingOrder 任何一行——它只是又一个 `ModalRequest<TResult>` 子类 + 静态 wrapper，与 `MessageBoxRequest` 完全平级。
+2. **结果类型安全且语义清晰**：`TResult = string`。确定 → 返回输入文本（可能是空串 `""`）；取消 / ESC → 返回 `null`。用 `null` vs `""` 区分「取消」和「提交了空内容」。
+3. **caller 端 API 最小化**：常见路径一行 `await InputBox.Open(title)`；高级需求（password 输入、自定义按钮文案、初始值、placeholder）走可选具名参数。
+4. **内置 + 可覆盖**：XML 是包内 Resources 资源，`InputBox.XmlSrc` 可写覆盖，与 MessageBox 一致。
+
+### 非目标
+
+- 不做内置必填 / 格式校验（调用方自己判 `null` / 空 / 正则）。需要时调用方写自定义 `ModalRequest<T>`。
+- 不透传 `InputField` 的全部属性（`characterLimit` / `lineType` / `align` / 颜色…）。v1 只暴露 `contentType`（password 等高频场景）；其余通过覆盖 XML 表达。
+- 不做多字段表单（一个对话框多个输入框）。那是独立特性，调用方走自定义 `ModalRequest<T>`。
+- 不改动 ESC / sortingOrder / 队列 / teardown 任何既有行为。
+
+---
+
+## 2. C# API
+
+命名空间沿用 `PromptUGUI.Application.Modals`。无新增枚举（结果是 `string`，不需要 `MsgBtn` 那样的标志枚举）。
+
+### 2.1 静态便捷 wrapper `InputBox`
+
+```csharp
+public static class InputBox {
+    // 与 MessageBox 一致：必须带 .ui 后缀（Unity 只剥离 .ui.xml 的最后 .xml）。
+    public static string XmlSrc { get; set; } = "PromptUGUI/Modals/InputBox.ui";
+
+    public static UnityEngine.Awaitable<string> Open(
+        string title,
+        string message     = null,   // 可选：title 下方一行说明文字；null/空 → 隐藏该节点
+        string initial     = null,   // 输入框初始文本
+        string placeholder = null,   // 空时的占位提示
+        string contentType = null,   // 透传 InputField.contentType，如 "password" / "email"
+        string okLabel     = null,   // 覆盖 OK 按钮文案（默认走 XML 内 "OK" + .po 翻译）
+        string cancelLabel = null,   // 覆盖 Cancel 按钮文案
+        ModalMode mode     = ModalMode.Popup);
+}
+```
+
+`title` 是唯一必填项（输入框的提示语通常就是它）。其余全可选具名参数。
+
+### 2.2 内置 `InputBoxRequest`
+
+```csharp
+public sealed class InputBoxRequest : ModalRequest<string> {
+    public string Title;
+    public string Message;
+    public string Initial;
+    public string Placeholder;
+    public string ContentType;
+    public string OkLabel;
+    public string CancelLabel;
+
+    public override string XmlSrc => InputBox.XmlSrc;
+    public override void Bind(IScreen screen, Action<string> close);   // §4
+    public override bool TryEscape(out string result) {                // ESC → 取消
+        result = null;
+        return true;
+    }
+}
+```
+
+ESC 始终映射为「取消」（返回 `null`），与「输入框对话框总能被取消」的直觉一致——这点与 MessageBox 不同（MessageBox 仅 OK 时 ESC 不响应，因为没有 cancel 语义键）。
+
+### 2.3 调用例子
+
+```csharp
+// 最简
+string name = await InputBox.Open(UI.Tr("Your name?"));
+if (name != null) game.PlayerName = name;   // null = 取消/ESC；"" = 提交了空串
+
+// password + 初始值 + placeholder
+string pw = await InputBox.Open(
+    UI.Tr("Enter password"),
+    contentType: "password",
+    placeholder: UI.Tr("at least 8 chars"));
+
+// 自定义按钮文案 + 排队
+string code = await InputBox.Open(
+    UI.Tr("Redeem code"), message: UI.Tr("Paste your gift code below."),
+    okLabel: UI.Tr("Redeem"), cancelLabel: UI.Tr("Later"),
+    mode: ModalMode.Queued);
+```
+
+---
+
+## 3. 内置 XML 模板
+
+文件位置：`Runtime/Resources/PromptUGUI/Modals/InputBox.ui.xml`。结构沿用 MessageBox 的 dialog 皮肤（同一个九宫格 sprite + backdrop），把按钮行换成 title + message + InputField：
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<PromptUGUI version="1">
+  <Screen name="PromptUGUI/Modals/InputBox.ui" reference="1920x1080" reference.portrait="1080x1920">
+    <Image id="backdrop" anchor="stretch" color="#000000FE"/>
+
+    <Image id="dialog" sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round"
+           anchor="center" size="640x280">
+      <VStack anchor="stretch" margin="24" spacing="12">
+        <Text id="title" fontSize="24" height="40"/>
+        <Text id="message" width="stretch" height="stretch" fontSize="18"/>
+        <InputField id="field" height="44"/>
+        <HStack height="44" spacing="8">
+          <Btn id="ok">OK</Btn>
+          <Btn id="cancel">Cancel</Btn>
+        </HStack>
+      </VStack>
+    </Image>
+  </Screen>
+</PromptUGUI>
+```
+
+- `<Screen name>` 与 `InputBox.XmlSrc` 默认值**逐字节相等**——`ModalDocCache.EnsureLoaded` 的硬约束（见 MessageBox spec §6.2）。
+- `id` 契约（Bind 依赖）：`title` / `message` / `field` / `ok` / `cancel`。`message` 节点 message 为空时 `SetActive(false)`，VStack 自动 collapse。
+- 按钮英文写死作 msgid 兜底，`.po` 翻译 "OK" / "Cancel"。
+- 颜色 / size / 字号是粗糙默认——pixel-art 项目大概率覆盖 XML。与 MessageBox 同样的「内置 + 可覆盖」定位。
+
+---
+
+## 4. `InputBoxRequest.Bind` 实现
+
+```csharp
+public override void Bind(IScreen screen, Action<string> close) {
+    var titleCtl = screen.Get<Controls.Text>("title");
+    if (string.IsNullOrEmpty(Title)) titleCtl.GameObject.SetActive(false);
+    else titleCtl.TextValue = Title;
+
+    // message 节点可选（XML 覆盖时可能删掉）→ 容忍 KeyNotFoundException
+    try {
+        var msgCtl = screen.Get<Controls.Text>("message");
+        if (string.IsNullOrEmpty(Message)) msgCtl.GameObject.SetActive(false);
+        else msgCtl.TextValue = Message;
+    } catch (System.Collections.Generic.KeyNotFoundException) { }
+
+    var field = screen.Get<Controls.InputField>("field");
+    if (!string.IsNullOrEmpty(ContentType)) field.ContentType = ContentType;
+    if (Placeholder != null) field.Placeholder = Placeholder;
+    field.TextValue = Initial ?? "";
+
+    // 回车 = 确定。OnSubmit 直接给出当前文本。
+    field.OnSubmit.Subscribe(v => close(v)).AddTo(screen);
+
+    var ok = screen.Get<Controls.Btn>("ok");
+    if (!string.IsNullOrEmpty(OkLabel)) ok.Text = OkLabel;
+    ok.OnClick.Subscribe(_ => close(field.TextValue)).AddTo(screen);
+
+    var cancel = screen.Get<Controls.Btn>("cancel");
+    if (!string.IsNullOrEmpty(CancelLabel)) cancel.Text = CancelLabel;
+    cancel.OnClick.Subscribe(_ => close(null)).AddTo(screen);
+}
+```
+
+关键点：
+- **确定时通过 `field.TextValue`（getter）读最终文本**——这是本特性需要给 `InputField` 补 getter 的唯一动因（§5）。
+- `close` 多次调用由模态系统幂等保证（MessageBox spec §4.4：`_currentResolved` flag）——回车后又点 OK 不会二次 resolve。
+- `message` 节点缺失被容忍，与 MessageBox 对 `icon` 节点的处理一致。
+
+---
+
+## 5. `InputField` 公开 `TextValue` getter
+
+当前 `InputField.TextValue` 是只写属性（`[UIAttr("text")]`）：
+
+```csharp
+[UIAttr("text"), Preserve]
+public string TextValue { set => _input.text = value ?? string.Empty; }
+```
+
+改为读写：
+
+```csharp
+[UIAttr("text"), Preserve]
+public string TextValue {
+    get => _input != null ? _input.text : null;
+    set => _input.text = value ?? string.Empty;
+}
+```
+
+理由与取舍：
+- **复用 `TextValue` 而非新增 `Value` / `Text`**：`TextValue` 已是该类（及 `Text` 控件）的既有「当前文本」属性名，加 getter 最一致，不引入第二个名字。
+- **修正既有 skill 不实之处**：C# skill 的 `NamePickerRequest` 示例引用 `.Text`（不存在）→ 改为 `.TextValue`。
+- `_input` 为 null 时返回 `null`（防御 OnAttached 之前的访问），与既有 `PeekDefaultText()` 的 null 处理一致。`PeekDefaultText()` 是内部 ReSolve 用途，保持不动。
+- `[UIAttr]` / `[Preserve]` 不变——加 getter 不影响属性应用或反射裁剪。
+
+---
+
+## 6. 边界情况
+
+| 情况 | 行为 |
+|---|---|
+| `title` 传 `null`/空 | title 节点 `SetActive(false)`（虽是必填参数，仍防御） |
+| `message` 为空 | message 节点 `SetActive(false)`；覆盖 XML 删了 message 节点也不报错（catch KeyNotFound） |
+| 用户输入空串后点 OK | 返回 `""`（**非** `null`）——与「取消」区分 |
+| 回车后又点 OK | 第二次 `close` 被模态系统幂等忽略 |
+| `contentType` 传非法值 | `InputField.ContentType` setter 抛 `ArgumentException`（既有行为）→ 走模态 Bind 异常路径（MessageBox spec §4.4：close Screen + SetException + pump 下一个） |
+| 覆盖 XML 缺 `field` id | `screen.Get<InputField>("field")` 抛 KeyNotFound → 同上异常路径 |
+| Locale / Variant 切换 | InputBox 是普通 Screen，ReSolve 原地生效（输入框文本由 `RuntimeStateAttr` 机制保住，不被 ReSolve 重置——既有行为） |
+| ESC | `TryEscape` 返回 `null`（取消），仅顶层 modal 响应（既有 `ModalEscapeListener`） |
+
+无新增模态基础设施，故 ESC / sortingOrder / 队列 / teardown / hot-reload 全部沿用 MessageBox 已验证的路径，本特性不重测。
+
+---
+
+## 7. 测试策略
+
+测试集中在 EditMode（Bind 逻辑 + getter），模态机制本身已被 MessageBox 测试覆盖，不重复。
+
+### 7.1 EditMode（`PromptUGUI.Tests.EditMode`，新增 `Tests/EditMode/Modals/InputBoxTests.cs`）
+
+沿用 `ModalTestFixture` / fake-resolver 模式（把 `InputBox.XmlSrc` 指向测试 XML，或直接用内置 Resources 路径）：
+
+```csharp
+[Test] public void Open_then_clickOk_returns_current_text();
+[Test] public void Open_then_clickCancel_returns_null();
+[Test] public void Submit_via_OnSubmit_resolves_with_text();   // 模拟回车
+[Test] public void Empty_input_then_ok_returns_empty_string_not_null();
+[Test] public void Initial_text_prefills_field();
+[Test] public void ContentType_password_applied_to_field();
+[Test] public void Custom_ok_cancel_labels_override_default();
+[Test] public void Null_message_hides_message_node();
+[Test] public void TryEscape_returns_null_and_true();
+[Test] public void Missing_message_node_in_xml_is_tolerated();   // 覆盖 XML 删 message
+```
+
+模拟点击/提交：`Controls.Btn` 已有 internal `SimulateClick()`（MessageBox 测试用过）；`InputField` 提交走 `OnSubmit`——测试期可对 internal `_input` 或新增一个 internal `SimulateSubmit(string)` 辅助（实现细节留 plan 决定，优先不加新 API：可直接设 `TextValue` 后触 OnSubmit 的既有路径）。
+
+### 7.2 InputField getter 单测（`Tests/EditMode`，并入既有 `InputFieldTests.cs`）
+
+```csharp
+[Test] public void TextValue_getter_roundtrips_set_value();
+[Test] public void TextValue_getter_before_attach_returns_null();   // 防御 _input==null
+```
+
+### 7.3 不测的
+
+- PlayMode 端到端弹窗 + 真实键盘回车——模态弹出/ESC/sortingOrder 已由 MessageBox PlayMode 测试覆盖，InputBox 无新机制。
+- 视觉样式（默认皮肤好不好看）——靠用户覆盖 XML，做 visual QA。
+
+---
+
+## 8. SKILL.md 影响
+
+按 `CLAUDE.md` trigger 规则：
+
+- 新公开 C# API（`InputBox` 静态类 + `InputBoxRequest` + `InputField.TextValue` getter）→ **`scripting-promptugui-csharp/SKILL.md` 必须更新**：
+  - "Modal dialogs" 节的 intro 从「two builtin overlays」改为「three builtin overlays」，新增 InputBox 的 Quick usage + API surface。
+  - 修正 `NamePickerRequest` 示例 `.Text` → `.TextValue`。
+- 内置 `InputBox.ui.xml` 全部用已有 built-in tag（`<Image>` / `<VStack>` / `<HStack>` / `<Text>` / `<InputField>` / `<Btn>`）→ 无新 XML tag/attribute → **`authoring-promptugui-xml/SKILL.md` 不需要更新**。
+- 不涉及 `PROMPTUGUI_HAS_ADDRESSABLES` → **addressables skill 不需要更新**。
+- 无新 XML tag → **无 XSD / `BuiltinTags.cs` 改动**。
+
+---
+
+## 9. 实施顺序（plan 阶段细化）
+
+1. **`InputField.TextValue` getter** + 2 条 getter 单测（红 → 绿）。
+2. **`InputBoxRequest`**（Bind + TryEscape）+ 内置 `InputBox.ui.xml`。
+3. **`InputBox` 静态 wrapper**（`Open` + `XmlSrc`）。
+4. **EditMode `InputBoxTests`**——10 条用例红 → 绿。
+5. **C# SKILL.md 更新**（overlay 计数 + InputBox 节 + 修 `.Text` → `.TextValue`）。
+
+每步跑 lint（`dotnet format --verify-no-changes --severity warn`）+ UnityMCP 编译检查 + 对应单元测试。
+
+---
+
+## 10. 验收标准
+
+- `await InputBox.Open("Your name?")` 弹出输入对话框，输入 "Link" 点 OK → task 返回 `"Link"`。
+- 点 Cancel / 按 ESC → 返回 `null`。
+- 不输入直接点 OK → 返回 `""`（非 `null`）。
+- `contentType: "password"` 时输入框走密码掩码。
+- `okLabel` / `cancelLabel` 覆盖按钮文案；`initial` 预填；`placeholder` 显示占位。
+- `InputBox.XmlSrc = "MyUI/Modals/Foo.ui"` 能整体替换皮肤（`<Screen name>` 须 byte-equal）。
+- EditMode 测试全绿；`dotnet format --verify-no-changes --severity warn` 干净。

--- a/docs~/superpowers/specs/2026-06-07-input-box-modal-design.md
+++ b/docs~/superpowers/specs/2026-06-07-input-box-modal-design.md
@@ -221,7 +221,7 @@ public string TextValue {
 | 回车后又点 OK | 第二次 `close` 被模态系统幂等忽略 |
 | `contentType` 传非法值 | `InputField.ContentType` setter 抛 `ArgumentException`（既有行为）→ 走模态 Bind 异常路径（MessageBox spec §4.4：close Screen + SetException + pump 下一个） |
 | 覆盖 XML 缺 `field` id | `screen.Get<InputField>("field")` 抛 KeyNotFound → 同上异常路径 |
-| Locale / Variant 切换 | InputBox 是普通 Screen，ReSolve 原地生效（输入框文本由 `RuntimeStateAttr` 机制保住，不被 ReSolve 重置——既有行为） |
+| Locale / Variant 切换 | InputBox 是普通 Screen，ReSolve 原地生效。输入框文本不被 ReSolve 重置——但**不是**靠 `RuntimeStateAttr`：`InputField` 没有注册 runtimeStateAttr（见 `BuiltinPrimitives.cs`，对比 Toggle/Tab/Slider/Dropdown 都注册了）。真实原因是内置 `InputBox.ui.xml` 的 `<InputField id="field">` 上**没有 `text=` 属性**，ReSolve 因此根本不调 `TextValue` setter。⚠️ 反过来：若用户覆盖 XML 时给 field 写了字面 `text="…"`，开着对话框切 Locale 会清掉已输入内容——v1 不处理，作者覆盖 XML 时勿在 field 上写 `text=`。 |
 | ESC | `TryEscape` 返回 `null`（取消），仅顶层 modal 响应（既有 `ModalEscapeListener`） |
 
 无新增模态基础设施，故 ESC / sortingOrder / 队列 / teardown / hot-reload 全部沿用 MessageBox 已验证的路径，本特性不重测。


### PR DESCRIPTION
## Summary

新增第三个内置 modal overlay **`InputBox`** —— 一个返回用户输入文本的强模态对话框，与 `MessageBox` / `Loading` 并列。

```csharp
// 确定/回车 → 输入文本（空输入返回 ""）；取消/ESC → null
string name = await InputBox.Open("Your name?", placeholder: "e.g. Link");
if (name != null) game.PlayerName = name;
```

- **`InputBox.Open(title, message?, initial?, placeholder?, contentType?, okLabel?, cancelLabel?, mode?)` → `Awaitable<string>`**，用 `null` 区分「取消」与「提交空串 `""`」。
- **`InputBoxRequest : ModalRequest<string>`** + 内置 `InputBox.ui.xml`（title + 可选 message + `<InputField>` + OK/Cancel）。完全复用既有 `ModalRequest<T>` / `UI.Modal` / `ModalDocCache` / ESC / sortingOrder / 队列机制，**未改动任何模态基础设施**。
- **`InputField.TextValue` 补 getter**（复用既有属性名）—— Bind 读回输入所需；顺手修正 C# skill 里引用了不存在的 `.Text` 的 NamePicker 示例。
- 无新 XML 标签 → 无 XSD / `BuiltinTags.cs` 改动。C# SKILL.md 已同步（overlay 计数 2→3 + InputBox 节）。

设计与计划：`docs~/superpowers/specs/2026-06-07-input-box-modal-design.md`、`docs~/superpowers/plans/2026-06-07-input-box-modal.md`。

## Test Plan

- [x] 全量 EditMode：**1382/1382** 通过（含新增 16 条：14 InputBoxTests + 2 InputField getter）
- [x] `dotnet format --verify-no-changes --severity warn`：干净
- [x] UIXmlLint 整个 `Runtime/Resources/`：no issues（3 files）
- [x] 终审 holistic review：READY TO MERGE，无 critical/important
- [ ] **Visual QA（待 author）**：host 工程跑 `InputBox.Open(...)`，确认弹窗居中 / 输入聚焦 / 回车=OK / ESC=Cancel→null / `contentType:"password"` 掩码

🤖 Generated with [Claude Code](https://claude.com/claude-code)