### PR TITLE
feat(modal): post-bind `configure` hook on all modals + Btn runtime greying

### DIFF
--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -504,6 +504,11 @@ MODAL          var r = await MessageBox.Open(text, MsgBtn.OK|MsgBtn.Cancel, icon
                var s = await InputBox.Open(title, message, initial, placeholder,
                                            contentType, okLabel, cancelLabel, mode)
                        // confirm → text ("" if empty); cancel/ESC → null
+                       // Enter respects ok.Interactable (disable ok → Enter gated too)
+               configure:     Action<IScreen> trailing arg on every Open (MessageBox/InputBox/Loading)
+                              // post-bind hook → live Screen; reach any control w/o subclassing
+                              // e.g. InputBox.Open(t, configure: s => s.Get<Btn>("ok").Interactable = false)
+                              // base ModalRequest<T>.Configure field → custom modals get it free
                ESC priority   Cancel > No > Close   (OK-only → no-op)
                override XML   MessageBox.XmlSrc = "MyUI/Modals/Foo.ui"   (keep .ui suffix)
                               prereq #1  resolver registered + (Addressables) address pre-registered
@@ -516,7 +521,7 @@ MODAL          var r = await MessageBox.Open(text, MsgBtn.OK|MsgBtn.Cancel, icon
                               override TryEscape(out T) to map ESC → result
                UI.Modal.CloseAll()                          cancel all (OperationCanceledException)
                UI.Modal.SortingOrderBase = 1000             default; configurator can't pin sortingOrder
-LOADING        var h = Loading.Open(text); h.Close()        idempotent; h.IsClosed
+LOADING        var h = Loading.Open(text, configure); h.Close()  idempotent; h.IsClosed
                Loading.XmlSrc = "MyUI/Modals/Foo.ui"        override; only <Text id="text"> recognised
                Loading.SortingOrder = 500                   overlay 层带,低于 dialog
                concurrent Open() → independent overlays at the same band (no ref-count)
@@ -562,25 +567,33 @@ string pw = await InputBox.Open(UI.Tr("Enter password"),
 ### API surface (`PromptUGUI.Application.Modals`)
 
 ```csharp
+// Every Open helper takes a trailing `configure: Action<IScreen>` — a post-bind hook that
+// hands you the live modal Screen so you can reach ANY control without subclassing (disable
+// the OK Btn, wire field validation, restyle, …). It runs AFTER the builtin Bind, so it
+// overrides builtin wiring. See "Customizing a builtin modal" below.
 public static class MessageBox {
     public static string XmlSrc { get; set; } = "PromptUGUI/Modals/MessageBox.ui";
 
     public static Awaitable<MsgBtn> Open(
         string text, MsgBtn buttons = MsgBtn.OK,
         string icon = null, string title = null,
-        ModalMode mode = ModalMode.Popup);
+        ModalMode mode = ModalMode.Popup,
+        Action<IScreen> configure = null);
 
     public static Awaitable<MsgBtn> Open(
         string text,
         IEnumerable<(string label, MsgBtn key)> buttons,   // also sets the .Buttons mask
         string icon = null, string title = null,
-        ModalMode mode = ModalMode.Popup);
+        ModalMode mode = ModalMode.Popup,
+        Action<IScreen> configure = null);
 }
 
 public static class InputBox {
     public static string XmlSrc { get; set; } = "PromptUGUI/Modals/InputBox.ui";
 
     // confirm/Enter → entered text ("" if empty); cancel/ESC → null
+    // Enter (OnSubmit) respects the ok Btn's Interactable — disabling ok in `configure`
+    // gates Enter too, so OK is the single source of truth for "can submit".
     public static Awaitable<string> Open(
         string title,
         string message     = null,   // optional line under the title
@@ -589,7 +602,8 @@ public static class InputBox {
         string contentType = null,   // InputField.contentType, e.g. "password" / "email"
         string okLabel     = null,
         string cancelLabel = null,
-        ModalMode mode     = ModalMode.Popup);
+        ModalMode mode     = ModalMode.Popup,
+        Action<IScreen> configure = null);
 }
 
 [Flags] public enum MsgBtn { None=0, OK=1, Cancel=2, Yes=4, No=8, Close=16 }
@@ -598,7 +612,7 @@ public enum ModalMode { Popup = 0, Queued = 1 }
 public static class Loading {
     public static string XmlSrc { get; set; } = "PromptUGUI/Modals/Loading.ui";
     public static int SortingOrder { get; set; } = 500;   // keep < SortingOrderBase
-    public static LoadingHandle Open(string text = null);
+    public static LoadingHandle Open(string text = null, Action<IScreen> configure = null);
 }
 
 public sealed class LoadingHandle {
@@ -646,6 +660,38 @@ UI.Modal.SortingOrderBase` so dialogs opened during a Loading appear above it.
 - **Locale / Variant**: a dialog is a regular `Screen` — `UI.Locale.Set(...)` and
   `UI.Variants.Set(...)` ReSolve open modals in place, no rebuild. Fonts swap on locale
   switch like in any other Screen (`<Text font="title">` etc.).
+
+### Customizing a builtin modal (the `configure` hook)
+
+Every builtin `Open` (`MessageBox` / `InputBox` / `Loading`) takes a trailing
+`configure: Action<IScreen>`. It fires **once, right after the builtin Bind**, with the
+live modal `Screen` — so you reach any control via `screen.Get<T>(id)` and customize
+without writing a `ModalRequest<T>` subclass. Because it runs after Bind, it overrides
+builtin wiring (labels, etc.) rather than being overwritten.
+
+```csharp
+// Disable OK until the field is non-empty. Disabling the OK Btn gates BOTH click and Enter
+// (InputBox's OnSubmit checks ok.Interactable), and greys the button (runtime Btn.Interactable
+// drives the Selectable, not just the CanvasGroup).
+string name = await InputBox.Open(UI.Tr("Your name?"), configure: screen => {
+    var ok    = screen.Get<Btn>("ok");
+    var field = screen.Get<InputField>("field");
+    ok.Interactable = false;
+    field.OnValueChanged
+         .Subscribe(v => ok.Interactable = !string.IsNullOrWhiteSpace(v))
+         .AddTo(screen);
+});
+```
+
+The hook is declared once on the base `ModalRequest<TResult>` as a public
+`Action<IScreen> Configure` field (the builtin helpers just thread their `configure`
+param into it), so **custom `ModalRequest<T>` subclasses inherit it for free** — set
+`new MyRequest { Configure = s => … }`. Subscriptions made in the hook should still
+`.AddTo(screen)`. A throwing `configure` cancels that modal's await (logged for Loading).
+
+> **Btn.Interactable at runtime**: setting it from code (here or anywhere) now drives the
+> underlying Button — greying it + emitting `InteractState.Disabled` — and blocks raycasts
+> via the CanvasGroup. Same end state as the XML `interactable="false"` attr.
 
 ### Cancelling
 

--- a/Runtime/Application/Modals/InputBoxRequest.cs
+++ b/Runtime/Application/Modals/InputBoxRequest.cs
@@ -35,12 +35,13 @@ namespace PromptUGUI.Application.Modals
             if (Placeholder != null) field.Placeholder = Placeholder;
             field.TextValue = Initial ?? "";
 
-            // 回车 = 确定；OnSubmit 直接给出当前文本。
-            field.OnSubmit.Subscribe(v => close(v)).AddTo(screen);
-
             var ok = screen.Get<PromptUGUI.Controls.Btn>("ok");
             if (!string.IsNullOrEmpty(OkLabel)) ok.Text = OkLabel;
             ok.OnClick.Subscribe(_ => close(field.TextValue)).AddTo(screen);
+
+            // 回车 = 确定，但尊重 OK 的禁用态：Configure 钩子里把 ok.Interactable 置 false 做校验门控时，
+            // 回车也一并被挡（否则光禁用按钮挡不住 OnSubmit，禁用就成了半成品）。
+            field.OnSubmit.Where(_ => ok.Interactable).Subscribe(v => close(v)).AddTo(screen);
 
             var cancel = screen.Get<PromptUGUI.Controls.Btn>("cancel");
             if (!string.IsNullOrEmpty(CancelLabel)) cancel.Text = CancelLabel;
@@ -67,7 +68,8 @@ namespace PromptUGUI.Application.Modals
             string contentType = null,
             string okLabel = null,
             string cancelLabel = null,
-            ModalMode mode = ModalMode.Popup)
+            ModalMode mode = ModalMode.Popup,
+            System.Action<IScreen> configure = null)
             => UI.Modal.OpenAsync(new InputBoxRequest
             {
                 Title = title,
@@ -77,6 +79,7 @@ namespace PromptUGUI.Application.Modals
                 ContentType = contentType,
                 OkLabel = okLabel,
                 CancelLabel = cancelLabel,
+                Configure = configure,
             }, mode);
     }
 }

