### PR TITLE
feat: `UI.Router` navigation system (deep-link == manual, layer reconcile; Page/Modal/Tab/Prompt)

### DIFF
--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -574,6 +574,32 @@ LOADING        var h = Loading.Open(text, configure); h.Close()  idempotent; h.I
                Loading.XmlSrc = "MyUI/Modals/Foo.ui"        override; only <Text id="text"> recognised
                Loading.SortingOrder = 500                   overlay 层带,低于 dialog
                concurrent Open() → independent overlays at the same band (no ref-count)
+
+ROUTER         UI.Router.Scheme = "myapp"                   optional scheme enforcement (null = any/none)
+               UI.Router.Map(name, src, screen=null,        register a Page or Modal destination
+                             present=Page, parent=null,
+                             onEnter: (screen,q)=>{})
+               UI.Router.MapTab(name, parent, tabId,        register a Tab destination (selects <Tab> in host)
+                                onEnter: (screen,q)=>{})
+               UI.Router.MapPrompt(name, parent, run)       register a Prompt (async flow, no screen)
+                             run = async (RouteQuery q, CancellationToken ct) => { ... }
+               UI.Router.IsMapped(name)                     bool
+               UI.Router.Clear()                            remove all registrations
+
+               await UI.Router.Open("name")                 reconcile chain to name
+               await UI.Router.Open("name", query)          with RouteQuery
+               await UI.Router.Navigate("myapp://name?k=v") parse URL then Open
+               await UI.Router.Back()                       navigate to parent; no-op at root
+               await UI.Router.Reset()                      close entire chain
+
+               UI.Router.Current                            top name (null when empty)
+               UI.Router.Chain                              IReadOnlyList<string> root→top
+               UI.Router.Changed                            event Action; fires after each reconcile
+
+               q.Get("k", fallback)  q.GetInt("k", 0)      RouteQuery read helpers
+               q.Has("k")  q["k"]  q.Raw                   (IReadOnlyDictionary<string,string>)
+
+               pass ct: to InputBox.Open/MessageBox.Open    so Prompt run can cancel the dialog cleanly
 ```
 
 ## Modal dialogs
@@ -1027,6 +1053,170 @@ tip is a normal `<Text>`.
 
 The optional trailing `configure: Action<IScreen>` runs after the text is bound, giving access to the
 live toast `IScreen` (recolor, add nodes) — same shape as the modal `configure` hook.
+
+## Router navigation
+
+`UI.Router` is an **optional, declarative navigation layer** on top of the raw `UI.Open` / `UI.Close` API. You register every navigable destination **once at boot** with a stable opaque `name`; the router then reconciles the screen chain on each navigation call.
+
+### Mental model
+
+Every destination carries a canonical `parent` (declared at registration, never encoded in the URL). `Open("details")` walks the parent chain from the root to `"details"` and **reconciles** the live chain: it closes the non-shared tail (in reverse order) and opens the missing tail (bottom-up). Navigating via a button and navigating via a deep-link both call `Open` — identical chain → identical result. Ad-hoc modals (`MessageBox`, `InputBox`, `Loading`, `Toast`) that happen to be open at navigation time are closed first (equivalent to the user dismissing them before navigating), so a deep-link cannot bypass them unpredictably.
+
+`Navigate(url)` parses `<scheme>://<name>?<query>` (or just `<name>?<query>` when no scheme enforcement is needed) and calls `Open`. All of:
+
+```csharp
+await UI.Router.Open("details");
+await UI.Router.Navigate("myapp://details?id=42");
+```
+
+produce the same result when `"details"` is registered with the same parent chain.
+
+### Registration (call once at boot)
+
+```csharp
+using PromptUGUI.Application;
+
+// Full-screen page
+UI.Router.Map("home", src: "screens/Home");
+
+// Full-screen page with a parent (shown after home in the chain)
+UI.Router.Map("details", src: "screens/Details", parent: "home",
+    onEnter: (screen, q) => screen.Get<Text>("title").TextValue = q.Get("name", "—"));
+
+// Overlay/panel rendered above its parent chain (modal-style Canvas)
+UI.Router.Map("settings", src: "screens/Settings",
+    present: RoutePresent.Modal, parent: "home");
+
+// Tab inside a TabBar on the host Page/Modal (host is the nearest Page/Modal ancestor)
+UI.Router.MapTab("deals", parent: "home", tabId: "bar/deals");
+
+// Prompt: an async flow (InputBox / MessageBox / custom); no src, no screen
+UI.Router.MapPrompt("rename", parent: "home", run: async (q, ct) =>
+{
+    var name = await InputBox.Open("New name", initial: PlayerName, ct: ct);
+    if (name != null) await Api.Rename(name);
+});
+
+// Optional scheme enforcement (null = accept any / no scheme)
+UI.Router.Scheme = "myapp";
+
+// Utilities
+UI.Router.IsMapped("home");   // bool
+UI.Router.Clear();            // remove all registrations (does not close active chain)
+```
+
+**`Map` parameters** (full signature):
+```
+UI.Router.Map(name, src, screen = null, present = RoutePresent.Page, parent = null, onEnter = null)
+```
+- `name` — stable opaque destination id used in URLs and `Open()` calls.
+- `src` — `.ui.xml` src key (resolved on first navigation to that route, not at registration).
+- `screen` — name of the `<Screen>` to open inside the document. When null, the document must have exactly one `<Screen>`; if it has multiple, specify this explicitly.
+- `present` — `RoutePresent.Page` (default) or `RoutePresent.Modal` (overlay panel with sorting-order bump and ESC→Back).
+- `parent` — parent route name (`null` = root). Declared at registration; not encoded in URLs.
+- `onEnter` — `Action<IScreen, RouteQuery>` called each time this node is entered or re-entered.
+
+**`MapTab` parameters**:
+```
+UI.Router.MapTab(name, parent, tabId, onEnter = null)
+```
+- `parent` — required; must resolve to a Page/Modal ancestor in the chain.
+- `tabId` — screen-relative control id-path (e.g. `"topbar/deals"`) of the `<Tab>` to select. A Tab node can itself be the `parent` of deeper routes.
+- `onEnter` — `Action<IScreen, RouteQuery>` called with the host Page/Modal screen.
+
+**`MapPrompt` parameters**:
+```
+UI.Router.MapPrompt(name, parent, run)
+```
+- `run` — `RoutePromptRun` = `Awaitable Run(RouteQuery query, CancellationToken ct)`. The node stays active while `run` runs; it auto-pops from the chain when `run` returns. Navigating away cancels `ct` — pass it to `InputBox.Open(..., ct: ct)` so the dialog cancels cleanly.
+- A Prompt cannot be the `parent` of another route.
+
+### Navigation API
+
+All navigation methods return `Awaitable` that completes when the reconcile is done:
+
+```csharp
+await UI.Router.Open("details");                              // by name
+await UI.Router.Open("details", new RouteQuery(dict));        // name + pre-built query
+await UI.Router.Navigate("myapp://details?id=42&tab=info");   // URL form
+
+await UI.Router.Back();    // navigate to Current's parent; no-op at root
+await UI.Router.Reset();   // close the entire chain (does not clear registrations)
+```
+
+**State** (synchronous, no await):
+
+```csharp
+string name     = UI.Router.Current;   // top-of-chain name; null when empty
+IReadOnlyList<string> chain = UI.Router.Chain;   // root→top, e.g. ["home","details"]
+UI.Router.Changed += () => Debug.Log(UI.Router.Current);  // event Action; fires after every reconcile
+```
+
+### Four presentations
+
+| Kind | Registration | What opens | Deactivated by |
+|---|---|---|---|
+| **Page** | `Map(present: RoutePresent.Page)` | `UI.Open(screenName)` — full-screen Canvas | `UI.Close(screenName)` |
+| **Modal** | `Map(present: RoutePresent.Modal)` | Same as Page + `overrideSorting`, `ModalEscapeListener` (ESC→`Back()`) | `UI.Close(screenName)` |
+| **Tab** | `MapTab(tabId: ...)` | Selects the `<Tab>` (`tab.IsOn = true`) in the host Page/Modal | Tab is deselected (the host Page/Modal is closed if it leaves the chain) |
+| **Prompt** | `MapPrompt(run: ...)` | Runs `run` async; no screen of its own | `run` returns normally (self-pop) or `ct` is cancelled (navigated away) |
+
+### RouteQuery
+
+Query params come from a URL's `?k=v&...` or from the `RouteQuery` you pass to `Open(name, query)`.
+
+```csharp
+RouteQuery q;                             // received in onEnter or run
+
+q.Has("id")                              // bool
+q.Get("id")                              // string or null
+q.Get("id", fallback: "default")         // string (with default)
+q.GetInt("page", fallback: 0)            // int (TryParse, fallback on failure)
+q["id"]                                  // same as Get(key) — string or null
+q.Raw                                    // IReadOnlyDictionary<string, string>
+```
+
+### Rename pattern — button and deep-link share one Prompt
+
+```csharp
+// Registration (boot)
+UI.Router.MapPrompt("rename", parent: "home", run: async (q, ct) =>
+{
+    var name = await InputBox.Open("New name", initial: PlayerName, ct: ct);
+    if (name != null) await Api.Rename(name);
+});
+
+// Button (in-game)
+screen.Get<Btn>("renameBtn").OnClick
+      .Subscribe(_ => UI.Router.Open("rename"))
+      .AddTo(screen);
+
+// Deep-link (e.g., from a login flow that detected an illegal name)
+await UI.Router.Navigate("myapp://rename?reason=illegal");
+```
+
+Both paths run the same `run` delegate. The `reason` query param is available inside `run` via `q.Get("reason")` if needed.
+
+### Coexistence rules
+
+- **Open router destinations only via the router** — calling `UI.Open("myScreen")` directly on a router-managed screen bypasses reconciliation and corrupts the chain state.
+- **Modal route's close button should call `UI.Router.Back()`**, not `UI.Close(...)`. The ESC listener already does this automatically.
+- **Ad-hoc overlays** (`MessageBox`, `InputBox`, `Loading`, `Toast`) remain entirely outside the router. They are closed during reconcile if they block navigation — this is by design.
+- At teardown (`UI.UnloadAll()` / `UI.ResetForTests()`), all active router screens are closed and any running Prompt `ct` tokens are cancelled.
+
+### CancellationToken on modal Open helpers
+
+`MessageBox.Open` and `InputBox.Open` accept an optional trailing `ct: CancellationToken`. When navigation cancels a Prompt's `ct`, pass it through to cleanly dismiss the dialog:
+
+```csharp
+UI.Router.MapPrompt("confirm-delete", parent: "home", run: async (q, ct) =>
+{
+    var r = await MessageBox.Open("Delete account?", MsgBtn.Yes | MsgBtn.Cancel, ct: ct);
+    if (r == MsgBtn.Yes) await Api.DeleteAccount();
+});
+```
+
+Navigating away while the dialog is open cancels `ct`, the dialog throws `OperationCanceledException`, and the Prompt exits cleanly.
 
 ## `<Trigger>` and `<Animation>` from C#
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ Two entry points to this pipeline:
 
 The host Unity project is at `C:\xsoft\PromptUGUIDev`; this repo is referenced as a UPM package via `file://`. R3 (Cysharp) is provided by NuGetForUnity in the host project.
 
-**Always test via UnityMCP, not batch-mode Unity.** Tools (deferred — load with `ToolSearch(query="select:run_tests,refresh_unity,read_console", max_results=3)`):
+**Always test via UnityMCP, not batch-mode Unity.** Tools (deferred — load with `ToolSearch(query="select:mcp__UnityMCP__run_tests,mcp__UnityMCP__get_test_job,mcp__UnityMCP__refresh_unity,mcp__UnityMCP__read_console", max_results=4)` — `select:` matches on the **full** `mcp__UnityMCP__*` names; the short form won't resolve):
 
 ```
 mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
@@ -162,7 +162,7 @@ mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.Play
 mcp__UnityMCP__read_console(action="get", types=["error"])
 ```
 
-Filter to a single test class with `filter="ClassName"` (matches by name fragment).
+`run_tests` is **async**: it returns a `job_id` immediately — poll `mcp__UnityMCP__get_test_job(job_id=...)` until it completes to read pass/fail counts. Filter to a single test class with `group_names=["ClassName"]` (or specific tests via `test_names=[...]`); there is **no** `filter` parameter.
 
 After any source edit, refresh first, then check console for compile errors before running tests.
 

--- a/README.md
+++ b/README.md
@@ -273,9 +273,10 @@ C# Code:
 
 一个让 Unity 6+ 的 UI 可以用大模型进行开发的解决方案。
 
-提供极其精简的 UI 描述语言 `.ui.xml` 和一个运行时解析器，翻译成uGUI结构。
+通过描述语言 `.ui.xml` 和一个运行时解析器，翻译成uGUI结构。
+整体架构全面且简洁，适合大模型直接书写而脱离MCP。
 
-比UI Toolkit更自由，更容易实现自定的样式，和GameObject体系结合更紧密。
+比UI Toolkit更自由，和GameObject体系结合更紧密。
 
 ## 功能特性
 
@@ -284,10 +285,10 @@ C# Code:
   - 全响应式UI支持，自动根据屏幕和设备切换布局
   - 像素艺术风格UI支持
   - 自动XSD Schema语法检查 + 内置语法检查 CLI
-- **控件完善**
+- **控件丰富**
   - 基础UI元素支持（Btn/Image/Frame/InputField/Toggle/Dropdown/Slider/ScrollList/Progress/TabBar等）
   - Carousel 轮播卡片组件，用于显示Banner公告等；
-  - Markdown文本组件，支持markdown全解析，包括网络图片等；
+  - Markdown文本组件，支持markdown全解析(除html标签)，支持网络图片等；
   - 布局元素（HStack/VStack/Grid等）
   - 高扩展性，允许模板/Prefab模板
 - **自动sprite/icon引用**
@@ -311,6 +312,11 @@ C# Code:
   - 多次调用通过队列依次弹出避免冲突
   - Toast小信息弹出提示系统，Loading转圈模态窗口等等内置支持
   - 可继承实现高度自定义的对话框
+- **Deep Linking** 支持，专业的 Router 系统
+  - 所有UI都应该由Router打开/管理
+  - 可通过 appid://ui_name?param=value 的形式定位到对应功能模块
+  - 自动处理层级依赖关系，导航时会自动关闭冲突的UI，防止独占UI重叠。
+  - 适合外部链接跳转、公告/活动跳转、装备信息跳转、外部操作后返回游戏等场景。
 
 
 ## 安装/升级方法

--- a/Runtime/Application/AwaitableHelpers.cs
+++ b/Runtime/Application/AwaitableHelpers.cs
@@ -9,6 +9,13 @@ namespace PromptUGUI.Application
     /// </summary>
     internal static class AwaitableHelpers
     {
+        internal static Awaitable Completed()
+        {
+            var src = new AwaitableCompletionSource();
+            src.SetResult();
+            return src.Awaitable;
+        }
+
         internal static Awaitable<T> Completed<T>(T value)
         {
             var src = new AwaitableCompletionSource<T>();

--- a/Runtime/Application/Modals/InputBoxRequest.cs
+++ b/Runtime/Application/Modals/InputBoxRequest.cs
@@ -69,7 +69,8 @@ namespace PromptUGUI.Application.Modals
             string okLabel = null,
             string cancelLabel = null,
             ModalMode mode = ModalMode.Popup,
-            System.Action<IScreen> configure = null)
+            System.Action<IScreen> configure = null,
+            System.Threading.CancellationToken ct = default)
             => UI.Modal.OpenAsync(new InputBoxRequest
             {
                 Title = title,
@@ -80,6 +81,6 @@ namespace PromptUGUI.Application.Modals
                 OkLabel = okLabel,
                 CancelLabel = cancelLabel,
                 Configure = configure,
-            }, mode);
+            }, mode, ct);
     }
 }

--- a/Runtime/Application/Modals/MessageBoxRequest.cs
+++ b/Runtime/Application/Modals/MessageBoxRequest.cs
@@ -72,7 +72,8 @@ namespace PromptUGUI.Application.Modals
         public static UnityEngine.Awaitable<MsgBtn> Open(
             string text, MsgBtn buttons = MsgBtn.OK, string icon = null, string title = null,
             ModalMode mode = ModalMode.Popup,
-            System.Action<IScreen> configure = null)
+            System.Action<IScreen> configure = null,
+            System.Threading.CancellationToken ct = default)
             => UI.Modal.OpenAsync(new MessageBoxRequest
             {
                 Text = text,
@@ -80,14 +81,15 @@ namespace PromptUGUI.Application.Modals
                 Icon = icon,
                 Title = title,
                 Configure = configure,
-            }, mode);
+            }, mode, ct);
 
         public static UnityEngine.Awaitable<MsgBtn> Open(
             string text,
             System.Collections.Generic.IEnumerable<(string label, MsgBtn key)> buttons,
             string icon = null, string title = null,
             ModalMode mode = ModalMode.Popup,
-            System.Action<IScreen> configure = null)
+            System.Action<IScreen> configure = null,
+            System.Threading.CancellationToken ct = default)
         {
             var list = new System.Collections.Generic.List<(string, MsgBtn)>(buttons);
             var mask = MsgBtn.None;
@@ -100,7 +102,7 @@ namespace PromptUGUI.Application.Modals
                 Icon = icon,
                 Title = title,
                 Configure = configure,
-            }, mode);
+            }, mode, ct);
         }
     }
 }

--- a/Runtime/Application/Router.meta
+++ b/Runtime/Application/Router.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: da3279601159c644f8d19947d40dfd54
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Application/Router/RouteException.cs
+++ b/Runtime/Application/Router/RouteException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace PromptUGUI.Application
+{
+    /// <summary>Router 注册 / 导航期的错误(未注册、缺失/成环 parent、tab 解析失败等)。</summary>
+    public sealed class RouteException : Exception
+    {
+        public RouteException(string message) : base(message) { }
+        public RouteException(string message, Exception inner) : base(message, inner) { }
+    }
+}

--- a/Runtime/Application/Router/RouteException.cs.meta
+++ b/Runtime/Application/Router/RouteException.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6c27af17c48d27141b57b2f508ce0d65

--- a/Runtime/Application/Router/RouteNode.cs
+++ b/Runtime/Application/Router/RouteNode.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace PromptUGUI.Application
+{
+    /// <summary>screen-backed 节点的呈现方式。Tab/Prompt 由 MapTab/MapPrompt 表达,不在此枚举。</summary>
+    public enum RoutePresent { Page, Modal }
+
+    /// <summary>Prompt 节点的支撑 handler:跑内置对话框 + 处理结果。ct 取消 = 被导航走。</summary>
+    public delegate UnityEngine.Awaitable RoutePromptRun(
+        RouteQuery query, System.Threading.CancellationToken ct);
+
+    internal enum RouteKind { Page, Modal, Tab, Prompt }
+
+    /// <summary>一个路由节点的注册记录(运行时,非 XML IR)。</summary>
+    internal sealed class RouteNode
+    {
+        public string Name;                      // 稳定不透明 ID,全局唯一
+        public string Parent;                    // null = 根
+        public RouteKind Kind;
+        public string Src;                       // Page/Modal:.ui.xml 的 src key
+        public string Screen;                    // Page/Modal:screen 名;null → 激活时按"单 Screen"解析
+        public string TabId;                     // Tab:宿主 screen 内 <Tab> 控件的 id 路径
+        public RoutePromptRun Run;               // Prompt
+        public Action<IScreen, RouteQuery> OnEnter;  // Page/Modal/Tab
+    }
+}

--- a/Runtime/Application/Router/RouteNode.cs.meta
+++ b/Runtime/Application/Router/RouteNode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7af5cc37ac5da2e4b932a9d3358d12ff

--- a/Runtime/Application/Router/RouteQuery.cs
+++ b/Runtime/Application/Router/RouteQuery.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace PromptUGUI.Application
+{
+    /// <summary>路由查询参数的只读包装。从 URL 的 ?k=v&... 或 Open 传入的字典构造。</summary>
+    public sealed class RouteQuery
+    {
+        public static readonly RouteQuery Empty = new(new Dictionary<string, string>(0));
+
+        private readonly IReadOnlyDictionary<string, string> _q;
+
+        public RouteQuery(IReadOnlyDictionary<string, string> query)
+            => _q = query ?? new Dictionary<string, string>(0);
+
+        public bool Has(string key) => _q.ContainsKey(key);
+
+        public string Get(string key, string fallback = null)
+            => _q.TryGetValue(key, out var v) ? v : fallback;
+
+        public int GetInt(string key, int fallback = 0)
+            => _q.TryGetValue(key, out var v) && int.TryParse(v, out var n) ? n : fallback;
+
+        public string this[string key] => Get(key);
+
+        public IReadOnlyDictionary<string, string> Raw => _q;
+
+        /// <summary>解析 "k=v&k2=v2"(无前导 '?')。空串 → Empty。k/v 各做 URL decode。</summary>
+        internal static RouteQuery ParseQueryString(string qs)
+        {
+            if (string.IsNullOrEmpty(qs)) return Empty;
+            var d = new Dictionary<string, string>();
+            foreach (var pair in qs.Split('&'))
+            {
+                if (pair.Length == 0) continue;
+                var eq = pair.IndexOf('=');
+                var k = eq >= 0 ? pair.Substring(0, eq) : pair;
+                var v = eq >= 0 ? pair.Substring(eq + 1) : "";
+                if (k.Length == 0) continue;
+                d[Uri.UnescapeDataString(k)] = Uri.UnescapeDataString(v);
+            }
+            return new RouteQuery(d);
+        }
+    }
+}

--- a/Runtime/Application/Router/RouteQuery.cs.meta
+++ b/Runtime/Application/Router/RouteQuery.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 54c988a5048f556478972acc1c8b4b56

--- a/Runtime/Application/UI.Modal.cs
+++ b/Runtime/Application/UI.Modal.cs
@@ -43,15 +43,38 @@ namespace PromptUGUI.Application
                 _stack.Count > 0 ? _stack[_stack.Count - 1].Screen : null;
 
             public static Awaitable<TResult> OpenAsync<TResult>(
-                ModalRequest<TResult> request, ModalMode mode = ModalMode.Popup)
+                ModalRequest<TResult> request, ModalMode mode = ModalMode.Popup,
+                System.Threading.CancellationToken ct = default)
             {
                 if (request == null) throw new ArgumentNullException(nameof(request));
                 var (entry, awaitable) = ModalEntry<TResult>.Create(request);
+                if (ct.CanBeCanceled)
+                    ct.Register(() => CancelEntry(entry, new OperationCanceledException(ct)));
                 if (mode == ModalMode.Queued && !IsIdle())
                     _waiting.Enqueue(entry);
                 else
                     QueueForMaterialize(entry);
                 return awaitable;
+            }
+
+            // 取消某个 entry,不论它在 stack / pending / inflight / waiting 哪一态。
+            // 在 stack 上 → 同 close:resolve + 销毁 Screen + 弹栈 + 提升等待队列。
+            // 其余态 → 仅 Cancel(标记 Resolved);pump 与 PromoteWaiting 出队时跳过 Resolved。
+            internal static void CancelEntry(IModalEntry entry, Exception ex)
+            {
+                for (int i = 0; i < _stack.Count; i++)
+                {
+                    if (_stack[i].Entry == entry)
+                    {
+                        var slot = _stack[i];
+                        entry.Cancel(ex);
+                        RemoveSlot(slot);
+                        RefreshTopListener();
+                        PromoteWaiting();
+                        return;
+                    }
+                }
+                entry.Cancel(ex);
             }
 
             // dialog 系统完全空闲:无在屏、无待实例化、无 in-flight、pump 未运行。

--- a/Runtime/Application/UI.Router.Reconcile.cs
+++ b/Runtime/Application/UI.Router.Reconcile.cs
@@ -66,6 +66,12 @@ namespace PromptUGUI.Application
                 return tcs.Awaitable;
             }
 
