### PR TITLE
feat(states): `<Btn disabledSprite>` + Tab/Toggle 运行时 Interactable 变灰

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -196,6 +196,7 @@ Image + Button + R3 `OnClick` / `OnState`。`<Btn>开始</Btn>` 简写生成内�
 | `color` | hex / CSS named / theme token | — | 背景基色，见 **Color Tokens** |
 | `sprite` | sprite key | — | 背景图 |
 | `pressedSprite` | sprite key | — | 按下换 bg `overrideSprite`、松开还原（不动 `sprite`）；自动切 Btn off uGUI ColorTint 避免双重变暗；`""` / `none`=不换；与 `pressedModulate` 叠加；见 states.md |
+| `disabledSprite` | sprite key | — | Disabled 态换 bg `overrideSprite`（`interactable="false"` 或运行时 `Btn.Interactable=false`）；同 `pressedSprite` 契约；与 `pressedSprite` 共存（Disabled 优先）；仅 `<Btn>`；见 states.md |
 | `hoverColor` · `pressedColor` · `disabledColor` | hex / CSS / token | — | **绝对**单态 bg 色（仅 targetGraphic，不扩散） |
 | `hoverModulate` · `pressedModulate` · `disabledModulate` | hex / CSS / token | white | **相对**乘子，扩散到 bg + 所有子 Graphic |
 | `fontSize` | int | — | 仅作用于自动 label；其它 Text 属性（`align` / `wrap`）需显式 `<Text>` 子节点 |
@@ -1077,7 +1078,7 @@ I18N XML      <Text>...</Text>                 extract + translate
 
 ## State visuals (Btn / Tab / Toggle)
 
-`<Btn>` / `<Tab>` / `<Toggle>` 广播 uGUI 交互状态，三种响应（递进）：① `*Color`（绝对 bg 基色）/ `*Modulate`（相对乘子，向子树扩散，`stateReact="false"` 退出）；② `<Show on="state-*">` 按状态换整块美术（`<Btn pressedSprite>` / `<Tab selectedSprite>` 是单图简写）；③ `<Trigger>` / `<Animation on="state-*">` 状态触发动效。**用任何 `*Color` / `*Modulate` / `selectedColor` / `<Show on=state-*>` / `pressedSprite` / `selectedSprite` 前，先读 [`reference/states.md`](reference/states.md)。**
+`<Btn>` / `<Tab>` / `<Toggle>` 广播 uGUI 交互状态，三种响应（递进）：① `*Color`（绝对 bg 基色）/ `*Modulate`（相对乘子，向子树扩散，`stateReact="false"` 退出）；② `<Show on="state-*">` 按状态换整块美术（`<Btn pressedSprite>` / `<Btn disabledSprite>` / `<Tab selectedSprite>` 是单图简写）；③ `<Trigger>` / `<Animation on="state-*">` 状态触发动效。**用任何 `*Color` / `*Modulate` / `selectedColor` / `<Show on=state-*>` / `pressedSprite` / `selectedSprite` 前，先读 [`reference/states.md`](reference/states.md)。**
 
 ## Worked end-to-end example (XML)
 

--- a/.claude/skills/authoring-promptugui-xml/reference/states.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/states.md
@@ -1,6 +1,6 @@
 # State visuals (Btn / Tab / Toggle)
 