--- a/Runtime/Application/Modals/Loading.cs
+++ b/Runtime/Application/Modals/Loading.cs
@@ -12,8 +12,13 @@ namespace PromptUGUI.Application.Modals
         /// <summary>overlay 的 sortingOrder。须低于 <see cref="UI.Modal.SortingOrderBase"/>(默认 1000)。</summary>
         public static int SortingOrder { get; set; } = 500;
 
-        public static LoadingHandle Open(string text = null)
-            => LoadingOverlay.Open(text);
+        /// <param name="configure">
+        /// Optional post-bind hook receiving the live overlay <see cref="IScreen"/> — same shape as
+        /// the dialog modals' <c>configure</c>. Runs after the builtin text bind, so it can reach
+        /// any control (custom spinner, extra text, …) without subclassing.
+        /// </param>
+        public static LoadingHandle Open(string text = null, System.Action<IScreen> configure = null)
+            => LoadingOverlay.Open(text, configure);
     }
 
     /// <summary>

--- a/Runtime/Application/Modals/LoadingOverlay.cs
+++ b/Runtime/Application/Modals/LoadingOverlay.cs
@@ -15,6 +15,7 @@ namespace PromptUGUI.Application.Modals
         {
             public string Src;
             public string Text;
+            public Action<IScreen> Configure;   // 可选 post-bind 钩子
             public Screen Screen;     // 实例化前为 null
             public string Key;        // _open instance key,实例化前为 null
             public bool Closed;
@@ -38,9 +39,9 @@ namespace PromptUGUI.Application.Modals
             }
         }
 