+            public static async Awaitable Navigate(string url)
+            {
+                var (name, query) = ParseUrl(url);
+                await Open(name, query);
+            }
+
             private static async Awaitable Pump()
             {
                 _reconciling = true;
@@ -139,6 +145,11 @@ namespace PromptUGUI.Application
                 var removed = new List<ActiveNode>();
                 for (int i = k; i < _chain.Count; i++) removed.Add(_chain[i]);
                 if (removed.Count > 0) _chain.RemoveRange(k, removed.Count);
+
+                // §3.3:顶上压着的 ad-hoc 临时模态(不属 router)先关掉 —— 等价"用户先关弹窗再导航"。
+                // 尾部已先于此移除,故即便 CloseAll 同步唤醒某 Prompt 续体,其 SelfPop 也已 no-op。
+                // SameChain 早退路径不经过这里:重复导航到正在显示的同一链路不会误关其对话框。
+                if (UI.Modal.IsAnyOpen) UI.Modal.CloseAll();
 
                 for (int i = removed.Count - 1; i >= 0; i--) Deactivate(removed[i]);
 

--- a/Runtime/Application/UI.Router.Reconcile.cs
+++ b/Runtime/Application/UI.Router.Reconcile.cs
@@ -340,6 +340,7 @@ namespace PromptUGUI.Application
                 AbandonPump(cancel: true);
                 foreach (var a in _chain)
                 {
+                    a.Deactivated = true;          // 防止 SelfPop 续体在 Cancel 同步回调里修改 _chain
                     a.PromptCts?.Cancel();
                     a.PromptCts?.Dispose();
                 }

--- a/Runtime/Application/UI.Router.Reconcile.cs
+++ b/Runtime/Application/UI.Router.Reconcile.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PromptUGUI.Application
+{
+    public static partial class UI
+    {
+        public static partial class Router
+        {
+            private sealed class ActiveNode
+            {
+                public RouteNode Def;
+                public string ScreenKey;                 // Page/Modal:_open 的 key(== screen 名)
+                public System.Threading.CancellationTokenSource PromptCts;  // Prompt
+                public bool Deactivated;                 // Prompt:reconcile 正在移除它,SelfPop 让位
+            }
+
+            private static readonly List<ActiveNode> _chain = new();
+            private static readonly HashSet<string> _loadedSrcs = new();
+            private static readonly Dictionary<string, string> _srcSingleScreen = new();
+
+            public static event Action Changed;
+
+            public static string Current =>
+                _chain.Count > 0 ? _chain[_chain.Count - 1].Def.Name : null;
+
+            public static IReadOnlyList<string> Chain
+            {
+                get
+                {
+                    var l = new List<string>(_chain.Count);
+                    foreach (var a in _chain) l.Add(a.Def.Name);
+                    return l;
+                }
+            }
+
+            public static async Awaitable Open(string name, RouteQuery query = null)
+            {
+                await Reconcile(name, query ?? RouteQuery.Empty);
+            }
+
+            private static async Awaitable Reconcile(string name, RouteQuery query)
+            {
+                var target = ResolveChain(name);   // 校验 + 根→叶
+
+                // 完全相同的链路 = 无结构变化:跳过(后续 Task 6 的)临时模态清理,只刷新栈顶。
+                // 这条也保证"重复导航到正在显示的 Prompt"是 no-op,不会把它误关再重开。
+                if (SameChain(target))
+                {
+                    if (_chain.Count > 0) RefreshTarget(_chain[_chain.Count - 1], query);
+                    Changed?.Invoke();
+                    return;
+                }
+
+                int k = 0;
+                while (k < _chain.Count && k < target.Count
+                       && _chain[k].Def.Name == target[k].Name) k++;
+
+                // 先把尾部从 _chain 快照 + 移除,再 deactivate。这样若 deactivate(或 Task 6 的
+                // 临时模态清理)同步触发了某个 Prompt 续体的 SelfPop,它看到自己已不在 _chain → no-op,
+                // 不会与这里的链路改动撞车。
+                var removed = new List<ActiveNode>();
+                for (int i = k; i < _chain.Count; i++) removed.Add(_chain[i]);
+                if (removed.Count > 0) _chain.RemoveRange(k, removed.Count);
+
+                for (int i = removed.Count - 1; i >= 0; i--) Deactivate(removed[i]);
+
+                for (int i = k; i < target.Count; i++)
+                {
+                    var active = await Activate(target[i], query);
+                    _chain.Add(active);
+                }
+
+                // 目标落在公共前缀里(Open 某个祖先)→ 刷新目标 OnEnter
+                if (k == target.Count && _chain.Count > 0)
+                    RefreshTarget(_chain[_chain.Count - 1], query);
+
+                Changed?.Invoke();
+            }
+
+            private static bool SameChain(List<RouteNode> target)
+            {
+                if (target.Count != _chain.Count) return false;
+                for (int i = 0; i < target.Count; i++)
+                    if (_chain[i].Def.Name != target[i].Name) return false;
+                return true;
+            }
+
+            private static async Awaitable<ActiveNode> Activate(RouteNode def, RouteQuery query)
+            {
+                switch (def.Kind)
+                {
+                    case RouteKind.Page: return await ActivatePage(def, query);
+                    default:
+                        throw new RouteException($"route '{def.Name}': kind not yet supported");
+                }
+            }
+
+            private static void Deactivate(ActiveNode a)
+            {
+                switch (a.Def.Kind)
+                {
+                    case RouteKind.Page:
+                        UI.Close(a.ScreenKey);
+                        break;
+                }
+            }
+
+            private static void RefreshTarget(ActiveNode a, RouteQuery query)
+            {
+                if (a.Def.OnEnter == null) return;
+                var screen = UI.Get(a.ScreenKey);
+                if (screen != null) a.Def.OnEnter(screen, query);
+            }
+
+            // —— Page ——
+            private static async Awaitable<ActiveNode> ActivatePage(RouteNode def, RouteQuery query)
+            {
+                var screenName = await EnsureLoaded(def);
+                var screen = UI.Open(screenName);
+                def.OnEnter?.Invoke(screen, query);
+                return new ActiveNode { Def = def, ScreenKey = screenName };
+            }
+
+            // 加载 def.Src 一次,解析出要 Open 的 screen 名。
+            private static async Awaitable<string> EnsureLoaded(RouteNode def)
+            {
+                if (!_loadedSrcs.Contains(def.Src))
+                {
+                    var names = await UI.LoadDocumentAsync(def.Src);
+                    _loadedSrcs.Add(def.Src);
+                    if (names.Count == 1) _srcSingleScreen[def.Src] = names[0];
+                }
+                if (!string.IsNullOrEmpty(def.Screen)) return def.Screen;
+                if (_srcSingleScreen.TryGetValue(def.Src, out var single)) return single;
+                throw new RouteException(
+                    $"route '{def.Name}': src '{def.Src}' has multiple screens; specify screen=");
+            }
+
+            // UI.UnloadAll 调用:取消 prompt/清 router 链路;链路屏在 _open 里由 UnloadAll 的
+            // _open 循环统一销毁。保留注册表(配置)。
+            internal static void CancelAllForTeardown()
+            {
+                foreach (var a in _chain)
+                {
+                    a.PromptCts?.Cancel();
+                    a.PromptCts?.Dispose();
+                }
+                _chain.Clear();
+                _loadedSrcs.Clear();
+                _srcSingleScreen.Clear();
+            }
+
+            // UI.ResetForTests 调用:teardown + 清注册表 + 复位 Scheme/Changed。
+            internal static void ResetForTestsInternal()
+            {
+                CancelAllForTeardown();
+                _routes.Clear();
+                Scheme = null;
+                Changed = null;
+            }
+        }
+    }
+}

--- a/Runtime/Application/UI.Router.Reconcile.cs
+++ b/Runtime/Application/UI.Router.Reconcile.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using PromptUGUI.Application.Modals;
 using UnityEngine;
 
 namespace PromptUGUI.Application
@@ -178,7 +179,8 @@ namespace PromptUGUI.Application
             {
                 switch (def.Kind)
                 {
-                    case RouteKind.Page: return await ActivatePage(def, query);
+                    case RouteKind.Page: return await ActivatePage(def, query, modal: false);
+                    case RouteKind.Modal: return await ActivatePage(def, query, modal: true);
                     default:
                         throw new RouteException($"route '{def.Name}': kind not yet supported");
                 }
@@ -189,6 +191,7 @@ namespace PromptUGUI.Application
                 switch (a.Def.Kind)
                 {
                     case RouteKind.Page:
+                    case RouteKind.Modal:
                         UI.Close(a.ScreenKey);
                         break;
                 }
@@ -201,14 +204,39 @@ namespace PromptUGUI.Application
                 if (screen != null) a.Def.OnEnter(screen, query);
             }
 
-            // —— Page ——
-            private static async Awaitable<ActiveNode> ActivatePage(RouteNode def, RouteQuery query)
+            // —— Page / Modal ——
+            private static async Awaitable<ActiveNode> ActivatePage(
+                RouteNode def, RouteQuery query, bool modal)
             {
                 var screenName = await EnsureLoaded(def);
                 var screen = UI.Open(screenName);
+                if (modal)
+                {
+                    var canvas = screen.RootGameObject.GetComponent<Canvas>();
+                    canvas.overrideSorting = true;
+                    canvas.sortingOrder = UI.Modal.SortingOrderBase + CountModalsInChain();
+                    var esc = screen.RootGameObject.AddComponent<ModalEscapeListener>();
+                    var captured = def.Name;
+                    esc.OnEscape = () =>
+                    {
+                        // 只栈顶 routed modal 响应;有 ad-hoc 模态在上时让位给它
+                        if (IsTop(captured) && !UI.Modal.IsAnyOpen) _ = Back();
+                    };
+                }
                 def.OnEnter?.Invoke(screen, query);
                 return new ActiveNode { Def = def, ScreenKey = screenName };
             }
+
+            // 当前链路里已有的 Modal 节点数(此节点尚未入链)→ modal 带内的层序偏移。
+            private static int CountModalsInChain()
+            {
+                int n = 0;
+                foreach (var a in _chain) if (a.Def.Kind == RouteKind.Modal) n++;
+                return n;
+            }
+
+            private static bool IsTop(string name) =>
+                _chain.Count > 0 && _chain[_chain.Count - 1].Def.Name == name;
 
             // 加载 def.Src 一次,解析出要 Open 的 screen 名。
             private static async Awaitable<string> EnsureLoaded(RouteNode def)

--- a/Runtime/Application/UI.Router.Reconcile.cs
+++ b/Runtime/Application/UI.Router.Reconcile.cs
@@ -35,6 +35,23 @@ namespace PromptUGUI.Application
                 }
             }
 
+            public static Awaitable Back()
+            {
+                if (_chain.Count == 0) return AwaitableHelpers.Completed();
+                var parent = _chain[_chain.Count - 1].Def.Parent;
+                if (parent == null) return AwaitableHelpers.Completed();   // 已在根
+                return Open(parent);
+            }
+
+            public static Awaitable Reset()
+            {
+                AbandonPump(cancel: false);
+                for (int i = _chain.Count - 1; i >= 0; i--) Deactivate(_chain[i]);
+                _chain.Clear();
+                Changed?.Invoke();
+                return AwaitableHelpers.Completed();
+            }
+
             private static (string name, RouteQuery query)? _pending;
             private static readonly List<AwaitableCompletionSource> _waiters = new();
             private static bool _reconciling;

--- a/Runtime/Application/UI.Router.Reconcile.cs
+++ b/Runtime/Application/UI.Router.Reconcile.cs
@@ -86,7 +86,7 @@ namespace PromptUGUI.Application
                         var t = _pending.Value;
                         _pending = null;
                         error = null;
-                        try { await Reconcile(t.name, t.query); }
+                        try { await Reconcile(t.name, t.query, epoch); }
                         catch (Exception ex) { error = ex; }
                     }
                 }
@@ -123,7 +123,7 @@ namespace PromptUGUI.Application
                 }
             }
 
-            private static async Awaitable Reconcile(string name, RouteQuery query)
+            private static async Awaitable Reconcile(string name, RouteQuery query, int epoch)
             {
                 var target = ResolveChain(name);   // 校验 + 根→叶
 
@@ -157,6 +157,16 @@ namespace PromptUGUI.Application
                 for (int i = k; i < target.Count; i++)
                 {
                     var active = await Activate(target[i], query);
+                    if (epoch != _epoch)
+                    {
+                        // 异步加载期间发生了 teardown/Reset:_chain 已被清空,别再塞回陈旧节点。
+                        // 关掉这个孤儿(Page/Modal 已 UI.Open),Prompt 释放其 CTS,避免泄漏。
+                        if (active.Def.Kind == RouteKind.Page || active.Def.Kind == RouteKind.Modal)
+                            UI.Close(active.ScreenKey);
+                        else
+                            active.PromptCts?.Dispose();
+                        return;
+                    }
                     _chain.Add(active);
                     if (active.Def.Kind == RouteKind.Prompt) StartPrompt(active, query);
                 }

--- a/Runtime/Application/UI.Router.Reconcile.cs
+++ b/Runtime/Application/UI.Router.Reconcile.cs
@@ -158,6 +158,7 @@ namespace PromptUGUI.Application
                 {
                     var active = await Activate(target[i], query);
                     _chain.Add(active);
+                    if (active.Def.Kind == RouteKind.Prompt) StartPrompt(active, query);
                 }
 
                 // 目标落在公共前缀里(Open 某个祖先)→ 刷新目标 OnEnter
@@ -182,6 +183,7 @@ namespace PromptUGUI.Application
                     case RouteKind.Page: return await ActivatePage(def, query, modal: false);
                     case RouteKind.Modal: return await ActivatePage(def, query, modal: true);
                     case RouteKind.Tab: return ActivateTab(def, query);
+                    case RouteKind.Prompt: return ActivatePrompt(def);
                     default:
                         throw new RouteException($"route '{def.Name}': kind not yet supported");
                 }
@@ -194,6 +196,11 @@ namespace PromptUGUI.Application
                     case RouteKind.Page:
                     case RouteKind.Modal:
                         UI.Close(a.ScreenKey);
+                        break;
+                    case RouteKind.Prompt:
+                        a.Deactivated = true;          // 告诉 SelfPop 让位:reconcile 负责移除
+                        a.PromptCts?.Cancel();
+                        a.PromptCts?.Dispose();
                         break;
                 }
             }
@@ -254,6 +261,50 @@ namespace PromptUGUI.Application
                         return _chain[i].ScreenKey;
                 throw new RouteException(
                     $"tab route '{tabDef.Name}': no Page/Modal host ancestor active");
+            }
+
+            // —— Prompt —— 无 src,由 run handler 支撑;入链后由 StartPrompt 起跑。
+            private static ActiveNode ActivatePrompt(RouteNode def)
+            {
+                return new ActiveNode
+                {
+                    Def = def,
+                    PromptCts = new System.Threading.CancellationTokenSource(),
+                };
+            }
+
+            private static void StartPrompt(ActiveNode node, RouteQuery query)
+            {
+                _ = RunPrompt(node, query);
+            }
+
+            private static async Awaitable RunPrompt(ActiveNode node, RouteQuery query)
+            {
+                try
+                {
+                    await node.Def.Run(query, node.PromptCts.Token);
+                }
+                catch (OperationCanceledException) { /* 被导航走 */ }
+                catch (Exception ex)
+                {
+                    UnityEngine.Debug.LogError($"prompt route '{node.Def.Name}' run failed: {ex}");
+                }
+                finally
+                {
+                    SelfPop(node);
+                }
+            }
+
+            // run 正常结束 → 自动出栈(仅当它仍是栈顶且未被 reconcile 接管移除)。
+            private static void SelfPop(ActiveNode node)
+            {
+                if (node.Deactivated) return;   // reconcile 正在移除它
+                if (_chain.Count > 0 && _chain[_chain.Count - 1] == node)
+                {
+                    _chain.RemoveAt(_chain.Count - 1);
+                    node.PromptCts?.Dispose();
+                    Changed?.Invoke();
+                }
             }
 
             // 当前链路里已有的 Modal 节点数(此节点尚未入链)→ modal 带内的层序偏移。

--- a/Runtime/Application/UI.Router.Reconcile.cs
+++ b/Runtime/Application/UI.Router.Reconcile.cs
@@ -181,6 +181,7 @@ namespace PromptUGUI.Application
                 {
                     case RouteKind.Page: return await ActivatePage(def, query, modal: false);
                     case RouteKind.Modal: return await ActivatePage(def, query, modal: true);
+                    case RouteKind.Tab: return ActivateTab(def, query);
                     default:
                         throw new RouteException($"route '{def.Name}': kind not yet supported");
                 }
@@ -225,6 +226,34 @@ namespace PromptUGUI.Application
                 }
                 def.OnEnter?.Invoke(screen, query);
                 return new ActiveNode { Def = def, ScreenKey = screenName };
+            }
+
+            // —— Tab —— 宿主 = 链路里最近的已激活 Page/Modal(此刻已在 _chain 中,因 bottom-up 激活)
+            private static ActiveNode ActivateTab(RouteNode def, RouteQuery query)
+            {
+                var hostKey = ResolveHostScreenKey(def);
+                var host = UI.Get(hostKey)
+                    ?? throw new RouteException(
+                        $"tab route '{def.Name}': host screen '{hostKey}' not open");
+                PromptUGUI.Controls.Tab tab;
+                try { tab = host.Get<PromptUGUI.Controls.Tab>(def.TabId); }
+                catch (Exception ex)
+                {
+                    throw new RouteException(
+                        $"tab route '{def.Name}': tab '{def.TabId}' not found in host '{hostKey}'", ex);
+                }
+                tab.IsOn = true;
+                def.OnEnter?.Invoke(host, query);
+                return new ActiveNode { Def = def, ScreenKey = hostKey };
+            }
+
+            private static string ResolveHostScreenKey(RouteNode tabDef)
+            {
+                for (int i = _chain.Count - 1; i >= 0; i--)
+                    if (_chain[i].Def.Kind == RouteKind.Page || _chain[i].Def.Kind == RouteKind.Modal)
+                        return _chain[i].ScreenKey;
+                throw new RouteException(
+                    $"tab route '{tabDef.Name}': no Page/Modal host ancestor active");
             }
 
             // 当前链路里已有的 Modal 节点数(此节点尚未入链)→ modal 带内的层序偏移。

--- a/Runtime/Application/UI.Router.Reconcile.cs
+++ b/Runtime/Application/UI.Router.Reconcile.cs
@@ -35,9 +35,68 @@ namespace PromptUGUI.Application
                 }
             }
 
-            public static async Awaitable Open(string name, RouteQuery query = null)
+            private static (string name, RouteQuery query)? _pending;
+            private static readonly List<AwaitableCompletionSource> _waiters = new();
+            private static bool _reconciling;
+            private static int _epoch;
+
+            public static Awaitable Open(string name, RouteQuery query = null)
             {
-                await Reconcile(name, query ?? RouteQuery.Empty);
+                var tcs = new AwaitableCompletionSource();
+                _waiters.Add(tcs);
+                _pending = (name, query ?? RouteQuery.Empty);
+                if (!_reconciling) _ = Pump();
+                return tcs.Awaitable;
+            }
+
+            private static async Awaitable Pump()
+            {
+                _reconciling = true;
+                int epoch = _epoch;
+                Exception error = null;
+                try
+                {
+                    while (_pending != null)
+                    {
+                        if (epoch != _epoch) return;   // 被 teardown 抛弃
+                        var t = _pending.Value;
+                        _pending = null;
+                        error = null;
+                        try { await Reconcile(t.name, t.query); }
+                        catch (Exception ex) { error = ex; }
+                    }
+                }
+                finally
+                {
+                    if (epoch == _epoch)
+                    {
+                        _reconciling = false;
+                        var done = _waiters.ToArray();
+                        _waiters.Clear();
+                        foreach (var w in done)
+                        {
+                            if (error != null) w.TrySetException(error);
+                            else w.TrySetResult();
+                        }
+                    }
+                }
+            }
+
+            // 抛弃进行中的 pump:自增 epoch 让它恢复即退;完成所有等待者。
+            // cancel=true(teardown)→ 抛 OCE;cancel=false(Reset)→ 正常完成。
+            private static void AbandonPump(bool cancel)
+            {
+                _epoch++;
+                _reconciling = false;
+                _pending = null;
+                var done = _waiters.ToArray();
+                _waiters.Clear();
+                foreach (var w in done)
+                {
+                    if (cancel) w.TrySetException(
+                        new OperationCanceledException("Router torn down"));
+                    else w.TrySetResult();
+                }
             }
 
             private static async Awaitable Reconcile(string name, RouteQuery query)
@@ -142,6 +201,7 @@ namespace PromptUGUI.Application
             // _open 循环统一销毁。保留注册表(配置)。
             internal static void CancelAllForTeardown()
             {
+                AbandonPump(cancel: true);
                 foreach (var a in _chain)
                 {
                     a.PromptCts?.Cancel();

--- a/Runtime/Application/UI.Router.Reconcile.cs.meta
+++ b/Runtime/Application/UI.Router.Reconcile.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e3f328682e2ffc64baf7d3d8c333546d

--- a/Runtime/Application/UI.Router.cs
+++ b/Runtime/Application/UI.Router.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+
+namespace PromptUGUI.Application
+{
+    public static partial class UI
+    {
+        public static partial class Router
+        {
+            private static readonly Dictionary<string, RouteNode> _routes = new();
+
+            /// <summary>Navigate(url) 校验的 scheme;null = 不校验(接受任意 scheme 或无 scheme)。</summary>
+            public static string Scheme { get; set; }
+
+            public static void Map(string name, string src, string screen = null,
+                RoutePresent present = RoutePresent.Page, string parent = null,
+                Action<IScreen, RouteQuery> onEnter = null)
+            {
+                if (src == null) throw new RouteException($"route '{name}': src required");
+                AddRoute(new RouteNode
+                {
+                    Name = Req(name),
+                    Parent = parent,
+                    Kind = present == RoutePresent.Modal ? RouteKind.Modal : RouteKind.Page,
+                    Src = src,
+                    Screen = screen,
+                    OnEnter = onEnter,
+                });
+            }
+
+            public static void MapTab(string name, string parent, string tabId,
+                Action<IScreen, RouteQuery> onEnter = null)
+            {
+                if (parent == null) throw new RouteException($"tab route '{name}': parent required");
+                if (tabId == null) throw new RouteException($"tab route '{name}': tabId required");
+                AddRoute(new RouteNode
+                {
+                    Name = Req(name),
+                    Parent = parent,
+                    Kind = RouteKind.Tab,
+                    TabId = tabId,
+                    OnEnter = onEnter,
+                });
+            }
+
+            public static void MapPrompt(string name, string parent, RoutePromptRun run)
+            {
+                if (run == null) throw new RouteException($"prompt route '{name}': run required");
+                AddRoute(new RouteNode
+                {
+                    Name = Req(name),
+                    Parent = parent,
+                    Kind = RouteKind.Prompt,
+                    Run = run,
+                });
+            }
+
+            public static bool IsMapped(string name) => name != null && _routes.ContainsKey(name);
+
+            /// <summary>清空注册表(不动活动链路;teardown 另走 ResetForTestsInternal)。</summary>
+            public static void Clear() => _routes.Clear();
+
+            private static string Req(string name) =>
+                string.IsNullOrEmpty(name)
+                    ? throw new RouteException("route name required")
+                    : name;
+
+            private static void AddRoute(RouteNode n)
+            {
+                if (_routes.ContainsKey(n.Name))
+                    throw new RouteException($"route '{n.Name}' already mapped");
+                _routes[n.Name] = n;
+            }
+
+            /// <summary>沿 Parent 走到根,返回 根→name 的链路。检测缺失/成环/prompt-as-parent。</summary>
+            internal static List<RouteNode> ResolveChain(string name)
+            {
+                var chain = new List<RouteNode>();
+                var visited = new HashSet<string>();
+                var cur = name;
+                while (cur != null)
+                {
+                    if (!visited.Add(cur))
+                        throw new RouteException($"route '{name}': cyclic parent at '{cur}'");
+                    if (!_routes.TryGetValue(cur, out var node))
+                        throw new RouteException($"route '{cur}' not mapped");
+                    chain.Add(node);
+                    cur = node.Parent;
+                }
+                chain.Reverse();
+                for (int i = 0; i < chain.Count - 1; i++)
+                    if (chain[i].Kind == RouteKind.Prompt)
+                        throw new RouteException(
+                            $"route '{name}': prompt '{chain[i].Name}' cannot be a parent");
+                return chain;
+            }
+        }
+    }
+}

--- a/Runtime/Application/UI.Router.cs
+++ b/Runtime/Application/UI.Router.cs
@@ -94,6 +94,29 @@ namespace PromptUGUI.Application
                             $"route '{name}': prompt '{chain[i].Name}' cannot be a parent");
                 return chain;
             }
+            // <scheme>://<name>?<query>,或无 scheme 的 <name>?<query>。
+            // ://(若有)与 ? 之间整段当 name(含斜杠不拆)。
+            internal static (string name, RouteQuery query) ParseUrl(string url)
+            {
+                if (string.IsNullOrEmpty(url)) throw new RouteException("navigate: empty url");
+                var rest = url;
+                int s = url.IndexOf("://", StringComparison.Ordinal);
+                if (s >= 0)
+                {
+                    var scheme = url.Substring(0, s);
+                    if (Scheme != null && !string.Equals(scheme, Scheme, StringComparison.Ordinal))
+                        throw new RouteException($"navigate: scheme '{scheme}' != Router.Scheme '{Scheme}'");
+                    rest = url.Substring(s + 3);
+                }
+                else if (Scheme != null)
+                    throw new RouteException($"navigate: url '{url}' missing scheme '{Scheme}'");
+
+                int q = rest.IndexOf('?');
+                var name = q >= 0 ? rest.Substring(0, q) : rest;
+                var qs = q >= 0 ? rest.Substring(q + 1) : "";
+                if (name.Length == 0) throw new RouteException($"navigate: url '{url}' has empty route name");
+                return (name, RouteQuery.ParseQueryString(qs));
+            }
         }
     }
 }