-> Part of the **authoring-promptugui-xml** skill. Main reference: [`../SKILL.md`](../SKILL.md). Read this before using any `*Color` / `*Modulate` / `selectedColor` / `<Show on="state-*">` / `pressedSprite` / `selectedSprite`. For the `state-*` `on=` event values and `<Trigger>` / `<Animation>`, see [`animations.md`](animations.md).
+> Part of the **authoring-promptugui-xml** skill. Main reference: [`../SKILL.md`](../SKILL.md). Read this before using any `*Color` / `*Modulate` / `selectedColor` / `<Show on="state-*">` / `pressedSprite` / `disabledSprite` / `selectedSprite`. For the `state-*` `on=` event values and `<Trigger>` / `<Animation>`, see [`animations.md`](animations.md).
 
 `<Btn>`, `<Tab>`, and `<Toggle>` all broadcast their uGUI interaction state. `<Btn>` emits `Normal` / `Hover` / `Pressed` / `Disabled` (Selectable's `Selected` is folded into `Normal`). `<Tab>` and `<Toggle>` also emit `Selected` (= the active/`isOn` control at rest; transient Hover/Pressed/Disabled override it and it reverts on release). Three ways to react, in increasing power:
 
@@ -55,10 +55,12 @@ They compose: per state, `displayed = (absolute ?? color) × (modulate ?? white)
 
 Here PC `state-hover` has no explicit block, so the `state-normal` artwork covers it too; add a `<Show on="state-hover">` to give hover its own art.
 
-**Single-bg shorthand — `pressedSprite`.** When the only per-state change is the button's own bg image, `<Btn pressedSprite="ui:play-pressed">` is the one-attribute form of a `state-normal`/`state-pressed` `<Show>` pair: it swaps the bg's `overrideSprite` while Pressed and reverts on release (the authored `sprite` is never touched). Setting it auto-switches the Btn off uGUI's built-in ColorTint (so the pressed art isn't additionally darkened), and it composes with `pressedColor` / `pressedModulate` (swap + tint/modulate stack). `""` / `none` = no swap. For swapping whole child subtrees (icon + label together, or more than two states), use `<Show>` instead. `<Tab selectedSprite>` is the same `overrideSprite`-swap mechanism keyed on `isOn` (the selected look) instead of `Pressed`.
+**Single-bg shorthand — `pressedSprite` / `disabledSprite`.** When the only per-state change is the button's own bg image, `<Btn pressedSprite="ui:play-pressed">` is the one-attribute form of a `state-normal`/`state-pressed` `<Show>` pair: it swaps the bg's `overrideSprite` while Pressed and reverts on release (the authored `sprite` is never touched). Setting it auto-switches the Btn off uGUI's built-in ColorTint (so the pressed art isn't additionally darkened), and it composes with `pressedColor` / `pressedModulate` (swap + tint/modulate stack). `""` / `none` = no swap. For swapping whole child subtrees (icon + label together, or more than two states), use `<Show>` instead. `<Tab selectedSprite>` is the same `overrideSprite`-swap mechanism keyed on `isOn` (the selected look) instead of `Pressed`.
+
+`<Btn disabledSprite="ui:play-disabled">` is the identical mechanism for the **Disabled** state (greyed-out art instead of just a darkened tint). Same contract as `pressedSprite` — swaps `overrideSprite` while disabled (`interactable="false"`, or runtime `Btn.Interactable=false`), reverts when re-enabled, takes the Btn off ColorTint, `""` / `none` = no swap. Disabled and Pressed are mutually exclusive states, so the two attributes coexist (Disabled wins). Only `<Btn>` has `disabledSprite` (like `pressedSprite`); for Tab/Toggle use `disabledColor` / `disabledModulate` or a `<Show on="state-disabled">`.
 
 ```xml
-<Btn sprite="ui:play-normal" pressedSprite="ui:play-pressed">Play</Btn>
+<Btn sprite="ui:play-normal" pressedSprite="ui:play-pressed" disabledSprite="ui:play-disabled">Play</Btn>
 ```
 
 ## 3. State-triggered animation — `<Trigger>` / `<Animation on="state-...">`

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -689,9 +689,10 @@ param into it), so **custom `ModalRequest<T>` subclasses inherit it for free** �
 `new MyRequest { Configure = s => … }`. Subscriptions made in the hook should still
 `.AddTo(screen)`. A throwing `configure` cancels that modal's await (logged for Loading).
 
-> **Btn.Interactable at runtime**: setting it from code (here or anywhere) now drives the
-> underlying Button — greying it + emitting `InteractState.Disabled` — and blocks raycasts
-> via the CanvasGroup. Same end state as the XML `interactable="false"` attr.
+> **`Interactable` at runtime (Btn / Tab / Toggle)**: setting it from code (here or anywhere)
+> now drives the underlying uGUI Selectable — greying it + emitting `InteractState.Disabled` —
+> and blocks raycasts via the CanvasGroup. Same end state as the XML `interactable="false"`
+> attr. (Other controls' runtime `Interactable` is CanvasGroup-only — blocks input, no grey.)
 
 ### Cancelling
 

--- a/Runtime/Controls/Btn.cs
+++ b/Runtime/Controls/Btn.cs
@@ -18,7 +18,8 @@ namespace PromptUGUI.Controls
         private readonly Subject<Unit> _click = new();
         private PointerEventRelay _pointerRelay;
         private Sprite _pressedSprite;
-        private IDisposable _pressedSpriteSub;
+        private Sprite _disabledSprite;
+        private IDisposable _stateSpriteSub;
 
         // Absolute per-state bg colours (set targetGraphic). Resolved in OnAfterApply.
         private string _hoverColor;
@@ -49,7 +50,7 @@ namespace PromptUGUI.Controls
             _btn = GameObject.GetComponent<PuiButton>() ?? GameObject.AddComponent<PuiButton>();
             _btn.targetGraphic = _bg;
             _btn.onClick.AddListener(() => _click.OnNext(Unit.Default));
-            _pressedSpriteSub = _btn.OnState.Subscribe(ApplyPressedSpriteForState);
+            _stateSpriteSub = _btn.OnState.Subscribe(ApplyStateSprite);
             PromptUGUI.Application.UI.Locale.Changed += ApplyFont;
         }
 
@@ -97,10 +98,10 @@ namespace PromptUGUI.Controls
             var abs = StateColorSet.Resolve(_hoverColor, _pressedColor, null, _disabledColor);
             var mod = StateColorSet.Resolve(_hoverModulate, _pressedModulate, null, _disabledModulate);
             StateTintInstaller.Install(GameObject, _btn, Children, abs, mod);
-            // A pressedSprite is itself a state visual: drop uGUI's built-in ColorTint so the
-            // swapped pressed image isn't double-darkened. Set-only, matching the state-colour path
+            // A pressed/disabled sprite is itself a state visual: drop uGUI's built-in ColorTint so the
+            // swapped image isn't double-darkened. Set-only, matching the state-colour path
             // (StateTintInstaller flips transition to None when any *Color / *Modulate is present).
-            if (_pressedSprite != null)
+            if (_pressedSprite != null || _disabledSprite != null)
                 _btn.transition = UnityEngine.UI.Selectable.Transition.None;
         }
 
@@ -198,13 +199,30 @@ namespace PromptUGUI.Controls
                     ? null
                     : UI.ResolveSprite(value);
                 // Re-evaluate for the live state so a Variant-driven change takes effect immediately.
-                ApplyPressedSpriteForState(_btn.Current);
+                ApplyStateSprite(_btn.Current);
+            }
+        }
+
+        [UIAttr(IsSprite = true), Preserve]
+        public string DisabledSprite
+        {
+            set
+            {
+                // Same contract as pressedSprite: "" / "none" => no swap. Shown while the Btn is
+                // disabled (interactable=false / runtime Interactable=false).
+                _disabledSprite = string.IsNullOrEmpty(value) || value == "none"
+                    ? null
+                    : UI.ResolveSprite(value);
+                ApplyStateSprite(_btn.Current);
             }
         }
 
         // Swaps the bg's overrideSprite (never its authored `sprite`) so revert is overrideSprite=null.
-        private void ApplyPressedSpriteForState(InteractState state)
-            => _bg.overrideSprite = state == InteractState.Pressed ? _pressedSprite : null;
+        // Priority Disabled > Pressed (states are mutually exclusive); authored bg.sprite shows otherwise.
+        private void ApplyStateSprite(InteractState state)
+            => _bg.overrideSprite = state == InteractState.Disabled ? _disabledSprite
+                                  : state == InteractState.Pressed ? _pressedSprite
+                                  : null;
 
         public override Vector2? GetNativeSize()
         {
@@ -225,7 +243,7 @@ namespace PromptUGUI.Controls
         public override void Dispose()
         {
             PromptUGUI.Application.UI.Locale.Changed -= ApplyFont;
-            _pressedSpriteSub?.Dispose();
+            _stateSpriteSub?.Dispose();
             _click.Dispose();
             base.Dispose();
         }

--- a/Runtime/Controls/Tab.cs
+++ b/Runtime/Controls/Tab.cs
@@ -287,6 +287,22 @@ namespace PromptUGUI.Controls
         /// <summary>Broadcasts the Tab's interaction state. Selected = this Tab is the active (isOn) one at rest.</summary>
         public Observable<InteractState> OnState => _toggle.OnState;
 
+        /// <summary>
+        /// Runtime override so setting <see cref="Interactable"/> from code also drives the
+        /// underlying Toggle — greying it + emitting <see cref="InteractState.Disabled"/> — not
+        /// just the base CanvasGroup. Mirrors the XML-attr path (<see cref="OnAfterApply"/>) and
+        /// <c>Btn.Interactable</c>, so code- and Variant-applied disables look identical.
+        /// </summary>
+        public override bool Interactable
+        {
+            get => base.Interactable;
+            set
+            {
+                base.Interactable = value;
+                if (_toggle != null) _toggle.interactable = value;
+            }
+        }
+
         public Observable<bool> OnValueChanged => _changed;
         public Observable<Unit> OnSelected => _selected;
 

--- a/Runtime/Controls/Toggle.cs
+++ b/Runtime/Controls/Toggle.cs
@@ -176,6 +176,22 @@ namespace PromptUGUI.Controls
         /// <summary>Broadcasts the Toggle's interaction state. Selected = checked (isOn) and at rest.</summary>
         public Observable<InteractState> OnState => _toggle.OnState;
 
+        /// <summary>
+        /// Runtime override so setting <see cref="Interactable"/> from code also drives the
+        /// underlying Toggle — greying it + emitting <see cref="InteractState.Disabled"/> — not
+        /// just the base CanvasGroup. Mirrors the XML-attr path (<see cref="OnAfterApply"/>) and
+        /// <c>Btn.Interactable</c>, so code- and Variant-applied disables look identical.
+        /// </summary>
+        public override bool Interactable
+        {
+            get => base.Interactable;
+            set
+            {
+                base.Interactable = value;
+                if (_toggle != null) _toggle.interactable = value;
+            }
+        }
+
         internal override void OnAfterApply()
         {
             base.OnAfterApply();

--- a/Tests/EditMode/Controls/BtnStateTests.cs
+++ b/Tests/EditMode/Controls/BtnStateTests.cs
@@ -440,6 +440,73 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.AreEqual(authored, bg.overrideSprite, "pressedSprite='none' => no swap on press");
         }
 
+        [Test]
+        public void DisabledSprite_SwapsBgOverrideWhenDisabled_RevertsWhenEnabled()
+        {
+            var stub = Sprite.Create(Texture2D.whiteTexture, new Rect(0, 0, 1, 1), Vector2.zero);
+            UI.SpriteResolver = _ => stub;
+
+            var btn = BuildBtn("disabledSprite='ui:disabled'");
+            var bg = btn.GameObject.GetComponent<UnityImage>();
+            var authored = bg.sprite;
+            var puiBtn = btn.GameObject.GetComponent<PuiButton>();
+
+            Assert.AreEqual(authored, bg.overrideSprite, "no override while interactable");
+
+            puiBtn.SimulateState(Disabled);
+            Assert.AreEqual(stub, bg.overrideSprite, "Disabled shows disabledSprite via overrideSprite");
+            Assert.AreEqual(authored, bg.sprite, "authored sprite untouched while disabled");
+
+            puiBtn.SimulateState(Normal);
+            Assert.AreEqual(authored, bg.overrideSprite, "back to base sprite when re-enabled");
+        }
+
+        [Test]
+        public void DisabledSprite_DisablesDefaultColorTint()
+        {
+            var stub = Sprite.Create(Texture2D.whiteTexture, new Rect(0, 0, 1, 1), Vector2.zero);
+            UI.SpriteResolver = _ => stub;
+
+            var btn = BuildBtn("disabledSprite='ui:disabled'");
+            var puiBtn = btn.GameObject.GetComponent<PuiButton>();
+            Assert.AreEqual(Selectable.Transition.None, puiBtn.transition,
+                "a disabledSprite must switch the Btn off uGUI's built-in ColorTint (no double-darken)");
+        }
+
+        // Disabled and Pressed are mutually exclusive states; the resolver prioritises Disabled.
+        [Test]
+        public void DisabledAndPressedSprite_EachStateShowsItsOwnSprite()
+        {
+            var pressed = Sprite.Create(Texture2D.whiteTexture, new Rect(0, 0, 1, 1), Vector2.zero);
+            var disabled = Sprite.Create(Texture2D.whiteTexture, new Rect(0, 0, 1, 1), Vector2.zero);
+            UI.SpriteResolver = key => key == "ui:disabled" ? disabled : pressed;
+
+            var btn = BuildBtn("pressedSprite='ui:pressed' disabledSprite='ui:disabled'");
+            var bg = btn.GameObject.GetComponent<UnityImage>();
+            var puiBtn = btn.GameObject.GetComponent<PuiButton>();
+
+            puiBtn.SimulateState(Pressed);
+            Assert.AreEqual(pressed, bg.overrideSprite, "Pressed shows pressedSprite");
+
+            puiBtn.SimulateState(Disabled);
+            Assert.AreEqual(disabled, bg.overrideSprite, "Disabled shows disabledSprite");
+        }
+
+        [Test]
+        public void DisabledSprite_None_NoSwapAndKeepsColorTint()
+        {
+            var btn = BuildBtn("disabledSprite='none'");
+            var bg = btn.GameObject.GetComponent<UnityImage>();
+            var authored = bg.sprite;
+            var puiBtn = btn.GameObject.GetComponent<PuiButton>();
+
+            Assert.AreEqual(Selectable.Transition.ColorTint, puiBtn.transition,
+                "disabledSprite='none' must not disable the default ColorTint");
+
+            puiBtn.SimulateState(Disabled);
+            Assert.AreEqual(authored, bg.overrideSprite, "disabledSprite='none' => no swap when disabled");
+        }
+
         private static void AssertColorsEqual(Color expected, Color actual)
         {
             Assert.That(actual.r, Is.EqualTo(expected.r).Within(0.001f), "r");

--- a/Tests/EditMode/Controls/TabStateTests.cs
+++ b/Tests/EditMode/Controls/TabStateTests.cs
@@ -159,6 +159,21 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.AreEqual(InteractState.Disabled, pt.Current);
         }
 
+        // Runtime symmetry with the XML attr above: setting Interactable from code must drive
+        // the underlying Toggle too (grey + Disabled), not just the base CanvasGroup.
+        [Test]
+        public void RuntimeInteractableFalse_BridgesToToggleAndEmitsDisabled()
+        {
+            var tab = BuildTab("");
+            var pt = tab.GameObject.GetComponent<PuiToggle>();
+            Assert.IsTrue(pt.interactable, "precondition: starts interactable");
+
+            tab.Interactable = false;
+
+            Assert.IsFalse(pt.interactable, "runtime Interactable=false should drive Toggle.interactable");
+            Assert.AreEqual(InteractState.Disabled, pt.Current);
+        }
+
         [Test]
         public void ShowInsideTab_ResolvesTabAsStateSource()
         {

--- a/Tests/EditMode/Controls/ToggleStateTests.cs
+++ b/Tests/EditMode/Controls/ToggleStateTests.cs
@@ -27,6 +27,21 @@ namespace PromptUGUI.Tests.EditMode.Controls
             return UI.Open("S").Get<Toggle>("tg");
         }
 
+        // Setting Interactable from code must drive the underlying Toggle (grey + Disabled),
+        // not just the base CanvasGroup — symmetry with the XML interactable="false" path.
+        [Test]
+        public void RuntimeInteractableFalse_BridgesToToggleAndEmitsDisabled()
+        {
+            var tg = BuildToggle("");
+            var pt = tg.GameObject.GetComponent<PuiToggle>();
+            Assert.IsTrue(pt.interactable, "precondition: starts interactable");
+
+            tg.Interactable = false;
+
+            Assert.IsFalse(pt.interactable, "runtime Interactable=false should drive Toggle.interactable");
+            Assert.AreEqual(InteractState.Disabled, pt.Current);
+        }
+
         [Test]
         public void PressedModulate_SwitchesTransitionNone_AndInstallsReactors()
         {


### PR DESCRIPTION
跟进 #57,补齐 disabled 状态视觉的两个缺口。

## 1. `<Btn disabledSprite="...">`

`pressedSprite` 的 disabled 版本:Btn 处于禁用态(XML `interactable="false"` 或运行时 `Btn.Interactable=false`)时,把 bg 的 `overrideSprite` 换成它(灰态美术,而不只是变暗的 tint),重新启用时还原;设了就把 Btn 切下 uGUI 的 ColorTint,避免双重变暗。

单图 resolver 泛化成 **Disabled > Pressed** 优先级(两态互斥,所以两个属性可共存)。仅 `<Btn>`,与 `pressedSprite`(Btn)/`selectedSprite`(Tab)的"按需逐控件"一致。

\`\`\`xml
<Btn sprite="ui:play-normal" pressedSprite="ui:play-pressed" disabledSprite="ui:play-disabled">Play</Btn>
\`\`\`

## 2. Tab / Toggle 运行时 Interactable 变灰

#57 给 Btn override 了 `Interactable`,这次给 Tab、Toggle 也补上:运行时 C# 设 `.Interactable=false` 现在会驱动底层 Toggle(变灰 + 发 `InteractState.Disabled`),不再只翻 CanvasGroup。三个控件的代码态 / XML 态 / Variant 态禁用外观现在完全一致。

> 这正是上一轮聊到的"不对称"修复。Slider/Dropdown 等其余控件运行时 `Interactable` 仍是 CanvasGroup-only(挡输入、不变灰)——无需求,未触及。

## 验证

- EditMode **1395/1395**(+6:4 disabledSprite + Tab 1 + Toggle 1)
- PlayMode **125/125**
- EditorOnly **182/182**(XSD 自动反射出 `disabledSprite`)
- `dotnet format --verify` EXIT=0

SKILL 已同步:`reference/states.md`(disabledSprite 段)+ XML 主文档 catalog 行 + C# 运行时 Interactable 说明(Btn→Btn/Tab/Toggle)。

## 待办

视觉 QA(disabledSprite 换图 + Tab/Toggle 灰态外观)由维护者人工确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)