-        internal static LoadingHandle Open(string text)
+        internal static LoadingHandle Open(string text, Action<IScreen> configure = null)
         {
-            var entry = new LoadingEntry { Src = Loading.XmlSrc, Text = text };
+            var entry = new LoadingEntry { Src = Loading.XmlSrc, Text = text, Configure = configure };
             var handle = new LoadingHandle(entry);
             _entries.Add(entry);
             _pending.Enqueue(entry);
@@ -100,6 +101,7 @@ namespace PromptUGUI.Application.Modals
                         canvas.sortingOrder = Loading.SortingOrder;
 
                         BindText(screen, entry.Text);
+                        entry.Configure?.Invoke(screen);   // post-bind 钩子,与 dialog 路径一致
                     }
                     catch (Exception ex)
                     {

--- a/Runtime/Application/Modals/MessageBoxRequest.cs
+++ b/Runtime/Application/Modals/MessageBoxRequest.cs
@@ -71,20 +71,23 @@ namespace PromptUGUI.Application.Modals
 
         public static UnityEngine.Awaitable<MsgBtn> Open(
             string text, MsgBtn buttons = MsgBtn.OK, string icon = null, string title = null,
-            ModalMode mode = ModalMode.Popup)
+            ModalMode mode = ModalMode.Popup,
+            System.Action<IScreen> configure = null)
             => UI.Modal.OpenAsync(new MessageBoxRequest
             {
                 Text = text,
                 Buttons = buttons,
                 Icon = icon,
                 Title = title,
+                Configure = configure,
             }, mode);
 
         public static UnityEngine.Awaitable<MsgBtn> Open(
             string text,
             System.Collections.Generic.IEnumerable<(string label, MsgBtn key)> buttons,
             string icon = null, string title = null,
-            ModalMode mode = ModalMode.Popup)
+            ModalMode mode = ModalMode.Popup,
+            System.Action<IScreen> configure = null)
         {
             var list = new System.Collections.Generic.List<(string, MsgBtn)>(buttons);
             var mask = MsgBtn.None;
@@ -96,6 +99,7 @@ namespace PromptUGUI.Application.Modals
                 Buttons = mask,
                 Icon = icon,
                 Title = title,
+                Configure = configure,
             }, mode);
         }
     }

--- a/Runtime/Application/Modals/ModalEntry.cs
+++ b/Runtime/Application/Modals/ModalEntry.cs
@@ -42,6 +42,8 @@ namespace PromptUGUI.Application.Modals
                 _tcs.TrySetResult(result);
                 onClose?.Invoke();
             });
+            // Caller customization layers on top of (after) the request's own Bind.
+            _request.Configure?.Invoke(screen);
         }
 
         public bool TryEscape(Action wakePump)