--- a/Runtime/Application/UI.Router.cs.meta
+++ b/Runtime/Application/UI.Router.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 89f7139f8d3ad174992bd45014f283b0

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -844,6 +844,7 @@ namespace PromptUGUI.Application
         /// </summary>
         public static void UnloadAll()
         {
+            Router.CancelAllForTeardown();
             Modal.CancelAllForTeardown();
             Modals.LoadingOverlay.CancelAllForTeardown();
             Toasts.ToastOverlay.CancelAllForTeardown();
@@ -1010,6 +1011,7 @@ namespace PromptUGUI.Application
             Theme.ResetForTestsInternal();
             Markdown.ResetForTestsInternal();
             TranslationStore.Instance.UnloadAll();
+            Router.ResetForTestsInternal();
             Modal.CancelAllForTeardown();
             Modals.LoadingOverlay.CancelAllForTeardown();
             Toasts.ToastOverlay.CancelAllForTeardown();

--- a/Tests/EditMode/Modals/ModalCancelTests.cs
+++ b/Tests/EditMode/Modals/ModalCancelTests.cs
@@ -55,5 +55,19 @@ namespace PromptUGUI.Tests.Modals
 
             Assert.Throws<OperationCanceledException>(() => t1.GetAwaiter().GetResult());
         }
+
+        [Test]
+        public void OpenAsync_CancellationToken_CancelsAndClosesModal()
+        {
+            var cts = new System.Threading.CancellationTokenSource();
+            var box = MessageBox.Open("hi", MsgBtn.OK, ct: cts.Token);
+            Assert.IsTrue(UI.Modal.IsAnyOpen);
+
+            cts.Cancel();
+
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+            Assert.Throws<System.OperationCanceledException>(() => box.GetAwaiter().GetResult());
+            cts.Dispose();
+        }
     }
 }

--- a/Tests/EditMode/Router.meta
+++ b/Tests/EditMode/Router.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f1ffb65f3c88164c86fe343b5877b2c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Router/RouteQueryTests.cs
+++ b/Tests/EditMode/Router/RouteQueryTests.cs
@@ -1,0 +1,42 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+
+namespace PromptUGUI.Tests.Router
+{
+    public class RouteQueryTests
+    {
+        [Test]
+        public void Empty_HasNothing()
+        {
+            Assert.IsFalse(RouteQuery.Empty.Has("x"));
+            Assert.IsNull(RouteQuery.Empty["x"]);
+            Assert.AreEqual("fb", RouteQuery.Empty.Get("x", "fb"));
+            Assert.AreEqual(7, RouteQuery.Empty.GetInt("x", 7));
+        }
+
+        [Test]
+        public void Parse_SplitsPairs_AndUrlDecodes()
+        {
+            var q = RouteQuery.ParseQueryString("uid=123&name=a%20b&flag=");
+            Assert.AreEqual("123", q["uid"]);
+            Assert.AreEqual(123, q.GetInt("uid"));
+            Assert.AreEqual("a b", q["name"]);
+            Assert.IsTrue(q.Has("flag"));
+            Assert.AreEqual("", q["flag"]);
+        }
+
+        [Test]
+        public void Parse_Empty_ReturnsEmptyQuery()
+        {
+            var q = RouteQuery.ParseQueryString("");
+            Assert.IsFalse(q.Has("x"));
+        }
+
+        [Test]
+        public void GetInt_NonNumeric_ReturnsFallback()
+        {
+            var q = RouteQuery.ParseQueryString("n=abc");
+            Assert.AreEqual(-1, q.GetInt("n", -1));
+        }
+    }
+}

--- a/Tests/EditMode/Router/RouteQueryTests.cs.meta
+++ b/Tests/EditMode/Router/RouteQueryTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d1070917666c8184b93a7259649886ad

--- a/Tests/EditMode/Router/RouteRegistryTests.cs
+++ b/Tests/EditMode/Router/RouteRegistryTests.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Application;
+
+namespace PromptUGUI.Tests.Router
+{
+    public class RouteRegistryTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Map_ThenIsMapped()
+        {
+            UI.Router.Map("home", "Screens/Home");
+            Assert.IsTrue(UI.Router.IsMapped("home"));
+            Assert.IsFalse(UI.Router.IsMapped("nope"));
+        }
+
+        [Test]
+        public void Map_Duplicate_Throws()
+        {
+            UI.Router.Map("home", "Screens/Home");
+            Assert.Throws<RouteException>(() => UI.Router.Map("home", "Screens/Other"));
+        }
+
+        [Test]
+        public void Map_NullSrc_Throws()
+            => Assert.Throws<RouteException>(() => UI.Router.Map("home", null));
+
+        [Test]
+        public void ResolveChain_RootToLeaf_InOrder()
+        {
+            UI.Router.Map("home", "S/Home");
+            UI.Router.Map("shop", "S/Shop", parent: "home");
+            UI.Router.MapTab("shop/deals", parent: "shop", tabId: "bar/deals");
+            var names = UI.Router.ResolveChain("shop/deals").Select(n => n.Name).ToArray();
+            CollectionAssert.AreEqual(new[] { "home", "shop", "shop/deals" }, names);
+        }
+
+        [Test]
+        public void ResolveChain_UnmappedParent_Throws()
+        {
+            UI.Router.Map("shop", "S/Shop", parent: "ghost");
+            Assert.Throws<RouteException>(() => UI.Router.ResolveChain("shop"));
+        }
+
+        [Test]
+        public void ResolveChain_Cycle_Throws()
+        {
+            UI.Router.Map("a", "S/A", parent: "b");
+            UI.Router.Map("b", "S/B", parent: "a");
+            Assert.Throws<RouteException>(() => UI.Router.ResolveChain("a"));
+        }
+
+        [Test]
+        public void ResolveChain_PromptAsParent_Throws()
+        {
+            UI.Router.Map("home", "S/Home");
+            UI.Router.MapPrompt("ask", parent: "home", run: (q, ct) => null);
+            UI.Router.Map("deep", "S/Deep", parent: "ask");
+            Assert.Throws<RouteException>(() => UI.Router.ResolveChain("deep"));
+        }
+
+        [Test]
+        public void Open_Unmapped_Throws()
+            => Assert.ThrowsAsync<RouteException>(async () => await UI.Router.Open("ghost"));
+    }
+}

--- a/Tests/EditMode/Router/RouteRegistryTests.cs
+++ b/Tests/EditMode/Router/RouteRegistryTests.cs
@@ -65,5 +65,52 @@ namespace PromptUGUI.Tests.Router
         [Test]
         public void Open_Unmapped_Throws()
             => Assert.ThrowsAsync<RouteException>(async () => await UI.Router.Open("ghost"));
+
+        [Test]
+        public void MapTab_NullParent_Throws()
+            => Assert.Throws<RouteException>(() => UI.Router.MapTab("t", null, "bar/x"));
+
+        [Test]
+        public void MapTab_NullTabId_Throws()
+            => Assert.Throws<RouteException>(() => UI.Router.MapTab("t", "home", null));
+
+        [Test]
+        public void MapPrompt_NullRun_Throws()
+            => Assert.Throws<RouteException>(() => UI.Router.MapPrompt("p", "home", null));
+
+        [Test]
+        public void Open_MultiScreenSrc_NoExplicitScreen_Throws()
+        {
+            var files = new System.Collections.Generic.Dictionary<string, string>
+            {
+                ["multi"] = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='A'><Image id='x' anchor='stretch'/></Screen>
+  <Screen name='B'><Image id='x' anchor='stretch'/></Screen>
+</PromptUGUI>",
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("m", "multi");   // no screen= → ambiguous
+            Assert.ThrowsAsync<RouteException>(async () => await UI.Router.Open("m"));
+        }
+
+        [Test]
+        public void Open_TabIdNotFound_Throws()
+        {
+            var files = new System.Collections.Generic.Dictionary<string, string>
+            {
+                ["home"] = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='home'><Image id='bg' anchor='stretch'/></Screen></PromptUGUI>",
+                ["shop"] = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='shop'><Image id='x' anchor='stretch'/></Screen></PromptUGUI>",
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+            UI.Router.Map("shop", "shop", parent: "home");
+            UI.Router.MapTab("shop/deals", parent: "shop", tabId: "bar/deals");   // no such tab in shop
+            Assert.ThrowsAsync<RouteException>(async () => await UI.Router.Open("shop/deals"));
+        }
     }
 }

--- a/Tests/EditMode/Router/RouteRegistryTests.cs.meta
+++ b/Tests/EditMode/Router/RouteRegistryTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ee1ca0f1b7bd9594a9c9d12db2e89e23

--- a/Tests/EditMode/Router/RouterModalTabTests.cs
+++ b/Tests/EditMode/Router/RouterModalTabTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Router
+{
+    public class RouterModalTabTests
+    {
+        private static string PageXml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'><Image id='bg' anchor='stretch'/></Screen></PromptUGUI>";
+
+        private static string ModalXml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'>
+  <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+  <Frame id='panel' anchor='center' size='300x200'/>
+</Screen></PromptUGUI>";
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            var files = new Dictionary<string, string>
+            {
+                ["home"] = PageXml("home"),
+                ["settings"] = ModalXml("settings"),
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+            UI.Router.Map("settings", "settings", present: RoutePresent.Modal, parent: "home");
+        }
+
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Modal_Activates_OnModalSortingBand()
+        {
+            UI.Router.Open("settings").GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home", "settings" }, UI.Router.Chain.ToList());
+            var canvas = UI.Get("settings").RootGameObject.GetComponent<Canvas>();
+            // Note: overrideSorting does not read back as true on a root ScreenSpaceOverlay
+            // canvas (only meaningful for nested canvases — same as LoadingOverlayTests).
+            // Verify sortingOrder is in the modal sorting band instead.
+            Assert.GreaterOrEqual(canvas.sortingOrder, UI.Modal.SortingOrderBase);
+        }
+
+        [Test]
+        public void Modal_Esc_GoesBackToParent()
+        {
+            UI.Router.Open("settings").GetAwaiter().GetResult();
+            var esc = UI.Get("settings").RootGameObject.GetComponent<ModalEscapeListener>();
+            Assert.IsNotNull(esc);
+            esc.FireForTests();
+            CollectionAssert.AreEqual(new[] { "home" }, UI.Router.Chain.ToList());
+            Assert.IsNull(UI.Get("settings"));
+        }
+
+        [Test]
+        public void Modal_Deactivate_ClosesScreen()
+        {
+            UI.Router.Open("settings").GetAwaiter().GetResult();
+            UI.Router.Open("home").GetAwaiter().GetResult();
+            Assert.IsNull(UI.Get("settings"));
+        }
+    }
+}

--- a/Tests/EditMode/Router/RouterModalTabTests.cs
+++ b/Tests/EditMode/Router/RouterModalTabTests.cs
@@ -67,5 +67,64 @@ namespace PromptUGUI.Tests.Router
             UI.Router.Open("home").GetAwaiter().GetResult();
             Assert.IsNull(UI.Get("settings"));
         }
+
+        private const string ShopWithTabsXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='shop'>
+  <TabBar id='bar' anchor='stretch'>
+    <Tab id='deals'>Deals</Tab>
+    <Tab id='cart'>Cart</Tab>
+  </TabBar>
+</Screen></PromptUGUI>";
+
+        private void SetUpShopTabs()
+        {
+            UI.ResetForTests();
+            var files = new Dictionary<string, string>
+            {
+                ["home"] = PageXml("home"),
+                ["shop"] = ShopWithTabsXml,
+                ["item"] = PageXml("item"),
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+            UI.Router.Map("shop", "shop", parent: "home");
+            UI.Router.MapTab("shop/deals", parent: "shop", tabId: "bar/deals");
+            UI.Router.MapTab("shop/cart", parent: "shop", tabId: "bar/cart");
+            UI.Router.Map("item", "item", parent: "shop/deals");   // drill-in 自某个 tab
+        }
+
+        [Test]
+        public void Tab_Activate_SelectsTab_HostOpened()
+        {
+            SetUpShopTabs();
+            UI.Router.Open("shop/deals").GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home", "shop", "shop/deals" }, UI.Router.Chain.ToList());
+            var deals = UI.Get("shop").Get<PromptUGUI.Controls.Tab>("bar/deals");
+            Assert.IsTrue(deals.IsOn);
+        }
+
+        [Test]
+        public void Tab_SiblingSwitch_DoesNotRebuildHost()
+        {
+            SetUpShopTabs();
+            UI.Router.Open("shop/deals").GetAwaiter().GetResult();
+            var hostBefore = UI.Get("shop");
+            UI.Router.Open("shop/cart").GetAwaiter().GetResult();
+            Assert.AreSame(hostBefore, UI.Get("shop"));    // 宿主未重建
+            Assert.IsTrue(UI.Get("shop").Get<PromptUGUI.Controls.Tab>("bar/cart").IsOn);
+            CollectionAssert.AreEqual(new[] { "home", "shop", "shop/cart" }, UI.Router.Chain.ToList());
+        }
+
+        [Test]
+        public void Tab_DrillIn_FullChainReconciles()
+        {
+            SetUpShopTabs();
+            UI.Router.Open("item").GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(
+                new[] { "home", "shop", "shop/deals", "item" }, UI.Router.Chain.ToList());
+            Assert.IsTrue(UI.Get("shop").Get<PromptUGUI.Controls.Tab>("bar/deals").IsOn);
+            Assert.IsNotNull(UI.Get("item"));
+        }
     }
 }

--- a/Tests/EditMode/Router/RouterModalTabTests.cs.meta
+++ b/Tests/EditMode/Router/RouterModalTabTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6c70be20df0645c5b7fd721ef4584c99

--- a/Tests/EditMode/Router/RouterNavigateTests.cs
+++ b/Tests/EditMode/Router/RouterNavigateTests.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+
+namespace PromptUGUI.Tests.Router
+{
+    public class RouterNavigateTests
+    {
+        private static string Xml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'>
+  <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+  <Btn id='ok'>OK</Btn>
+</Screen></PromptUGUI>";
+
+        // MessageBox.Bind requires text/title/ok/cancel/yes/no/close controls.
+        private const string MboxXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='mbox'>
+    <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+    <Frame id='dialog' anchor='center' size='400x200'>
+      <VStack anchor='stretch' margin='16' spacing='8'>
+        <Text id='title' fontSize='20'/>
+        <Text id='text'  fontSize='14'/>
+        <Btn  id='ok'>OK</Btn>
+        <Btn  id='cancel'>Cancel</Btn>
+        <Btn  id='yes'>Yes</Btn>
+        <Btn  id='no'>No</Btn>
+        <Btn  id='close'>Close</Btn>
+      </VStack>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            var files = new Dictionary<string, string>
+            {
+                ["home"] = Xml("home"),
+                ["profile"] = Xml("profile"),
+                ["mbox"] = MboxXml,
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+            UI.Router.Map("profile", "profile", parent: "home");
+        }
+
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Navigate_ParsesNameAndQuery()
+        {
+            string seen = null;
+            UI.ResetForTests();
+            var files = new Dictionary<string, string> { ["home"] = Xml("home"), ["profile"] = Xml("profile") };
+            UI.SourceResolver = src => AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+            UI.Router.Map("profile", "profile", parent: "home", onEnter: (s, q) => seen = q["uid"]);
+
+            UI.Router.Navigate("appid://profile?uid=123").GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home", "profile" }, UI.Router.Chain.ToList());
+            Assert.AreEqual("123", seen);
+        }
+
+        [Test]
+        public void Navigate_SlashInName_NotSplitAsHierarchy()
+        {
+            UI.ResetForTests();
+            var files = new Dictionary<string, string> { ["home"] = Xml("home"), ["f"] = Xml("f") };
+            UI.SourceResolver = src => AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+            UI.Router.Map("home/friend", "f", parent: "home");
+
+            UI.Router.Navigate("appid://home/friend").GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home", "home/friend" }, UI.Router.Chain.ToList());
+        }
+
+        [Test]
+        public void Navigate_SchemeMismatch_Throws()
+        {
+            UI.Router.Scheme = "appid";
+            Assert.ThrowsAsync<RouteException>(
+                async () => await UI.Router.Navigate("other://profile"));
+        }
+
+        [Test]
+        public void Navigate_NoSchemeConfigured_AcceptsAny()
+        {
+            UI.Router.Navigate("whatever://home").GetAwaiter().GetResult();
+            Assert.AreEqual("home", UI.Router.Current);
+        }
+
+        [Test]
+        public void Reconcile_ClosesAdHocModalFirst()
+        {
+            MessageBox.XmlSrc = "mbox";
+            UI.Router.Open("home").GetAwaiter().GetResult();
+            _ = MessageBox.Open("hi");
+            Assert.IsTrue(UI.Modal.IsAnyOpen);
+            UI.Router.Open("profile").GetAwaiter().GetResult();
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+            CollectionAssert.AreEqual(new[] { "home", "profile" }, UI.Router.Chain.ToList());
+        }
+    }
+}

--- a/Tests/EditMode/Router/RouterNavigateTests.cs.meta
+++ b/Tests/EditMode/Router/RouterNavigateTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1afd6e24e8b6a1945b18a25379896844

--- a/Tests/EditMode/Router/RouterPromptTests.cs
+++ b/Tests/EditMode/Router/RouterPromptTests.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Router
+{
+    public class RouterPromptTests
+    {
+        private static string PageXml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'><Image id='bg' anchor='stretch'/></Screen></PromptUGUI>";
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            var files = new Dictionary<string, string>
+            {
+                ["home"] = PageXml("home"),
+                ["shop"] = PageXml("shop"),
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+            UI.Router.Map("shop", "shop", parent: "home");
+        }
+
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Prompt_RunCompletes_AutoPops()
+        {
+            bool ran = false;
+            UI.Router.MapPrompt("ask", parent: "home", run: (q, ct) =>
+            {
+                ran = true;
+                return AwaitableHelpers.Completed();   // 立即完成
+            });
+
+            UI.Router.Open("ask").GetAwaiter().GetResult();
+
+            Assert.IsTrue(ran);
+            CollectionAssert.AreEqual(new[] { "home" }, UI.Router.Chain.ToList());   // 自动出栈
+        }
+
+        [Test]
+        public void Prompt_ReceivesQuery()
+        {
+            string seen = null;
+            UI.Router.MapPrompt("ask", parent: "home", run: (q, ct) =>
+            {
+                seen = q["reason"];
+                return AwaitableHelpers.Completed();
+            });
+            UI.Router.Navigate("appid://ask?reason=illegal").GetAwaiter().GetResult();
+            Assert.AreEqual("illegal", seen);
+        }
+
+        [Test]
+        public void Prompt_NavigatedAway_Cancels()
+        {
+            // run 永不自完成 → 靠 ct 取消。canceled 在 ct.Register 回调里置位:
+            // cts.Cancel() 同步触发该回调,不依赖 await 续体的恢复时机(EditMode 无 PlayerLoop)。
+            bool canceled = false;
+            UI.Router.MapPrompt("ask", parent: "home", run: async (q, ct) =>
+            {
+                var box = new AwaitableCompletionSource();
+                ct.Register(() => { canceled = true; box.TrySetResult(); });
+                await box.Awaitable;
+            });
+
+            UI.Router.Open("ask").GetAwaiter().GetResult();   // 起 prompt(挂起)
+            CollectionAssert.AreEqual(new[] { "home", "ask" }, UI.Router.Chain.ToList());
+
+            UI.Router.Open("shop").GetAwaiter().GetResult();  // 导航走 → 取消 prompt
+            Assert.IsTrue(canceled);                          // 取消同步发生
+            CollectionAssert.AreEqual(new[] { "home", "shop" }, UI.Router.Chain.ToList());
+        }
+    }
+}

--- a/Tests/EditMode/Router/RouterPromptTests.cs
+++ b/Tests/EditMode/Router/RouterPromptTests.cs
@@ -79,5 +79,45 @@ namespace PromptUGUI.Tests.Router
             Assert.IsTrue(canceled);                          // 取消同步发生
             CollectionAssert.AreEqual(new[] { "home", "shop" }, UI.Router.Chain.ToList());
         }
+
+        private const string IBoxXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='ibox'>
+  <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+  <Frame id='dialog' anchor='center' size='400x200'>
+    <VStack anchor='stretch' margin='16' spacing='8'>
+      <Text id='title'/>
+      <InputField id='field'/>
+      <Btn id='ok'>OK</Btn>
+      <Btn id='cancel'>Cancel</Btn>
+    </VStack>
+  </Frame>
+</Screen></PromptUGUI>";
+
+        [Test]
+        public void Prompt_RenameViaInputBox_ReachableShowsDialog()
+        {
+            InputBox.XmlSrc = "ibox";   // 非 builtin 前缀 → 走 SourceResolver(fake)
+            var files = new Dictionary<string, string>
+            {
+                ["home"] = PageXml("home"),
+                ["ibox"] = IBoxXml,
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Clear();
+            UI.Router.Map("home", "home");
+            UI.Router.MapPrompt("rename", parent: "home", run: async (q, ct) =>
+            {
+                var name = await InputBox.Open("改名", initial: "old", ct: ct);
+                // 确认后的结果处理在 PlayMode 验;EditMode 只验证可达 + 弹窗已起
+            });
+
+            UI.Router.Navigate("appid://rename").GetAwaiter().GetResult();
+
+            CollectionAssert.AreEqual(new[] { "home", "rename" }, UI.Router.Chain.ToList());
+            var ibox = UI.Modal.TopScreen;   // internal,Tests.EditMode 可见
+            Assert.IsNotNull(ibox, "InputBox 应已实例化在 modal 栈顶");
+            Assert.DoesNotThrow(() => ibox.Get<PromptUGUI.Controls.InputField>("field"));
+        }
     }
 }

--- a/Tests/EditMode/Router/RouterPromptTests.cs.meta
+++ b/Tests/EditMode/Router/RouterPromptTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0f25e07e35ddbfc47a0a647a2a61cd08

--- a/Tests/EditMode/Router/RouterReconcileTests.cs
+++ b/Tests/EditMode/Router/RouterReconcileTests.cs
@@ -126,5 +126,25 @@ namespace PromptUGUI.Tests.Router
             UI.Router.Open("shop").GetAwaiter().GetResult();
             Assert.GreaterOrEqual(fired, 1);
         }
+
+        [Test]
+        public void ConcurrentOpen_LatestWins_BothAwaitablesComplete()
+        {
+            var a = UI.Router.Open("item");
+            var b = UI.Router.Open("battle");
+            b.GetAwaiter().GetResult();
+            a.GetAwaiter().GetResult();   // 被取代的也应完成,不挂死
+            CollectionAssert.AreEqual(new[] { "home", "battle" }, UI.Router.Chain.ToList());
+        }
+
+        [Test]
+        public void ResetForTests_ClearsChain()
+        {
+            UI.Router.Open("shop").GetAwaiter().GetResult();
+            Assert.IsNotEmpty(UI.Router.Chain.ToList());
+            UI.ResetForTests();
+            Assert.IsEmpty(UI.Router.Chain.ToList());
+            Assert.IsNull(UI.Router.Current);
+        }
     }
 }

--- a/Tests/EditMode/Router/RouterReconcileTests.cs
+++ b/Tests/EditMode/Router/RouterReconcileTests.cs
@@ -146,5 +146,36 @@ namespace PromptUGUI.Tests.Router
             Assert.IsEmpty(UI.Router.Chain.ToList());
             Assert.IsNull(UI.Router.Current);
         }
+
+        [Test]
+        public void Back_GoesToParent()
+        {
+            UI.Router.Open("item").GetAwaiter().GetResult();   // home/shop/item
+            UI.Router.Back().GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home", "shop" }, UI.Router.Chain.ToList());
+        }
+
+        [Test]
+        public void Back_AtRoot_IsNoop()
+        {
+            UI.Router.Open("home").GetAwaiter().GetResult();
+            UI.Router.Back().GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home" }, UI.Router.Chain.ToList());
+        }
+
+        [Test]
+        public void Back_EmptyChain_IsNoop()
+            => Assert.DoesNotThrow(() => UI.Router.Back().GetAwaiter().GetResult());
+
+        [Test]
+        public void Reset_ClosesWholeChain()
+        {
+            UI.Router.Open("item").GetAwaiter().GetResult();
+            UI.Router.Reset().GetAwaiter().GetResult();
+            Assert.IsEmpty(UI.Router.Chain.ToList());
+            Assert.IsNull(UI.Get("home"));
+            Assert.IsNull(UI.Get("shop"));
+            Assert.IsNull(UI.Get("item"));
+        }
     }
 }

--- a/Tests/EditMode/Router/RouterReconcileTests.cs
+++ b/Tests/EditMode/Router/RouterReconcileTests.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Application;
+
+namespace PromptUGUI.Tests.Router
+{
+    public class RouterReconcileTests
+    {
+        private static string Xml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'>
+  <Image id='bg' anchor='stretch'/>
+</Screen></PromptUGUI>";
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            var files = new Dictionary<string, string>
+            {
+                ["home"] = Xml("home"),
+                ["shop"] = Xml("shop"),
+                ["battle"] = Xml("battle"),
+                ["item"] = Xml("item"),
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            // src == screen name 简化:每个 src 内 <Screen name> 同名
+            UI.Router.Map("home", "home");
+            UI.Router.Map("shop", "shop", parent: "home");
+            UI.Router.Map("battle", "battle", parent: "home");
+            UI.Router.Map("item", "item", parent: "shop");
+        }
+
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static List<string> Chain() => UI.Router.Chain.ToList();
+
+        [Test]
+        public void Open_BuildsCanonicalChainFromRoot()
+        {
+            UI.Router.Open("shop").GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home", "shop" }, Chain());
+            Assert.AreEqual("shop", UI.Router.Current);
+            Assert.IsNotNull(UI.Get("home"));
+            Assert.IsNotNull(UI.Get("shop"));
+        }
+
+        [Test]
+        public void Open_Child_PushesOnly()
+        {
+            UI.Router.Open("shop").GetAwaiter().GetResult();
+            UI.Router.Open("item").GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home", "shop", "item" }, Chain());
+        }
+
+        [Test]
+        public void Open_Ancestor_PopsToIt()
+        {
+            UI.Router.Open("item").GetAwaiter().GetResult();
+            UI.Router.Open("shop").GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home", "shop" }, Chain());
+            Assert.IsNull(UI.Get("item"));   // item 屏被销毁
+        }
+
+        [Test]
+        public void Open_SiblingBranch_ClosesToCommonAncestor()
+        {
+            UI.Router.Open("item").GetAwaiter().GetResult();   // home/shop/item
+            UI.Router.Open("battle").GetAwaiter().GetResult(); // home/battle
+            CollectionAssert.AreEqual(new[] { "home", "battle" }, Chain());
+            Assert.IsNull(UI.Get("shop"));
+            Assert.IsNull(UI.Get("item"));
+            Assert.IsNotNull(UI.Get("home"));  // 公共前缀 home 不重建
+        }
+
+        [Test]
+        public void OnEnter_ReceivesQuery_OnTargetAndNewIntermediates()
+        {
+            var seen = new Dictionary<string, string>();
+            UI.ResetForTests();
+            var files = new Dictionary<string, string>
+            {
+                ["home"] = Xml("home"),
+                ["shop"] = Xml("shop"),
+                ["item"] = Xml("item"),
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+            UI.Router.Map("shop", "shop", parent: "home",
+                onEnter: (s, q) => seen["shop"] = q["k"]);
+            UI.Router.Map("item", "item", parent: "shop",
+                onEnter: (s, q) => seen["item"] = q["k"]);
+
+            var q = new RouteQuery(new Dictionary<string, string> { ["k"] = "v" });
+            UI.Router.Open("item", q).GetAwaiter().GetResult();
+
+            Assert.AreEqual("v", seen["shop"]);   // 新激活中间节点也收到
+            Assert.AreEqual("v", seen["item"]);   // 目标收到
+        }
+
+        [Test]
+        public void ReNavigate_SameTarget_RefreshesOnEnter_NoRebuild()
+        {
+            int count = 0;
+            UI.ResetForTests();
+            var files = new Dictionary<string, string> { ["home"] = Xml("home") };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home", onEnter: (s, q) => count++);
+
+            UI.Router.Open("home").GetAwaiter().GetResult();
+            var first = UI.Get("home");
+            UI.Router.Open("home").GetAwaiter().GetResult();
+            Assert.AreEqual(2, count);                 // OnEnter 再触发
+            Assert.AreSame(first, UI.Get("home"));     // 同一 Screen,未重建
+        }
+
+        [Test]
+        public void Changed_FiresOnNavigation()
+        {
+            int fired = 0;
+            UI.Router.Changed += () => fired++;
+            UI.Router.Open("shop").GetAwaiter().GetResult();
+            Assert.GreaterOrEqual(fired, 1);
+        }
+    }
+}

--- a/Tests/EditMode/Router/RouterReconcileTests.cs.meta
+++ b/Tests/EditMode/Router/RouterReconcileTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3cf8e8d8a92ca6247b59081eb4b490b2

--- a/Tests/PlayMode/RouterPlayTests.cs
+++ b/Tests/PlayMode/RouterPlayTests.cs
@@ -83,5 +83,29 @@ namespace PromptUGUI.Tests.PlayMode
             Assert.AreEqual("newName", applied);
             CollectionAssert.AreEqual(new[] { "home" }, new List<string>(UI.Router.Chain));  // 自动出栈
         }
+
+        [UnityTest]
+        public IEnumerator Teardown_DuringAsyncPageLoad_NoCorruptionNoLeak()
+        {
+            var gate = new AwaitableCompletionSource<string>();
+            UI.ResetForTests();
+            UI.SourceResolver = src =>
+                src == "home" ? gate.Awaitable : AwaitableHelpers.Completed<string>(null);
+            UI.Router.Map("home", "home");
+
+            _ = UI.Router.Open("home");           // suspends at LoadDocumentAsync("home")
+            yield return null;
+            Assert.IsEmpty(new List<string>(UI.Router.Chain));   // not added yet (still loading)
+
+            UI.ResetForTests();                    // teardown mid-load → AbandonPump bumps epoch, clears chain
+
+            gate.SetResult(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='home'><Image id='bg' anchor='stretch'/></Screen></PromptUGUI>");
+            for (int i = 0; i < 5; i++) yield return null;   // let the orphaned continuation run
+
+            // WITH the fix: reconcile bails → chain stays empty, no leaked screen.
+            Assert.IsEmpty(new List<string>(UI.Router.Chain));
+            Assert.IsNull(UI.Get("home"));
+        }
     }
 }

--- a/Tests/PlayMode/RouterPlayTests.cs
+++ b/Tests/PlayMode/RouterPlayTests.cs
@@ -1,0 +1,87 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.PlayMode
+{
+    public class RouterPlayTests
+    {
+        private static string PageXml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'><Image id='bg' anchor='stretch'/></Screen></PromptUGUI>";
+        private static string ModalXml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'>
+  <Image id='backdrop' anchor='stretch' color='#0000007F'/></Screen></PromptUGUI>";
+        private const string IBoxXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='ibox'>
+  <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+  <Frame id='dialog' anchor='center' size='400x200'>
+    <VStack anchor='stretch' margin='16' spacing='8'>
+      <Text id='title'/><InputField id='field'/>
+      <Btn id='ok'>OK</Btn><Btn id='cancel'>Cancel</Btn>
+    </VStack>
+  </Frame>
+</Screen></PromptUGUI>";
+
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static void Setup(Dictionary<string, string> files)
+        {
+            UI.ResetForTests();
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+        }
+
+        [UnityTest]
+        public IEnumerator Modal_SortsAbovePage()
+        {
+            Setup(new Dictionary<string, string>
+            {
+                ["home"] = PageXml("home"),
+                ["settings"] = ModalXml("settings"),
+            });
+            UI.Router.Map("home", "home");
+            UI.Router.Map("settings", "settings", present: RoutePresent.Modal, parent: "home");
+
+            _ = UI.Router.Open("settings");
+            for (int i = 0; i < 10 && UI.Get("settings") == null; i++) yield return null;
+
+            var home = UI.Get("home").RootGameObject.GetComponent<Canvas>();
+            var settings = UI.Get("settings").RootGameObject.GetComponent<Canvas>();
+            Assert.Greater(settings.sortingOrder, home.sortingOrder);
+            Assert.GreaterOrEqual(settings.sortingOrder, UI.Modal.SortingOrderBase);
+        }
+
+        [UnityTest]
+        public IEnumerator Prompt_RenameConfirm_AppliesAndAutoPops()
+        {
+            Setup(new Dictionary<string, string> { ["home"] = PageXml("home"), ["ibox"] = IBoxXml });
+            InputBox.XmlSrc = "ibox";
+            UI.Router.Map("home", "home");
+            string applied = null;
+            UI.Router.MapPrompt("rename", parent: "home", run: async (q, ct) =>
+            {
+                var name = await InputBox.Open("改名", initial: "old", ct: ct);
+                if (name != null) applied = name;
+            });
+
+            _ = UI.Router.Navigate("appid://rename");
+            for (int i = 0; i < 10 && UI.Modal.TopScreen == null; i++) yield return null;
+            var ibox = UI.Modal.TopScreen;
+            Assert.IsNotNull(ibox);
+
+            ibox.Get<PromptUGUI.Controls.InputField>("field").TextValue = "newName";
+            ibox.Get<PromptUGUI.Controls.Btn>("ok").SimulateClick();   // = close(field.TextValue)
+
+            for (int i = 0; i < 10 && applied == null; i++) yield return null;
+
+            Assert.AreEqual("newName", applied);
+            CollectionAssert.AreEqual(new[] { "home" }, new List<string>(UI.Router.Chain));  // 自动出栈
+        }
+    }
+}

--- a/Tests/PlayMode/RouterPlayTests.cs.meta
+++ b/Tests/PlayMode/RouterPlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 171820ee77d616b4d8b553d91cba1f17