--- a/Runtime/Application/Modals/ModalRequest.cs
+++ b/Runtime/Application/Modals/ModalRequest.cs
@@ -7,6 +7,16 @@ namespace PromptUGUI.Application.Modals
     {
         public abstract string XmlSrc { get; }
 
+        /// <summary>
+        /// Optional post-bind customization hook. Invoked once by
+        /// <see cref="ModalEntry{TResult}.RunBind"/> AFTER <see cref="Bind"/>, with the live modal
+        /// <see cref="IScreen"/>. Lets callers reach any control (disable the OK <c>Btn</c>, wire
+        /// field validation, restyle, …) without subclassing. Runs after Bind so it overrides
+        /// builtin wiring rather than being overwritten by it. The builtin <c>MessageBox.Open</c> /
+        /// <c>InputBox.Open</c> helpers expose it as a <c>configure</c> parameter.
+        /// </summary>
+        public Action<IScreen> Configure;
+
         public abstract void Bind(IScreen screen, Action<TResult> close);
 
         public virtual bool TryEscape(out TResult result)

--- a/Runtime/Controls/Btn.cs
+++ b/Runtime/Controls/Btn.cs
@@ -63,6 +63,24 @@ namespace PromptUGUI.Controls
         public Observable<InteractState> OnState => _btn.OnState;
 
         /// <summary>
+        /// Runtime override so setting <see cref="Interactable"/> from code (e.g. a modal
+        /// <c>Configure</c> hook gating the OK button) also drives the underlying
+        /// <see cref="UnityEngine.UI.Button"/> — greying it out + emitting
+        /// <see cref="InteractState.Disabled"/> — not just the base CanvasGroup. Mirrors the
+        /// XML-attr path (<see cref="OnAfterApply"/>), so code-applied and Variant-applied
+        /// disables look identical. The CanvasGroup side (from base) still blocks raycasts.
+        /// </summary>
+        public override bool Interactable
+        {
+            get => base.Interactable;
+            set
+            {
+                base.Interactable = value;
+                if (_btn != null) _btn.interactable = value;
+            }
+        }
+
+        /// <summary>
         /// Bridges the common <c>interactable</c> attribute (already applied by
         /// <see cref="ControlAttributeApplier"/> via <c>ApplyCommon</c> → base
         /// <see cref="Control.Interactable"/>, CanvasGroup-backed) to the underlying

--- a/Runtime/Controls/Control.cs
+++ b/Runtime/Controls/Control.cs
@@ -31,7 +31,7 @@ namespace PromptUGUI.Controls
             set => GameObject.SetActive(!value);
         }
 