--- a/docs~/superpowers/plans/2026-06-09-router-navigation.md
+++ b/docs~/superpowers/plans/2026-06-09-router-navigation.md
@@ -1,0 +1,2234 @@
+# Router 导航系统 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增 `UI.Router` 导航子系统——游戏内所有界面打开的统一入口:`Open(name)` 把当前层栈 reconcile 到 name 的标准链路;深链 `Navigate(url)` 与手点同入口、同结果。支持 Page / Modal / Tab / Prompt 四种呈现。
+
+**Architecture:** 稳定不透明名字 + 注册时声明的标准 parent → 一棵导航节点树。`Open` 求目标的根→叶链路,与当前活动链路求最长公共前缀,关掉非共享尾部(top-down)、开缺失尾部(bottom-up)。Page/Modal 复用 `UI.Open`/`UI.Close`(Modal 另把 Canvas 提到 modal sorting 带 + route-aware ESC);Tab 复用现有 `<Tab>.IsOn`;Prompt 由一段 async handler 支撑、自动出栈,靠给 `InputBox`/`MessageBox.Open` 新增的 `CancellationToken` 重载实现"被导航走即撤销"。reconcile 异步串行(epoch + latest-wins),临时 ad-hoc 模态在 reconcile 前清掉。
+
+**Tech Stack:** C# (Unity 6, LangVersion 9)、Unity `Awaitable` / `AwaitableCompletionSource`(禁用 .NET `Task`/`Thread`)、`System.Threading.CancellationToken`、uGUI、R3、NUnit EditMode + PlayMode、UnityMCP 跑测试、`dotnet format` 做 lint。
+
+参考 spec:`docs~/superpowers/specs/2026-06-09-router-navigation-design.md`
+
+---
+
+## File Structure
+
+| 文件 | 动作 | 责任 |
+|---|---|---|
+| `Runtime/Application/Router/RouteException.cs` | 新建 | `public sealed class RouteException : Exception` |
+| `Runtime/Application/Router/RouteQuery.cs` | 新建 | `public sealed class RouteQuery`:`Has`/`Get`/`GetInt`/索引器/`Raw` + 内部 `ParseQueryString` |
+| `Runtime/Application/Router/RouteNode.cs` | 新建 | `public enum RoutePresent { Page, Modal }`、`public delegate Awaitable RoutePromptRun(...)`、`internal enum RouteKind`、`internal sealed class RouteNode` POCO |
+| `Runtime/Application/UI.Router.cs` | 新建 | `partial class UI { static partial class Router }`:facade(Scheme / Map / MapTab / MapPrompt / IsMapped / Clear)+ 注册表 `_routes` + `ResolveChain` + URL 解析 |
+| `Runtime/Application/UI.Router.Reconcile.cs` | 新建 | 同 `partial class Router`:活动链路 `_chain` + `Open`/`Navigate`/`Back`/`Reset` + reconcile + 四种 activate/deactivate + 串行化 + teardown 内部方法 + `Current`/`Chain`/`Changed` |
+| `Runtime/Application/AwaitableHelpers.cs` | 修改 | 补非泛型 `Completed()` |
+| `Runtime/Application/UI.cs` | 修改 | `UnloadAll`(845)、`ResetForTests`(1006)各加一行 router teardown 钩 |
+| `Runtime/Application/UI.Modal.cs` | 修改 | `OpenAsync` 加 `CancellationToken ct = default` + 新 `internal CancelEntry` |
+| `Runtime/Application/Modals/InputBoxRequest.cs` | 修改 | `InputBox.Open` 加 `CancellationToken ct = default` 透传 |
+| `Runtime/Application/Modals/MessageBoxRequest.cs` | 修改 | `MessageBox.Open` 两重载各加 `CancellationToken ct = default` 透传 |
+| `Tests/EditMode/Router/RouteQueryTests.cs` | 新建 | RouteQuery 解析 / getter |
+| `Tests/EditMode/Router/RouteRegistryTests.cs` | 新建 | 注册 / 重复 / 缺失 parent / 环 / prompt-as-parent / ResolveChain |
+| `Tests/EditMode/Router/RouterReconcileTests.cs` | 新建 | Page 推/弹/跨分支/兄弟、Current/Chain/Changed、query、串行化 |
+| `Tests/EditMode/Router/RouterNavigateTests.cs` | 新建 | URL 解析 / Scheme / 临时模态清理 |
+| `Tests/EditMode/Router/RouterModalTabTests.cs` | 新建 | Modal 带 + ESC=Back;Tab 选中 / 兄弟切换 / drill-in |
+| `Tests/EditMode/Router/RouterPromptTests.cs` | 新建 | Prompt 自动出栈 / 被导航走撤销 / 改名范式 |
+| `Tests/EditMode/Modals/ModalCancelTests.cs` | 修改 | 追加 `ct` 取消 OpenAsync 的用例 |
+| `Tests/PlayMode/RouterPlayTests.cs` | 新建 | Modal sorting 分带、ESC 实按、Prompt 实弹 |
+| `.claude/skills/scripting-promptugui-csharp/SKILL.md` | 修改 | 新增 Router 节 + InputBox/MessageBox 的 `ct` 重载说明 + cheatsheet |
+
+**约定**:每改源码先 `refresh_unity` 再 `read_console` 看编译错误,再 `run_tests`。EditMode 里不存在的类型/成员表现为**编译错误**(本计划的"红"),非 NUnit 失败。新 `.cs` 在 `refresh_unity` 后会生成 `.cs.meta`,commit 时一并 `git add`。Router 不新增 XML 标签 → **不动** `Runtime/Core/Lint/BuiltinTags.cs` / XSD。
+
+---
+
+## Task 1: 公共类型 — RouteException / RouteQuery / RouteNode
+
+**Files:**
+- Create: `Runtime/Application/Router/RouteException.cs`
+- Create: `Runtime/Application/Router/RouteQuery.cs`
+- Create: `Runtime/Application/Router/RouteNode.cs`
+- Test: `Tests/EditMode/Router/RouteQueryTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `Tests/EditMode/Router/RouteQueryTests.cs`:
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application;
+
+namespace PromptUGUI.Tests.Router
+{
+    public class RouteQueryTests
+    {
+        [Test]
+        public void Empty_HasNothing()
+        {
+            Assert.IsFalse(RouteQuery.Empty.Has("x"));
+            Assert.IsNull(RouteQuery.Empty["x"]);
+            Assert.AreEqual("fb", RouteQuery.Empty.Get("x", "fb"));
+            Assert.AreEqual(7, RouteQuery.Empty.GetInt("x", 7));
+        }
+
+        [Test]
+        public void Parse_SplitsPairs_AndUrlDecodes()
+        {
+            var q = RouteQuery.ParseQueryString("uid=123&name=a%20b&flag=");
+            Assert.AreEqual("123", q["uid"]);
+            Assert.AreEqual(123, q.GetInt("uid"));
+            Assert.AreEqual("a b", q["name"]);
+            Assert.IsTrue(q.Has("flag"));
+            Assert.AreEqual("", q["flag"]);
+        }
+
+        [Test]
+        public void Parse_Empty_ReturnsEmptyQuery()
+        {
+            var q = RouteQuery.ParseQueryString("");
+            Assert.IsFalse(q.Has("x"));
+        }
+
+        [Test]
+        public void GetInt_NonNumeric_ReturnsFallback()
+        {
+            var q = RouteQuery.ParseQueryString("n=abc");
+            Assert.AreEqual(-1, q.GetInt("n", -1));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 刷新并确认红(编译错误)**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: `CS0103`/`CS0246` —— `RouteQuery` 不存在。
+
+- [ ] **Step 3: 实现三个类型文件**
+
+新建 `Runtime/Application/Router/RouteException.cs`:
+
+```csharp
+using System;
+
+namespace PromptUGUI.Application
+{
+    /// <summary>Router 注册 / 导航期的错误(未注册、缺失/成环 parent、tab 解析失败等)。</summary>
+    public sealed class RouteException : Exception
+    {
+        public RouteException(string message) : base(message) { }
+        public RouteException(string message, Exception inner) : base(message, inner) { }
+    }
+}
+```
+
+新建 `Runtime/Application/Router/RouteQuery.cs`:
+
+```csharp
+using System;
+using System.Collections.Generic;
+
+namespace PromptUGUI.Application
+{
+    /// <summary>路由查询参数的只读包装。从 URL 的 ?k=v&... 或 Open 传入的字典构造。</summary>
+    public sealed class RouteQuery
+    {
+        public static readonly RouteQuery Empty = new(new Dictionary<string, string>(0));
+
+        private readonly IReadOnlyDictionary<string, string> _q;
+
+        public RouteQuery(IReadOnlyDictionary<string, string> query)
+            => _q = query ?? new Dictionary<string, string>(0);
+
+        public bool Has(string key) => _q.ContainsKey(key);
+
+        public string Get(string key, string fallback = null)
+            => _q.TryGetValue(key, out var v) ? v : fallback;
+
+        public int GetInt(string key, int fallback = 0)
+            => _q.TryGetValue(key, out var v) && int.TryParse(v, out var n) ? n : fallback;
+
+        public string this[string key] => Get(key);
+
+        public IReadOnlyDictionary<string, string> Raw => _q;
+
+        /// <summary>解析 "k=v&k2=v2"(无前导 '?')。空串 → Empty。k/v 各做 URL decode。</summary>
+        internal static RouteQuery ParseQueryString(string qs)
+        {
+            if (string.IsNullOrEmpty(qs)) return Empty;
+            var d = new Dictionary<string, string>();
+            foreach (var pair in qs.Split('&'))
+            {
+                if (pair.Length == 0) continue;
+                var eq = pair.IndexOf('=');
+                var k = eq >= 0 ? pair.Substring(0, eq) : pair;
+                var v = eq >= 0 ? pair.Substring(eq + 1) : "";
+                if (k.Length == 0) continue;
+                d[Uri.UnescapeDataString(k)] = Uri.UnescapeDataString(v);
+            }
+            return new RouteQuery(d);
+        }
+    }
+}
+```
+
+新建 `Runtime/Application/Router/RouteNode.cs`:
+
+```csharp
+using System;
+
+namespace PromptUGUI.Application
+{
+    /// <summary>screen-backed 节点的呈现方式。Tab/Prompt 由 MapTab/MapPrompt 表达,不在此枚举。</summary>
+    public enum RoutePresent { Page, Modal }
+
+    /// <summary>Prompt 节点的支撑 handler:跑内置对话框 + 处理结果。ct 取消 = 被导航走。</summary>
+    public delegate UnityEngine.Awaitable RoutePromptRun(
+        RouteQuery query, System.Threading.CancellationToken ct);
+
+    internal enum RouteKind { Page, Modal, Tab, Prompt }
+
+    /// <summary>一个路由节点的注册记录(运行时,非 XML IR)。</summary>
+    internal sealed class RouteNode
+    {
+        public string Name;                      // 稳定不透明 ID,全局唯一
+        public string Parent;                    // null = 根
+        public RouteKind Kind;
+        public string Src;                       // Page/Modal:.ui.xml 的 src key
+        public string Screen;                    // Page/Modal:screen 名;null → 激活时按"单 Screen"解析
+        public string TabId;                     // Tab:宿主 screen 内 <Tab> 控件的 id 路径
+        public RoutePromptRun Run;               // Prompt
+        public Action<IScreen, RouteQuery> OnEnter;  // Page/Modal/Tab
+    }
+}
+```
+
+- [ ] **Step 4: 刷新并确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RouteQueryTests")
+```
+Expected: 无编译错误;`RouteQueryTests` 4 条全绿。
+
+- [ ] **Step 5: Lint**
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+Expected: 退出码 0。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Runtime/Application/Router/RouteException.cs Runtime/Application/Router/RouteException.cs.meta \
+        Runtime/Application/Router/RouteQuery.cs Runtime/Application/Router/RouteQuery.cs.meta \
+        Runtime/Application/Router/RouteNode.cs Runtime/Application/Router/RouteNode.cs.meta \
+        Tests/EditMode/Router/RouteQueryTests.cs Tests/EditMode/Router/RouteQueryTests.cs.meta
+git commit -m "feat(router): RouteException / RouteQuery / RouteNode types"
+```
+
+---
+
+## Task 2: 注册表 + ResolveChain + 校验
+
+**Files:**
+- Create: `Runtime/Application/UI.Router.cs`
+- Test: `Tests/EditMode/Router/RouteRegistryTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `Tests/EditMode/Router/RouteRegistryTests.cs`:
+
+```csharp
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Application;
+
+namespace PromptUGUI.Tests.Router
+{
+    public class RouteRegistryTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Map_ThenIsMapped()
+        {
+            UI.Router.Map("home", "Screens/Home");
+            Assert.IsTrue(UI.Router.IsMapped("home"));
+            Assert.IsFalse(UI.Router.IsMapped("nope"));
+        }
+
+        [Test]
+        public void Map_Duplicate_Throws()
+        {
+            UI.Router.Map("home", "Screens/Home");
+            Assert.Throws<RouteException>(() => UI.Router.Map("home", "Screens/Other"));
+        }
+
+        [Test]
+        public void Map_NullSrc_Throws()
+            => Assert.Throws<RouteException>(() => UI.Router.Map("home", null));
+
+        [Test]
+        public void ResolveChain_RootToLeaf_InOrder()
+        {
+            UI.Router.Map("home", "S/Home");
+            UI.Router.Map("shop", "S/Shop", parent: "home");
+            UI.Router.MapTab("shop/deals", parent: "shop", tabId: "bar/deals");
+            var names = UI.Router.ResolveChain("shop/deals").Select(n => n.Name).ToArray();
+            CollectionAssert.AreEqual(new[] { "home", "shop", "shop/deals" }, names);
+        }
+
+        [Test]
+        public void ResolveChain_UnmappedParent_Throws()
+        {
+            UI.Router.Map("shop", "S/Shop", parent: "ghost");
+            Assert.Throws<RouteException>(() => UI.Router.ResolveChain("shop"));
+        }
+
+        [Test]
+        public void ResolveChain_Cycle_Throws()
+        {
+            UI.Router.Map("a", "S/A", parent: "b");
+            UI.Router.Map("b", "S/B", parent: "a");
+            Assert.Throws<RouteException>(() => UI.Router.ResolveChain("a"));
+        }
+
+        [Test]
+        public void ResolveChain_PromptAsParent_Throws()
+        {
+            UI.Router.Map("home", "S/Home");
+            UI.Router.MapPrompt("ask", parent: "home", run: (q, ct) => null);
+            UI.Router.Map("deep", "S/Deep", parent: "ask");
+            Assert.Throws<RouteException>(() => UI.Router.ResolveChain("deep"));
+        }
+
+        [Test]
+        public void Open_Unmapped_Throws()
+            => Assert.ThrowsAsync<RouteException>(async () => await UI.Router.Open("ghost"));
+    }
+}
+```
+
+> 注:`Open_Unmapped_Throws` 用 `ThrowsAsync` —— `Open` 在 Task 3 实现;本步它编译不过(红的一部分),Task 3 才转绿。先写在这里以免遗漏。
+
+- [ ] **Step 2: 刷新并确认红**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: `UI.Router` 不存在(`CS0117`/`CS0246`)。
+
+- [ ] **Step 3: 实现注册 facade + ResolveChain**
+
+新建 `Runtime/Application/UI.Router.cs`:
+
+```csharp
+using System;
+using System.Collections.Generic;
+
+namespace PromptUGUI.Application
+{
+    public static partial class UI
+    {
+        public static partial class Router
+        {
+            private static readonly Dictionary<string, RouteNode> _routes = new();
+
+            /// <summary>Navigate(url) 校验的 scheme;null = 不校验(接受任意 scheme 或无 scheme)。</summary>
+            public static string Scheme { get; set; }
+
+            public static void Map(string name, string src, string screen = null,
+                RoutePresent present = RoutePresent.Page, string parent = null,
+                Action<IScreen, RouteQuery> onEnter = null)
+            {
+                if (src == null) throw new RouteException($"route '{name}': src required");
+                AddRoute(new RouteNode
+                {
+                    Name = Req(name),
+                    Parent = parent,
+                    Kind = present == RoutePresent.Modal ? RouteKind.Modal : RouteKind.Page,
+                    Src = src,
+                    Screen = screen,
+                    OnEnter = onEnter,
+                });
+            }
+
+            public static void MapTab(string name, string parent, string tabId,
+                Action<IScreen, RouteQuery> onEnter = null)
+            {
+                if (parent == null) throw new RouteException($"tab route '{name}': parent required");
+                if (tabId == null) throw new RouteException($"tab route '{name}': tabId required");
+                AddRoute(new RouteNode
+                {
+                    Name = Req(name), Parent = parent, Kind = RouteKind.Tab,
+                    TabId = tabId, OnEnter = onEnter,
+                });
+            }
+
+            public static void MapPrompt(string name, string parent, RoutePromptRun run)
+            {
+                if (run == null) throw new RouteException($"prompt route '{name}': run required");
+                AddRoute(new RouteNode
+                {
+                    Name = Req(name), Parent = parent, Kind = RouteKind.Prompt, Run = run,
+                });
+            }
+
+            public static bool IsMapped(string name) => name != null && _routes.ContainsKey(name);
+
+            /// <summary>清空注册表(不动活动链路;teardown 另走 ResetForTestsInternal)。</summary>
+            public static void Clear() => _routes.Clear();
+
+            private static string Req(string name) =>
+                string.IsNullOrEmpty(name)
+                    ? throw new RouteException("route name required")
+                    : name;
+
+            private static void AddRoute(RouteNode n)
+            {
+                if (_routes.ContainsKey(n.Name))
+                    throw new RouteException($"route '{n.Name}' already mapped");
+                _routes[n.Name] = n;
+            }
+
+            /// <summary>沿 Parent 走到根,返回 根→name 的链路。检测缺失/成环/prompt-as-parent。</summary>
+            internal static List<RouteNode> ResolveChain(string name)
+            {
+                var chain = new List<RouteNode>();
+                var visited = new HashSet<string>();
+                var cur = name;
+                while (cur != null)
+                {
+                    if (!visited.Add(cur))
+                        throw new RouteException($"route '{name}': cyclic parent at '{cur}'");
+                    if (!_routes.TryGetValue(cur, out var node))
+                        throw new RouteException($"route '{cur}' not mapped");
+                    chain.Add(node);
+                    cur = node.Parent;
+                }
+                chain.Reverse();
+                for (int i = 0; i < chain.Count - 1; i++)
+                    if (chain[i].Kind == RouteKind.Prompt)
+                        throw new RouteException(
+                            $"route '{name}': prompt '{chain[i].Name}' cannot be a parent");
+                return chain;
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: 刷新 + 确认 registry 测试绿(Open_Unmapped 仍红)**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: 仍有 1 个编译错误 —— `UI.Router.Open` 不存在(来自 `Open_Unmapped_Throws`)。这是预期的;Task 3 实现 `Open` 后整文件转绿。**本步不跑 run_tests**(编译未过)。
+
+- [ ] **Step 5: Commit(WIP,留到 Task 3 一起绿)**
+
+```bash
+git add Runtime/Application/UI.Router.cs Runtime/Application/UI.Router.cs.meta \
+        Tests/EditMode/Router/RouteRegistryTests.cs Tests/EditMode/Router/RouteRegistryTests.cs.meta
+git commit -m "feat(router): registration table + ResolveChain validation"
+```
+
+---
+
+## Task 3: reconcile 核心 + Page 呈现 + 链路状态
+
+**Files:**
+- Create: `Runtime/Application/UI.Router.Reconcile.cs`
+- Test: `Tests/EditMode/Router/RouterReconcileTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `Tests/EditMode/Router/RouterReconcileTests.cs`:
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Application;
+
+namespace PromptUGUI.Tests.Router
+{
+    public class RouterReconcileTests
+    {
+        private static string Xml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'>
+  <Image id='bg' anchor='stretch'/>
+</Screen></PromptUGUI>";
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            var files = new Dictionary<string, string>
+            {
+                ["home"] = Xml("home"),
+                ["shop"] = Xml("shop"),
+                ["battle"] = Xml("battle"),
+                ["item"] = Xml("item"),
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            // src == screen name 简化:每个 src 内 <Screen name> 同名
+            UI.Router.Map("home", "home");
+            UI.Router.Map("shop", "shop", parent: "home");
+            UI.Router.Map("battle", "battle", parent: "home");
+            UI.Router.Map("item", "item", parent: "shop");
+        }
+
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static List<string> Chain() => UI.Router.Chain.ToList();
+
+        [Test]
+        public void Open_BuildsCanonicalChainFromRoot()
+        {
+            UI.Router.Open("shop").GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home", "shop" }, Chain());
+            Assert.AreEqual("shop", UI.Router.Current);
+            Assert.IsNotNull(UI.Get("home"));
+            Assert.IsNotNull(UI.Get("shop"));
+        }
+
+        [Test]
+        public void Open_Child_PushesOnly()
+        {
+            UI.Router.Open("shop").GetAwaiter().GetResult();
+            UI.Router.Open("item").GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home", "shop", "item" }, Chain());
+        }
+
+        [Test]
+        public void Open_Ancestor_PopsToIt()
+        {
+            UI.Router.Open("item").GetAwaiter().GetResult();
+            UI.Router.Open("shop").GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home", "shop" }, Chain());
+            Assert.IsNull(UI.Get("item"));   // item 屏被销毁
+        }
+
+        [Test]
+        public void Open_SiblingBranch_ClosesToCommonAncestor()
+        {
+            UI.Router.Open("item").GetAwaiter().GetResult();   // home/shop/item
+            UI.Router.Open("battle").GetAwaiter().GetResult(); // home/battle
+            CollectionAssert.AreEqual(new[] { "home", "battle" }, Chain());
+            Assert.IsNull(UI.Get("shop"));
+            Assert.IsNull(UI.Get("item"));
+            Assert.IsNotNull(UI.Get("home"));  // 公共前缀 home 不重建
+        }
+
+        [Test]
+        public void OnEnter_ReceivesQuery_OnTargetAndNewIntermediates()
+        {
+            var seen = new Dictionary<string, string>();
+            UI.ResetForTests();
+            var files = new Dictionary<string, string>
+            {
+                ["home"] = Xml("home"), ["shop"] = Xml("shop"), ["item"] = Xml("item"),
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+            UI.Router.Map("shop", "shop", parent: "home",
+                onEnter: (s, q) => seen["shop"] = q["k"]);
+            UI.Router.Map("item", "item", parent: "shop",
+                onEnter: (s, q) => seen["item"] = q["k"]);
+
+            var q = new RouteQuery(new Dictionary<string, string> { ["k"] = "v" });
+            UI.Router.Open("item", q).GetAwaiter().GetResult();
+
+            Assert.AreEqual("v", seen["shop"]);   // 新激活中间节点也收到
+            Assert.AreEqual("v", seen["item"]);   // 目标收到
+        }
+
+        [Test]
+        public void ReNavigate_SameTarget_RefreshesOnEnter_NoRebuild()
+        {
+            int count = 0;
+            UI.ResetForTests();
+            var files = new Dictionary<string, string> { ["home"] = Xml("home") };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home", onEnter: (s, q) => count++);
+
+            UI.Router.Open("home").GetAwaiter().GetResult();
+            var first = UI.Get("home");
+            UI.Router.Open("home").GetAwaiter().GetResult();
+            Assert.AreEqual(2, count);                 // OnEnter 再触发
+            Assert.AreSame(first, UI.Get("home"));     // 同一 Screen,未重建
+        }
+
+        [Test]
+        public void Changed_FiresOnNavigation()
+        {
+            int fired = 0;
+            UI.Router.Changed += () => fired++;
+            UI.Router.Open("shop").GetAwaiter().GetResult();
+            Assert.GreaterOrEqual(fired, 1);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 刷新并确认红**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: `UI.Router.Open` / `Chain` / `Current` / `Changed` 不存在。
+
+- [ ] **Step 3: 实现 reconcile + Page(单飞版,串行化留 Task 4)**
+
+新建 `Runtime/Application/UI.Router.Reconcile.cs`:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PromptUGUI.Application
+{
+    public static partial class UI
+    {
+        public static partial class Router
+        {
+            private sealed class ActiveNode
+            {
+                public RouteNode Def;
+                public string ScreenKey;                 // Page/Modal:_open 的 key(== screen 名)
+                public System.Threading.CancellationTokenSource PromptCts;  // Prompt
+                public bool Deactivated;                 // Prompt:reconcile 正在移除它,SelfPop 让位
+            }
+
+            private static readonly List<ActiveNode> _chain = new();
+            private static readonly HashSet<string> _loadedSrcs = new();
+            private static readonly Dictionary<string, string> _srcSingleScreen = new();
+
+            public static event Action Changed;
+
+            public static string Current =>
+                _chain.Count > 0 ? _chain[_chain.Count - 1].Def.Name : null;
+
+            public static IReadOnlyList<string> Chain
+            {
+                get
+                {
+                    var l = new List<string>(_chain.Count);
+                    foreach (var a in _chain) l.Add(a.Def.Name);
+                    return l;
+                }
+            }
+
+            public static async Awaitable Open(string name, RouteQuery query = null)
+            {
+                await Reconcile(name, query ?? RouteQuery.Empty);
+            }
+
+            private static async Awaitable Reconcile(string name, RouteQuery query)
+            {
+                var target = ResolveChain(name);   // 校验 + 根→叶
+
+                // 完全相同的链路 = 无结构变化:跳过(后续 Task 6 的)临时模态清理,只刷新栈顶。
+                // 这条也保证"重复导航到正在显示的 Prompt"是 no-op,不会把它误关再重开。
+                if (SameChain(target))
+                {
+                    if (_chain.Count > 0) RefreshTarget(_chain[_chain.Count - 1], query);
+                    Changed?.Invoke();
+                    return;
+                }
+
+                int k = 0;
+                while (k < _chain.Count && k < target.Count
+                       && _chain[k].Def.Name == target[k].Name) k++;
+
+                // 先把尾部从 _chain 快照 + 移除,再 deactivate。这样若 deactivate(或 Task 6 的
+                // 临时模态清理)同步触发了某个 Prompt 续体的 SelfPop,它看到自己已不在 _chain → no-op,
+                // 不会与这里的链路改动撞车。
+                var removed = new List<ActiveNode>();
+                for (int i = k; i < _chain.Count; i++) removed.Add(_chain[i]);
+                if (removed.Count > 0) _chain.RemoveRange(k, removed.Count);
+
+                for (int i = removed.Count - 1; i >= 0; i--) Deactivate(removed[i]);
+
+                for (int i = k; i < target.Count; i++)
+                {
+                    var active = await Activate(target[i], query);
+                    _chain.Add(active);
+                }
+
+                // 目标落在公共前缀里(Open 某个祖先)→ 刷新目标 OnEnter
+                if (k == target.Count && _chain.Count > 0)
+                    RefreshTarget(_chain[_chain.Count - 1], query);
+
+                Changed?.Invoke();
+            }
+
+            private static bool SameChain(List<RouteNode> target)
+            {
+                if (target.Count != _chain.Count) return false;
+                for (int i = 0; i < target.Count; i++)
+                    if (_chain[i].Def.Name != target[i].Name) return false;
+                return true;
+            }
+
+            private static async Awaitable<ActiveNode> Activate(RouteNode def, RouteQuery query)
+            {
+                switch (def.Kind)
+                {
+                    case RouteKind.Page: return await ActivatePage(def, query);
+                    default:
+                        throw new RouteException($"route '{def.Name}': kind not yet supported");
+                }
+            }
+
+            private static void Deactivate(ActiveNode a)
+            {
+                switch (a.Def.Kind)
+                {
+                    case RouteKind.Page:
+                        UI.Close(a.ScreenKey);
+                        break;
+                }
+            }
+
+            private static void RefreshTarget(ActiveNode a, RouteQuery query)
+            {
+                if (a.Def.OnEnter == null) return;
+                var screen = UI.Get(a.ScreenKey);
+                if (screen != null) a.Def.OnEnter(screen, query);
+            }
+
+            // —— Page ——
+            private static async Awaitable<ActiveNode> ActivatePage(RouteNode def, RouteQuery query)
+            {
+                var screenName = await EnsureLoaded(def);
+                var screen = UI.Open(screenName);
+                def.OnEnter?.Invoke(screen, query);
+                return new ActiveNode { Def = def, ScreenKey = screenName };
+            }
+
+            // 加载 def.Src 一次,解析出要 Open 的 screen 名。
+            private static async Awaitable<string> EnsureLoaded(RouteNode def)
+            {
+                if (!_loadedSrcs.Contains(def.Src))
+                {
+                    var names = await UI.LoadDocumentAsync(def.Src);
+                    _loadedSrcs.Add(def.Src);
+                    if (names.Count == 1) _srcSingleScreen[def.Src] = names[0];
+                }
+                if (!string.IsNullOrEmpty(def.Screen)) return def.Screen;
+                if (_srcSingleScreen.TryGetValue(def.Src, out var single)) return single;
+                throw new RouteException(
+                    $"route '{def.Name}': src '{def.Src}' has multiple screens; specify screen=");
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: 刷新并确认绿(含 Task 2 的 Open_Unmapped)**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RouterReconcileTests")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RouteRegistryTests")
+```
+Expected: 两个测试类全绿(`RouteRegistryTests` 含 `Open_Unmapped_Throws` 现已可编译并通过)。
+
+- [ ] **Step 5: Lint + Commit**
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+cd .. && git add Runtime/Application/UI.Router.Reconcile.cs Runtime/Application/UI.Router.Reconcile.cs.meta \
+        Tests/EditMode/Router/RouterReconcileTests.cs Tests/EditMode/Router/RouterReconcileTests.cs.meta
+git commit -m "feat(router): reconcile core + Page presentation + Current/Chain/Changed"
+```
+
+---
+
+## Task 4: 串行化(epoch + latest-wins) + teardown 接线
+
+**Files:**
+- Modify: `Runtime/Application/UI.Router.Reconcile.cs`(替换 `Open` + 加 pump/teardown)
+- Modify: `Runtime/Application/UI.cs:845`(`UnloadAll`)、`:1006`(`ResetForTests`)
+- Test: `Tests/EditMode/Router/RouterReconcileTests.cs`(追加)
+
+- [ ] **Step 1: 写失败测试**
+
+在 `RouterReconcileTests` 类末尾(最后一个 `}` 前)追加:
+
+```csharp
+        [Test]
+        public void ConcurrentOpen_LatestWins_BothAwaitablesComplete()
+        {
+            // 不 await 第一个,立刻发第二个 —— 最终落到 battle。
+            var a = UI.Router.Open("item");
+            var b = UI.Router.Open("battle");
+            b.GetAwaiter().GetResult();
+            a.GetAwaiter().GetResult();   // 被取代的也应完成,不挂死
+            CollectionAssert.AreEqual(new[] { "home", "battle" }, UI.Router.Chain.ToList());
+        }
+
+        [Test]
+        public void ResetForTests_ClearsChain()
+        {
+            UI.Router.Open("shop").GetAwaiter().GetResult();
+            Assert.IsNotEmpty(UI.Router.Chain);
+            UI.ResetForTests();
+            Assert.IsEmpty(UI.Router.Chain);
+            Assert.IsNull(UI.Router.Current);
+        }
+```
+
+> EditMode 下 fake resolver 经 `AwaitableHelpers.Completed` 同步完成,`Open` 内无真实 yield,因此 `a`/`b` 实际同步推进;此测试主要锁"被取代请求的 Awaitable 不挂死"与 latest-wins 的最终态。
+
+- [ ] **Step 2: 刷新并确认红**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RouterReconcileTests")
+```
+Expected:`ResetForTests_ClearsChain` 红(`ResetForTests` 尚未清链路,链路仍有残留 → 断言失败或后续测试串扰)。
+
+- [ ] **Step 3: 用串行化版替换 `Open`,并加 pump + teardown 方法**
+
+把 `UI.Router.Reconcile.cs` 里的:
+
+```csharp
+            public static async Awaitable Open(string name, RouteQuery query = null)
+            {
+                await Reconcile(name, query ?? RouteQuery.Empty);
+            }
+```
+
+替换为:
+
+```csharp
+            private static (string name, RouteQuery query)? _pending;
+            private static readonly List<AwaitableCompletionSource> _waiters = new();
+            private static bool _reconciling;
+            private static int _epoch;
+
+            public static Awaitable Open(string name, RouteQuery query = null)
+            {
+                var tcs = new AwaitableCompletionSource();
+                _waiters.Add(tcs);
+                _pending = (name, query ?? RouteQuery.Empty);
+                if (!_reconciling) _ = Pump();
+                return tcs.Awaitable;
+            }
+
+            private static async Awaitable Pump()
+            {
+                _reconciling = true;
+                int epoch = _epoch;
+                Exception error = null;
+                try
+                {
+                    while (_pending != null)
+                    {
+                        if (epoch != _epoch) return;   // 被 teardown 抛弃
+                        var t = _pending.Value;
+                        _pending = null;
+                        error = null;
+                        try { await Reconcile(t.name, t.query); }
+                        catch (Exception ex) { error = ex; }
+                    }
+                }
+                finally
+                {
+                    if (epoch == _epoch)
+                    {
+                        _reconciling = false;
+                        var done = _waiters.ToArray();
+                        _waiters.Clear();
+                        foreach (var w in done)
+                        {
+                            if (error != null) w.TrySetException(error);
+                            else w.TrySetResult();
+                        }
+                    }
+                }
+            }
+
+            // 抛弃进行中的 pump:自增 epoch 让它恢复即退;完成所有等待者。
+            // cancel=true(teardown)→ 抛 OCE;cancel=false(Reset)→ 正常完成。
+            private static void AbandonPump(bool cancel)
+            {
+                _epoch++;
+                _reconciling = false;
+                _pending = null;
+                var done = _waiters.ToArray();
+                _waiters.Clear();
+                foreach (var w in done)
+                {
+                    if (cancel) w.TrySetException(
+                        new OperationCanceledException("Router torn down"));
+                    else w.TrySetResult();
+                }
+            }
+
+            // UI.UnloadAll 调用:取消 pump + prompt,清链路;链路屏在 _open 里由 UnloadAll 的
+            // _open 循环统一销毁。保留注册表(配置)。
+            internal static void CancelAllForTeardown()
+            {
+                AbandonPump(cancel: true);
+                foreach (var a in _chain)
+                {
+                    a.PromptCts?.Cancel();
+                    a.PromptCts?.Dispose();
+                }
+                _chain.Clear();
+                _loadedSrcs.Clear();
+                _srcSingleScreen.Clear();
+            }
+
+            // UI.ResetForTests 调用:teardown + 清注册表 + 复位 Scheme/Changed。
+            internal static void ResetForTestsInternal()
+            {
+                CancelAllForTeardown();
+                _routes.Clear();
+                Scheme = null;
+                Changed = null;
+            }
+```
+
+- [ ] **Step 4: 在 `UI.cs` 接线 teardown**
+
+在 `Runtime/Application/UI.cs` 的 `UnloadAll()`(约 845 行)里,把:
+
+```csharp
+        public static void UnloadAll()
+        {
+            Modal.CancelAllForTeardown();
+```
+
+改为:
+
+```csharp
+        public static void UnloadAll()
+        {
+            Router.CancelAllForTeardown();
+            Modal.CancelAllForTeardown();
+```
+
+在 `ResetForTests()`(约 1006 行)里,把:
+
+```csharp
+            Modal.CancelAllForTeardown();
+            Modals.LoadingOverlay.CancelAllForTeardown();
+            Toasts.ToastOverlay.CancelAllForTeardown();
+```
+
+改为:
+
+```csharp
+            Router.ResetForTestsInternal();
+            Modal.CancelAllForTeardown();
+            Modals.LoadingOverlay.CancelAllForTeardown();
+            Toasts.ToastOverlay.CancelAllForTeardown();
+```
+
+> `Router.ResetForTestsInternal` 放在 `_open` 销毁循环之前:它只取消 prompt/清 router 链路,不关 screen;screen 由其后的 `foreach (_open) s.Close()` 统一关。
+
+- [ ] **Step 5: 刷新并确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RouterReconcileTests")
+```
+Expected: `RouterReconcileTests` 全绿(含新 2 条)。
+
+- [ ] **Step 6: Lint + Commit**
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+cd .. && git add Runtime/Application/UI.Router.Reconcile.cs Runtime/Application/UI.cs \
+        Tests/EditMode/Router/RouterReconcileTests.cs
+git commit -m "feat(router): serialize reconcile (epoch + latest-wins) + teardown wiring"
+```
+
+---
+
+## Task 5: Back + Reset(+ 非泛型 AwaitableHelpers.Completed)
+
+**Files:**
+- Modify: `Runtime/Application/AwaitableHelpers.cs`(加非泛型 `Completed()`)
+- Modify: `Runtime/Application/UI.Router.Reconcile.cs`(加 `Back`/`Reset`)
+- Test: `Tests/EditMode/Router/RouterReconcileTests.cs`(追加)
+
+- [ ] **Step 1: 写失败测试**
+
+在 `RouterReconcileTests` 末尾追加:
+
+```csharp
+        [Test]
+        public void Back_GoesToParent()
+        {
+            UI.Router.Open("item").GetAwaiter().GetResult();   // home/shop/item
+            UI.Router.Back().GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home", "shop" }, UI.Router.Chain.ToList());
+        }
+
+        [Test]
+        public void Back_AtRoot_IsNoop()
+        {
+            UI.Router.Open("home").GetAwaiter().GetResult();
+            UI.Router.Back().GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home" }, UI.Router.Chain.ToList());
+        }
+
+        [Test]
+        public void Back_EmptyChain_IsNoop()
+            => Assert.DoesNotThrow(() => UI.Router.Back().GetAwaiter().GetResult());
+
+        [Test]
+        public void Reset_ClosesWholeChain()
+        {
+            UI.Router.Open("item").GetAwaiter().GetResult();
+            UI.Router.Reset().GetAwaiter().GetResult();
+            Assert.IsEmpty(UI.Router.Chain.ToList());
+            Assert.IsNull(UI.Get("home"));
+            Assert.IsNull(UI.Get("shop"));
+            Assert.IsNull(UI.Get("item"));
+        }
+```
+
+- [ ] **Step 2: 刷新并确认红**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: `UI.Router.Back` / `Reset` 不存在。
+
+- [ ] **Step 3: 加非泛型 `Completed()`**
+
+在 `Runtime/Application/AwaitableHelpers.cs` 的 `Completed<T>` 之上插入:
+
+```csharp
+        internal static Awaitable Completed()
+        {
+            var src = new AwaitableCompletionSource();
+            src.SetResult();
+            return src.Awaitable;
+        }
+
+```
+
+- [ ] **Step 4: 实现 `Back` / `Reset`**
+
+在 `UI.Router.Reconcile.cs` 的 `Current` 属性下方插入:
+
+```csharp
+            public static Awaitable Back()
+            {
+                if (_chain.Count == 0) return AwaitableHelpers.Completed();
+                var parent = _chain[_chain.Count - 1].Def.Parent;
+                if (parent == null) return AwaitableHelpers.Completed();   // 已在根
+                return Open(parent);
+            }
+
+            public static Awaitable Reset()
+            {
+                AbandonPump(cancel: false);
+                for (int i = _chain.Count - 1; i >= 0; i--) Deactivate(_chain[i]);
+                _chain.Clear();
+                Changed?.Invoke();
+                return AwaitableHelpers.Completed();
+            }
+```
+
+- [ ] **Step 5: 刷新并确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RouterReconcileTests")
+```
+Expected: 全绿(含新 4 条)。
+
+- [ ] **Step 6: Lint + Commit**
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+cd .. && git add Runtime/Application/AwaitableHelpers.cs Runtime/Application/UI.Router.Reconcile.cs \
+        Tests/EditMode/Router/RouterReconcileTests.cs
+git commit -m "feat(router): Back() + Reset() + non-generic AwaitableHelpers.Completed"
+```
+
+---
+
+## Task 6: Navigate(URL 解析 + Scheme) + 临时模态清理(§3.3)
+
+**Files:**
+- Modify: `Runtime/Application/UI.Router.cs`(加 `ParseUrl`)
+- Modify: `Runtime/Application/UI.Router.Reconcile.cs`(加 `Navigate`;reconcile 头部加 §3.3)
+- Test: `Tests/EditMode/Router/RouterNavigateTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `Tests/EditMode/Router/RouterNavigateTests.cs`:
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+
+namespace PromptUGUI.Tests.Router
+{
+    public class RouterNavigateTests
+    {
+        private static string Xml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'>
+  <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+  <Btn id='ok'>OK</Btn>
+</Screen></PromptUGUI>";
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            var files = new Dictionary<string, string>
+            {
+                ["home"] = Xml("home"), ["profile"] = Xml("profile"), ["mbox"] = Xml("mbox"),
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+            UI.Router.Map("profile", "profile", parent: "home");
+        }
+
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Navigate_ParsesNameAndQuery()
+        {
+            string seen = null;
+            UI.ResetForTests();
+            var files = new Dictionary<string, string> { ["home"] = Xml("home"), ["profile"] = Xml("profile") };
+            UI.SourceResolver = src => AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+            UI.Router.Map("profile", "profile", parent: "home", onEnter: (s, q) => seen = q["uid"]);
+
+            UI.Router.Navigate("appid://profile?uid=123").GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home", "profile" }, UI.Router.Chain.ToList());
+            Assert.AreEqual("123", seen);
+        }
+
+        [Test]
+        public void Navigate_SlashInName_NotSplitAsHierarchy()
+        {
+            UI.ResetForTests();
+            var files = new Dictionary<string, string> { ["home"] = Xml("home"), ["f"] = Xml("f") };
+            UI.SourceResolver = src => AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+            UI.Router.Map("home/friend", "f", parent: "home");   // 名字含斜杠,但只是名字
+
+            UI.Router.Navigate("appid://home/friend").GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home", "home/friend" }, UI.Router.Chain.ToList());
+        }
+
+        [Test]
+        public void Navigate_SchemeMismatch_Throws()
+        {
+            UI.Router.Scheme = "appid";
+            Assert.ThrowsAsync<RouteException>(
+                async () => await UI.Router.Navigate("other://profile"));
+        }
+
+        [Test]
+        public void Navigate_NoSchemeConfigured_AcceptsAny()
+        {
+            UI.Router.Navigate("whatever://home").GetAwaiter().GetResult();
+            Assert.AreEqual("home", UI.Router.Current);
+        }
+
+        [Test]
+        public void Reconcile_ClosesAdHocModalFirst()
+        {
+            MessageBox.XmlSrc = "mbox";
+            UI.Router.Open("home").GetAwaiter().GetResult();
+            // 起一个 ad-hoc 模态(不进 router)
+            _ = MessageBox.Open("hi");
+            Assert.IsTrue(UI.Modal.IsAnyOpen);
+            // 导航 → 先关掉它
+            UI.Router.Open("profile").GetAwaiter().GetResult();
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+            CollectionAssert.AreEqual(new[] { "home", "profile" }, UI.Router.Chain.ToList());
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 刷新并确认红**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: `UI.Router.Navigate` 不存在。
+
+- [ ] **Step 3: 加 `ParseUrl`(UI.Router.cs)**
+
+在 `UI.Router.cs` 的 `ResolveChain` 方法下方(类内最后一个 `}` 前)插入:
+
+```csharp
+            // <scheme>://<name>?<query>,或无 scheme 的 <name>?<query>。
+            // ://(若有)与 ? 之间整段当 name(含斜杠不拆)。
+            internal static (string name, RouteQuery query) ParseUrl(string url)
+            {
+                if (string.IsNullOrEmpty(url)) throw new RouteException("navigate: empty url");
+                var rest = url;
+                int s = url.IndexOf("://", StringComparison.Ordinal);
+                if (s >= 0)
+                {
+                    var scheme = url.Substring(0, s);
+                    if (Scheme != null && !string.Equals(scheme, Scheme, StringComparison.Ordinal))
+                        throw new RouteException($"navigate: scheme '{scheme}' != Router.Scheme '{Scheme}'");
+                    rest = url.Substring(s + 3);
+                }
+                else if (Scheme != null)
+                    throw new RouteException($"navigate: url '{url}' missing scheme '{Scheme}'");
+
+                int q = rest.IndexOf('?');
+                var name = q >= 0 ? rest.Substring(0, q) : rest;
+                var qs = q >= 0 ? rest.Substring(q + 1) : "";
+                if (name.Length == 0) throw new RouteException($"navigate: url '{url}' has empty route name");
+                return (name, RouteQuery.ParseQueryString(qs));
+            }
+```
+
+- [ ] **Step 4: 加 `Navigate` + reconcile 头部清临时模态**
+
+在 `UI.Router.Reconcile.cs` 的 `Open` 方法下方插入:
+
+```csharp
+            public static Awaitable Navigate(string url)
+            {
+                var (name, query) = ParseUrl(url);   // 同步抛 RouteException(scheme/格式)
+                return Open(name, query);
+            }
+```
+
+> 注:`Navigate` 让 `ParseUrl` 的同步异常通过返回的 `Awaitable` 抛给 `await`(`async Awaitable` 方法体里调用即可)。把上面改成:
+> ```csharp
+>             public static async Awaitable Navigate(string url)
+>             {
+>                 var (name, query) = ParseUrl(url);
+>                 await Open(name, query);
+>             }
+> ```
+> 这样 `ThrowsAsync<RouteException>` 能捕获 scheme 不符。
+
+在 `Reconcile` 方法体里(Task 3 的健壮形态),把"移除尾部 → deactivate"之间插入 §3.3。即把:
+
+```csharp
+                if (removed.Count > 0) _chain.RemoveRange(k, removed.Count);
+
+                for (int i = removed.Count - 1; i >= 0; i--) Deactivate(removed[i]);
+```
+
+改为:
+
+```csharp
+                if (removed.Count > 0) _chain.RemoveRange(k, removed.Count);
+
+                // §3.3:顶上压着的 ad-hoc 临时模态(不属 router)先关掉 —— 等价"用户先关弹窗再导航"。
+                // 尾部已先于此移除,故即便 CloseAll 同步唤醒某 Prompt 续体,其 SelfPop 也已 no-op。
+                // SameChain 早退路径不经过这里:重复导航到正在显示的同一链路不会误关其对话框。
+                if (UI.Modal.IsAnyOpen) UI.Modal.CloseAll();
+
+                for (int i = removed.Count - 1; i >= 0; i--) Deactivate(removed[i]);
+```
+
+- [ ] **Step 5: 刷新并确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RouterNavigateTests")
+```
+Expected: `RouterNavigateTests` 5 条全绿。
+
+- [ ] **Step 6: Lint + Commit**
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+cd .. && git add Runtime/Application/UI.Router.cs Runtime/Application/UI.Router.Reconcile.cs \
+        Tests/EditMode/Router/RouterNavigateTests.cs Tests/EditMode/Router/RouterNavigateTests.cs.meta
+git commit -m "feat(router): Navigate(url) + scheme + close ad-hoc modals on reconcile"
+```
+
+---
+
+## Task 7: Modal 呈现(modal sorting 带 + route-aware ESC=Back)
+
+**Files:**
+- Modify: `Runtime/Application/UI.Router.Reconcile.cs`(`Activate`/`Deactivate` 支持 Modal)
+- Test: `Tests/EditMode/Router/RouterModalTabTests.cs`(新建,本任务先写 Modal 部分)
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `Tests/EditMode/Router/RouterModalTabTests.cs`:
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Router
+{
+    public class RouterModalTabTests
+    {
+        private static string PageXml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'><Image id='bg' anchor='stretch'/></Screen></PromptUGUI>";
+
+        private static string ModalXml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'>
+  <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+  <Frame id='panel' anchor='center' size='300x200'/>
+</Screen></PromptUGUI>";
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            var files = new Dictionary<string, string>
+            {
+                ["home"] = PageXml("home"),
+                ["settings"] = ModalXml("settings"),
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+            UI.Router.Map("settings", "settings", present: RoutePresent.Modal, parent: "home");
+        }
+
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Modal_Activates_OnModalSortingBand()
+        {
+            UI.Router.Open("settings").GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home", "settings" }, UI.Router.Chain.ToList());
+            var canvas = UI.Get("settings").RootGameObject.GetComponent<Canvas>();
+            Assert.IsTrue(canvas.overrideSorting);
+            Assert.GreaterOrEqual(canvas.sortingOrder, UI.Modal.SortingOrderBase);
+        }
+
+        [Test]
+        public void Modal_Esc_GoesBackToParent()
+        {
+            UI.Router.Open("settings").GetAwaiter().GetResult();
+            var esc = UI.Get("settings").RootGameObject.GetComponent<ModalEscapeListener>();
+            Assert.IsNotNull(esc);
+            esc.FireForTests();
+            // ESC = Back → 回到 home
+            CollectionAssert.AreEqual(new[] { "home" }, UI.Router.Chain.ToList());
+            Assert.IsNull(UI.Get("settings"));
+        }
+
+        [Test]
+        public void Modal_Deactivate_ClosesScreen()
+        {
+            UI.Router.Open("settings").GetAwaiter().GetResult();
+            UI.Router.Open("home").GetAwaiter().GetResult();
+            Assert.IsNull(UI.Get("settings"));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 刷新并确认红**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RouterModalTabTests")
+```
+Expected: `Activate` 抛 "kind not yet supported"(Modal 分支未实现)→ `Modal_*` 三条红。
+
+- [ ] **Step 3: 实现 Modal 激活**
+
+在 `UI.Router.Reconcile.cs` 顶部 `using` 区确保有 `using PromptUGUI.Application.Modals;`(没有则加)。
+
+把 `Activate` 的 switch 改为:
+
+```csharp
+            private static async Awaitable<ActiveNode> Activate(RouteNode def, RouteQuery query)
+            {
+                switch (def.Kind)
+                {
+                    case RouteKind.Page: return await ActivatePage(def, query, modal: false);
+                    case RouteKind.Modal: return await ActivatePage(def, query, modal: true);
+                    default:
+                        throw new RouteException($"route '{def.Name}': kind not yet supported");
+                }
+            }
+```
+
+把 `ActivatePage` 改为带 `modal` 参数:
+
+```csharp
+            private static async Awaitable<ActiveNode> ActivatePage(
+                RouteNode def, RouteQuery query, bool modal)
+            {
+                var screenName = await EnsureLoaded(def);
+                var screen = UI.Open(screenName);
+                if (modal)
+                {
+                    var canvas = screen.RootGameObject.GetComponent<Canvas>();
+                    canvas.overrideSorting = true;
+                    canvas.sortingOrder = UI.Modal.SortingOrderBase + CountModalsInChain();
+                    var esc = screen.RootGameObject.AddComponent<ModalEscapeListener>();
+                    var captured = def.Name;
+                    esc.OnEscape = () =>
+                    {
+                        // 只栈顶 routed modal 响应;有 ad-hoc 模态在上时让位给它(§12)
+                        if (IsTop(captured) && !UI.Modal.IsAnyOpen) _ = Back();
+                    };
+                }
+                def.OnEnter?.Invoke(screen, query);
+                return new ActiveNode { Def = def, ScreenKey = screenName };
+            }
+
+            // 当前链路里已有的 Modal 节点数(此节点尚未入链)→ modal 带内的层序偏移。
+            private static int CountModalsInChain()
+            {
+                int n = 0;
+                foreach (var a in _chain) if (a.Def.Kind == RouteKind.Modal) n++;
+                return n;
+            }
+
+            private static bool IsTop(string name) =>
+                _chain.Count > 0 && _chain[_chain.Count - 1].Def.Name == name;
+```
+
+把 `Deactivate` 的 Page 分支扩成 Page+Modal:
+
+```csharp
+            private static void Deactivate(ActiveNode a)
+            {
+                switch (a.Def.Kind)
+                {
+                    case RouteKind.Page:
+                    case RouteKind.Modal:
+                        UI.Close(a.ScreenKey);
+                        break;
+                }
+            }
+```
+
+- [ ] **Step 4: 刷新并确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RouterModalTabTests")
+```
+Expected: `Modal_*` 三条绿。
+
+- [ ] **Step 5: Lint + Commit**
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+cd .. && git add Runtime/Application/UI.Router.Reconcile.cs \
+        Tests/EditMode/Router/RouterModalTabTests.cs Tests/EditMode/Router/RouterModalTabTests.cs.meta
+git commit -m "feat(router): Modal presentation (sorting band + route-aware ESC=Back)"
+```
+
+---
+
+## Task 8: Tab 呈现(宿主解析 + IsOn 选中 + 兄弟切换不重建)
+
+**Files:**
+- Modify: `Runtime/Application/UI.Router.Reconcile.cs`(`Activate` 支持 Tab + 宿主解析)
+- Test: `Tests/EditMode/Router/RouterModalTabTests.cs`(追加 Tab 部分)
+
+- [ ] **Step 1: 写失败测试**
+
+在 `RouterModalTabTests` 类末尾追加(并在文件顶部补 `using PromptUGUI.Controls;` 若无):
+
+```csharp
+        private const string ShopWithTabsXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='shop'>
+  <TabBar id='bar' anchor='stretch'>
+    <Tab id='deals'>Deals</Tab>
+    <Tab id='cart'>Cart</Tab>
+  </TabBar>
+</Screen></PromptUGUI>";
+
+        private void SetUpShopTabs()
+        {
+            UI.ResetForTests();
+            var files = new Dictionary<string, string>
+            {
+                ["home"] = PageXml("home"),
+                ["shop"] = ShopWithTabsXml,
+                ["item"] = PageXml("item"),
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+            UI.Router.Map("shop", "shop", parent: "home");
+            UI.Router.MapTab("shop/deals", parent: "shop", tabId: "bar/deals");
+            UI.Router.MapTab("shop/cart", parent: "shop", tabId: "bar/cart");
+            UI.Router.Map("item", "item", parent: "shop/deals");   // drill-in 自某个 tab
+        }
+
+        [Test]
+        public void Tab_Activate_SelectsTab_HostOpened()
+        {
+            SetUpShopTabs();
+            UI.Router.Open("shop/deals").GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(new[] { "home", "shop", "shop/deals" }, UI.Router.Chain.ToList());
+            var deals = UI.Get("shop").Get<PromptUGUI.Controls.Tab>("bar/deals");
+            Assert.IsTrue(deals.IsOn);
+        }
+
+        [Test]
+        public void Tab_SiblingSwitch_DoesNotRebuildHost()
+        {
+            SetUpShopTabs();
+            UI.Router.Open("shop/deals").GetAwaiter().GetResult();
+            var hostBefore = UI.Get("shop");
+            UI.Router.Open("shop/cart").GetAwaiter().GetResult();
+            Assert.AreSame(hostBefore, UI.Get("shop"));    // 宿主未重建
+            Assert.IsTrue(UI.Get("shop").Get<PromptUGUI.Controls.Tab>("bar/cart").IsOn);
+            CollectionAssert.AreEqual(new[] { "home", "shop", "shop/cart" }, UI.Router.Chain.ToList());
+        }
+
+        [Test]
+        public void Tab_DrillIn_FullChainReconciles()
+        {
+            SetUpShopTabs();
+            UI.Router.Open("item").GetAwaiter().GetResult();
+            CollectionAssert.AreEqual(
+                new[] { "home", "shop", "shop/deals", "item" }, UI.Router.Chain.ToList());
+            Assert.IsTrue(UI.Get("shop").Get<PromptUGUI.Controls.Tab>("bar/deals").IsOn);
+            Assert.IsNotNull(UI.Get("item"));
+        }
+```
+
+- [ ] **Step 2: 刷新并确认红**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RouterModalTabTests")
+```
+Expected: `Tab_*` 三条红("kind not yet supported")。
+
+- [ ] **Step 3: 实现 Tab 激活 + 宿主解析**
+
+把 `Activate` 的 switch 加上 Tab 分支:
+
+```csharp
+            private static async Awaitable<ActiveNode> Activate(RouteNode def, RouteQuery query)
+            {
+                switch (def.Kind)
+                {
+                    case RouteKind.Page: return await ActivatePage(def, query, modal: false);
+                    case RouteKind.Modal: return await ActivatePage(def, query, modal: true);
+                    case RouteKind.Tab: return ActivateTab(def, query);
+                    default:
+                        throw new RouteException($"route '{def.Name}': kind not yet supported");
+                }
+            }
+```
+
+在 `ActivatePage` 下方加:
+
+```csharp
+            // —— Tab —— 宿主 = 链路里最近的已激活 Page/Modal(此刻已在 _chain 中,因 bottom-up 激活)
+            private static ActiveNode ActivateTab(RouteNode def, RouteQuery query)
+            {
+                var hostKey = ResolveHostScreenKey(def);
+                var host = UI.Get(hostKey)
+                    ?? throw new RouteException(
+                        $"tab route '{def.Name}': host screen '{hostKey}' not open");
+                PromptUGUI.Controls.Tab tab;
+                try { tab = host.Get<PromptUGUI.Controls.Tab>(def.TabId); }
+                catch (Exception ex)
+                {
+                    throw new RouteException(
+                        $"tab route '{def.Name}': tab '{def.TabId}' not found in host '{hostKey}'", ex);
+                }
+                tab.IsOn = true;
+                def.OnEnter?.Invoke(host, query);
+                return new ActiveNode { Def = def, ScreenKey = hostKey };
+            }
+
+            private static string ResolveHostScreenKey(RouteNode tabDef)
+            {
+                for (int i = _chain.Count - 1; i >= 0; i--)
+                    if (_chain[i].Def.Kind == RouteKind.Page || _chain[i].Def.Kind == RouteKind.Modal)
+                        return _chain[i].ScreenKey;
+                throw new RouteException(
+                    $"tab route '{tabDef.Name}': no Page/Modal host ancestor active");
+            }
+```
+
+> Tab 的 `Deactivate` 无需新分支:宿主仍在屏时 TabBar 永远有选中态(`SyncInitialSelection`),Tab 节点出栈不强改控件;宿主整屏关闭则 tab 随之消失(spec §5.3)。
+
+- [ ] **Step 4: 刷新并确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RouterModalTabTests")
+```
+Expected: `RouterModalTabTests` 全绿(Modal 3 + Tab 3)。
+
+- [ ] **Step 5: Lint + Commit**
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+cd .. && git add Runtime/Application/UI.Router.Reconcile.cs Tests/EditMode/Router/RouterModalTabTests.cs
+git commit -m "feat(router): Tab presentation (host resolve + IsOn select + sibling/drill-in)"
+```
+
+---
+
+## Task 9: InputBox/MessageBox 加 CancellationToken + UI.Modal.CancelEntry
+
+**Files:**
+- Modify: `Runtime/Application/UI.Modal.cs`(`OpenAsync` 加 `ct` + 新 `CancelEntry`)
+- Modify: `Runtime/Application/Modals/InputBoxRequest.cs`(`InputBox.Open` 加 `ct`)
+- Modify: `Runtime/Application/Modals/MessageBoxRequest.cs`(两 `Open` 加 `ct`)
+- Test: `Tests/EditMode/Modals/ModalCancelTests.cs`(追加)
+
+- [ ] **Step 1: 写失败测试**
+
+在 `Tests/EditMode/Modals/ModalCancelTests.cs` 的类末尾追加(若类名/命名空间不同,按文件实际为准):
+
+```csharp
+        [Test]
+        public void OpenAsync_CancellationToken_CancelsAndClosesModal()
+        {
+            var cts = new System.Threading.CancellationTokenSource();
+            var box = MessageBox.Open("hi", MsgBtn.OK, ct: cts.Token);
+            Assert.IsTrue(UI.Modal.IsAnyOpen);
+
+            cts.Cancel();
+
+            Assert.IsFalse(UI.Modal.IsAnyOpen);   // modal 被关
+            Assert.ThrowsAsync<System.OperationCanceledException>(async () => await box);
+            cts.Dispose();
+        }
+```
+
+> 该文件已有 `using PromptUGUI.Application;` / `using PromptUGUI.Application.Modals;` 与 `MessageBox.XmlSrc` 的 fake-files 设置(沿用其既有 `[SetUp]`)。若 `ModalCancelTests` 未设 `MessageBox.XmlSrc`,在该测试开头加 `MessageBox.XmlSrc = "test/Box1";` 并确保 `UI.SourceResolver` 提供该 src(参照 `ModalTestFixture`)。
+
+- [ ] **Step 2: 刷新并确认红**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: `MessageBox.Open` 无 `ct` 命名参数(`CS1739`/`CS1503`)。
+
+- [ ] **Step 3: `UI.Modal.OpenAsync` 加 `ct` + `CancelEntry`**
+
+在 `Runtime/Application/UI.Modal.cs`,把:
+
+```csharp
+            public static Awaitable<TResult> OpenAsync<TResult>(
+                ModalRequest<TResult> request, ModalMode mode = ModalMode.Popup)
+            {
+                if (request == null) throw new ArgumentNullException(nameof(request));
+                var (entry, awaitable) = ModalEntry<TResult>.Create(request);
+                if (mode == ModalMode.Queued && !IsIdle())
+                    _waiting.Enqueue(entry);
+                else
+                    QueueForMaterialize(entry);
+                return awaitable;
+            }
+```
+
+替换为:
+
+```csharp
+            public static Awaitable<TResult> OpenAsync<TResult>(
+                ModalRequest<TResult> request, ModalMode mode = ModalMode.Popup,
+                System.Threading.CancellationToken ct = default)
+            {
+                if (request == null) throw new ArgumentNullException(nameof(request));
+                var (entry, awaitable) = ModalEntry<TResult>.Create(request);
+                if (ct.CanBeCanceled)
+                    ct.Register(() => CancelEntry(entry, new OperationCanceledException(ct)));
+                if (mode == ModalMode.Queued && !IsIdle())
+                    _waiting.Enqueue(entry);
+                else
+                    QueueForMaterialize(entry);
+                return awaitable;
+            }
+
+            // 取消某个 entry,不论它在 stack / pending / inflight / waiting 哪一态。
+            // 在 stack 上 → 同 close:resolve + 销毁 Screen + 弹栈 + 提升等待队列。
+            // 其余态 → 仅 Cancel(标记 Resolved);pump 与 PromoteWaiting 出队时跳过 Resolved。
+            internal static void CancelEntry(IModalEntry entry, Exception ex)
+            {
+                for (int i = 0; i < _stack.Count; i++)
+                {
+                    if (_stack[i].Entry == entry)
+                    {
+                        var slot = _stack[i];
+                        entry.Cancel(ex);
+                        RemoveSlot(slot);
+                        RefreshTopListener();
+                        PromoteWaiting();
+                        return;
+                    }
+                }
+                entry.Cancel(ex);
+            }
+```
+
+- [ ] **Step 4: `InputBox.Open` / `MessageBox.Open` 透传 `ct`**
+
+`InputBoxRequest.cs`:把 `InputBox.Open` 的签名与调用改为带 `ct`:
+
+```csharp
+        public static UnityEngine.Awaitable<string> Open(
+            string title,
+            string message = null,
+            string initial = null,
+            string placeholder = null,
+            string contentType = null,
+            string okLabel = null,
+            string cancelLabel = null,
+            ModalMode mode = ModalMode.Popup,
+            System.Action<IScreen> configure = null,
+            System.Threading.CancellationToken ct = default)
+            => UI.Modal.OpenAsync(new InputBoxRequest
+            {
+                Title = title,
+                Message = message,
+                Initial = initial,
+                Placeholder = placeholder,
+                ContentType = contentType,
+                OkLabel = okLabel,
+                CancelLabel = cancelLabel,
+                Configure = configure,
+            }, mode, ct);
+```
+
+`MessageBoxRequest.cs`:两个 `Open` 各加 `ct` 并传给 `OpenAsync`:
+
+第一个重载——签名末尾加 `System.Threading.CancellationToken ct = default`,调用末尾 `}, mode)` 改 `}, mode, ct)`。
+第二个重载——同样在签名末尾加 `System.Threading.CancellationToken ct = default`,`return UI.Modal.OpenAsync(... }, mode);` 改为 `}, mode, ct);`。
+
+- [ ] **Step 5: 刷新并确认绿(含既有 Modal 测试不回归)**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="ModalCancelTests")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="Modal")
+```
+Expected: 新用例绿;`Modal*` 全部不回归。
+
+- [ ] **Step 6: Lint + Commit**
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+cd .. && git add Runtime/Application/UI.Modal.cs Runtime/Application/Modals/InputBoxRequest.cs \
+        Runtime/Application/Modals/MessageBoxRequest.cs Tests/EditMode/Modals/ModalCancelTests.cs
+git commit -m "feat(modal): CancellationToken overload on Open + UI.Modal.CancelEntry"
+```
+
+---
+
+## Task 10: Prompt 呈现(MapPrompt + 自动出栈 + 被导航走撤销)
+
+**Files:**
+- Modify: `Runtime/Application/UI.Router.Reconcile.cs`(`Activate`/`Deactivate` 支持 Prompt + RunPrompt/SelfPop)
+- Test: `Tests/EditMode/Router/RouterPromptTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `Tests/EditMode/Router/RouterPromptTests.cs`:
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+
+namespace PromptUGUI.Tests.Router
+{
+    public class RouterPromptTests
+    {
+        private static string PageXml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'><Image id='bg' anchor='stretch'/></Screen></PromptUGUI>";
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            var files = new Dictionary<string, string>
+            {
+                ["home"] = PageXml("home"), ["shop"] = PageXml("shop"),
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+            UI.Router.Map("shop", "shop", parent: "home");
+        }
+
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Prompt_RunCompletes_AutoPops()
+        {
+            bool ran = false;
+            UI.Router.MapPrompt("ask", parent: "home", run: (q, ct) =>
+            {
+                ran = true;
+                return AwaitableHelpers.Completed();   // 立即完成
+            });
+
+            UI.Router.Open("ask").GetAwaiter().GetResult();
+
+            Assert.IsTrue(ran);
+            // run 同步完成 → 自动出栈,回到 home
+            CollectionAssert.AreEqual(new[] { "home" }, UI.Router.Chain.ToList());
+        }
+
+        [Test]
+        public void Prompt_ReceivesQuery()
+        {
+            string seen = null;
+            UI.Router.MapPrompt("ask", parent: "home", run: (q, ct) =>
+            {
+                seen = q["reason"];
+                return AwaitableHelpers.Completed();
+            });
+            UI.Router.Navigate("appid://ask?reason=illegal").GetAwaiter().GetResult();
+            Assert.AreEqual("illegal", seen);
+        }
+
+        [Test]
+        public void Prompt_NavigatedAway_Cancels()
+        {
+            // run 永不自完成 → 靠 ct 取消。canceled 在 ct.Register 回调里置位:
+            // cts.Cancel() 同步触发该回调,不依赖 await 续体的恢复时机(EditMode 无 PlayerLoop)。
+            bool canceled = false;
+            UI.Router.MapPrompt("ask", parent: "home", run: async (q, ct) =>
+            {
+                var box = new AwaitableCompletionSource();
+                ct.Register(() => { canceled = true; box.TrySetResult(); });
+                await box.Awaitable;
+            });
+
+            UI.Router.Open("ask").GetAwaiter().GetResult();   // 起 prompt(挂起)
+            CollectionAssert.AreEqual(new[] { "home", "ask" }, UI.Router.Chain.ToList());
+
+            UI.Router.Open("shop").GetAwaiter().GetResult();  // 导航走 → 取消 prompt
+            Assert.IsTrue(canceled);                          // 取消同步发生
+            CollectionAssert.AreEqual(new[] { "home", "shop" }, UI.Router.Chain.ToList());
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 刷新并确认红**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RouterPromptTests")
+```
+Expected: Prompt 激活抛 "kind not yet supported" → 三条红。
+
+- [ ] **Step 3: 实现 Prompt 激活 + 生命周期**
+
+把 `Activate` 的 switch 加 Prompt 分支(其余分支保持):
+
+```csharp
+                    case RouteKind.Prompt: return ActivatePrompt(def);
+```
+
+在 `Reconcile` 的激活循环里,加入"prompt 入链后再起 run"(防止 run 同步完成时节点尚未入链)。把:
+
+```csharp
+                for (int i = k; i < target.Count; i++)
+                {
+                    var active = await Activate(target[i], query);
+                    _chain.Add(active);
+                }
+```
+
+改为:
+
+```csharp
+                for (int i = k; i < target.Count; i++)
+                {
+                    var active = await Activate(target[i], query);
+                    _chain.Add(active);
+                    if (active.Def.Kind == RouteKind.Prompt) StartPrompt(active, query);
+                }
+```
+
+把 `Deactivate` 加 Prompt 分支:
+
+```csharp
+            private static void Deactivate(ActiveNode a)
+            {
+                switch (a.Def.Kind)
+                {
+                    case RouteKind.Page:
+                    case RouteKind.Modal:
+                        UI.Close(a.ScreenKey);
+                        break;
+                    case RouteKind.Prompt:
+                        a.Deactivated = true;          // 告诉 SelfPop 让位:reconcile 负责移除
+                        a.PromptCts?.Cancel();
+                        a.PromptCts?.Dispose();
+                        break;
+                }
+            }
+```
+
+在 `ActivateTab` 下方加:
+
+```csharp
+            // —— Prompt —— 无 src,由 run handler 支撑;入链后由 StartPrompt 起跑。
+            private static ActiveNode ActivatePrompt(RouteNode def)
+            {
+                return new ActiveNode
+                {
+                    Def = def,
+                    PromptCts = new System.Threading.CancellationTokenSource(),
+                };
+            }
+
+            private static void StartPrompt(ActiveNode node, RouteQuery query)
+            {
+                _ = RunPrompt(node, query);
+            }
+
+            private static async Awaitable RunPrompt(ActiveNode node, RouteQuery query)
+            {
+                try
+                {
+                    await node.Def.Run(query, node.PromptCts.Token);
+                }
+                catch (OperationCanceledException) { /* 被导航走 */ }
+                catch (Exception ex)
+                {
+                    UnityEngine.Debug.LogError($"prompt route '{node.Def.Name}' run failed: {ex}");
+                }
+                finally
+                {
+                    SelfPop(node);
+                }
+            }
+
+            // run 正常结束 → 自动出栈(仅当它仍是栈顶且未被 reconcile 接管移除)。
+            private static void SelfPop(ActiveNode node)
+            {
+                if (node.Deactivated) return;   // reconcile 正在移除它
+                if (_chain.Count > 0 && _chain[_chain.Count - 1] == node)
+                {
+                    _chain.RemoveAt(_chain.Count - 1);
+                    node.PromptCts?.Dispose();
+                    Changed?.Invoke();
+                }
+            }
+```
+
+- [ ] **Step 4: 刷新并确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RouterPromptTests")
+```
+Expected: `RouterPromptTests` 三条绿。
+
+- [ ] **Step 5: Lint + Commit**
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+cd .. && git add Runtime/Application/UI.Router.Reconcile.cs \
+        Tests/EditMode/Router/RouterPromptTests.cs Tests/EditMode/Router/RouterPromptTests.cs.meta
+git commit -m "feat(router): Prompt presentation (MapPrompt + auto-pop + cancel-on-navigate)"
+```
+
+---
+
+## Task 11: 改名范式(InputBox-backed Prompt)EditMode 可达性 + PlayMode 完整流程
+
+> **拆分理由**:`run` 里 `await InputBox.Open(...)` 之后的"应用改名 + 自动出栈"挂在一个**续体**上;EditMode 无 PlayerLoop,点 OK(`SimulateClick`)解析 InputBox 的 awaitable 后,该续体不保证同步运行 → EditMode 只验证**同步可达**(导航到 rename → 链路 `[home,rename]` + InputBox 已实例化);**点 OK→改名→出栈**的完整流程放 PlayMode 用逐帧轮询。
+
+**Files:**
+- Test: `Tests/EditMode/Router/RouterPromptTests.cs`(追加可达性)
+- Test: `Tests/PlayMode/RouterPlayTests.cs`(新建)
+
+- [ ] **Step 1: 写 EditMode 可达性测试**
+
+在 `RouterPromptTests` 末尾追加。InputBox 的 fake XML 含 `InputBoxRequest.Bind` 需要的 id(`title`/`field`/`ok`/`cancel`):
+
+```csharp
+        private const string IBoxXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='ibox'>
+  <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+  <Frame id='dialog' anchor='center' size='400x200'>
+    <VStack anchor='stretch' margin='16' spacing='8'>
+      <Text id='title'/>
+      <InputField id='field'/>
+      <Btn id='ok'>OK</Btn>
+      <Btn id='cancel'>Cancel</Btn>
+    </VStack>
+  </Frame>
+</Screen></PromptUGUI>";
+
+        [Test]
+        public void Prompt_RenameViaInputBox_ReachableShowsDialog()
+        {
+            InputBox.XmlSrc = "ibox";   // 非 builtin 前缀 → 走 SourceResolver(fake)
+            var files = new Dictionary<string, string>
+            {
+                ["home"] = PageXml("home"),
+                ["ibox"] = IBoxXml,
+            };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Clear();
+            UI.Router.Map("home", "home");
+            UI.Router.MapPrompt("rename", parent: "home", run: async (q, ct) =>
+            {
+                var name = await InputBox.Open("改名", initial: "old", ct: ct);
+                // 确认后的结果处理在 PlayMode 验;EditMode 只验证可达 + 弹窗已起
+            });
+
+            UI.Router.Navigate("appid://rename").GetAwaiter().GetResult();
+
+            CollectionAssert.AreEqual(new[] { "home", "rename" }, UI.Router.Chain.ToList());
+            // InputBox 已在 modal 栈实例化(materialize pump 在 EditMode 同步完成)
+            var ibox = UI.Modal.TopScreen;   // internal,Tests.EditMode 可见
+            Assert.IsNotNull(ibox, "InputBox 应已实例化在 modal 栈顶");
+            Assert.DoesNotThrow(() => ibox.Get<PromptUGUI.Controls.InputField>("field"));
+        }
+```
+
+- [ ] **Step 2: 刷新并确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="RouterPromptTests")
+```
+Expected: 可达性测试绿。
+
+- [ ] **Step 3: 写 PlayMode 测试(sorting 带 + 改名完整流程)**
+
+新建 `Tests/PlayMode/RouterPlayTests.cs`。改名用例**逐帧轮询**(`SimulateClick` 是 `Btn` 的既有测试钩,见 `InputBoxTests.cs`):
+
+```csharp
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+
+namespace PromptUGUI.Tests.PlayMode
+{
+    public class RouterPlayTests
+    {
+        private static string PageXml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'><Image id='bg' anchor='stretch'/></Screen></PromptUGUI>";
+        private static string ModalXml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'>
+  <Image id='backdrop' anchor='stretch' color='#0000007F'/></Screen></PromptUGUI>";
+        private const string IBoxXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='ibox'>
+  <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+  <Frame id='dialog' anchor='center' size='400x200'>
+    <VStack anchor='stretch' margin='16' spacing='8'>
+      <Text id='title'/><InputField id='field'/>
+      <Btn id='ok'>OK</Btn><Btn id='cancel'>Cancel</Btn>
+    </VStack>
+  </Frame>
+</Screen></PromptUGUI>";
+
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static void Setup(Dictionary<string, string> files)
+        {
+            UI.ResetForTests();
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+        }
+
+        [UnityTest]
+        public IEnumerator Modal_SortsAbovePage()
+        {
+            Setup(new Dictionary<string, string>
+            {
+                ["home"] = PageXml("home"), ["settings"] = ModalXml("settings"),
+            });
+            UI.Router.Map("home", "home");
+            UI.Router.Map("settings", "settings", present: RoutePresent.Modal, parent: "home");
+
+            _ = UI.Router.Open("settings");
+            for (int i = 0; i < 10 && UI.Get("settings") == null; i++) yield return null;
+
+            var home = UI.Get("home").RootGameObject.GetComponent<Canvas>();
+            var settings = UI.Get("settings").RootGameObject.GetComponent<Canvas>();
+            Assert.Greater(settings.sortingOrder, home.sortingOrder);
+            Assert.GreaterOrEqual(settings.sortingOrder, UI.Modal.SortingOrderBase);
+        }
+
+        [UnityTest]
+        public IEnumerator Prompt_RenameConfirm_AppliesAndAutoPops()
+        {
+            Setup(new Dictionary<string, string> { ["home"] = PageXml("home"), ["ibox"] = IBoxXml });
+            InputBox.XmlSrc = "ibox";
+            UI.Router.Map("home", "home");
+            string applied = null;
+            UI.Router.MapPrompt("rename", parent: "home", run: async (q, ct) =>
+            {
+                var name = await InputBox.Open("改名", initial: "old", ct: ct);
+                if (name != null) applied = name;
+            });
+
+            _ = UI.Router.Navigate("appid://rename");
+            for (int i = 0; i < 10 && UI.Modal.TopScreen == null; i++) yield return null;
+            var ibox = UI.Modal.TopScreen;
+            Assert.IsNotNull(ibox);
+
+            ibox.Get<PromptUGUI.Controls.InputField>("field").TextValue = "newName";
+            ibox.Get<PromptUGUI.Controls.Btn>("ok").SimulateClick();   // = close(field.TextValue)
+
+            for (int i = 0; i < 10 && applied == null; i++) yield return null;
+
+            Assert.AreEqual("newName", applied);
+            CollectionAssert.AreEqual(new[] { "home" }, new List<string>(UI.Router.Chain));  // 自动出栈
+        }
+    }
+}
+```
+
+> 核对点:`Btn.SimulateClick()` 已确认存在(`InputBoxTests.cs` 用 `Get<PBtn>("ok").SimulateClick()`)。`UI.Modal.TopScreen` 为 `internal`,`PromptUGUI.Tests.PlayMode` 在 `InternalsVisibleTo` 列表内 → 可用。
+
+- [ ] **Step 4: 刷新并确认绿(EditMode + PlayMode)**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], filter="Router")
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], filter="RouterPlayTests")
+```
+Expected: 所有 `Router*` EditMode 绿;`RouterPlayTests` 2 条绿。
+
+- [ ] **Step 5: Lint + Commit**
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+cd .. && git add Tests/EditMode/Router/RouterPromptTests.cs \
+        Tests/PlayMode/RouterPlayTests.cs Tests/PlayMode/RouterPlayTests.cs.meta
+git commit -m "test(router): rename-via-InputBox prompt (EditMode reach + PlayMode confirm)"
+```
+
+---
+
+## Task 12: SKILL.md 更新 + 全量回归 + 收尾
+
+**Files:**
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md`
+
+- [ ] **Step 1: 读现状 + 写 Router 节**
+
+先读 `.claude/skills/scripting-promptugui-csharp/SKILL.md` 找到合适插入点(modal 节附近 + cheatsheet)。新增一节,覆盖:
+
+- 心智模型:稳定不透明名字(URL 只认名字)+ 注册时声明标准 parent → 树;`Open(name)` reconcile 当前层栈到标准链路;深链 `Navigate(url)` = 解析后 `Open`,与手点同结果。
+- API:`UI.Router.Map(name, src, screen?, present: Page|Modal, parent?, onEnter?)`、`MapTab(name, parent, tabId, onEnter?)`、`MapPrompt(name, parent, run)`、`Open(name, query?)` / `Navigate(url)` / `Back()` / `Reset()`、`Current` / `Chain` / `Changed`、`Scheme`、`IsMapped` / `Clear`。
+- 四种呈现表(Page / Modal / Tab / Prompt)+ 各自 activate 语义。
+- 改名 Prompt 范式代码(button 与深链同走 `Open("rename")`,逻辑一份)。
+- 共存须知:routed screen 只经 router 开关;Modal 节点的关闭按钮接 `Router.Back()`;ad-hoc `MessageBox`/`InputBox` 不进 router、导航时被清掉。
+- modal 节补一句:`InputBox.Open` / `MessageBox.Open` 新增 `CancellationToken ct` 重载,routed Prompt 用它实现"被导航走即撤销"。
+- cheatsheet 增 ROUTER 区。
+
+具体行文按该 SKILL 既有风格写(英文)。
+
+- [ ] **Step 2: 全量回归(EditMode + EditorOnly + PlayMode)**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])
+```
+Expected: 全绿,无回归。
+
+- [ ] **Step 3: 全量 lint**
+
+```bash
+cd .lint && dotnet restore PromptUGUI.Lint.slnx
+dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+Expected: 退出码 0(忽略 `Local.props` 缺失的 CS0246 噪音)。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/scripting-promptugui-csharp/SKILL.md
+git commit -m "doc(skill): document UI.Router navigation in scripting-promptugui-csharp"
+```
+
+---
+
+## 自检(写完计划后回看 spec)
+
+**Spec 覆盖**(逐节对照):
+- §2 节点模型(Name/Parent/Kind/present/OnEnter)→ Task 1(RouteNode)+ Task 2(注册)。
+- §3.1-3.2 reconcile(公共前缀 / query 投递 / 目标刷新)→ Task 3。§3.3 临时模态 → Task 6。§3.5 串行化 → Task 4。
+- §4 URL / RouteQuery → Task 1(RouteQuery)+ Task 6(ParseUrl/Navigate)。
+- §5.1 Page → Task 3;§5.2 Modal → Task 7;§5.3 Tab → Task 8;§5.4 Prompt(含 InputBox `ct`)→ Task 9 + 10 + 11。
+- §6 临时模态边界 → Task 6。§7 TabBar 集成 → Task 8。§8 Back/Current/Chain/Changed → Task 3 + 5。
+- §9 API 全表 → Task 2/3/5/6 合计。§10 错误处理 → Task 2(注册/链路)+ Task 8(tab 解析)。
+- §11 共存 / teardown → Task 4(UnloadAll/ResetForTests 钩)。§14 SKILL → Task 12。§16 验收 → Task 11 + 12 回归。
+
+**占位符扫描**:无 TBD/TODO;每个改代码的 Step 均含完整代码。Task 11 用已确认存在的 `Btn.SimulateClick()` + `UI.Modal.TopScreen`(`internal`,两个测试 asmdef 均在 `InternalsVisibleTo` 内),非待定写法。
+
+**异步语义健壮性**(EditMode 无 PlayerLoop):凡断言"`await` 未完成 awaitable 之后的续体副作用"的点,要么改为在 `ct.Register` 同步回调里置位(Task 10 取消用例),要么移到 PlayMode 逐帧轮询(Task 11 改名确认)。`Reconcile` 采用"先移除尾部再 deactivate" + `SameChain` 早退,使 §3.3 `CloseAll` 唤醒 Prompt 续体导致的 `SelfPop` 重入安全(节点已不在链中 → no-op),并保证重复导航到正在显示的 Prompt 不被误关。
+
+**类型一致性**:`RouteNode`/`RouteKind`/`RoutePresent`/`RoutePromptRun`/`RouteQuery`/`RouteException`、`ActiveNode`(`Def`/`ScreenKey`/`PromptCts`/`Deactivated`)、`_chain`/`_routes`/`_pending`/`_waiters`/`_epoch`、`ResolveChain`/`Reconcile`/`Activate`/`ActivatePage(modal)`/`ActivateTab`/`ActivatePrompt`/`StartPrompt`/`RunPrompt`/`SelfPop`/`Deactivate`/`EnsureLoaded`/`CountModalsInChain`/`IsTop`/`ResolveHostScreenKey`/`AbandonPump`/`CancelAllForTeardown`/`ResetForTestsInternal`、`UI.Modal.CancelEntry`——跨 Task 命名一致。
+
+**已知 v1 边界**(spec §12,计划内已落地为具体取舍,非遗漏):用户手点 tab 不反向同步 router 链路;routed Modal 的 ESC 在 `UI.Modal.IsAnyOpen` 时让位给 ad-hoc 栈顶;§3.3 只清 ad-hoc dialog 栈(`UI.Modal.CloseAll`),不动 Loading/Toast;routed screen 的 src 仅经 router 加载(外部已 `LoadDocumentAsync` 过会撞"already loaded")。

--- a/docs~/superpowers/specs/2026-06-09-router-navigation-design.md
+++ b/docs~/superpowers/specs/2026-06-09-router-navigation-design.md
@@ -1,0 +1,384 @@
+# Router 导航系统:稳定名字 + 标准链路 reconcile + Page/Modal/Tab/Prompt 四呈现
+
+**日期**:2026-06-09
+**状态**:设计阶段(待 review,未进入实施)
+**作用域**:新增一套 `UI.Router` 导航子系统,作为**游戏内所有界面打开操作的统一入口**。支持深链(`appid://home/friend?tab=x`)与手点按钮走完全相同的码路、落到完全相同的显示结果。建立在现有 `UI.Open` / `UI.Modal` / `InputBox` / `MessageBox` 之上,不改动它们的对外语义。
+**关联**:复用 [`2026-05-20-modal-layering-design.md`](2026-05-20-modal-layering-design.md) 的 dialog 栈(Modal 呈现)与 `InputBox`/`MessageBox`(Prompt 呈现);不修订该 spec。无 XML 元素/属性变更,故 `authoring-promptugui-xml` 不动;公开 C# API 新增,`scripting-promptugui-csharp` 必须更新(见 §14)。
+
+---
+
+## 1. 背景与目标
+
+### 1.1 现状
+
+当前三套界面机制彼此平级、各自为政,**没有任何层级/路由/统一入口**:
+
+- **普通 Screen**:`UI.Open(name)` / `UI.Close(name)`,按 name 存进 `_open` 字典,sortingOrder 由 `CanvasConfigurator` 给。屏上多个 Screen 之间无父子、无栈、无先后约束。
+- **Modal dialog 栈**:`UI.Modal` 的 `_displayStack` + `_waiting`(`Popup`/`Queued`),sortingOrder 1000+,ESC 只关栈顶。
+- **Loading overlay / Toast**:各自独立的瞬态层。
+
+打开一个界面 = 调用方直接 `UI.Open` / `UI.Modal.OpenAsync`。没有人统一知道"现在屏上这条链路是什么"。
+
+### 1.2 需求
+
+游戏里存在**深链跳转**:轮播广告卡、聊天里的超链接、推送通知等,点击后跳到游戏内某界面,形如 `appid://home/friend?tab=members`,类似 web router。两条硬约束:
+
+1. **路径进来 = 手点进来,显示结果必须一模一样。** 不能因为"从深链进"就出现手点永远到不了的状态。
+   - 反例:用户手动操作时,模态窗口挡住下层,他**不可能**点到下面的按钮再开另一个窗口。深链若直接把目标盖上去,就打破了这条天然约束。
+2. **游戏层级经常变动,但 URL/广告卡不应跟着改。** 今天 `friend` 挂在 `home` 下,明天挪到 `social` 下,满世界发出去的 `appid://friend` 链接一个都不能失效。
+
+并且这套东西**不只为深链**——它是一套管理系统,游戏内**所有**界面打开都要经过它,深链只是其中一个入口。
+
+### 1.3 目标
+
+- 一个统一入口 `UI.Router.Open(name)`:把当前层栈 **reconcile** 到 `name` 的"标准链路"(从根到它)。手点按钮与深链调用同一入口 ⇒ 同一结果。
+- 名字与层级**解耦**:URL 只认稳定名字;父子关系在注册时单独声明,层级变动只改注册那一处。
+- 节点支持四种呈现:整屏 **Page**、遮罩弹窗 **Modal**、父界面 TabBar 里的 **Tab**、由内置对话框支撑的 **Prompt**(`InputBox`/`MessageBox` 包成路由目的地)。
+- 临时对话框(就地 `await MessageBox.Open`)仍可脱离 router 存在;reconcile 时自动清掉挡在目标链路之外的临时模态,守住 §1.2 约束 1。
+
+### 1.4 非目标(v1)
+
+- **转场动画**:节点激活/反激活先是即时的(SetActive / 实例化 / 销毁)。动画留待后续(可挂在现有 `<Trigger>`/`<Animation>` 上)。
+- **一个节点多 parent(DAG)**:每个节点恰好一个标准 parent → 一棵树。多入口同一界面的需求用"多个名字指向同一 src"或后续扩展解决。
+- **超出当前链路的历史前进/后退**:不维护浏览历史栈。当前链路本身就是状态,`Back()` = 回到 parent(见 §8)。
+- **并行常驻层**(常驻 HUD、世界 UI 等):不进 router,继续用裸 `UI.Open`(见 §11)。
+- **路由守卫 / 拦截器**(navigation guard、登录校验重定向):v1 不做;`onEnter` 里调用方可自行 `Open` 别处近似实现。
+
+---
+
+## 2. 核心模型:导航节点树
+
+一棵**导航节点树**。每个**路由节点**(`RouteNode`,内部 POCO)有:
+
+| 字段 | 含义 |
+|---|---|
+| `Name` | 稳定不透明 ID。可含斜杠(`"home/friend"`),但**斜杠只是名字字符,不解析成层级**。URL 与所有 API 只认它。全局唯一。 |
+| `Parent` | 标准父节点的 `Name`;`null` = 根。注册时声明,层级变动只改这里。 |
+| `Kind` | `Page` / `Modal` / `Tab` / `Prompt`(见 §5)。 |
+| 目标 | Page/Modal → `Src`(`.ui.xml` 的 src key) + 要 `Open` 的 screen 名;Tab → `TabId`(父 Page screen 内 `<Tab>` 控件的 id 路径);Prompt → `Run` handler。 |
+| `OnEnter` | (Page/Modal/Tab)激活后的回调 `Action<IScreen, RouteQuery>`,拿到目标 screen + 查询参数。可空。 |
+
+**名字与层级解耦的意义**:`appid://friend` 永远写 `friend`;`friend` 的 parent 从 `home` 改成 `social`,只动 `MapTab/Map` 那一行注册,所有外发链接与按钮代码不变。这是 §1.2 约束 2 的实现。
+
+> **为什么不是"URL 路径即层级"(web router 那套)?** 那样 `appid://home/shop` 里 shop 是 home 的子——层级一变就得改满世界 URL,正中 §1.2 约束 2 的痛点。**为什么不是"纯运行时栈(parent=谁打开我)"?** 那样深链时无法重建标准链路,做不到 §1.2 约束 1。本设计取两者之外的第三条:稳定名字 + 注册时声明的标准 parent + reconcile。
+
+---
+
+## 3. 中枢:`Open(name)` 与 reconcile
+
+### 3.1 不变量
+
+**屏上的路由链路,永远是从某个根到某个节点的一条标准路径。** 没有"凭空盖在任意当前界面上"的操作。所有打开都经 `Open` → reconcile,因此深链与手点天然同构。
+
+### 3.2 reconcile 算法
+
+`Open(name, query)`:
+
+1. **求目标链路** `target = [root … name]`:从 `name` 沿 `Parent` 向上走到根,反转。途中检测环(visited 集)与未注册的 parent → 抛 `RouteException`(见 §10)。
+2. **取当前链路** `current`:router 持有的活动节点栈(root→top,见 §3.4)。
+3. **最长公共前缀** `k`:逐位比较 `current[i].Name == target[i].Name`,首个不等处为分界。
+4. **反激活**:`current` 中下标 `≥ k` 的节点,**从顶往下**逐个 deactivate(§5)。
+5. **激活**:`target` 中下标 `≥ k` 的节点,**从下往上**逐个 activate(§5)。每个**新激活**的节点的 `OnEnter` 收到本次 `query`。
+6. **目标刷新**:若目标节点已在公共前缀内(重复导航到已开节点),不重建、不动其余节点,只对**目标节点**重新触发一次 `OnEnter(screen, query)`(Prompt 已在显示中则为 no-op)。
+7. reconcile 完成后 fire `Changed`(§9)。
+
+> **query 的投递**:本次新激活的每个节点、以及目标节点(即便已开)都收到**完整** `query` 字典,各取所需(例:`appid://shop/item?shopId=5&itemId=10` 中 shop 与 item 同时被新激活,各读各的 key)。公共前缀里未被重激活的中间节点不收、不重触发。
+
+### 3.3 临时模态的处理(§1.2 约束 1 的实现)
+
+reconcile 第 4 步**之前**,若 router 链路**之上**还压着脱离 router 的临时模态(它们在 modal 栈里、不是 router 节点;`MessageBox`/`InputBox`/`Loading` 等,见 §6),则先按"关栈顶"的方式逐个关掉。等价于"用户必须先关掉弹窗才能导航",杜绝越过模态偷开下层。
+
+### 3.4 活动链路的数据结构
+
+`UI.Router` 内部:
+
+- `_chain`:`List<ActiveNode>`,自底向上(root→top)。
+- `ActiveNode`:`{ RouteNode Def; … 各 Kind 的运行时 handle }` —— Page/Modal 持有其 `Screen`(及 Modal 的 slot/Canvas);Tab 持有所选 `Tab` 控件引用;Prompt 持有其 `run` 的运行任务 + cancel 通道(§5.4)。
+
+### 3.5 异步与串行化
+
+激活 Page/Modal 要 `await` XML 加载/实例化(异步)。reconcile 全程 `async Awaitable`,且**串行化**:同一时刻只跑一个 reconcile(仿 `UI.Modal` 的 materialize pump 的 epoch 机制)。reconcile 进行中再来 `Open` → 入一个**单槽 latest-wins** 待办:当前 reconcile 结束后,以最新一次请求为目标再跑一次(中间被覆盖的请求直接丢弃——它们的最终意图已被后来者取代,符合"导航以最后一次为准"的直觉)。`Open`/`Navigate`/`Back`/`Reset` 返回的 `Awaitable` 在**本次请求对应的 reconcile 真正完成**时 resolve;被 latest-wins 覆盖丢弃的请求,其 `Awaitable` 同样在那一刻 resolve(目标已被取代,不抛错)。
+
+---
+
+## 4. 名字、URL 与参数
+
+### 4.1 URL 解析
+
+`Navigate(url)` 把 `<scheme>://<name>?<query>` 拆成 `(name, query)` 后等价于 `Open(name, query)`:
+
+- `://` 与 `?`(或串尾)之间**整段**当 `name`(含斜杠,不拆)。
+- `?` 之后按 `k=v&k2=v2` 解析成 `RouteQuery`;`k`/`v` 做 URL decode。
+- **scheme 校验**:`UI.Router.Scheme`(可写,默认 `null`)。为 `null` 时不校验 scheme(接受任意 `xxx://…`,甚至无 scheme 的裸 `name?…`);非 `null` 时 scheme 不符抛 `RouteException`。
+
+### 4.2 RouteQuery
+
+只读小包装,从 URL query 或 `Open` 传入的字典构造:
+
+```csharp
+public sealed class RouteQuery
+{
+    public static readonly RouteQuery Empty;
+    public bool Has(string key);
+    public string Get(string key, string fallback = null);   // 缺省 → fallback
+    public int GetInt(string key, int fallback = 0);
+    public string this[string key] { get; }                  // 缺省 → null
+    public IReadOnlyDictionary<string, string> Raw { get; }
+}
+```
+
+`Open(name)`(无 query)→ 节点收到 `RouteQuery.Empty`。
+
+---
+
+## 5. 四种呈现的激活 / 反激活
+
+reconcile(§3.2)对四种 Kind 一视同仁,只是 activate/deactivate 动作不同。
+
+### 5.1 Page
+
+| | 动作 |
+|---|---|
+| activate | `await` 加载 src(若未加载)→ `UI.Open(screenName)`(普通 sorting 带)→ `OnEnter(screen, query)`。 |
+| deactivate | `UI.Close(screenName)`(销毁 Screen)。 |
+
+### 5.2 Modal
+
+| | 动作 |
+|---|---|
+| activate | 实例化 Screen 到 **modal sorting 带**(复用 §2026-05-20 的 `ModalSourceLoader` + backdrop + route-aware ESC),作为**持久面板**压上 → `OnEnter(screen, query)`。**不**走结果导向的 `OpenAsync<T>` / `ModalRequest`——routed Modal 是持久目的地,不 await 结果、由 router 关闭。 |
+| deactivate | 关闭该面板的 Screen + backdrop。 |
+
+> 复用方式(把 `UI.Modal` 重构出一个"持久面板"原语供两边共享 vs. Router 自行复刻 band/backdrop/ESC 那几步)= plan 阶段定;见 §12。
+
+**ESC / backdrop / 自带关闭按钮的同步**(关键):routed Modal 的关闭**必须经 router**,否则 router 链路与屏幕脱节。其 `ModalEscapeListener` 的回调改为 route-aware:若该节点是链路顶 → 等价 `Router.Back()`;否则不响应(沿用"只关栈顶"语义)。作者在 Modal screen 里放的"关闭"按钮也应接 `Router.Back()`,不要裸 `screen.Close()`。
+
+### 5.3 Tab
+
+Tab 节点不是自己的 Canvas,它寄生在某个 Page/Modal screen 的 `<TabBar>` 里。
+
+- **宿主 screen** = 沿 `Parent` 向上走遇到的第一个 Page/Modal 节点(允许 Tab 的 parent 是同屏内另一个 Tab,做嵌套 tab)。reconcile 保证宿主在 Tab 之前已激活。
+- `TabId` = 宿主 screen 内 `<Tab>` 控件的 id 路径。
+
+| | 动作 |
+|---|---|
+| activate | `host.Get<Tab>(TabId).IsOn = true`(ToggleGroup 自动互斥,内容随 `ApplyBindFrame` 切换)→ `OnEnter(host, query)`。切换兄弟 tab 时**宿主不重建**。 |
+| deactivate | **不强制改控件**:宿主仍在屏时,TabBar 永远有一个被选中(`SyncInitialSelection` 保证),Tab 节点出栈只是 router 不再跟踪它,控件保持当前选中态。真正换 tab 只发生在"导航到兄弟 Tab 节点"时。宿主整屏关闭则 tab 随之消失。 |
+
+> 边界(已知、可接受):`current=[home,shop,shop/deals]` 时 `Open("shop")` → 公共前缀 `[home,shop]`,deals 节点出栈但 shop 屏上仍显示 deals tab(不重置成默认 tab,避免突兀)。文档化此行为。
+
+### 5.4 Prompt
+
+由内置对话框(`InputBox`/`MessageBox`/自定义 await 流)支撑、**无自己的 src** 的节点。把"小到用 InputBox 就够、但又得能被深链直达"的功能(典型:改名)包成路由目的地。
+
+Prompt 是**叶子**:不可作为任何节点的 parent(它会自动出栈,挂持久子节点无意义)。注册时若有人把 Prompt 声明为自己的 parent → 抛 `RouteException`(§10)。
+
+```csharp
+// run 的签名:RouteQuery + 取消信号 → Awaitable
+public delegate UnityEngine.Awaitable RoutePromptRun(
+    RouteQuery query, System.Threading.CancellationToken ct);
+```
+
+| | 动作 |
+|---|---|
+| activate | **启动** `run(query, ct)`,记录其任务,**立即返回**(不等用户答完)——所以 reconcile 在"对话框已显示"时即完成。 |
+| 存活期 | = `run` 运行时长。 |
+| 自动出栈 | `run` 正常返回(用户答完、逻辑跑完)→ router 把该节点从链路顶移除 + fire `Changed`。 |
+| deactivate(被导航走) | router `Cancel` 它的 `ct` → 内置对话框的 `await` 抛 `OperationCanceledException` → `run` 退栈 → router 移除节点。 |
+
+**取消的接线**:`InputBox.Open` / `MessageBox.Open` 新增**可选** `CancellationToken ct = default` 重载——`ct` 取消时令底层 modal entry `Cancel(OCE)`(复用 §2026-05-20 既有的 `entry.Cancel(oce)` 路径,`ct.Register` 触发)。这是对 `UI.Modal` 体系**纯增量**的重载,不改既有签名/语义。`run` 作者把 `ct` 透传给 `InputBox.Open(..., ct)` 即获得"被导航走时自动撤销改名"的正确行为;不透传则 router 兜底关掉它当前的对话框 slot(对话框 resolve 为取消值,`run` 通常随即 `if(name!=null)` 跳过收尾)。
+
+**示例(改名:小按钮 + 违规提醒深链,逻辑只写一份)**:
+
+```csharp
+UI.Router.MapPrompt("rename", parent: "home", run: async (q, ct) =>
+{
+    var name = await InputBox.Open("请输入新名字", initial: PlayerName, ct: ct);
+    if (name != null) await Api.Rename(name);
+});
+
+// 小按钮:
+renameBtn.OnClick.Subscribe(_ => UI.Router.Open("rename")).AddTo(screen);
+// 违规提醒处:
+await UI.Router.Navigate("appid://rename?reason=illegal");   // q["reason"] 可用
+```
+
+---
+
+## 6. 临时模态的边界
+
+- **纯就地、非目的地的对话框**(流程中间的一个确认)→ 仍完全 ad-hoc `await MessageBox.Open(...)`,**不注册、不进 router**。reconcile 时若它挡在目标链路外则被关掉(§3.3)。
+- **既是目的地、又想用内置对话框** → 注册成 **Prompt 节点**(§5.4)。
+- `Loading` / `Toast`:始终脱离 router(瞬态、无结果/不可深链)。`Loading` 在 dialog 之下、`Toast` 自管层级,均不参与 reconcile;但顶层临时 `Loading` 若挡路同样可被 §3.3 关掉。
+
+---
+
+## 7. 与 `<TabBar>`/`<Tab>` 控件的集成
+
+复用现有控件公开面,**不新增 XML**:
+
+- `Tab.IsOn { get; set; }`:`set true` 选中并触发内容切换(`OnIsOnChanged → ApplyBindFrame`)。
+- `screen.Get<Tab>(idPath)`:按 id 路径取 Tab 控件。
+- `TabBar.SelectedIndex` / `SelectedTab` / `GetAt(int)` / `Count` / `OnSelectionChanged`:供诊断与可能的反向同步(用户在 UI 上手点 tab 时,router 链路是否跟随——见 §12 待评估项)。
+
+---
+
+## 8. Back 与当前状态
+
+- `Back()` = `Open(current.Top.Parent.Name)`;top 已是根 → no-op(返回已完成 `Awaitable`)。top 是 Prompt → 取消该 Prompt(deactivate)即回到 parent。
+- `Current`:链路顶节点 `Name`(空链路 → `null`)。
+- `Chain`:`IReadOnlyList<string>`,root→top 的名字序列。
+- `Changed`:`event Action`,每次 reconcile 成功改变链路后触发(供 HUD 高亮当前页等)。
+
+---
+
+## 9. 公开 API 汇总
+
+命名空间沿用 `UI.Xxx` 嵌套惯例(与 `UI.Modal`/`UI.Toast`/`UI.Locale`/`UI.Theme` 一致):
+
+```csharp
+namespace PromptUGUI.Application
+{
+    public static partial class UI
+    {
+        public static class Router
+        {
+            // —— 配置 ——
+            public static string Scheme { get; set; }            // 默认 null:不校验 scheme
+
+            // —— 注册(功能式)——
+            public static void Map(string name, string src, string screen = null,
+                RoutePresent present = RoutePresent.Page, string parent = null,
+                System.Action<IScreen, RouteQuery> onEnter = null);
+            public static void MapTab(string name, string parent, string tabId,
+                System.Action<IScreen, RouteQuery> onEnter = null);
+            public static void MapPrompt(string name, string parent, RoutePromptRun run);
+            public static bool IsMapped(string name);
+            public static void Clear();                          // 清空注册表(主要给测试 / 重配)
+
+            // —— 导航 ——
+            public static UnityEngine.Awaitable Open(string name, RouteQuery query = null);
+            public static UnityEngine.Awaitable Navigate(string url);
+            public static UnityEngine.Awaitable Back();
+            public static UnityEngine.Awaitable Reset();         // 关闭整条链路
+
+            // —— 状态 ——
+            public static string Current { get; }
+            public static System.Collections.Generic.IReadOnlyList<string> Chain { get; }
+            public static event System.Action Changed;
+        }
+    }
+
+    public enum RoutePresent { Page, Modal }     // Tab/Prompt 由 MapTab/MapPrompt 表达
+    public sealed class RouteQuery { /* §4.2 */ }
+    public delegate UnityEngine.Awaitable RoutePromptRun(
+        RouteQuery query, System.Threading.CancellationToken ct);
+    public sealed class RouteException : System.Exception { /* §10 */ }
+}
+```
+
+- `Map` 的 `screen` 省略时,在该节点**首次激活**(doc 已加载)时解析:doc 恰含一个 `<Screen>` → 用它;含多个 → 抛 `RouteException`(要求显式给 `screen`)。`Map` 本身同步、不加载 doc,故此校验落在激活时。
+- `present` 仅区分 Page/Modal(都是"一个 screen",差在 sorting 带 + backdrop)。
+
+`InputBox` / `MessageBox` 各新增一个 `CancellationToken ct = default` 重载(§5.4),为唯一对既有类型的改动,且纯增量。
+
+---
+
+## 10. 错误处理
+
+统一抛 `RouteException`(继承 `System.Exception`),消息含触发的 `name`:
+
+| 情形 | 处理 |
+|---|---|
+| `Open`/`Navigate` 未注册的 `name` | 抛 `RouteException`("route 'x' not mapped")。 |
+| parent 链中有未注册的 parent | 抛 `RouteException`(指出断点)。 |
+| parent 链成环 | 抛 `RouteException`(visited 集检测)。 |
+| 重复 `Map`/`MapTab`/`MapPrompt` 同名 | 抛 `RouteException`("route 'x' already mapped")。 |
+| Tab 节点 activate 时 `Get<Tab>(TabId)` 解析失败 | 抛 `RouteException`(指出 tabId 与宿主 screen)。 |
+| 把 Prompt 节点声明为别人的 parent | 抛 `RouteException`(Prompt 只能是叶子,§5.4)。 |
+| Page/Modal 节点的 src 的 doc 含多 `<Screen>` 却未显式给 `screen` | 抛 `RouteException`(激活时,§9)。 |
+| `Navigate` scheme 与 `Router.Scheme` 不符 | 抛 `RouteException`。 |
+| `Navigate` URL 格式无法解析出 name | 抛 `RouteException`。 |
+
+reconcile 进行中某节点 activate 抛错:已激活的部分**不回滚**(屏上是一条合法的部分链路),异常向 `Open` 的 `Awaitable` 抛出由调用方处理(深链入口通常 try/catch + 记日志)。
+
+---
+
+## 11. 与现有系统的关系 / 共存
+
+- Router **建立在** `UI.Open` / `UI.Close` / `UI.Modal` / `InputBox` / `MessageBox` 之上,不改它们对外语义(仅 §5.4 的两个增量 `ct` 重载)。
+- **路由管理的 screen 只能经 router 开关**:裸 `UI.Open` 一个 router 节点的 screen 会绕过 reconcile、污染 `_chain` —— 视为调用方错误。Modal 节点的 ESC/关闭按钮须接 `Router.Back()`(§5.2)。
+- **非路由界面**(常驻 HUD、splash、世界空间 UI 等)继续用裸 `UI.Open`,与 router 链路并存、互不干扰(它们 sortingOrder 由各自 `CanvasConfigurator` 决定)。
+- **teardown 接线**:`UI.ResetForTests` / `UI.UnloadAll` 必须清空 `_chain`(逐个 deactivate 或直接随 `_open` 统一销毁)并取消进行中的 reconcile / Prompt(epoch 自增,仿 `UI.Modal.CancelAllForTeardown`)。`Router.Clear()` 另清注册表。
+
+---
+
+## 12. 待评估项(plan 阶段定夺,不阻塞 v1 主线)
+
+- **用户手点 UI 上的 tab 时,router 链路是否跟随?** 例:shop 屏里用户直接点了 deals tab(没走 `Router.Open`)。v1 默认 router 链路**不**自动跟随(链路只反映经 `Open` 的导航);若要跟随,需订阅 `TabBar.OnSelectionChanged` 把链路顶替换为对应 Tab 节点。倾向 v1 先不跟随,文档说明。
+- **Prompt 兜底取消**(作者没透传 `ct`)的精确 slot 关闭策略(关"最近一次该 Prompt 开的 modal" vs "当前栈顶 modal")。
+- **routed Modal 与 ad-hoc dialog 栈共处 modal 带时的 sorting / ESC 归属**:原则定为 ad-hoc dialog 永远在 routed Modal 面板**之上**、ESC 先归 ad-hoc 栈顶(routed Modal 在屏时弹的 `MessageBox` 盖在它上面);两套 sorting 计数如何不打架 = plan 阶段定。这也牵涉 §5.2 "复用 vs 复刻" 的取舍。
+- **`Open` 到"已在链路中但非顶"的节点**(例 current=`[home,shop,item]`,`Open("shop")`):按 §3.2 等价"反激活 item、停在 shop",即回退。确认这就是期望(应当是——等于 `Back` 到 shop)。
+
+---
+
+## 13. 测试策略
+
+EditMode(`PromptUGUI.Tests.EditMode`,沿用 `UI.ResetForTests` + fake-files 模式):
+
+- **reconcile 核心**:公共前缀计算;跨分支(无公共前缀)全关全开;`Open(child)` 纯 push;`Open(ancestor)` 纯 pop;`Open(sibling)` 关到公共祖先再开。
+- **名字/层级解耦**:改一个节点的 `parent`,同一 `Open(name)` 落到新链路;URL `appid://friend` 不因 parent 变而失效。
+- **Page/Modal**:激活实例化、反激活销毁;Modal 走高 sorting 带;ESC=Back。
+- **Tab**:激活选中 + 内容切换;切兄弟 tab 宿主不重建;离屏随宿主消失;§5.3 边界行为。
+- **Prompt**:`run` 跑完自动出栈;导航走时 `ct` 取消、`run` 退栈、不执行收尾;改名示例(button 与 Navigate 同结果)。
+- **临时模态边界**(§3.3):顶上压着 ad-hoc `MessageBox` 时 `Open("shop")` 先关它再导航。
+- **query 投递**:目标与新激活中间节点都收到完整 query;重复导航刷新目标 `OnEnter`。
+- **串行化**:连续两次 `Open`,latest-wins;两个 `Awaitable` 都在最终 reconcile 后 resolve。
+- **错误**:§10 各情形抛 `RouteException`;reconcile 中途抛错不回滚、异常上抛。
+- **teardown**:`ResetForTests` 清空链路、取消进行中 reconcile/Prompt。
+
+PlayMode(`PromptUGUI.Tests.PlayMode`):sortingOrder 分带(Page 带 < Modal 带);ESC 在 routed Modal 上等价 Back;Prompt 的 InputBox 实弹实收。
+
+### 13.1 测试期 Awaitable 同步展开
+
+EditMode 用 `.GetAwaiter().GetResult()` 同步展开;fake resolver 经 `AwaitableHelpers.Completed(value)` 同步完成,使 reconcile 无真实 yield 点、在测试线程返回(沿用仓库既有模式)。
+
+---
+
+## 14. SKILL.md 影响
+
+`scripting-promptugui-csharp/SKILL.md` —— **必须更新**(新增公开 C# API):
+
+- 新增 "Router / 导航" 一节:`UI.Router.Map`/`MapTab`/`MapPrompt`、`Open`/`Navigate`/`Back`/`Reset`、`Current`/`Chain`/`Changed`、`RoutePresent`/`RouteQuery`/`RoutePromptRun`/`RouteException`;reconcile 心智模型(稳定名字 + 标准链路);四种呈现表;改名 Prompt 范式。
+- "Modal dialogs" 节补一句:`InputBox.Open`/`MessageBox.Open` 新增 `CancellationToken ct` 重载,routed Prompt 用它支持"被导航走时撤销"。
+- cheatsheet 增 ROUTER 区。
+
+`authoring-promptugui-xml` —— **不更新**(无 XML 元素/属性变更;Tab 节点复用现有 `<TabBar>`/`<Tab>` 与 id 路径)。
+`using-promptugui-addressables` —— **不更新**(Router 经 `SourceResolver` 间接用 Addressables,无 Addressables 专属面)。
+
+---
+
+## 15. 实施顺序(plan 阶段细化)
+
+每步 TDD(红→绿)+ lint + UnityMCP 编译/测试。
+
+1. **注册表 + 链路骨架** —— `RouteNode` IR、`UI.Router.Map`/`IsMapped`/`Clear`、parent 链解析 + 环/缺失检测、`RouteException`、`Chain`/`Current`/`Changed`。纯逻辑,无 Screen。
+2. **reconcile + Page** —— `Open` 的公共前缀算法 + Page activate/deactivate(走 `UI.Open`/`UI.Close`)+ 串行化(epoch + latest-wins)+ teardown 接线。
+3. **RouteQuery + Navigate** —— URL 解析、`Scheme`、query 投递规则(§3.2)。
+4. **Modal 呈现** —— 走 dialog 栈,ESC/关闭 = route-aware Back。
+5. **Tab 呈现** —— `MapTab`、宿主 screen 解析、`IsOn` 选中、§5.3 边界。
+6. **Prompt 呈现** —— `MapPrompt`/`RoutePromptRun`、`InputBox`/`MessageBox` 的 `ct` 重载、自动出栈 + 取消。
+7. **临时模态边界**(§3.3)接入 reconcile。
+8. **`scripting-promptugui-csharp/SKILL.md` 更新。**
+
+---
+
+## 16. 验收标准
+
+- 同一 `appid://friend?...` 深链与对应按钮 `Open("friend")` 落到**完全相同**的链路与显示。
+- 顶上压着模态时深链到别处,先关模态再导航(§1.2 约束 1)。
+- 改 `friend` 的 parent,`appid://friend` 不失效、reconcile 走新链路(§1.2 约束 2)。
+- 改名:小按钮与"违规提醒"深链走同一 `rename` Prompt,逻辑只写一份;改名中被导航走则撤销。
+- Tab:导航选中并切内容;切兄弟 tab 宿主不重建;`home→shop→deals→item` 整链 reconcile。
+- 跨分支导航全关全开;`Back`/`Open(ancestor)` 正确回退。
+- EditMode + PlayMode 全绿;`dotnet format --verify-no-changes --severity warn` 干净;`UIXmlLint` 对涉及的 XML exit 0。


### PR DESCRIPTION
## Summary

A unified navigation subsystem `UI.Router` — **every screen-open goes through it**, so a deep-link (`appid://home/friend?tab=x`) and a button click follow the same code path and land on the **same display state**.

- **Stable opaque names + canonical `parent` declared at registration** (not encoded in the URL) → a navigation tree. Changing the hierarchy only touches the registration, never the links/ad-cards out in the wild.
- **`Open(name)` / `Navigate(url)` reconcile** the current layer chain to the target's canonical chain (root→name): close the non-shared tail, open the missing tail. This is what makes "path nav == manual nav" hold — and it closes any ad-hoc modal on top during reconcile, so a deep-link can't bypass a modal.
- **Four presentations:** `Page` (full screen), `Modal` (overlay band + ESC=Back), `Tab` (selects a `<Tab>` inside an ancestor screen; can itself parent deeper routes), `Prompt` (an `InputBox`/`MessageBox`-backed destination that auto-pops when answered — e.g. a rename dialog reachable from both a button and a deep-link, logic written once).
- Built on existing `UI.Open`/`UI.Close`/`UI.Modal`; the only change to existing types is an additive `CancellationToken` overload on `InputBox.Open`/`MessageBox.Open` + `UI.Modal.CancelEntry` (so routed Prompts cancel cleanly when navigated away).
- Async reconcile is serialized (epoch + latest-wins pump, mirroring `UI.Modal.MaterializePump`) and teardown-safe.

Docs: design spec + implementation plan under `docs~/superpowers/`, new "Router navigation" section in `scripting-promptugui-csharp/SKILL.md`. Also bundles a small fix to `CLAUDE.md`'s UnityMCP test-tooling commands (encountered while implementing: `ToolSearch select:` full names, `run_tests` async `job_id`, `group_names` not `filter`).

Implemented via TDD, 12 task-units + a final-review fix.

## Test Plan

- [x] EditMode `PromptUGUI.Tests.EditMode` — 1492/1492 pass (router: RouteQuery / RouteRegistry / RouterReconcile / RouterNavigate / RouterModalTab / RouterPrompt)
- [x] EditMode `PromptUGUI.Tests.EditorOnly` — 183/183 (no regression)
- [x] PlayMode `PromptUGUI.Tests.PlayMode` — RouterPlayTests 3/3 (modal sorting band; rename confirm→apply→auto-pop; teardown-mid-async-load safety) + suite green
- [x] `dotnet format --verify-no-changes --severity warn` — clean
- [ ] Visual QA in the host project (carousel ad-card deep-link, Modal/Tab/Prompt flows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)