-        public bool Interactable
+        public virtual bool Interactable
         {
             get => CanvasGroup.interactable;
             set { CanvasGroup.interactable = value; CanvasGroup.blocksRaycasts = value; }

--- a/Tests/EditMode/Controls/BtnStateTests.cs
+++ b/Tests/EditMode/Controls/BtnStateTests.cs
@@ -158,6 +158,41 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
+        public void RuntimeInteractableFalse_DrivesButtonAndEmitsDisabled()
+        {
+            // Setting Btn.Interactable from code (e.g. a modal Configure hook) must bridge to
+            // Button.interactable too — not just the CanvasGroup — so the button greys out and
+            // OnState emits Disabled, matching the interactable='false' XML path. Before the
+            // Btn override this only touched CanvasGroup, leaving the button un-greyed.
+            var btn = BuildBtn();
+            var puiBtn = btn.GameObject.GetComponent<PuiButton>();
+            Assert.IsTrue(puiBtn.interactable, "precondition: starts interactable");
+
+            btn.Interactable = false;
+
+            Assert.IsFalse(puiBtn.interactable,
+                "runtime Interactable=false should drive Button.interactable");
+            InteractState seen = (InteractState)(-1);
+            using var _ = btn.OnState.Subscribe(s => seen = s);
+            Assert.AreEqual(InteractState.Disabled, seen);
+        }
+
+        [Test]
+        public void RuntimeInteractableTrue_ReEnablesButton()
+        {
+            var btn = BuildBtn();
+            var puiBtn = btn.GameObject.GetComponent<PuiButton>();
+            btn.Interactable = false;
+            btn.Interactable = true;
+
+            Assert.IsTrue(puiBtn.interactable,
+                "runtime Interactable=true should re-enable Button.interactable");
+            InteractState seen = (InteractState)(-1);
+            using var _ = btn.OnState.Subscribe(s => seen = s);
+            Assert.AreEqual(InteractState.Normal, seen);
+        }
+
+        [Test]
         public void PlainBtn_BackCompat_TargetGraphicIsBgAndTransitionIsColorTint()
         {
             var btn = BuildBtn();

--- a/Tests/EditMode/Modals/ModalConfigureHookTests.cs
+++ b/Tests/EditMode/Modals/ModalConfigureHookTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using R3;
+using TMPro;
+using PBtn = PromptUGUI.Controls.Btn;
+using PInputField = PromptUGUI.Controls.InputField;
+using PText = PromptUGUI.Controls.Text;
+
+namespace PromptUGUI.Tests.Modals
+{
+    // The post-bind `Configure` hook hands callers the live IScreen so they can reach any
+    // control without subclassing — disable the OK Btn, wire validation, restyle, etc. It is
+    // declared once on the base ModalRequest and invoked centrally in ModalEntry.RunBind, so
+    // MessageBox / InputBox / custom requests all get it; Loading mirrors it in its own pump.
+    public class ModalConfigureHookTests
+    {
+        private const string MboxXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/Box1'>
+    <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+    <Frame id='dialog' anchor='center' size='400x200'>
+      <VStack anchor='stretch' margin='16' spacing='8'>
+        <Text id='title' fontSize='20'/>
+        <Text id='text'  fontSize='14'/>
+        <Btn  id='ok'>OK</Btn>
+        <Btn  id='cancel'>Cancel</Btn>
+        <Btn  id='yes'>Yes</Btn>
+        <Btn  id='no'>No</Btn>
+        <Btn  id='close'>Close</Btn>
+      </VStack>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+
+        private const string InputXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/InputBox1'>
+    <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+    <Frame id='dialog' anchor='center' size='400x220'>
+      <VStack anchor='stretch' margin='16' spacing='8'>
+        <Text id='title' fontSize='20'/>
+        <Text id='message' fontSize='14'/>
+        <InputField id='field' height='44'/>
+        <Btn id='ok'>OK</Btn>
+        <Btn id='cancel'>Cancel</Btn>
+      </VStack>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+
+        private Dictionary<string, string> _files;
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            _files = new Dictionary<string, string>
+            {
+                ["test/Box1"] = MboxXml,
+                ["test/InputBox1"] = InputXml,
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(_files.TryGetValue(src, out var v) ? v : null);
+            MessageBox.XmlSrc = "test/Box1";
+            InputBox.XmlSrc = "test/InputBox1";
+        }
+
+        [TearDown]
+        public void TearDown() => UI.ResetForTests();
+
+        private static string Label(string id)
+            => UI.Modal.TopScreen.Get<PBtn>(id).GameObject
+                .GetComponentInChildren<TMP_Text>().text;
+
+        private static TMP_InputField Field()
+            => UI.Modal.TopScreen.Get<PInputField>("field").GameObject
+                .GetComponent<TMP_InputField>();
+
+        // --- MessageBox: hook fires, and fires AFTER Bind (overrides a Bind-set custom label) ---
+        [Test]
+        public void MessageBox_configure_runs_after_bind()
+        {
+            MessageBox.Open("hi", new[] { ("Retry", MsgBtn.OK) },
+                configure: s => s.Get<PBtn>("ok").Text = "HOOK");
+            Assert.AreEqual("HOOK", Label("ok"),
+                "Configure must run after Bind so it overrides the custom 'Retry' label");
+        }
+
+        // --- InputBox static helper threads `configure` through to the request ---
+        [Test]
+        public void InputBox_configure_can_disable_ok()
+        {
+            InputBox.Open("Name?", configure: s => s.Get<PBtn>("ok").Interactable = false);
+            Assert.IsFalse(UI.Modal.TopScreen.Get<PBtn>("ok").Interactable);
+        }
+
+        // --- The fix: Enter (OnSubmit) is gated by ok.Interactable ---
+        [Test]
+        public void InputBox_enter_is_gated_when_ok_disabled()
+        {
+            var task = UI.Modal.OpenAsync(new InputBoxRequest
+            {
+                Title = "Name?",
+                Configure = s => s.Get<PBtn>("ok").Interactable = false,
+            });
+
+            Field().onSubmit.Invoke("typed");
+            Assert.IsTrue(UI.Modal.IsAnyOpen, "Enter must not submit while OK is disabled");
+
+            // Re-enable → Enter now closes with the typed text.
+            UI.Modal.TopScreen.Get<PBtn>("ok").Interactable = true;
+            Field().onSubmit.Invoke("typed2");
+            Assert.AreEqual("typed2", task.GetAwaiter().GetResult());
+        }
+
+        // --- Loading overlay (separate subsystem) also honors configure ---
+        [Test]
+        public void Loading_configure_receives_screen_and_mutates()
+        {
+            Loading.XmlSrc = "PromptUGUI/Modals/Loading.ui";   // builtin, via Resources
+            IScreen captured = null;
+            var handle = Loading.Open("orig", configure: s =>
+            {
+                captured = s;
+                s.Get<PText>("text").TextValue = "HOOK";
+            });
+
+            Assert.IsNotNull(captured, "Configure must receive the live Loading screen");
+            Assert.AreEqual("HOOK",
+                LoadingOverlay.ActiveScreens.First().Get<PText>("text").TmpComponent.text);
+            handle.Close();
+        }
+
+        // --- Custom ModalRequest<T> subclasses inherit the hook for free ---
+        [Test]
+        public void Custom_request_configure_invoked_with_screen()
+        {
+            var ran = false;
+            UI.Modal.OpenAsync(new ProbeRequest
+            {
+                Configure = s => ran = s.Get<PBtn>("ok") != null,
+            });
+            Assert.IsTrue(ran, "Base-class Configure must fire for arbitrary ModalRequest subclasses");
+        }
+
+        private sealed class ProbeRequest : ModalRequest<string>
+        {
+            public override string XmlSrc => "test/InputBox1";
+
+            public override void Bind(IScreen screen, Action<string> close)
+                => screen.Get<PBtn>("ok").OnClick.Subscribe(_ => close("ok")).AddTo(screen);
+        }
+    }
+}

--- a/Tests/EditMode/Modals/ModalConfigureHookTests.cs.meta
+++ b/Tests/EditMode/Modals/ModalConfigureHookTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a4fc1cdbc430ad84ca30ecf22758f827


### PR DESCRIPTION
## 动机

`InputBox.Open` 等模态框只返回 `Awaitable<TResult>`,结果在关闭时才 resolve —— 调用方拿不到"还活着的"控件,没法在打开期间禁用 OK 按钮、加字段校验等。本 PR 给所有模态框加一个 **post-bind 钩子**,把 live 的 `IScreen` 交出去,任意定制、无需 subclass。

最初诉求是"暴露 OKButton",升级为"暴露整个 `IScreen`":因为 await-to-close 的时序决定了唯一访问点是 Bind 时刻,且 MessageBox 有 5 个按钮(没有单一 OK)。

## 改动

**一处贯通**:`Action<IScreen> Configure` 字段放基类 `ModalRequest<TResult>`,在 `ModalEntry.RunBind` 里 `Bind` 之后统一调一次 → MessageBox / InputBox / 自定义 `ModalRequest<T>` 全覆盖。Loading 非 ModalRequest,在 overlay 泵里 `BindText` 后对称补一行。

三个门面 `Open` 都加尾随 `configure: Action<IScreen>` 形参。

**两个让"禁用 OK"真生效的配套修正**:
1. **InputBox 回车门控** —— `field.OnSubmit.Where(_ => ok.Interactable)`,禁用 OK 时回车也被挡(OK 成为"能否提交"的唯一开关)。
2. **Btn 运行时变灰** —— `Control.Interactable` 改 `virtual`,`Btn` override 让运行时设 `Interactable` 也驱动 Selectable(变灰 + 发 `InteractState.Disabled`),与 XML `interactable=` 路径一致。之前运行时只改 CanvasGroup(点不动但不变灰)。

> 已知范围外不对称:Tab/Toggle 运行时 `Interactable` 仍只改 CanvasGroup —— 模态框按钮都是 Btn,本 PR 未触及它们。

## 用法

\`\`\`csharp
string name = await InputBox.Open(UI.Tr("Your name?"), configure: s => {
    var ok = s.Get<Btn>("ok"); var f = s.Get<InputField>("field");
    ok.Interactable = false;
    f.OnValueChanged.Subscribe(v => ok.Interactable = !string.IsNullOrWhiteSpace(v)).AddTo(s);
});
\`\`\`

自定义 modal 直接 `new MyRequest { Configure = s => … }`。

## 验证

- EditMode **1389/1389**(+7:5 modal + 2 Btn)
- PlayMode **125/125**
- `dotnet format --verify-no-changes --severity warn` EXIT=0
- SKILL `scripting-promptugui-csharp` 已同步(API surface + 新 "Customizing a builtin modal" 段 + cheatsheet)

## 待办

视觉 QA(禁用态变灰外观)由维护者人工确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)