### PR TITLE
feat: MarkdownBox 内置模态 — 无按钮富文本公告/邮件显示框

### DIFF
--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -568,6 +568,7 @@ MODAL          var r = await MessageBox.Open(text, MsgBtn.OK|MsgBtn.Cancel, icon
                               else: InvalidKeyException / "Modal screen 'X' not loaded; call LoadDocument first"
                               (do NOT call LoadDocument manually — auto via ModalDocCache.EnsureLoaded)
                required ids   text  title  ok  cancel  yes  no  close   (icon optional)
+                              MarkdownBox required ids: title  markdown  close  backdrop  (backdrop = Image, click closes)
                backdrop       author writes <Image anchor="stretch"/> — NOT auto-injected
                UI.Modal.OpenAsync(new MyRequest(), ModalMode.Popup) custom ModalRequest<T>
                               override TryEscape(out T) to map ESC → result

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -333,6 +333,15 @@ UI.Markdown.ImageResolver = myResolver;         // global fallback resolver
 | `UI.Markdown.ImageResolver` | Global image resolver fallback. Set once at boot. |
 | `UI.Markdown.UseWebImageResolver()` | Installs a built-in `UnityWebRequestTexture`-backed resolver with URL→`Texture2D` cache. WebGL-safe (`Awaitable`, no `System.Threading`). |
 
+**`UI.Markdown.HandleLink(string url)`** — the default link policy, also usable from
+your own `OnLinkClicked` subscriptions on standalone `<Markdown>` screens. If
+`UI.Router.Scheme` is set and the url starts with `<Scheme>://`, it navigates via
+`UI.Router.Navigate` (failures are logged, NOT handed to the system browser);
+everything else goes to `Application.OpenURL`. Note this changed MarkdownBox's default:
+with a Router scheme configured, deep links inside markdown now navigate instead of
+opening a browser. Want `.md` links to open nested MarkdownBoxes? That's one line:
+`onLinkClicked: url => { if (url.EndsWith(".md")) _ = MarkdownBox.OpenUrl(url); else UI.Markdown.HandleLink(url); }`
+
 **`text` is runtime content**: a value set from C# at runtime survives resize / Variant / Theme ReSolve. The DefaultText lock prevents the XML-declared value from overwriting runtime content (same mechanism as `<Text text>`). Variant overrides on `text.<variant>` still apply when the user has not yet set `Text` from C#; once set from C#, the runtime value wins.
 
 **Image loading**: `Text` set renders text immediately. Block-level images (`![ ](url)`) are loaded asynchronously by the configured `ImageResolver`. Each image shows alt text as a placeholder until the texture arrives. A render-generation token (`_renderGen`) ensures that textures arriving late (after a re-render or `Dispose`) are discarded safely. Without a registered resolver, images remain as alt-text placeholders.
@@ -526,6 +535,13 @@ DATA PUSH      Dropdown.BindOptions(Observable<IEnumerable<string>>)
                TabBar query: .Count / .SelectedIndex (-1 if empty) / .SelectedTab / .GetAt(i)
                Carousel query: .Count / .Current (get/set) / .Playing (get/set) / .GoTo(i,animated) / .Next() / .Previous()
 
+MARKDOWN       md.Text = "…"                                 set → full re-render (runtime-owned)
+               md.BindText(Observable<string>).AddTo(screen) reactive re-render
+               md.OnLinkClicked.Subscribe(url=>…).AddTo(screen)
+               UI.Markdown.UseWebImageResolver()             install http(s) image downloader
+               UI.Markdown.DefaultStyle = …                  global style baseline
+               UI.Markdown.HandleLink(url)      // 默认链接分发:Router scheme → Navigate,否则 OpenURL
+
 VARIANT        UI.Variants.Set("name", true|false)            re-applies, no rebuild
 ORIENTATION    UI.Orientation.IsPortrait                      auto-tracked: portrait / landscape variants
                UI.Orientation.Set(bool)                       manual override
@@ -557,6 +573,9 @@ MODAL          var r = await MessageBox.Open(text, MsgBtn.OK|MsgBtn.Cancel, icon
                await MarkdownBox.Open(markdown, title, onLinkClicked, mode, configure, ct)
                               // 无按钮富文本框(公告/邮件);×/点背景/ESC 三通道关闭,关闭即完成
                               // onLinkClicked null → 链接默认 Application.OpenURL
+               await MarkdownBox.Open(loader, title, ...)  // loader: Func<CT,Awaitable<string>>
+                              // 先显示 loadingText 占位,完成后热替换;关窗自动取消 loader 的 ct
+               await MarkdownBox.OpenUrl(url, title, ...)  // 裸 GET 糖;鉴权内容用 Open(loader)
                configure:     Action<IScreen> trailing arg on every Open (MessageBox/InputBox/Loading/MarkdownBox)
                               // post-bind hook → live Screen; reach any control w/o subclassing
                               // e.g. InputBox.Open(t, configure: s => s.Get<Btn>("ok").Interactable = false)
@@ -650,6 +669,13 @@ await MarkdownBox.Open(noticeMarkdown, title: UI.Tr("Notice"));
 // Custom link routing (replaces the default Application.OpenURL):
 await MarkdownBox.Open(mailBody, title: mail.Subject,
     onLinkClicked: url => MyRouter.HandleDeepLink(url));
+
+// Deferred content: opens immediately showing "*Loading…*", swaps in the markdown
+// when the fetch completes, and cancels the fetch if the user closes the box first.
+await MarkdownBox.OpenUrl("https://cdn.example.com/notice.md", title: UI.Tr("Notice"));
+
+// Authenticated content: bring your own loader (the ct is cancelled on close).
+await MarkdownBox.Open(ct => Api.FetchMailBodyAsync(mailId, ct), title: mail.Subject);
 ```
 
 ### API surface (`PromptUGUI.Application.Modals`)
@@ -700,10 +726,21 @@ public static class MarkdownBox {
     // (× button / backdrop click / ESC). No buttons can be configured.
     public static Awaitable Open(
         string markdown, string title = null,
-        Action<string> onLinkClicked = null,        // null → Application.OpenURL
+        Action<string> onLinkClicked = null,        // null → UI.Markdown.HandleLink
         ModalMode mode = ModalMode.Popup,
         Action<IScreen> configure = null,
         CancellationToken ct = default);
+    // Deferred content: shows loadingText (default "*Loading…*") until loader
+    // completes, then hot-swaps. The loader's ct is cancelled when the box closes
+    // (any channel). Loader errors render "**Failed to load.**" + message — catch
+    // inside your loader to customize.
+    public static Awaitable Open(
+        Func<CancellationToken, Awaitable<string>> loader, string title = null,
+        Action<string> onLinkClicked = null, string loadingText = null,
+        ModalMode mode = ModalMode.Popup, Action<IScreen> configure = null,
+        CancellationToken ct = default);
+    // Plain unauthenticated GET sugar over Open(loader).
+    public static Awaitable OpenUrl(string url, /* same trailing params */);
 }
 
 [Flags] public enum MsgBtn { None=0, OK=1, Cancel=2, Yes=4, No=8, Close=16 }
@@ -764,7 +801,7 @@ UI.Modal.SortingOrderBase` so dialogs opened during a Loading appear above it.
   completes when the box closes. `title: null` hides the title row and the markdown area
   expands to fill. The × close button always floats top-right above the content. To
   resize the box, use `configure` (e.g. `s.Get<Controls.Image>("dialog")`…). Links
-  default to `Application.OpenURL`; pass a non-null `onLinkClicked` to fully replace
+  default to `UI.Markdown.HandleLink` (see below); pass a non-null `onLinkClicked` to fully replace
   that behaviour.
 
 ### Customizing a builtin modal (the `configure` hook)

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -554,7 +554,10 @@ MODAL          var r = await MessageBox.Open(text, MsgBtn.OK|MsgBtn.Cancel, icon
                                            contentType, okLabel, cancelLabel, mode)
                        // confirm → text ("" if empty); cancel/ESC → null
                        // Enter respects ok.Interactable (disable ok → Enter gated too)
-               configure:     Action<IScreen> trailing arg on every Open (MessageBox/InputBox/Loading)
+               await MarkdownBox.Open(markdown, title, onLinkClicked, mode, configure, ct)
+                              // 无按钮富文本框(公告/邮件);×/点背景/ESC 三通道关闭,关闭即完成
+                              // onLinkClicked null → 链接默认 Application.OpenURL
+               configure:     Action<IScreen> trailing arg on every Open (MessageBox/InputBox/Loading/MarkdownBox)
                               // post-bind hook → live Screen; reach any control w/o subclassing
                               // e.g. InputBox.Open(t, configure: s => s.Get<Btn>("ok").Interactable = false)
                               // base ModalRequest<T>.Configure field → custom modals get it free
@@ -604,9 +607,10 @@ ROUTER         UI.Router.Scheme = "myapp"                   optional scheme enfo
 
 ## Modal dialogs
 
-PromptUGUI ships a generic modal stack in `PromptUGUI.Application.Modals` plus three
-builtin overlays: a `MessageBox` dialog, an `InputBox` text prompt, and a `Loading`
-spinner. **Every modal IS a real
+PromptUGUI ships a generic modal stack in `PromptUGUI.Application.Modals` plus four
+builtin overlays: a `MessageBox` dialog, an `InputBox` text prompt, a `MarkdownBox`
+read-only rich-text viewer (announcements / mail, built on the `<Markdown>` control),
+and a `Loading` spinner. **Every modal IS a real
 `Screen` instantiated from `.ui.xml`** — anchor / margin / Variant / locale / `<Icon>`
 all work normally. The modal subsystem only adds: stack management, ESC handling, and a
 sortingOrder band above regular Screens.
@@ -637,6 +641,14 @@ if (name != null) game.PlayerName = name;
 // password prompt with a sub-message line
 string pw = await InputBox.Open(UI.Tr("Enter password"),
     message: UI.Tr("at least 8 chars"), contentType: "password");
+
+// MarkdownBox: read-only rich-text viewer (announcements / mail). No buttons;
+// closes via the × button, clicking the backdrop, or ESC. Completes when closed.
+await MarkdownBox.Open(noticeMarkdown, title: UI.Tr("Notice"));
+
+// Custom link routing (replaces the default Application.OpenURL):
+await MarkdownBox.Open(mailBody, title: mail.Subject,
+    onLinkClicked: url => MyRouter.HandleDeepLink(url));
 ```
 
 ### API surface (`PromptUGUI.Application.Modals`)
@@ -679,6 +691,18 @@ public static class InputBox {
         string cancelLabel = null,
         ModalMode mode     = ModalMode.Popup,
         Action<IScreen> configure = null);
+}
+
+public static class MarkdownBox {
+    public static string XmlSrc { get; set; } = "PromptUGUI/Modals/MarkdownBox.ui";
+    // Returns a non-generic Awaitable: completes when the box is closed
+    // (× button / backdrop click / ESC). No buttons can be configured.
+    public static Awaitable Open(
+        string markdown, string title = null,
+        Action<string> onLinkClicked = null,        // null → Application.OpenURL
+        ModalMode mode = ModalMode.Popup,
+        Action<IScreen> configure = null,
+        CancellationToken ct = default);
 }
 
 [Flags] public enum MsgBtn { None=0, OK=1, Cancel=2, Yes=4, No=8, Close=16 }
@@ -735,10 +759,16 @@ UI.Modal.SortingOrderBase` so dialogs opened during a Loading appear above it.
 - **Locale / Variant**: a dialog is a regular `Screen` — `UI.Locale.Set(...)` and
   `UI.Variants.Set(...)` ReSolve open modals in place, no rebuild. Fonts swap on locale
   switch like in any other Screen (`<Text font="title">` etc.).
+- **MarkdownBox** has no result value — it returns a non-generic `Awaitable` that
+  completes when the box closes. `title: null` hides the title row and the markdown area
+  expands to fill. The × close button always floats top-right above the content. To
+  resize the box, use `configure` (e.g. `s.Get<Controls.Image>("dialog")`…). Links
+  default to `Application.OpenURL`; pass a non-null `onLinkClicked` to fully replace
+  that behaviour.
 
 ### Customizing a builtin modal (the `configure` hook)
 
-Every builtin `Open` (`MessageBox` / `InputBox` / `Loading`) takes a trailing
+Every builtin `Open` (`MessageBox` / `InputBox` / `MarkdownBox` / `Loading`) takes a trailing
 `configure: Action<IScreen>`. It fires **once, right after the builtin Bind**, with the
 live modal `Screen` — so you reach any control via `screen.Get<T>(id)` and customize
 without writing a `ModalRequest<T>` subclass. Because it runs after Bind, it overrides

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -303,7 +303,7 @@ md.BindText(localizedMarkdownStream).AddTo(screen);  // reactive — re-renders 
 
 // Link clicks
 md.OnLinkClicked
-  .Subscribe(Application.OpenURL)
+  .Subscribe(url => UI.Markdown.HandleLink(url))
   .AddTo(screen);                               // fires with the raw url string; default does NOT open browser
 
 // Per-control style (null falls back to UI.Markdown.DefaultStyle)
@@ -325,7 +325,7 @@ UI.Markdown.ImageResolver = myResolver;         // global fallback resolver
 |---|---|
 | `md.Text { get; set; }` | Markdown source string. `set` triggers a full synchronous re-render of the subtree (text is immediate; images load async). `get` returns the last-set source. |
 | `md.BindText(Observable<string>)` | Subscribes to a stream and re-renders on each push. Returns `IDisposable` — always `.AddTo(screen)`. |
-| `md.OnLinkClicked` | `Observable<string>` — emits the raw `url` string from `[text](url)` when the user taps a link. Default: no-op. Wire to `Application.OpenURL` or your own router. |
+| `md.OnLinkClicked` | `Observable<string>` — emits the raw `url` string from `[text](url)` when the user taps a link. Default: no-op. Wire to `UI.Markdown.HandleLink` or your own router. |
 | `md.Style` | Per-control `MarkdownStyle` override. `null` = use `UI.Markdown.DefaultStyle`. |
 | `md.ImageResolver` | `Func<string, Awaitable<Texture2D>>` per-control image resolver. `null` = use `UI.Markdown.ImageResolver`. |
 | `UI.Markdown.Renderer` | `IMarkdownRenderer` — auto-set by `MarkdigBootstrap` when Markdig is installed. `null` = plain-text fallback. |
@@ -572,7 +572,7 @@ MODAL          var r = await MessageBox.Open(text, MsgBtn.OK|MsgBtn.Cancel, icon
                        // Enter respects ok.Interactable (disable ok → Enter gated too)
                await MarkdownBox.Open(markdown, title, onLinkClicked, mode, configure, ct)
                               // 无按钮富文本框(公告/邮件);×/点背景/ESC 三通道关闭,关闭即完成
-                              // onLinkClicked null → 链接默认 Application.OpenURL
+                              // onLinkClicked null → 链接默认 UI.Markdown.HandleLink
                await MarkdownBox.Open(loader, title, ...)  // loader: Func<CT,Awaitable<string>>
                               // 先显示 loadingText 占位,完成后热替换;关窗自动取消 loader 的 ct
                await MarkdownBox.OpenUrl(url, title, ...)  // 裸 GET 糖;鉴权内容用 Open(loader)
@@ -666,7 +666,7 @@ string pw = await InputBox.Open(UI.Tr("Enter password"),
 // closes via the × button, clicking the backdrop, or ESC. Completes when closed.
 await MarkdownBox.Open(noticeMarkdown, title: UI.Tr("Notice"));
 
-// Custom link routing (replaces the default Application.OpenURL):
+// Custom link routing (replaces the default UI.Markdown.HandleLink dispatch):
 await MarkdownBox.Open(mailBody, title: mail.Subject,
     onLinkClicked: url => MyRouter.HandleDeepLink(url));
 

--- a/Runtime/Application/Modals/MarkdownBoxRequest.cs
+++ b/Runtime/Application/Modals/MarkdownBoxRequest.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Threading;
 using R3;
+using UnityEngine.Networking;
 
 namespace PromptUGUI.Application.Modals
 {
@@ -8,6 +10,11 @@ namespace PromptUGUI.Application.Modals
         public string Text;                       // markdown 源文
         public string Title;                      // null/空 → 隐藏标题行
         public Action<string> OnLinkClicked;      // null → 默认 UI.Markdown.HandleLink
+
+        /// <summary>非 null 时忽略 <see cref="Text"/>:先显示 <see cref="LoadingText"/>,
+        /// loader 完成后热替换;关窗(任何通道)自动取消传入的 ct。</summary>
+        public Func<CancellationToken, UnityEngine.Awaitable<string>> Loader;
+        public string LoadingText = "*Loading…*";
 
         public override string XmlSrc => MarkdownBox.XmlSrc;
 
@@ -18,7 +25,19 @@ namespace PromptUGUI.Application.Modals
             else titleCtl.TextValue = Title;
 
             var md = screen.Get<PromptUGUI.Controls.Markdown>("markdown");
-            md.Text = Text ?? "";
+            if (Loader != null)
+            {
+                md.Text = LoadingText;
+                var cts = new CancellationTokenSource();
+                // 关窗(×/backdrop/ESC/外部 ct)→ Screen Dispose → 取消加载
+                Disposable.Create(() => cts.Cancel()).AddTo(screen);
+                _ = FillAsync(md, Loader, cts.Token);
+            }
+            else
+            {
+                md.Text = Text ?? "";
+            }
+
             // C#9:lambda 无自然委托类型,不能写 `OnLinkClicked ?? (url => ...)`,
             // 在订阅内分支即可。传了 OnLinkClicked 则完全接管,不叠加默认分发。
             var onLink = OnLinkClicked;
@@ -40,6 +59,31 @@ namespace PromptUGUI.Application.Modals
             result = true;   // 点背景都能关,ESC 行为一致
             return true;
         }
+
+        private static async UnityEngine.Awaitable FillAsync(
+            PromptUGUI.Controls.Markdown md,
+            Func<CancellationToken, UnityEngine.Awaitable<string>> loader,
+            CancellationToken ct)
+        {
+            string result;
+            try
+            {
+                result = await loader(ct);
+            }
+            catch (OperationCanceledException)
+            {
+                return;                              // 关窗正常路径
+            }
+            catch (Exception ex)
+            {
+                if (ct.IsCancellationRequested) return;
+                UnityEngine.Debug.LogWarning($"MarkdownBox loader failed: {ex.Message}");
+                md.Text = "**Failed to load.**\n\n" + ex.Message;
+                return;
+            }
+            if (ct.IsCancellationRequested) return;  // 迟到的结果:控件已销毁,不得触碰
+            md.Text = result;
+        }
     }
 
     public static class MarkdownBox
@@ -54,7 +98,7 @@ namespace PromptUGUI.Application.Modals
             Action<string> onLinkClicked = null,
             ModalMode mode = ModalMode.Popup,
             Action<IScreen> configure = null,
-            System.Threading.CancellationToken ct = default)
+            CancellationToken ct = default)
             => await UI.Modal.OpenAsync(new MarkdownBoxRequest
             {
                 Text = markdown,
@@ -62,5 +106,54 @@ namespace PromptUGUI.Application.Modals
                 OnLinkClicked = onLinkClicked,
                 Configure = configure,
             }, mode, ct);
+
+        /// <summary>延迟内容:先开窗显示占位 loading,loader 完成后热替换;
+        /// 关窗自动取消 loader 的 ct。鉴权内容用此重载走游戏自己的网络栈。</summary>
+        public static async UnityEngine.Awaitable Open(
+            Func<CancellationToken, UnityEngine.Awaitable<string>> loader,
+            string title = null,
+            Action<string> onLinkClicked = null,
+            string loadingText = null,
+            ModalMode mode = ModalMode.Popup,
+            Action<IScreen> configure = null,
+            CancellationToken ct = default)
+        {
+            var req = new MarkdownBoxRequest
+            {
+                Loader = loader,
+                Title = title,
+                OnLinkClicked = onLinkClicked,
+                Configure = configure,
+            };
+            if (loadingText != null) req.LoadingText = loadingText;
+            await UI.Modal.OpenAsync(req, mode, ct);
+        }
+
+        /// <summary>裸 GET 便捷重载(无鉴权;镜像 UseWebImageResolver 的取数模式)。</summary>
+        public static UnityEngine.Awaitable OpenUrl(
+            string url,
+            string title = null,
+            Action<string> onLinkClicked = null,
+            string loadingText = null,
+            ModalMode mode = ModalMode.Popup,
+            Action<IScreen> configure = null,
+            CancellationToken ct = default)
+            => Open(ct2 => FetchAsync(url, ct2),
+                title, onLinkClicked, loadingText, mode, configure, ct);
+
+        private static async UnityEngine.Awaitable<string> FetchAsync(
+            string url, CancellationToken ct)
+        {
+            using var req = UnityWebRequest.Get(url);
+            var op = req.SendWebRequest();
+            var acs = new UnityEngine.AwaitableCompletionSource<bool>();
+            op.completed += _ => acs.TrySetResult(true);
+            using var reg = ct.Register(() => req.Abort());
+            if (!op.isDone) await acs.Awaitable;
+            ct.ThrowIfCancellationRequested();
+            if (req.result != UnityWebRequest.Result.Success)
+                throw new InvalidOperationException($"{url}: {req.error}");
+            return req.downloadHandler.text;
+        }
     }
 }

--- a/Runtime/Application/Modals/MarkdownBoxRequest.cs
+++ b/Runtime/Application/Modals/MarkdownBoxRequest.cs
@@ -1,0 +1,66 @@
+using System;
+using R3;
+
+namespace PromptUGUI.Application.Modals
+{
+    public sealed class MarkdownBoxRequest : ModalRequest<bool>
+    {
+        public string Text;                       // markdown 源文
+        public string Title;                      // null/空 → 隐藏标题行
+        public Action<string> OnLinkClicked;      // null → 默认 Application.OpenURL
+
+        public override string XmlSrc => MarkdownBox.XmlSrc;
+
+        public override void Bind(IScreen screen, Action<bool> close)
+        {
+            var titleCtl = screen.Get<PromptUGUI.Controls.Text>("title");
+            if (string.IsNullOrEmpty(Title)) titleCtl.GameObject.SetActive(false);
+            else titleCtl.TextValue = Title;
+
+            var md = screen.Get<PromptUGUI.Controls.Markdown>("markdown");
+            md.Text = Text ?? "";
+            // C#9:lambda 无自然委托类型,不能写 `OnLinkClicked ?? (url => ...)`,
+            // 在订阅内分支即可。传了 OnLinkClicked 则完全接管,不叠加默认 OpenURL。
+            var onLink = OnLinkClicked;
+            md.OnLinkClicked.Subscribe(url =>
+            {
+                if (onLink != null) onLink(url);
+                else UnityEngine.Application.OpenURL(url);
+            }).AddTo(screen);
+
+            screen.Get<PromptUGUI.Controls.Btn>("close")
+                .OnClick.Subscribe(_ => close(true)).AddTo(screen);
+
+            screen.Get<PromptUGUI.Controls.Image>("backdrop")
+                .OnPointerDown.Subscribe(_ => close(true)).AddTo(screen);
+        }
+
+        public override bool TryEscape(out bool result)
+        {
+            result = true;   // 点背景都能关,ESC 行为一致
+            return true;
+        }
+    }
+
+    public static class MarkdownBox
+    {
+        // 必须带 .ui 后缀：Unity 只剥离 .ui.xml 文件名的最后 .xml。
+        public static string XmlSrc { get; set; } = "PromptUGUI/Modals/MarkdownBox.ui";
+
+        /// <summary>无按钮的富文本只读模态;关闭即完成(×/点背景/ESC 三通道)。</summary>
+        public static async UnityEngine.Awaitable Open(
+            string markdown,
+            string title = null,
+            Action<string> onLinkClicked = null,
+            ModalMode mode = ModalMode.Popup,
+            Action<IScreen> configure = null,
+            System.Threading.CancellationToken ct = default)
+            => await UI.Modal.OpenAsync(new MarkdownBoxRequest
+            {
+                Text = markdown,
+                Title = title,
+                OnLinkClicked = onLinkClicked,
+                Configure = configure,
+            }, mode, ct);
+    }
+}

--- a/Runtime/Application/Modals/MarkdownBoxRequest.cs
+++ b/Runtime/Application/Modals/MarkdownBoxRequest.cs
@@ -29,8 +29,18 @@ namespace PromptUGUI.Application.Modals
             {
                 md.Text = LoadingText;
                 var cts = new CancellationTokenSource();
-                // 关窗(×/backdrop/ESC/外部 ct)→ Screen Dispose → 取消加载
-                Disposable.Create(() => cts.Cancel()).AddTo(screen);
+                // 关窗(×/backdrop/ESC/外部 ct)→ Screen Dispose → 取消加载。
+                // Cancel 会同步重抛 ct.Register 回调里的用户异常,而 Screen.Close 的
+                // dispose 循环没有 try/catch——这里兜住,别让一个坏回调中断关窗。
+                Disposable.Create(() =>
+                {
+                    try { cts.Cancel(); }
+                    catch (Exception e)
+                    {
+                        UnityEngine.Debug.LogError($"MarkdownBox: loader cancel threw: {e}");
+                    }
+                    cts.Dispose();
+                }).AddTo(screen);
                 _ = FillAsync(md, Loader, cts.Token);
             }
             else
@@ -65,7 +75,8 @@ namespace PromptUGUI.Application.Modals
             Func<CancellationToken, UnityEngine.Awaitable<string>> loader,
             CancellationToken ct)
         {
-            string result;
+            string result = null;
+            string error = null;
             try
             {
                 result = await loader(ct);
@@ -78,11 +89,19 @@ namespace PromptUGUI.Application.Modals
             {
                 if (ct.IsCancellationRequested) return;
                 UnityEngine.Debug.LogWarning($"MarkdownBox loader failed: {ex.Message}");
-                md.Text = "**Failed to load.**\n\n" + ex.Message;
-                return;
+                error = "**Failed to load.**\n\n" + ex.Message;
             }
             if (ct.IsCancellationRequested) return;  // 迟到的结果:控件已销毁,不得触碰
-            md.Text = result;
+            // 渲染同步发生在 setter 里;调用点是 fire-and-forget,异常必须落日志
+            // (LogError 同时让 LogAssert 把"取消守卫失效误触已销毁控件"变成测试失败)。
+            try
+            {
+                md.Text = error ?? result;
+            }
+            catch (Exception ex)
+            {
+                UnityEngine.Debug.LogError($"MarkdownBox: render failed: {ex}");
+            }
         }
     }
 

--- a/Runtime/Application/Modals/MarkdownBoxRequest.cs
+++ b/Runtime/Application/Modals/MarkdownBoxRequest.cs
@@ -7,7 +7,7 @@ namespace PromptUGUI.Application.Modals
     {
         public string Text;                       // markdown 源文
         public string Title;                      // null/空 → 隐藏标题行
-        public Action<string> OnLinkClicked;      // null → 默认 Application.OpenURL
+        public Action<string> OnLinkClicked;      // null → 默认 UI.Markdown.HandleLink
 
         public override string XmlSrc => MarkdownBox.XmlSrc;
 
@@ -20,12 +20,12 @@ namespace PromptUGUI.Application.Modals
             var md = screen.Get<PromptUGUI.Controls.Markdown>("markdown");
             md.Text = Text ?? "";
             // C#9:lambda 无自然委托类型,不能写 `OnLinkClicked ?? (url => ...)`,
-            // 在订阅内分支即可。传了 OnLinkClicked 则完全接管,不叠加默认 OpenURL。
+            // 在订阅内分支即可。传了 OnLinkClicked 则完全接管,不叠加默认分发。
             var onLink = OnLinkClicked;
             md.OnLinkClicked.Subscribe(url =>
             {
                 if (onLink != null) onLink(url);
-                else UnityEngine.Application.OpenURL(url);
+                else UI.Markdown.HandleLink(url);
             }).AddTo(screen);
 
             screen.Get<PromptUGUI.Controls.Btn>("close")

--- a/Runtime/Application/Modals/MarkdownBoxRequest.cs.meta
+++ b/Runtime/Application/Modals/MarkdownBoxRequest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 32fda3d6499b87b4a919ddebc54cac6f

--- a/Runtime/Application/Modals/ModalRequest.cs
+++ b/Runtime/Application/Modals/ModalRequest.cs
@@ -13,7 +13,8 @@ namespace PromptUGUI.Application.Modals
         /// <see cref="IScreen"/>. Lets callers reach any control (disable the OK <c>Btn</c>, wire
         /// field validation, restyle, …) without subclassing. Runs after Bind so it overrides
         /// builtin wiring rather than being overwritten by it. The builtin <c>MessageBox.Open</c> /
-        /// <c>InputBox.Open</c> helpers expose it as a <c>configure</c> parameter.
+        /// <c>InputBox.Open</c> / <c>MarkdownBox.Open</c> / <c>Loading.Open</c> helpers expose it as
+        /// a <c>configure</c> parameter.
         /// </summary>
         public Action<IScreen> Configure;
 

--- a/Runtime/Application/UI.Markdown.cs
+++ b/Runtime/Application/UI.Markdown.cs
@@ -15,6 +15,37 @@ namespace PromptUGUI.Application
             public static MarkdownStyle DefaultStyle { get; set; } = MarkdownStyle.CreateDefault();
             public static Func<string, Awaitable<Texture2D>> ImageResolver { get; set; }
 
+            /// <summary>Default link policy for markdown links: a url carrying the configured
+            /// <see cref="UI.Router.Scheme"/> navigates via <see cref="UI.Router"/>; anything
+            /// else opens in the system browser. <c>MarkdownBox</c> uses this when no
+            /// <c>onLinkClicked</c> is given; standalone &lt;Markdown&gt; screens can call it
+            /// from their own <c>OnLinkClicked</c> subscription.</summary>
+            public static void HandleLink(string url)
+            {
+                if (string.IsNullOrEmpty(url)) return;
+                var scheme = UI.Router.Scheme;
+                if (!string.IsNullOrEmpty(scheme) &&
+                    url.StartsWith(scheme + "://", StringComparison.Ordinal))
+                {
+                    // 失败只 LogError,不回落 OpenURL——深链交给系统浏览器只会更糟。
+                    _ = NavigateLogged(url);
+                    return;
+                }
+                if (OpenUrlHookForTests != null) OpenUrlHookForTests(url);
+                else UnityEngine.Application.OpenURL(url);
+            }
+
+            internal static Action<string> OpenUrlHookForTests;
+
+            private static async Awaitable NavigateLogged(string url)
+            {
+                try { await UI.Router.Navigate(url); }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"HandleLink: navigate '{url}' failed: {ex.Message}");
+                }
+            }
+
             private static readonly Dictionary<string, Texture2D> WebCache = new Dictionary<string, Texture2D>();
 
             public static void UseWebImageResolver()
@@ -44,6 +75,7 @@ namespace PromptUGUI.Application
                 Renderer = null;            // re-injected by the gated asmdef via UI.OnReset (end of reset)
                 DefaultStyle = MarkdownStyle.CreateDefault();
                 ImageResolver = null;
+                OpenUrlHookForTests = null;
                 foreach (var t in WebCache.Values)
                     if (t != null)
                     {

--- a/Runtime/Resources/PromptUGUI/Modals/MarkdownBox.ui.xml
+++ b/Runtime/Resources/PromptUGUI/Modals/MarkdownBox.ui.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PromptUGUI version="1">
+  <Screen name="PromptUGUI/Modals/MarkdownBox.ui" reference="1920x1080" reference.portrait="1080x1920" >
+    <Image id="backdrop" anchor="stretch" color="#000000FE"/>
+
+    <Image id="dialog" sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round"
+           anchor="stretch" margin="160,480" margin.portrait="240,80">
+      <VStack anchor="stretch" margin="24" spacing="12">
+        <Text id="title" fontSize="24" height="40"/>
+        <Markdown id="markdown" width="stretch" height="stretch"/>
+      </VStack>
+      <Btn id="close" anchor="top-right" size="36x36" margin="12"
+           sprite="" color="#00000000" fontSize="28">×</Btn>
+    </Image>
+  </Screen>
+</PromptUGUI>

--- a/Runtime/Resources/PromptUGUI/Modals/MarkdownBox.ui.xml.meta
+++ b/Runtime/Resources/PromptUGUI/Modals/MarkdownBox.ui.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6d634aef3409fbf44aeb452158a00834
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Markdown/HandleLinkTests.cs
+++ b/Tests/EditMode/Markdown/HandleLinkTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.Markdown
+{
+    public class HandleLinkTests
+    {
+        private const string PageXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='p1'>
+  <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+</Screen></PromptUGUI>";
+
+        private List<string> _opened;
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            _opened = new List<string>();
+            UI.Markdown.OpenUrlHookForTests = url => _opened.Add(url);
+            var files = new Dictionary<string, string> { ["p1"] = PageXml };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+        }
+
+        [TearDown]
+        public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Scheme_match_navigates_via_router()
+        {
+            UI.Router.Scheme = "app";
+            UI.Router.Map("p1", "p1");
+            UI.Markdown.HandleLink("app://p1");
+            // EditMode 假 resolver 下 Navigate 同步完成,链路立即可断言
+            CollectionAssert.AreEqual(new[] { "p1" }, UI.Router.Chain.ToList());
+            Assert.IsEmpty(_opened);
+        }
+
+        [Test]
+        public void Other_urls_fall_back_to_open_url()
+        {
+            UI.Router.Scheme = "app";
+            UI.Markdown.HandleLink("https://example.com");
+            CollectionAssert.AreEqual(new[] { "https://example.com" }, _opened);
+        }
+
+        [Test]
+        public void No_scheme_configured_everything_falls_back()
+        {
+            UI.Router.Scheme = null;
+            UI.Markdown.HandleLink("app://p1");
+            CollectionAssert.AreEqual(new[] { "app://p1" }, _opened);
+        }
+
+        // scheme 命中但路由失败 → LogError,不回落系统浏览器(spec §4)
+        [Test]
+        public void Failed_navigation_logs_error_no_browser_fallback()
+        {
+            UI.Router.Scheme = "app";   // 不注册任何路由
+            LogAssert.Expect(UnityEngine.LogType.Error,
+                new System.Text.RegularExpressions.Regex("HandleLink"));
+            UI.Markdown.HandleLink("app://nope");
+            Assert.IsEmpty(_opened);
+        }
+    }
+}

--- a/Tests/EditMode/Markdown/HandleLinkTests.cs.meta
+++ b/Tests/EditMode/Markdown/HandleLinkTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 26bac7f62ff221b4e9e17bfe3ce3560d

--- a/Tests/EditMode/Modals/MarkdownBoxLoaderTests.cs
+++ b/Tests/EditMode/Modals/MarkdownBoxLoaderTests.cs
@@ -128,5 +128,13 @@ namespace PromptUGUI.Tests.Modals
             task.GetAwaiter().GetResult();
             Assert.IsFalse(UI.Modal.IsAnyOpen);
         }
+
+        [Test]
+        public void Facade_custom_loading_text_used()
+        {
+            var acs = new AwaitableCompletionSource<string>();
+            MarkdownBox.Open(_ => acs.Awaitable, loadingText: "请稍候");
+            Assert.AreEqual("请稍候", Md().Text);
+        }
     }
 }

--- a/Tests/EditMode/Modals/MarkdownBoxLoaderTests.cs
+++ b/Tests/EditMode/Modals/MarkdownBoxLoaderTests.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using System.Threading;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using UnityEngine;
+using UnityEngine.TestTools;
+using PBtn = PromptUGUI.Controls.Btn;
+using PMarkdown = PromptUGUI.Controls.Markdown;
+
+namespace PromptUGUI.Tests.Modals
+{
+    public class MarkdownBoxLoaderTests
+    {
+        private const string MdBoxXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/MdBox2'>
+    <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+    <Frame id='dialog' anchor='center' size='600x400'>
+      <VStack anchor='stretch' margin='16' spacing='8'>
+        <Text id='title' fontSize='20'/>
+        <Markdown id='markdown' width='stretch' height='stretch'/>
+      </VStack>
+      <Btn id='close' anchor='top-right' size='36x36'>×</Btn>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+
+        private Dictionary<string, string> _files;
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            _files = new Dictionary<string, string> { ["test/MdBox2"] = MdBoxXml };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(_files.TryGetValue(src, out var v) ? v : null);
+            MarkdownBox.XmlSrc = "test/MdBox2";
+        }
+
+        [TearDown]
+        public void TearDown() => UI.ResetForTests();
+
+        private static PMarkdown Md()
+            => UI.Modal.TopScreen.Get<PMarkdown>("markdown");
+
+        [Test]
+        public void Completed_loader_replaces_content_immediately()
+        {
+            UI.Modal.OpenAsync(new MarkdownBoxRequest
+            {
+                Loader = _ => AwaitableHelpers.Completed("# done"),
+            });
+            Assert.AreEqual("# done", Md().Text);
+        }
+
+        [Test]
+        public void Pending_loader_shows_loading_placeholder_then_result()
+        {
+            var acs = new AwaitableCompletionSource<string>();
+            UI.Modal.OpenAsync(new MarkdownBoxRequest { Loader = _ => acs.Awaitable });
+            Assert.AreEqual("*Loading…*", Md().Text);
+            acs.SetResult("# late");
+            Assert.AreEqual("# late", Md().Text);
+        }
+
+        [Test]
+        public void Custom_loading_text_used()
+        {
+            var acs = new AwaitableCompletionSource<string>();
+            UI.Modal.OpenAsync(new MarkdownBoxRequest
+            {
+                Loader = _ => acs.Awaitable,
+                LoadingText = "稍候…",
+            });
+            Assert.AreEqual("稍候…", Md().Text);
+        }
+
+        // 关窗 → loader 的 ct 取消;迟到的完成不得触碰已销毁控件(EditMode 是
+        // DestroyImmediate,真触碰会抛)——本测试无异常即证明守卫生效。
+        [Test]
+        public void Close_cancels_loader_and_late_result_is_ignored()
+        {
+            CancellationToken seen = default;
+            var acs = new AwaitableCompletionSource<string>();
+            var task = UI.Modal.OpenAsync(new MarkdownBoxRequest
+            {
+                Loader = ct => { seen = ct; return acs.Awaitable; },
+            });
+            UI.Modal.TopScreen.Get<PBtn>("close").SimulateClick();
+            task.GetAwaiter().GetResult();
+            Assert.IsTrue(seen.IsCancellationRequested);
+            acs.SetResult("# late");   // 恢复 FillAsync;ct 守卫使其直接 return
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+
+        [Test]
+        public void Loader_failure_shows_error_markdown()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("MarkdownBox loader failed"));
+            UI.Modal.OpenAsync(new MarkdownBoxRequest
+            {
+                Loader = _ => throw new System.InvalidOperationException("boom"),
+            });
+            StringAssert.StartsWith("**Failed to load.**", Md().Text);
+            StringAssert.Contains("boom", Md().Text);
+        }
+
+        [Test]
+        public void Loader_wins_over_text()
+        {
+            UI.Modal.OpenAsync(new MarkdownBoxRequest
+            {
+                Text = "ignored",
+                Loader = _ => AwaitableHelpers.Completed("# loaded"),
+            });
+            Assert.AreEqual("# loaded", Md().Text);
+        }
+
+        [Test]
+        public void Facade_open_loader_overload_works()
+        {
+            var task = MarkdownBox.Open(
+                _ => AwaitableHelpers.Completed("# f"), title: "T");
+            Assert.AreEqual("# f", Md().Text);
+            UI.Modal.TopScreen.Get<PBtn>("close").SimulateClick();
+            task.GetAwaiter().GetResult();
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+    }
+}

--- a/Tests/EditMode/Modals/MarkdownBoxLoaderTests.cs.meta
+++ b/Tests/EditMode/Modals/MarkdownBoxLoaderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d45a817a3836b304c90dbfd6899500ee

--- a/Tests/EditMode/Modals/MarkdownBoxTests.cs
+++ b/Tests/EditMode/Modals/MarkdownBoxTests.cs
@@ -152,5 +152,16 @@ namespace PromptUGUI.Tests.Modals
             UI.Modal.TopScreen.Get<PBtn>("close").SimulateClick();
             Assert.IsTrue(task.GetAwaiter().GetResult());
         }
+
+        // 第一个带 margin.portrait 的内置模态:开着公告翻转横竖屏,ReSolve 不得动运行时状态。
+        [Test]
+        public void Variant_flip_keeps_text_and_hidden_title()
+        {
+            MarkdownBox.XmlSrc = "PromptUGUI/Modals/MarkdownBox.ui";
+            UI.Modal.OpenAsync(new MarkdownBoxRequest { Text = "# T" });   // no Title
+            UI.Variants.Set("portrait", true);   // triggers ReSolve
+            Assert.AreEqual("# T", Md().Text);
+            Assert.IsFalse(UI.Modal.TopScreen.Get<PText>("title").GameObject.activeSelf);
+        }
     }
 }

--- a/Tests/EditMode/Modals/MarkdownBoxTests.cs
+++ b/Tests/EditMode/Modals/MarkdownBoxTests.cs
@@ -163,5 +163,16 @@ namespace PromptUGUI.Tests.Modals
             Assert.AreEqual("# T", Md().Text);
             Assert.IsFalse(UI.Modal.TopScreen.Get<PText>("title").GameObject.activeSelf);
         }
+
+        // 默认链接行为 = UI.Markdown.HandleLink(spec 2026-06-10-markdown-box-loader §5)
+        [Test]
+        public void Default_link_handler_routes_through_HandleLink()
+        {
+            var opened = new List<string>();
+            UI.Markdown.OpenUrlHookForTests = url => opened.Add(url);
+            UI.Modal.OpenAsync(new MarkdownBoxRequest { Text = "x" });
+            Md().RaiseLinkClickedForTests("https://x");
+            CollectionAssert.AreEqual(new[] { "https://x" }, opened);
+        }
     }
 }

--- a/Tests/EditMode/Modals/MarkdownBoxTests.cs
+++ b/Tests/EditMode/Modals/MarkdownBoxTests.cs
@@ -141,5 +141,16 @@ namespace PromptUGUI.Tests.Modals
                 () => task.GetAwaiter().GetResult());
             Assert.IsFalse(UI.Modal.IsAnyOpen);
         }
+
+        [Test]
+        public void Default_xml_src_loads_builtin_template()
+        {
+            MarkdownBox.XmlSrc = "PromptUGUI/Modals/MarkdownBox.ui";
+            var task = UI.Modal.OpenAsync(new MarkdownBoxRequest { Text = "# T", Title = "公告" });
+            Assert.AreEqual("# T", Md().Text);
+            Assert.IsTrue(UI.Modal.TopScreen.Get<PText>("title").GameObject.activeSelf);
+            UI.Modal.TopScreen.Get<PBtn>("close").SimulateClick();
+            Assert.IsTrue(task.GetAwaiter().GetResult());
+        }
     }
 }

--- a/Tests/EditMode/Modals/MarkdownBoxTests.cs
+++ b/Tests/EditMode/Modals/MarkdownBoxTests.cs
@@ -1,0 +1,145 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using UnityEngine.EventSystems;
+using PBtn = PromptUGUI.Controls.Btn;
+using PImage = PromptUGUI.Controls.Image;
+using PMarkdown = PromptUGUI.Controls.Markdown;
+using PText = PromptUGUI.Controls.Text;
+
+namespace PromptUGUI.Tests.Modals
+{
+    public class MarkdownBoxTests
+    {
+        private const string MdBoxXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/MdBox1'>
+    <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+    <Frame id='dialog' anchor='center' size='600x400'>
+      <VStack anchor='stretch' margin='16' spacing='8'>
+        <Text id='title' fontSize='20'/>
+        <Markdown id='markdown' width='stretch' height='stretch'/>
+      </VStack>
+      <Btn id='close' anchor='top-right' size='36x36'>×</Btn>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+
+        private Dictionary<string, string> _files;
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            _files = new Dictionary<string, string> { ["test/MdBox1"] = MdBoxXml };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(_files.TryGetValue(src, out var v) ? v : null);
+            MarkdownBox.XmlSrc = "test/MdBox1";
+        }
+
+        [TearDown]
+        public void TearDown() => UI.ResetForTests();
+
+        private static PMarkdown Md()
+            => UI.Modal.TopScreen.Get<PMarkdown>("markdown");
+
+        [Test]
+        public void Open_sets_markdown_source_text()
+        {
+            UI.Modal.OpenAsync(new MarkdownBoxRequest { Text = "# Hello\nworld" });
+            Assert.AreEqual("# Hello\nworld", Md().Text);
+        }
+
+        [Test]
+        public void Null_title_hides_title_node()
+        {
+            UI.Modal.OpenAsync(new MarkdownBoxRequest { Text = "body" });
+            Assert.IsFalse(UI.Modal.TopScreen.Get<PText>("title").GameObject.activeSelf);
+        }
+
+        [Test]
+        public void Title_present_shows_title_with_text()
+        {
+            UI.Modal.OpenAsync(new MarkdownBoxRequest { Text = "body", Title = "公告" });
+            var title = UI.Modal.TopScreen.Get<PText>("title");
+            Assert.IsTrue(title.GameObject.activeSelf);
+            Assert.AreEqual("公告", title.TmpComponent.text);
+        }
+
+        [Test]
+        public void Click_close_btn_completes_and_closes()
+        {
+            var task = UI.Modal.OpenAsync(new MarkdownBoxRequest { Text = "body" });
+            UI.Modal.TopScreen.Get<PBtn>("close").SimulateClick();
+            Assert.IsTrue(task.GetAwaiter().GetResult());
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+
+        [Test]
+        public void Backdrop_pointer_down_closes()
+        {
+            var task = UI.Modal.OpenAsync(new MarkdownBoxRequest { Text = "body" });
+            var backdrop = UI.Modal.TopScreen.Get<PImage>("backdrop");
+            ExecuteEvents.Execute(backdrop.GameObject,
+                new PointerEventData(EventSystem.current),
+                ExecuteEvents.pointerDownHandler);
+            Assert.IsTrue(task.GetAwaiter().GetResult());
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+
+        [Test]
+        public void TryEscape_returns_true()
+        {
+            var req = new MarkdownBoxRequest { Text = "body" };
+            Assert.IsTrue(req.TryEscape(out var r));
+            Assert.IsTrue(r);
+        }
+
+        // ESC 走真实管线:pump → ModalEscapeListener → TryEscape → close。
+        [Test]
+        public void Escape_via_listener_closes()
+        {
+            var task = UI.Modal.OpenAsync(new MarkdownBoxRequest { Text = "body" });
+            var listener = UI.Modal.TopScreen
+                .RootGameObject.GetComponent<ModalEscapeListener>();
+            Assert.IsNotNull(listener);
+            listener.FireForTests();
+            Assert.IsTrue(task.GetAwaiter().GetResult());
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+
+        [Test]
+        public void Custom_onLinkClicked_receives_url()
+        {
+            string captured = null;
+            UI.Modal.OpenAsync(new MarkdownBoxRequest
+            {
+                Text = "[a](https://example.com)",
+                OnLinkClicked = url => captured = url,
+            });
+            Md().RaiseLinkClickedForTests("https://example.com");
+            Assert.AreEqual("https://example.com", captured);
+        }
+
+        [Test]
+        public void Static_Open_completes_on_close()
+        {
+            var task = MarkdownBox.Open("body", title: "T");
+            UI.Modal.TopScreen.Get<PBtn>("close").SimulateClick();
+            task.GetAwaiter().GetResult();   // 非泛型 Awaitable,不抛即通过
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+
+        [Test]
+        public void Cancel_via_ct_throws_OperationCanceled()
+        {
+            var cts = new System.Threading.CancellationTokenSource();
+            var task = MarkdownBox.Open("body", ct: cts.Token);
+            cts.Cancel();
+            Assert.Throws<System.OperationCanceledException>(
+                () => task.GetAwaiter().GetResult());
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+    }
+}

--- a/Tests/EditMode/Modals/MarkdownBoxTests.cs.meta
+++ b/Tests/EditMode/Modals/MarkdownBoxTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1dc54b905d2a3df458ca7c0a6909dbd8

--- a/docs~/superpowers/plans/2026-06-10-markdown-box-loader.md
+++ b/docs~/superpowers/plans/2026-06-10-markdown-box-loader.md
@@ -1,0 +1,709 @@
+# MarkdownBox 延迟内容加载 + HandleLink Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** MarkdownBox 支持"先开窗显示 Loading → 内容到达热替换 → 关窗自动取消加载"(`Open(loader)` / `OpenUrl` 糖),并新增 `UI.Markdown.HandleLink` 默认链接分发(Router scheme → `Router.Navigate`,否则 `Application.OpenURL`),MarkdownBox 默认链接行为切到它。
+
+**Architecture:** 加载生命周期全部收进 `MarkdownBoxRequest`:`Loader` 字段非 null 时 Bind 先显示 `LoadingText`,建 CTS 并挂 Screen 销毁钩子(关窗任何通道→自动取消),fire-and-forget `FillAsync` 完成后热替换(`Markdown.Text` setter 自带重渲染,带取消守卫防触碰已销毁控件)。`OpenUrl` = `Open(loader)` + 内置 `UnityWebRequest` fetcher(镜像 `UI.Markdown.LoadWebTextureAsync` 的 ACS 模式 + `ct.Register(req.Abort)`)。`HandleLink` 放 `UI.Markdown`(与 `DefaultStyle`/`ImageResolver` 同层)。
+
+**Tech Stack:** Unity 6 uGUI、R3、Unity `Awaitable`/`AwaitableCompletionSource`(禁 .NET `Task`)、`UnityWebRequest`(WebGL 安全)、NUnit EditMode(UnityMCP)、C# 9。
+
+**Spec:** `docs~/superpowers/specs/2026-06-10-markdown-box-loader-design.md`
+**分支:** 直接在 `feat/markdown-box-modal`(PR #64)上继续,不开新分支。
+
+**文件总览:**
+
+| 动作 | 路径 | 职责 |
+|---|---|---|
+| Create | `Tests/EditMode/Markdown/HandleLinkTests.cs` | HandleLink 分发测试(4) |
+| Modify | `Runtime/Application/UI.Markdown.cs` | `HandleLink` + `OpenUrlHookForTests` + reset |
+| Create | `Tests/EditMode/Modals/MarkdownBoxLoaderTests.cs` | Loader 生命周期 + 门面测试(7) |
+| Modify | `Runtime/Application/Modals/MarkdownBoxRequest.cs` | `Loader`/`LoadingText`/`FillAsync` + `Open(loader)`/`OpenUrl`/`FetchAsync` + 默认链接改 `HandleLink` |
+| Modify | `.claude/skills/scripting-promptugui-csharp/SKILL.md` | 新 API 文档 |
+
+约定提醒(执行者零上下文必读):
+
+- 每次改完 C# 源码:`mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)` → `mcp__UnityMCP__read_console(action="get", types=["error"])` 零错误后再跑测试。MCP 工具先 `ToolSearch(query="select:mcp__UnityMCP__refresh_unity,mcp__UnityMCP__read_console,mcp__UnityMCP__run_tests,mcp__UnityMCP__get_test_job", max_results=4)` 加载(select 须全名)。
+- `run_tests` 异步:拿 `job_id` 轮询 `get_test_job`;按类过滤用 `group_names=[...]`。
+- 新文件 commit 必须带 Unity 生成的 `.meta`(refresh 后出现)。
+- C# 9:lambda 无自然委托类型;禁 .NET `Task`。
+- 禁止提交 main;工作分支 `feat/markdown-box-modal`。
+- commit message 末尾带 `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`。
+
+---
+
+### Task 1: `UI.Markdown.HandleLink`(红→绿)
+
+**Files:**
+- Create: `Tests/EditMode/Markdown/HandleLinkTests.cs`
+- Modify: `Runtime/Application/UI.Markdown.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+`Tests/EditMode/Markdown/HandleLinkTests.cs`,完整内容:
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.Markdown
+{
+    public class HandleLinkTests
+    {
+        private const string PageXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='p1'>
+  <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+</Screen></PromptUGUI>";
+
+        private List<string> _opened;
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            _opened = new List<string>();
+            UI.Markdown.OpenUrlHookForTests = url => _opened.Add(url);
+            var files = new Dictionary<string, string> { ["p1"] = PageXml };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+        }
+
+        [TearDown]
+        public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Scheme_match_navigates_via_router()
+        {
+            UI.Router.Scheme = "app";
+            UI.Router.Map("p1", "p1");
+            UI.Markdown.HandleLink("app://p1");
+            // EditMode 假 resolver 下 Navigate 同步完成,链路立即可断言
+            CollectionAssert.AreEqual(new[] { "p1" }, UI.Router.Chain.ToList());
+            Assert.IsEmpty(_opened);
+        }
+
+        [Test]
+        public void Other_urls_fall_back_to_open_url()
+        {
+            UI.Router.Scheme = "app";
+            UI.Markdown.HandleLink("https://example.com");
+            CollectionAssert.AreEqual(new[] { "https://example.com" }, _opened);
+        }
+
+        [Test]
+        public void No_scheme_configured_everything_falls_back()
+        {
+            UI.Router.Scheme = null;
+            UI.Markdown.HandleLink("app://p1");
+            CollectionAssert.AreEqual(new[] { "app://p1" }, _opened);
+        }
+
+        // scheme 命中但路由失败 → LogError,不回落系统浏览器(spec §4)
+        [Test]
+        public void Failed_navigation_logs_error_no_browser_fallback()
+        {
+            UI.Router.Scheme = "app";   // 不注册任何路由
+            LogAssert.Expect(UnityEngine.LogType.Error,
+                new System.Text.RegularExpressions.Regex("HandleLink"));
+            UI.Markdown.HandleLink("app://nope");
+            Assert.IsEmpty(_opened);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: refresh,确认红 = 编译错误**
+
+Expected: CS0117 `UI.Markdown` 不含 `OpenUrlHookForTests` / `HandleLink`。其他错误(usings/typo)修测试文件自身。
+
+- [ ] **Step 3: 实现**
+
+`Runtime/Application/UI.Markdown.cs`:在 `UseWebImageResolver()` 方法之前插入(类内任意稳定位置均可,建议紧跟 `ImageResolver` 属性之后):
+
+```csharp
+            /// <summary>Default link policy for markdown links: a url carrying the configured
+            /// <see cref="UI.Router.Scheme"/> navigates via <see cref="UI.Router"/>; anything
+            /// else opens in the system browser. <c>MarkdownBox</c> uses this when no
+            /// <c>onLinkClicked</c> is given; standalone &lt;Markdown&gt; screens can call it
+            /// from their own <c>OnLinkClicked</c> subscription.</summary>
+            public static void HandleLink(string url)
+            {
+                if (string.IsNullOrEmpty(url)) return;
+                var scheme = UI.Router.Scheme;
+                if (!string.IsNullOrEmpty(scheme) &&
+                    url.StartsWith(scheme + "://", StringComparison.Ordinal))
+                {
+                    // 失败只 LogError,不回落 OpenURL——深链交给系统浏览器只会更糟。
+                    _ = NavigateLogged(url);
+                    return;
+                }
+                if (OpenUrlHookForTests != null) OpenUrlHookForTests(url);
+                else UnityEngine.Application.OpenURL(url);
+            }
+
+            internal static Action<string> OpenUrlHookForTests;
+
+            private static async Awaitable NavigateLogged(string url)
+            {
+                try { await UI.Router.Navigate(url); }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"HandleLink: navigate '{url}' failed: {ex.Message}");
+                }
+            }
+```
+
+并在 `ResetForTestsInternal()` 里加一行(`Renderer = null;` 之后):
+
+```csharp
+                OpenUrlHookForTests = null;
+```
+
+- [ ] **Step 4: refresh + 跑 HandleLinkTests,绿**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["HandleLinkTests"])
+```
+
+Expected: 4/4 PASS。
+
+- [ ] **Step 5: lint**
+
+```bash
+cd /workspace-PromptUGUI/.lint && dotnet restore PromptUGUI.Lint.slnx && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+Expected: 退出 0。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Tests/EditMode/Markdown/HandleLinkTests.cs Tests/EditMode/Markdown/HandleLinkTests.cs.meta Runtime/Application/UI.Markdown.cs
+git commit -m "feat: UI.Markdown.HandleLink 默认链接分发(Router scheme 联动)"
+```
+
+---
+
+### Task 2: MarkdownBox 默认链接行为切到 HandleLink
+
+**Files:**
+- Modify: `Tests/EditMode/Modals/MarkdownBoxTests.cs`(追加 1 测试)
+- Modify: `Runtime/Application/Modals/MarkdownBoxRequest.cs`(Bind 内 1 行)
+
+**TDD 例外说明**:本任务跳过"先看红"——失败路径是真调 `Application.OpenURL`,红跑一次会在开发机上弹真浏览器。规格由绿断言 + 一行 diff 评审兜底。
+
+- [ ] **Step 1: 追加测试**
+
+`Tests/EditMode/Modals/MarkdownBoxTests.cs` 类尾部追加:
+
+```csharp
+        // 默认链接行为 = UI.Markdown.HandleLink(spec 2026-06-10-markdown-box-loader §5)
+        [Test]
+        public void Default_link_handler_routes_through_HandleLink()
+        {
+            var opened = new List<string>();
+            UI.Markdown.OpenUrlHookForTests = url => opened.Add(url);
+            UI.Modal.OpenAsync(new MarkdownBoxRequest { Text = "x" });
+            Md().RaiseLinkClickedForTests("https://x");
+            CollectionAssert.AreEqual(new[] { "https://x" }, opened);
+        }
+```
+
+(`List<string>` 的 using 已存在;hook 由 `UI.ResetForTests` 在 TearDown 清空。)
+
+- [ ] **Step 2: 改默认行为**
+
+`Runtime/Application/Modals/MarkdownBoxRequest.cs` 的 `Bind` 内,把:
+
+```csharp
+            // C#9:lambda 无自然委托类型,不能写 `OnLinkClicked ?? (url => ...)`,
+            // 在订阅内分支即可。传了 OnLinkClicked 则完全接管,不叠加默认 OpenURL。
+            var onLink = OnLinkClicked;
+            md.OnLinkClicked.Subscribe(url =>
+            {
+                if (onLink != null) onLink(url);
+                else UnityEngine.Application.OpenURL(url);
+            }).AddTo(screen);
+```
+
+改为:
+
+```csharp
+            // C#9:lambda 无自然委托类型,不能写 `OnLinkClicked ?? (url => ...)`,
+            // 在订阅内分支即可。传了 OnLinkClicked 则完全接管,不叠加默认分发。
+            var onLink = OnLinkClicked;
+            md.OnLinkClicked.Subscribe(url =>
+            {
+                if (onLink != null) onLink(url);
+                else UI.Markdown.HandleLink(url);
+            }).AddTo(screen);
+```
+
+同时把字段注释 `public Action<string> OnLinkClicked;      // null → 默认 Application.OpenURL` 改为 `// null → 默认 UI.Markdown.HandleLink`。
+
+- [ ] **Step 3: refresh + 跑 MarkdownBoxTests,绿**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["MarkdownBoxTests"])
+```
+
+Expected: 13/13 PASS(原 12 + 新 1)。
+
+- [ ] **Step 4: lint 后 Commit**
+
+```bash
+cd /workspace-PromptUGUI/.lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+git add Tests/EditMode/Modals/MarkdownBoxTests.cs Runtime/Application/Modals/MarkdownBoxRequest.cs
+git commit -m "feat: MarkdownBox 默认链接行为改走 UI.Markdown.HandleLink"
+```
+
+---
+
+### Task 3: Loader 红测试
+
+**Files:**
+- Create: `Tests/EditMode/Modals/MarkdownBoxLoaderTests.cs`
+
+- [ ] **Step 1: 写失败测试**(完整内容)
+
+```csharp
+using System.Collections.Generic;
+using System.Threading;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using UnityEngine;
+using UnityEngine.TestTools;
+using PBtn = PromptUGUI.Controls.Btn;
+using PMarkdown = PromptUGUI.Controls.Markdown;
+
+namespace PromptUGUI.Tests.Modals
+{
+    public class MarkdownBoxLoaderTests
+    {
+        private const string MdBoxXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/MdBox2'>
+    <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+    <Frame id='dialog' anchor='center' size='600x400'>
+      <VStack anchor='stretch' margin='16' spacing='8'>
+        <Text id='title' fontSize='20'/>
+        <Markdown id='markdown' width='stretch' height='stretch'/>
+      </VStack>
+      <Btn id='close' anchor='top-right' size='36x36'>×</Btn>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+
+        private Dictionary<string, string> _files;
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            _files = new Dictionary<string, string> { ["test/MdBox2"] = MdBoxXml };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(_files.TryGetValue(src, out var v) ? v : null);
+            MarkdownBox.XmlSrc = "test/MdBox2";
+        }
+
+        [TearDown]
+        public void TearDown() => UI.ResetForTests();
+
+        private static PMarkdown Md()
+            => UI.Modal.TopScreen.Get<PMarkdown>("markdown");
+
+        [Test]
+        public void Completed_loader_replaces_content_immediately()
+        {
+            UI.Modal.OpenAsync(new MarkdownBoxRequest
+            {
+                Loader = _ => AwaitableHelpers.Completed("# done"),
+            });
+            Assert.AreEqual("# done", Md().Text);
+        }
+
+        [Test]
+        public void Pending_loader_shows_loading_placeholder_then_result()
+        {
+            var acs = new AwaitableCompletionSource<string>();
+            UI.Modal.OpenAsync(new MarkdownBoxRequest { Loader = _ => acs.Awaitable });
+            Assert.AreEqual("*Loading…*", Md().Text);
+            acs.SetResult("# late");
+            Assert.AreEqual("# late", Md().Text);
+        }
+
+        [Test]
+        public void Custom_loading_text_used()
+        {
+            var acs = new AwaitableCompletionSource<string>();
+            UI.Modal.OpenAsync(new MarkdownBoxRequest
+            {
+                Loader = _ => acs.Awaitable,
+                LoadingText = "稍候…",
+            });
+            Assert.AreEqual("稍候…", Md().Text);
+        }
+
+        // 关窗 → loader 的 ct 取消;迟到的完成不得触碰已销毁控件(EditMode 是
+        // DestroyImmediate,真触碰会抛)——本测试无异常即证明守卫生效。
+        [Test]
+        public void Close_cancels_loader_and_late_result_is_ignored()
+        {
+            CancellationToken seen = default;
+            var acs = new AwaitableCompletionSource<string>();
+            var task = UI.Modal.OpenAsync(new MarkdownBoxRequest
+            {
+                Loader = ct => { seen = ct; return acs.Awaitable; },
+            });
+            UI.Modal.TopScreen.Get<PBtn>("close").SimulateClick();
+            task.GetAwaiter().GetResult();
+            Assert.IsTrue(seen.IsCancellationRequested);
+            acs.SetResult("# late");   // 恢复 FillAsync;ct 守卫使其直接 return
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+
+        [Test]
+        public void Loader_failure_shows_error_markdown()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("MarkdownBox loader failed"));
+            UI.Modal.OpenAsync(new MarkdownBoxRequest
+            {
+                Loader = _ => throw new System.InvalidOperationException("boom"),
+            });
+            StringAssert.StartsWith("**Failed to load.**", Md().Text);
+            StringAssert.Contains("boom", Md().Text);
+        }
+
+        [Test]
+        public void Loader_wins_over_text()
+        {
+            UI.Modal.OpenAsync(new MarkdownBoxRequest
+            {
+                Text = "ignored",
+                Loader = _ => AwaitableHelpers.Completed("# loaded"),
+            });
+            Assert.AreEqual("# loaded", Md().Text);
+        }
+
+        [Test]
+        public void Facade_open_loader_overload_works()
+        {
+            var task = MarkdownBox.Open(
+                _ => AwaitableHelpers.Completed("# f"), title: "T");
+            Assert.AreEqual("# f", Md().Text);
+            UI.Modal.TopScreen.Get<PBtn>("close").SimulateClick();
+            task.GetAwaiter().GetResult();
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: refresh,确认红 = 编译错误**
+
+Expected: CS0117/CS1061 —— `MarkdownBoxRequest` 不含 `Loader`/`LoadingText`,`MarkdownBox.Open` 无该重载。测试文件自身错误(usings/typo)就地修。
+
+- [ ] **Step 3: Commit(红测试单独入库)**
+
+```bash
+git add Tests/EditMode/Modals/MarkdownBoxLoaderTests.cs Tests/EditMode/Modals/MarkdownBoxLoaderTests.cs.meta
+git commit -m "test: MarkdownBox Loader 生命周期红测试"
+```
+
+---
+
+### Task 4: 实现 Loader / FillAsync / Open(loader) / OpenUrl
+
+**Files:**
+- Modify: `Runtime/Application/Modals/MarkdownBoxRequest.cs`
+
+- [ ] **Step 1: 文件头部 usings**
+
+确保有(新增 `System.Threading` 与 `UnityEngine.Networking`):
+
+```csharp
+using System;
+using System.Threading;
+using R3;
+using UnityEngine.Networking;
+```
+
+- [ ] **Step 2: Request 字段与 Bind**
+
+`MarkdownBoxRequest` 字段区追加:
+
+```csharp
+        /// <summary>非 null 时忽略 <see cref="Text"/>:先显示 <see cref="LoadingText"/>,
+        /// loader 完成后热替换;关窗(任何通道)自动取消传入的 ct。</summary>
+        public Func<CancellationToken, UnityEngine.Awaitable<string>> Loader;
+        public string LoadingText = "*Loading…*";
+```
+
+`Bind` 中把 `md.Text = Text ?? "";` 一行替换为:
+
+```csharp
+            if (Loader != null)
+            {
+                md.Text = LoadingText;
+                var cts = new CancellationTokenSource();
+                // 关窗(×/backdrop/ESC/外部 ct)→ Screen Dispose → 取消加载
+                Disposable.Create(() => cts.Cancel()).AddTo(screen);
+                _ = FillAsync(md, Loader, cts.Token);
+            }
+            else
+            {
+                md.Text = Text ?? "";
+            }
+```
+
+(`Disposable.Create` 来自 R3。若所用 R3 版本缺失该工厂,用下面的等价私有类替代,行为相同:
+
+```csharp
+        private sealed class CancelOnDispose : IDisposable
+        {
+            private readonly CancellationTokenSource _cts;
+            public CancelOnDispose(CancellationTokenSource cts) => _cts = cts;
+            public void Dispose() => _cts.Cancel();
+        }
+        // 用法:new CancelOnDispose(cts).AddTo(screen);
+```
+)
+
+- [ ] **Step 3: FillAsync**
+
+`MarkdownBoxRequest` 类内追加:
+
+```csharp
+        private static async UnityEngine.Awaitable FillAsync(
+            PromptUGUI.Controls.Markdown md,
+            Func<CancellationToken, UnityEngine.Awaitable<string>> loader,
+            CancellationToken ct)
+        {
+            string result;
+            try
+            {
+                result = await loader(ct);
+            }
+            catch (OperationCanceledException)
+            {
+                return;                              // 关窗正常路径
+            }
+            catch (Exception ex)
+            {
+                if (ct.IsCancellationRequested) return;
+                UnityEngine.Debug.LogWarning($"MarkdownBox loader failed: {ex.Message}");
+                md.Text = "**Failed to load.**\n\n" + ex.Message;
+                return;
+            }
+            if (ct.IsCancellationRequested) return;  // 迟到的结果:控件已销毁,不得触碰
+            md.Text = result;
+        }
+```
+
+- [ ] **Step 4: 静态门面重载**
+
+`MarkdownBox` 静态类内,在既有 `Open(string markdown, ...)` 之后追加:
+
+```csharp
+        /// <summary>延迟内容:先开窗显示占位 loading,loader 完成后热替换;
+        /// 关窗自动取消 loader 的 ct。鉴权内容用此重载走游戏自己的网络栈。</summary>
+        public static async UnityEngine.Awaitable Open(
+            Func<CancellationToken, UnityEngine.Awaitable<string>> loader,
+            string title = null,
+            Action<string> onLinkClicked = null,
+            string loadingText = null,
+            ModalMode mode = ModalMode.Popup,
+            Action<IScreen> configure = null,
+            CancellationToken ct = default)
+        {
+            var req = new MarkdownBoxRequest
+            {
+                Loader = loader,
+                Title = title,
+                OnLinkClicked = onLinkClicked,
+                Configure = configure,
+            };
+            if (loadingText != null) req.LoadingText = loadingText;
+            await UI.Modal.OpenAsync(req, mode, ct);
+        }
+
+        /// <summary>裸 GET 便捷重载(无鉴权;镜像 UseWebImageResolver 的取数模式)。</summary>
+        public static UnityEngine.Awaitable OpenUrl(
+            string url,
+            string title = null,
+            Action<string> onLinkClicked = null,
+            string loadingText = null,
+            ModalMode mode = ModalMode.Popup,
+            Action<IScreen> configure = null,
+            CancellationToken ct = default)
+            => Open(ct2 => FetchAsync(url, ct2),
+                title, onLinkClicked, loadingText, mode, configure, ct);
+
+        private static async UnityEngine.Awaitable<string> FetchAsync(
+            string url, CancellationToken ct)
+        {
+            using var req = UnityWebRequest.Get(url);
+            var op = req.SendWebRequest();
+            var acs = new UnityEngine.AwaitableCompletionSource<bool>();
+            op.completed += _ => acs.TrySetResult(true);
+            using var reg = ct.Register(() => req.Abort());
+            if (!op.isDone) await acs.Awaitable;
+            ct.ThrowIfCancellationRequested();
+            if (req.result != UnityWebRequest.Result.Success)
+                throw new InvalidOperationException($"{url}: {req.error}");
+            return req.downloadHandler.text;
+        }
+```
+
+- [ ] **Step 5: refresh + 零编译错误 + 跑两个类,全绿**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["MarkdownBoxLoaderTests"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["MarkdownBoxTests"])
+```
+
+Expected: 7/7 + 13/13 PASS。
+
+- [ ] **Step 6: lint**
+
+```bash
+cd /workspace-PromptUGUI/.lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+Expected: 退出 0。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Runtime/Application/Modals/MarkdownBoxRequest.cs
+git commit -m "feat: MarkdownBox Loader 延迟加载 + OpenUrl 裸 GET 重载"
+```
+
+---
+
+### Task 5: C# SKILL 文档更新
+
+**Files:**
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md`(按内容定位,英文为主,cheatsheet 内中文注释沿用现状)
+
+- [ ] **Step 1: cheatsheet MODAL 块**,在已有 `await MarkdownBox.Open(markdown, title, onLinkClicked, mode, configure, ct)` 三行之后追加:
+
+```
+               await MarkdownBox.Open(loader, title, ...)  // loader: Func<CT,Awaitable<string>>
+                              // 先显示 loadingText 占位,完成后热替换;关窗自动取消 loader 的 ct
+               await MarkdownBox.OpenUrl(url, title, ...)  // 裸 GET 糖;鉴权内容用 Open(loader)
+```
+
+- [ ] **Step 2: `### Quick usage`** 的 MarkdownBox 例子后追加:
+
+```csharp
+// Deferred content: opens immediately showing "*Loading…*", swaps in the markdown
+// when the fetch completes, and cancels the fetch if the user closes the box first.
+await MarkdownBox.OpenUrl("https://cdn.example.com/notice.md", title: UI.Tr("Notice"));
+
+// Authenticated content: bring your own loader (the ct is cancelled on close).
+await MarkdownBox.Open(ct => Api.FetchMailBodyAsync(mailId, ct), title: mail.Subject);
+```
+
+- [ ] **Step 3: `### API surface`** 的 `MarkdownBox` 块替换为(补两个重载 + LoadingText 语义):
+
+```csharp
+public static class MarkdownBox {
+    public static string XmlSrc { get; set; } = "PromptUGUI/Modals/MarkdownBox.ui";
+    // Returns a non-generic Awaitable: completes when the box is closed
+    // (× button / backdrop click / ESC). No buttons can be configured.
+    public static Awaitable Open(
+        string markdown, string title = null,
+        Action<string> onLinkClicked = null,        // null → UI.Markdown.HandleLink
+        ModalMode mode = ModalMode.Popup,
+        Action<IScreen> configure = null,
+        CancellationToken ct = default);
+    // Deferred content: shows loadingText (default "*Loading…*") until loader
+    // completes, then hot-swaps. The loader's ct is cancelled when the box closes
+    // (any channel). Loader errors render "**Failed to load.**" + message — catch
+    // inside your loader to customize.
+    public static Awaitable Open(
+        Func<CancellationToken, Awaitable<string>> loader, string title = null,
+        Action<string> onLinkClicked = null, string loadingText = null,
+        ModalMode mode = ModalMode.Popup, Action<IScreen> configure = null,
+        CancellationToken ct = default);
+    // Plain unauthenticated GET sugar over Open(loader).
+    public static Awaitable OpenUrl(string url, /* same trailing params */);
+}
+```
+
+- [ ] **Step 4: `### Behavior`** 的 MarkdownBox 条目里,把链接默认行为句改为指向 `UI.Markdown.HandleLink`(原文是 "Links default to `Application.OpenURL`; pass a non-null `onLinkClicked` to fully replace that behaviour."),改为:
+
+```
+Links default to `UI.Markdown.HandleLink` (see below); pass a non-null `onLinkClicked` to fully replace that behaviour.
+```
+
+- [ ] **Step 5: `### Markdown`(C# bridge 一节)或 Behavior 附近**追加 HandleLink 条目(放在与 `UI.Markdown.DefaultStyle` / `UseWebImageResolver` 相邻的位置):
+
+```markdown
+**`UI.Markdown.HandleLink(string url)`** — the default link policy, also usable from
+your own `OnLinkClicked` subscriptions on standalone `<Markdown>` screens. If
+`UI.Router.Scheme` is set and the url starts with `<Scheme>://`, it navigates via
+`UI.Router.Navigate` (failures are logged, NOT handed to the system browser);
+everything else goes to `Application.OpenURL`. Note this changed MarkdownBox's default:
+with a Router scheme configured, deep links inside markdown now navigate instead of
+opening a browser. Want `.md` links to open nested MarkdownBoxes? That's one line:
+`onLinkClicked: url => { if (url.EndsWith(".md")) _ = MarkdownBox.OpenUrl(url); else UI.Markdown.HandleLink(url); }`
+```
+
+- [ ] **Step 6: cheatsheet MARKDOWN 区**(若有 `UI.Markdown.*` 行)补一行:
+
+```
+               UI.Markdown.HandleLink(url)      // 默认链接分发:Router scheme → Navigate,否则 OpenURL
+```
+
+- [ ] **Step 7: 通读 6 处插入点上下文无破损后 Commit**
+
+```bash
+git add .claude/skills/scripting-promptugui-csharp/SKILL.md
+git commit -m "docs(skill): MarkdownBox Open(loader)/OpenUrl + UI.Markdown.HandleLink"
+```
+
+---
+
+### Task 6: 全量回归 + 推送更新 PR #64
+
+**Files:** 无新改动(验证任务)
+
+- [ ] **Step 1: 全量测试**(三套顺序跑,逐个等 job 完成)
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])
+```
+
+Expected: 全 PASS(EditMode 基线 1512 + 新 12 ≈ 1524;EditorOnly 183;PlayMode 132;以实跑为准)。
+
+- [ ] **Step 2: lint 终验**
+
+```bash
+cd /workspace-PromptUGUI/.lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+cd /workspace-PromptUGUI && dotnet run --project .lint/UIXmlLint -- Runtime/Resources/
+```
+
+- [ ] **Step 3: 推送 + 更新 PR 描述**
+
+```bash
+git push
+gh pr view 64 --json body -q .body   # 取现有 body
+# 在 Summary 末尾追加 loader/HandleLink 两条要点,并在 Test Plan 勾选项里更新测试计数,然后:
+gh pr edit 64 --body "<更新后的完整 body>"
+```
+
+追加的 Summary 要点(措辞可微调):
+
+```
+- 延迟内容加载:`MarkdownBox.Open(loader)` 先显示占位 Loading、完成热替换、关窗自动取消;`OpenUrl(url)` 裸 GET 糖(镜像 UseWebImageResolver 模式 + ct.Register(Abort))
+- `UI.Markdown.HandleLink` 默认链接分发:Router scheme 命中 → `Router.Navigate`(失败 LogError 不回落浏览器),否则 `Application.OpenURL`;MarkdownBox 默认链接行为切到它(设计文档 `2026-06-10-markdown-box-loader-design.md`)
+```

--- a/docs~/superpowers/plans/2026-06-10-markdown-box-modal.md
+++ b/docs~/superpowers/plans/2026-06-10-markdown-box-modal.md
@@ -1,0 +1,494 @@
+# MarkdownBox 内置模态 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增第 4 个内置模态 `MarkdownBox.Open(markdown, title, ...)` —— 无按钮的富文本只读显示框(公告/邮件),三通道关闭(右上角 ×、点 backdrop、ESC)。
+
+**Architecture:** 完全复用 `ModalRequest<T>` / `UI.Modal.OpenAsync` 管线(零改动):新增 `MarkdownBoxRequest : ModalRequest<bool>` + 静态 `MarkdownBox` 门面 + 内置 XML `Runtime/Resources/PromptUGUI/Modals/MarkdownBox.ui.xml`。内容区是现成的 `<Markdown>` 控件(自带 ScrollRect / `OnLinkClicked` / 图片 resolver 兜底)。
+
+**Tech Stack:** Unity 6 uGUI、R3、Unity `Awaitable`(禁 .NET `Task`)、NUnit EditMode(UnityMCP 跑)、C# 9(`.lint` LangVersion 限制——**不可用 C#10 的 lambda 自然委托类型**)。
+
+**Spec:** `docs~/superpowers/specs/2026-06-10-markdown-box-modal-design.md`
+
+**文件总览:**
+
+| 动作 | 路径 | 职责 |
+|---|---|---|
+| Create | `Tests/EditMode/Modals/MarkdownBoxTests.cs` | 全部 EditMode 测试 |
+| Create | `Runtime/Application/Modals/MarkdownBoxRequest.cs` | Request + 静态门面 |
+| Create | `Runtime/Resources/PromptUGUI/Modals/MarkdownBox.ui.xml` | 内置布局 XML |
+| Modify | `.claude/skills/scripting-promptugui-csharp/SKILL.md` | 内置模态文档 + cheatsheet |
+
+约定提醒(执行者零上下文必读):
+
+- 每次改完 C# 源码:`mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)` → `mcp__UnityMCP__read_console(action="get", types=["error"])` 确认零编译错误,再跑测试。
+- `run_tests` 是异步的:拿到 `job_id` 后轮询 `mcp__UnityMCP__get_test_job(job_id=...)` 直到完成。过滤单个测试类用 `group_names=["MarkdownBoxTests"]`。
+- Unity 会为每个新文件生成 `.meta` sidecar —— **每次 commit 必须把 .meta 一起 add**(refresh 之后才会出现)。
+- 仓库规则:禁止提交到 main;当前工作分支为 `feat/markdown-box-modal`。
+
+---
+
+### Task 1: 红测试 — MarkdownBoxTests.cs
+
+**Files:**
+- Create: `Tests/EditMode/Modals/MarkdownBoxTests.cs`
+
+测试模式仿照 `Tests/EditMode/Modals/InputBoxTests.cs`:fake resolver 注册最小 XML、`XmlSrc` 指过去、`UI.ResetForTests()` 进出各一次。要点:
+
+- backdrop 点击用 `ExecuteEvents.Execute(..., pointerDownHandler)` 派发 —— `Image.OnPointerDown` 的订阅会让控件挂上 `PointerEventRelay`(实现 `IPointerDownHandler`)。
+- 自定义链接路由用 `Markdown.RaiseLinkClickedForTests`(internal,`InternalsVisibleTo` 已开)。
+- `MarkdownBox.Open` 返回**非泛型** `Awaitable`,`GetAwaiter().GetResult()` 无返回值;直接走 `UI.Modal.OpenAsync(new MarkdownBoxRequest...)` 的测试拿 `Awaitable<bool>`。
+- 关闭按钮 id 是 `close`,与 MessageBox 的 `close` 按钮同名但语义独立(本模态无 MsgBtn 概念)。
+
+- [ ] **Step 1: 写失败测试**
+
+```csharp
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using UnityEngine.EventSystems;
+using PBtn = PromptUGUI.Controls.Btn;
+using PImage = PromptUGUI.Controls.Image;
+using PMarkdown = PromptUGUI.Controls.Markdown;
+using PText = PromptUGUI.Controls.Text;
+
+namespace PromptUGUI.Tests.Modals
+{
+    public class MarkdownBoxTests
+    {
+        private const string MdBoxXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/MdBox1'>
+    <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+    <Frame id='dialog' anchor='center' size='600x400'>
+      <VStack anchor='stretch' margin='16' spacing='8'>
+        <Text id='title' fontSize='20'/>
+        <Markdown id='markdown' width='stretch' height='stretch'/>
+      </VStack>
+      <Btn id='close' anchor='top-right' size='36x36'>×</Btn>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+
+        private Dictionary<string, string> _files;
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            _files = new Dictionary<string, string> { ["test/MdBox1"] = MdBoxXml };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(_files.TryGetValue(src, out var v) ? v : null);
+            MarkdownBox.XmlSrc = "test/MdBox1";
+        }
+
+        [TearDown]
+        public void TearDown() => UI.ResetForTests();
+
+        private static PMarkdown Md()
+            => UI.Modal.TopScreen.Get<PMarkdown>("markdown");
+
+        [Test]
+        public void Open_sets_markdown_source_text()
+        {
+            UI.Modal.OpenAsync(new MarkdownBoxRequest { Text = "# Hello\nworld" });
+            Assert.AreEqual("# Hello\nworld", Md().Text);
+        }
+
+        [Test]
+        public void Null_title_hides_title_node()
+        {
+            UI.Modal.OpenAsync(new MarkdownBoxRequest { Text = "body" });
+            Assert.IsFalse(UI.Modal.TopScreen.Get<PText>("title").GameObject.activeSelf);
+        }
+
+        [Test]
+        public void Title_present_shows_title_with_text()
+        {
+            UI.Modal.OpenAsync(new MarkdownBoxRequest { Text = "body", Title = "公告" });
+            var title = UI.Modal.TopScreen.Get<PText>("title");
+            Assert.IsTrue(title.GameObject.activeSelf);
+            Assert.AreEqual("公告", title.TmpComponent.text);
+        }
+
+        [Test]
+        public void Click_close_btn_completes_and_closes()
+        {
+            var task = UI.Modal.OpenAsync(new MarkdownBoxRequest { Text = "body" });
+            UI.Modal.TopScreen.Get<PBtn>("close").SimulateClick();
+            Assert.IsTrue(task.GetAwaiter().GetResult());
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+
+        [Test]
+        public void Backdrop_pointer_down_closes()
+        {
+            var task = UI.Modal.OpenAsync(new MarkdownBoxRequest { Text = "body" });
+            var backdrop = UI.Modal.TopScreen.Get<PImage>("backdrop");
+            ExecuteEvents.Execute(backdrop.GameObject,
+                new PointerEventData(EventSystem.current),
+                ExecuteEvents.pointerDownHandler);
+            Assert.IsTrue(task.GetAwaiter().GetResult());
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+
+        [Test]
+        public void TryEscape_returns_true()
+        {
+            var req = new MarkdownBoxRequest { Text = "body" };
+            Assert.IsTrue(req.TryEscape(out var r));
+            Assert.IsTrue(r);
+        }
+
+        // ESC 走真实管线:pump → ModalEscapeListener → TryEscape → close。
+        [Test]
+        public void Escape_via_listener_closes()
+        {
+            var task = UI.Modal.OpenAsync(new MarkdownBoxRequest { Text = "body" });
+            var listener = UI.Modal.TopScreen
+                .RootGameObject.GetComponent<ModalEscapeListener>();
+            Assert.IsNotNull(listener);
+            listener.FireForTests();
+            Assert.IsTrue(task.GetAwaiter().GetResult());
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+
+        [Test]
+        public void Custom_onLinkClicked_receives_url()
+        {
+            string captured = null;
+            UI.Modal.OpenAsync(new MarkdownBoxRequest
+            {
+                Text = "[a](https://example.com)",
+                OnLinkClicked = url => captured = url,
+            });
+            Md().RaiseLinkClickedForTests("https://example.com");
+            Assert.AreEqual("https://example.com", captured);
+        }
+
+        [Test]
+        public void Static_Open_completes_on_close()
+        {
+            var task = MarkdownBox.Open("body", title: "T");
+            UI.Modal.TopScreen.Get<PBtn>("close").SimulateClick();
+            task.GetAwaiter().GetResult();   // 非泛型 Awaitable,不抛即通过
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+
+        [Test]
+        public void Cancel_via_ct_throws_OperationCanceled()
+        {
+            var cts = new System.Threading.CancellationTokenSource();
+            var task = MarkdownBox.Open("body", ct: cts.Token);
+            cts.Cancel();
+            Assert.Throws<System.OperationCanceledException>(
+                () => task.GetAwaiter().GetResult());
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: refresh,确认红 = 编译错误**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: CS0246 `MarkdownBoxRequest` / `MarkdownBox` 不存在 —— 这就是本任务的红状态(编译失败即测试失败)。
+
+- [ ] **Step 3: Commit(红测试单独入库)**
+
+```bash
+git add Tests/EditMode/Modals/MarkdownBoxTests.cs Tests/EditMode/Modals/MarkdownBoxTests.cs.meta
+git commit -m "test: MarkdownBox 内置模态红测试"
+```
+
+(`.meta` 由 Step 2 的 refresh 生成;若没生成则再 refresh 一次。)
+
+---
+
+### Task 2: 实现 MarkdownBoxRequest + 静态门面
+
+**Files:**
+- Create: `Runtime/Application/Modals/MarkdownBoxRequest.cs`
+
+- [ ] **Step 1: 写实现**
+
+```csharp
+using System;
+using R3;
+
+namespace PromptUGUI.Application.Modals
+{
+    public sealed class MarkdownBoxRequest : ModalRequest<bool>
+    {
+        public string Text;                       // markdown 源文
+        public string Title;                      // null/空 → 隐藏标题行
+        public Action<string> OnLinkClicked;      // null → 默认 Application.OpenURL
+
+        public override string XmlSrc => MarkdownBox.XmlSrc;
+
+        public override void Bind(IScreen screen, Action<bool> close)
+        {
+            var titleCtl = screen.Get<PromptUGUI.Controls.Text>("title");
+            if (string.IsNullOrEmpty(Title)) titleCtl.GameObject.SetActive(false);
+            else titleCtl.TextValue = Title;
+
+            var md = screen.Get<PromptUGUI.Controls.Markdown>("markdown");
+            md.Text = Text ?? "";
+            // C#9:lambda 无自然委托类型,不能写 `OnLinkClicked ?? (url => ...)`,
+            // 在订阅内分支即可。传了 OnLinkClicked 则完全接管,不叠加默认 OpenURL。
+            var onLink = OnLinkClicked;
+            md.OnLinkClicked.Subscribe(url =>
+            {
+                if (onLink != null) onLink(url);
+                else UnityEngine.Application.OpenURL(url);
+            }).AddTo(screen);
+
+            screen.Get<PromptUGUI.Controls.Btn>("close")
+                .OnClick.Subscribe(_ => close(true)).AddTo(screen);
+
+            screen.Get<PromptUGUI.Controls.Image>("backdrop")
+                .OnPointerDown.Subscribe(_ => close(true)).AddTo(screen);
+        }
+
+        public override bool TryEscape(out bool result)
+        {
+            result = true;   // 点背景都能关,ESC 行为一致
+            return true;
+        }
+    }
+
+    public static class MarkdownBox
+    {
+        // 必须带 .ui 后缀：Unity 只剥离 .ui.xml 文件名的最后 .xml。
+        public static string XmlSrc { get; set; } = "PromptUGUI/Modals/MarkdownBox.ui";
+
+        /// <summary>无按钮的富文本只读模态;关闭即完成(×/点背景/ESC 三通道)。</summary>
+        public static async UnityEngine.Awaitable Open(
+            string markdown,
+            string title = null,
+            Action<string> onLinkClicked = null,
+            ModalMode mode = ModalMode.Popup,
+            Action<IScreen> configure = null,
+            System.Threading.CancellationToken ct = default)
+            => await UI.Modal.OpenAsync(new MarkdownBoxRequest
+            {
+                Text = markdown,
+                Title = title,
+                OnLinkClicked = onLinkClicked,
+                Configure = configure,
+            }, mode, ct);
+    }
+}
+```
+
+- [ ] **Step 2: refresh + 零编译错误**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+Expected: 无 error。
+
+- [ ] **Step 3: 跑 MarkdownBoxTests,全绿**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["MarkdownBoxTests"])
+mcp__UnityMCP__get_test_job(job_id=...)   # 轮询到完成
+```
+
+Expected: 10/10 PASS。
+
+- [ ] **Step 4: lint**
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+Expected: 退出码 0。若有 whitespace/style 报修,跑 `dotnet format whitespace PromptUGUI.Lint.slnx` 后复验。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Application/Modals/MarkdownBoxRequest.cs Runtime/Application/Modals/MarkdownBoxRequest.cs.meta
+git commit -m "feat: MarkdownBoxRequest + MarkdownBox.Open 静态门面"
+```
+
+---
+
+### Task 3: 内置 XML + builtin 加载测试
+
+**Files:**
+- Create: `Runtime/Resources/PromptUGUI/Modals/MarkdownBox.ui.xml`
+- Modify: `Tests/EditMode/Modals/MarkdownBoxTests.cs`(追加 1 个测试)
+
+- [ ] **Step 1: 追加 builtin 红测试**
+
+加到 `MarkdownBoxTests` 类尾部(仿 `LoadingBuiltinTests`;`PromptUGUI/` 前缀走 `ModalSourceLoader` 的 Resources 同步分支,不经 fake resolver):
+
+```csharp
+        [Test]
+        public void Default_xml_src_loads_builtin_template()
+        {
+            MarkdownBox.XmlSrc = "PromptUGUI/Modals/MarkdownBox.ui";
+            var task = UI.Modal.OpenAsync(new MarkdownBoxRequest { Text = "# T", Title = "公告" });
+            Assert.AreEqual("# T", Md().Text);
+            Assert.IsTrue(UI.Modal.TopScreen.Get<PText>("title").GameObject.activeSelf);
+            UI.Modal.TopScreen.Get<PBtn>("close").SimulateClick();
+            Assert.IsTrue(task.GetAwaiter().GetResult());
+        }
+```
+
+- [ ] **Step 2: refresh + 跑该测试,确认失败**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["MarkdownBoxTests"])
+```
+
+Expected: 该测试 FAIL,`InvalidOperationException: Builtin modal XML missing at Resources/PromptUGUI/Modals/MarkdownBox.ui.xml`。
+
+- [ ] **Step 3: 写内置 XML**
+
+`Runtime/Resources/PromptUGUI/Modals/MarkdownBox.ui.xml`(margin 双分量 = `上下,左右`;× 按钮透明背景须 `sprite=""` **加** `color="#00000000"`,alpha 0 仍接收 raycast;字形用 Latin-1 `×` U+00D7,默认 TMP 字体不含 `✕` U+2715):
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<PromptUGUI version="1">
+  <Screen name="PromptUGUI/Modals/MarkdownBox.ui" reference="1920x1080" reference.portrait="1080x1920" >
+    <Image id="backdrop" anchor="stretch" color="#000000FE"/>
+
+    <Image id="dialog" sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round"
+           anchor="stretch" margin="160,480" margin.portrait="240,80">
+      <VStack anchor="stretch" margin="24" spacing="12">
+        <Text id="title" fontSize="24" height="40"/>
+        <Markdown id="markdown" width="stretch" height="stretch"/>
+      </VStack>
+      <Btn id="close" anchor="top-right" size="36x36" margin="12"
+           sprite="" color="#00000000" fontSize="28">×</Btn>
+    </Image>
+  </Screen>
+</PromptUGUI>
+```
+
+- [ ] **Step 4: XML lint**
+
+```bash
+dotnet run --project .lint/UIXmlLint -- Runtime/Resources/PromptUGUI/Modals/MarkdownBox.ui.xml
+```
+
+Expected: 退出码 0、无 error。(VStack 子节点只用了 `width`/`height`,没有非法 `anchor`/`margin`;× 按钮挂在非 layout-group 的 `dialog` 下,`anchor="top-right"` 合法。)
+
+- [ ] **Step 5: refresh + 跑全类,绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["MarkdownBoxTests"])
+```
+
+Expected: 11/11 PASS。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Runtime/Resources/PromptUGUI/Modals/MarkdownBox.ui.xml Runtime/Resources/PromptUGUI/Modals/MarkdownBox.ui.xml.meta Tests/EditMode/Modals/MarkdownBoxTests.cs
+git commit -m "feat: MarkdownBox 内置布局 XML(stretch+margin 自适应,× 浮层)"
+```
+
+---
+
+### Task 4: SKILL 文档更新
+
+**Files:**
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md`
+
+公开 C# API 新增 ⇒ 按 CLAUDE.md 必须同 PR 更新 C# skill。XML skill 不动(内置模态 XML 非作者可写面)。改四处(行号以当前 main 为准,执行时用内容定位):
+
+- [ ] **Step 1: cheatsheet MODAL 块**(`var s = await InputBox.Open(...)` 之后)追加:
+
+```
+               await MarkdownBox.Open(markdown, title, onLinkClicked, mode, configure, ct)
+                              // 无按钮富文本框(公告/邮件);×/点背景/ESC 三通道关闭,关闭即完成
+                              // onLinkClicked null → 链接默认 Application.OpenURL
+```
+
+- [ ] **Step 2: `## Modal dialogs` 开头一段**,把内置清单从三个改四个(在提到 `MessageBox` / `InputBox` / `Loading` 的句子里补 `MarkdownBox`,一句话描述:no-button rich-text viewer for announcements/mail, built on the `<Markdown>` control)。
+
+- [ ] **Step 3: `### Quick usage`** 追加示例:
+
+```csharp
+// MarkdownBox: read-only rich-text viewer (announcements / mail). No buttons;
+// closes via the × button, clicking the backdrop, or ESC. Completes when closed.
+await MarkdownBox.Open(noticeMarkdown, title: UI.Tr("Notice"));
+
+// Custom link routing (replaces the default Application.OpenURL):
+await MarkdownBox.Open(mailBody, title: mail.Subject,
+    onLinkClicked: url => MyRouter.HandleDeepLink(url));
+```
+
+- [ ] **Step 4: `### API surface`** 在 `InputBox` 块后追加:
+
+```csharp
+public static class MarkdownBox {
+    public static string XmlSrc { get; set; } = "PromptUGUI/Modals/MarkdownBox.ui";
+    // Returns a non-generic Awaitable: completes when the box is closed
+    // (× button / backdrop click / ESC). No buttons can be configured.
+    public static Awaitable Open(
+        string markdown, string title = null,
+        Action<string> onLinkClicked = null,        // null → Application.OpenURL
+        ModalMode mode = ModalMode.Popup,
+        Action<IScreen> configure = null,
+        CancellationToken ct = default);
+}
+```
+
+并在 `### Behavior` 一节补一行:MarkdownBox has no result value — title null hides the title row (the `<Markdown>` area expands to fill), the × close button always floats top-right above the content. Resize via `configure` (e.g. `s.Get<Controls.Image>("dialog")`…)。
+
+- [ ] **Step 5: `configure` 钩子那句** "Every builtin `Open` (`MessageBox` / `InputBox` / `Loading`)" 补上 `MarkdownBox`。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .claude/skills/scripting-promptugui-csharp/SKILL.md
+git commit -m "docs(skill): MarkdownBox 内置模态 API"
+```
+
+---
+
+### Task 5: 全量回归 + 收尾验证
+
+**Files:** 无新改动(验证任务)
+
+- [ ] **Step 1: 全量测试**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])
+```
+
+Expected: 全部 PASS(EditMode 基线 1496+11 新增;EditorOnly 183;PlayMode 132 —— 以实跑为准)。失败优先怀疑 Unity MCP flake(未保存场景/挂起),重跑或让用户重启 Unity 后再判定。
+
+- [ ] **Step 2: lint 终验**
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+dotnet run --project .lint/UIXmlLint -- Runtime/Resources/
+```
+
+Expected: 双零退出。
+
+- [ ] **Step 3: 控制台无残留 error**
+
+```
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+
+- [ ] **Step 4: 收尾**
+
+全绿后用 superpowers:finishing-a-development-branch 技能走分支收尾(推送 + 开 PR 到 main;本仓库禁止直接提交 main)。PR 描述引用 spec `docs~/superpowers/specs/2026-06-10-markdown-box-modal-design.md`,并提请用户做视觉 QA(横竖屏 margin、× 浮层与滚动区重叠、链接点击)。

--- a/docs~/superpowers/specs/2026-06-10-markdown-box-loader-design.md
+++ b/docs~/superpowers/specs/2026-06-10-markdown-box-loader-design.md
@@ -1,0 +1,133 @@
+# MarkdownBox 延迟内容加载 + 默认链接分发
+
+**日期**:2026-06-10
+**状态**:设计阶段(待 review,未进入实施)
+**作用域**:扩展 `MarkdownBox`(同分支 PR #64):(1) 延迟内容加载——先开窗显示占位 Loading,内容到达后热替换,关窗自动取消加载;(2) `OpenUrl` 裸 GET 便捷重载;(3) `UI.Markdown.HandleLink` 默认链接分发(Router scheme 联动),并成为 `MarkdownBoxRequest` 的默认链接行为。
+**关联**:叠加在 [`2026-06-10-markdown-box-modal-design.md`](2026-06-10-markdown-box-modal-design.md) 之上(同一 feature 分支/同一 PR);Router 联动建立在 [`2026-06-09-router-navigation-design.md`](2026-06-09-router-navigation-design.md) 的 `UI.Router.Navigate(url)` / `Router.Scheme` 之上,不改 Router。公开 C# API 新增,`scripting-promptugui-csharp` 必须更新(见 §8);XML skill 不动。
+
+---
+
+## 1. 背景与目标
+
+公告/邮件的 markdown 源文通常在服务器上。浏览器式体验是:**立即开窗显示 Loading → 下载完成热替换 → 用户关窗则取消下载**。这套生命周期(configure 时序、销毁守卫、取消方向)每个接 CDN 的游戏都要写、且容易写错,应进库。同时,markdown 里的链接目前默认裸 `Application.OpenURL`——对配置了 `Router.Scheme` 的游戏,`appid://` 深链会被错误地丢给系统浏览器,需要一个正确的默认分发。
+
+明确不做(上轮讨论已定):
+
+- `.md` 后缀自动嵌套打开 → **不做默认**(启发式易误判:签名 URL 带 query、API 路径无后缀;且隐含裸 GET 绕过鉴权)。游戏一行自定义:`onLinkClicked: url => url.EndsWith(".md") ? MarkdownBox.OpenUrl(url) : UI.Markdown.HandleLink(url)`。
+- `OpenUrl` 不加自定义 headers/鉴权参数——需要鉴权的内容走 `Open(loader)`,用游戏自己的网络栈。
+- 错误展示不参数化——loader 内自行 catch 并返回错误 markdown 即可定制。
+
+## 2. `MarkdownBoxRequest` 扩展(生命周期核心)
+
+```csharp
+public sealed class MarkdownBoxRequest : ModalRequest<bool>
+{
+    public string Text;                                      // 既有
+    public Func<CancellationToken, Awaitable<string>> Loader; // 新:非 null 时忽略 Text
+    public string LoadingText = "*Loading…*";                // 新:占位 markdown
+    // Title / OnLinkClicked / XmlSrc / TryEscape 不变
+}
+```
+
+`Bind` 中 `Loader != null` 时:
+
+1. `md.Text = LoadingText`(占位即一段普通 markdown);
+2. 建 `CancellationTokenSource`,`Disposable.Create(cts.Cancel).AddTo(screen)` —— **关窗(×/backdrop/ESC/外部 ct,任何通道)→ Screen Dispose → 自动取消加载**。Queued 模式排队时 Bind 尚未发生 → 真正上屏才开始加载,时序天然正确;
+3. fire-and-forget `FillAsync(md, Loader, cts.Token)`:
+   - 成功 → `md.Text = 结果`(热替换,`Markdown.Text` setter 自带重渲染);
+   - `OperationCanceledException` → 静默返回(关窗正常路径,**不得再触碰已销毁的控件**);
+   - 其他异常 → `Debug.LogWarning` + `md.Text = "**Failed to load.**\n\n" + ex.Message`(若此刻未取消)。
+
+`Loader` 与 `Text` 同时设置时 Loader 胜出(Text 被忽略),文档注明;不抛错。
+
+## 3. 静态门面新重载
+
+```csharp
+public static async Awaitable Open(
+    Func<CancellationToken, Awaitable<string>> loader,
+    string title = null,
+    Action<string> onLinkClicked = null,
+    string loadingText = null,                // null → 默认 "*Loading…*"
+    ModalMode mode = ModalMode.Popup,
+    Action<IScreen> configure = null,
+    CancellationToken ct = default);
+
+public static Awaitable OpenUrl(
+    string url, /* 同上,无 loader 参 */)
+    => Open(ct2 => FetchAsync(url, ct2), ...);
+```
+
+`FetchAsync`(private,`MarkdownBoxRequest.cs` 内)镜像 `UI.Markdown.LoadWebTextureAsync` 的既有模式(`UnityWebRequest.Get` + `AwaitableCompletionSource` + `op.completed`,WebGL 安全、无线程),加取消:
+
+```csharp
+using var req = UnityWebRequest.Get(url);
+var op = req.SendWebRequest();
+var acs = new AwaitableCompletionSource<bool>();
+op.completed += _ => acs.TrySetResult(true);
+using var reg = ct.Register(() => req.Abort());
+if (!op.isDone) await acs.Awaitable;
+ct.ThrowIfCancellationRequested();
+if (req.result != UnityWebRequest.Result.Success)
+    throw new InvalidOperationException($"{url}: {req.error}");
+return req.downloadHandler.text;
+```
+
+不做内容缓存(公告/邮件每次开窗重新拉是合理默认;要缓存的游戏在自己 loader 里做)。
+
+## 4. `UI.Markdown.HandleLink(string url)`(默认链接分发)
+
+放在 `UI.Markdown`(决策点 a):它是 markdown 子系统的链接政策,独立 `<Markdown>` 页面订阅 `OnLinkClicked` 时同样可用,与 `DefaultStyle` / `ImageResolver` 同层级。
+
+```csharp
+public static void HandleLink(string url)
+{
+    var scheme = UI.Router.Scheme;
+    if (!string.IsNullOrEmpty(scheme) &&
+        url.StartsWith(scheme + "://", StringComparison.Ordinal))
+        _ = NavigateLogged(url);          // try/catch + Debug.LogError,仿 HotReload 模式
+    else
+        UnityEngine.Application.OpenURL(url);
+}
+```
+
+- `Router.Scheme` 未设置 → 一切走 `OpenURL`(Router 未启用,库无意见)。
+- scheme 命中但路由解析失败(`RouteException` 等)→ LogError,不回落 OpenURL(深链交给系统浏览器只会更糟)。
+- 测试钩子:`internal static Action<string> OpenUrlHookForTests`(null → 真 `Application.OpenURL`),`ResetForTestsInternal` 清空。
+
+## 5. `MarkdownBoxRequest` 默认链接行为变更(决策点 b)
+
+`Bind` 中链接订阅的 else 分支由 `Application.OpenURL(url)` 改为 `UI.Markdown.HandleLink(url)`。
+
+**行为变化标注**:对已配置 `Router.Scheme` 的游戏,MarkdownBox 里的 `appid://` 链接从"丢给系统浏览器(坏)"变为"走 Router 导航(对)"。这是修正而非破坏;未配置 Scheme 的游戏行为完全不变。传了 `onLinkClicked` 的调用方不受影响(仍完全接管)。
+
+## 6. 与现有体系的交互
+
+- `ModalDocCache` / pump / dialog 栈:零改动。
+- `configure` 钩子:与 Loader 正交——configure 在 Bind 后照常触发,可改尺寸/拿控件。
+- 外部 `ct:` 取消模态 → 关窗 → Screen Dispose → loader 的 cts 一并取消,两个取消方向自动复合。
+- ReSolve(横竖屏翻转):`Markdown.Text` 是运行时赋值(builtin XML 无 `text=` 属性),变体翻转不重置内容——已有 `Variant_flip_keeps_text_and_hidden_title` 测试钉住,对 Loader 路径同样成立。
+
+## 7. 测试(EditMode,仿既有模式)
+
+1. **同步 loader 热替换**:loader 返回 `AwaitableHelpers.Completed("# done")` → `md.Text == "# done"`。
+2. **占位可见**:loader 用 `AwaitableCompletionSource<string>` 悬置 → 开窗后 `md.Text == "*Loading…*"`;`SetResult` 后 → 热替换。
+3. **自定义 LoadingText** 生效。
+4. **关窗取消**:悬置 loader 捕获传入的 ct;点 × 关窗 → `ct.IsCancellationRequested == true`;之后再 `SetResult` → 不抛、不触碰已销毁控件(测试无异常即过)。
+5. **loader 抛异常** → `LogAssert.Expect(LogType.Warning, ...)`,`md.Text` 以 `**Failed to load.**` 开头。
+6. **Loader 胜出**:`Text` 与 `Loader` 同时设置 → 显示 loader 结果。
+7. **HandleLink scheme 命中**:`Router.Scheme = "app"` + 注册假 Page 路由,`HandleLink("app://p1")` → 路由激活(断言方式仿 Router 既有 EditMode 测试)。
+8. **HandleLink 未命中/未启用**:`OpenUrlHookForTests` 捕获 → 普通 https、以及 Scheme 为 null 时的任意 url,都落到 hook。
+9. **MarkdownBox 默认走 HandleLink**:开 MarkdownBox(无 onLinkClicked),`RaiseLinkClickedForTests("https://x")` → `OpenUrlHookForTests` 捕获到。
+10. `OpenUrl` 的真实网络不测;其取消/错误路径由 §7.4/7.5 的 loader 层测试覆盖(FetchAsync 视为薄胶水)。
+
+## 8. SKILL 更新
+
+`scripting-promptugui-csharp/SKILL.md`:
+
+- MODAL cheatsheet:`MarkdownBox.Open(loader, ...)` / `OpenUrl(url, ...)` 行 + "关窗自动取消加载"注释;
+- `### Quick usage`:OpenUrl 一例 + 自带鉴权的 Open(loader) 一例;
+- `### API surface`:MarkdownBox 块补两个重载与 `LoadingText` 语义;
+- MARKDOWN 区(或 cheatsheet MARKDOWN 行):`UI.Markdown.HandleLink` 条目(scheme→Router,否则 OpenURL;默认链接行为变更说明);
+- `.md` 嵌套的"游戏自己做"一行示例。
+
+`authoring-promptugui-xml`:不动。

--- a/docs~/superpowers/specs/2026-06-10-markdown-box-modal-design.md
+++ b/docs~/superpowers/specs/2026-06-10-markdown-box-modal-design.md
@@ -1,0 +1,118 @@
+# MarkdownBox 内置模态:富文本公告/邮件显示框
+
+**日期**:2026-06-10
+**状态**:设计阶段(待 review,未进入实施)
+**作用域**:新增第 4 个内置模态 `MarkdownBox`,配合 `<Markdown>` 控件做富文本只读显示(公告、邮件、更新日志等)。复用 `ModalRequest<T>` / `UI.Modal.OpenAsync` 体系,不改动现有模态语义。
+**关联**:建立在 [`2026-06-09-markdown-control-design.md`](2026-06-09-markdown-control-design.md) 的 `<Markdown>` 控件与 [`2026-06-07-input-box-modal-design.md`](2026-06-07-input-box-modal-design.md) 的模态骨架之上。无作者可写的 XML 元素/属性变更,`authoring-promptugui-xml` 不动;公开 C# API 新增,`scripting-promptugui-csharp` 必须更新(见 §7)。
+
+---
+
+## 1. 背景与目标
+
+`MessageBox` 是按钮驱动的决策框;公告/邮件类内容是**只读浏览**,不需要任何按钮,但需要大面积、可滚动、支持富文本(标题、链接、图片、图文混排)。`<Markdown>` 控件已具备渲染能力(自带 ScrollRect、`OnLinkClicked`、`ImageResolver` 全局兜底),缺一个开箱即用的模态壳。
+
+与 `MessageBox` 的差异(需求原文):
+
+1. **没有任何 OK/Cancel 按钮,也不可设置按钮。**
+2. **关闭方式**:
+   - (a) 点击右上角的 ✕(始终存在,浮在 Markdown 文本区之上、与之重叠);
+   - (b) 点击暗色 backdrop 直接关闭;
+   - (c) ESC(设计补充:点背景都能关,ESC 行为应一致)。
+3. **标题可设置**:设置了则 Markdown 控件下移;未设置则该空间留给 Markdown。✕ 不受标题影响。
+
+## 2. XML 骨架
+
+`Runtime/Resources/PromptUGUI/Modals/MarkdownBox.ui.xml`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<PromptUGUI version="1">
+  <Screen name="PromptUGUI/Modals/MarkdownBox.ui" reference="1920x1080" reference.portrait="1080x1920">
+    <Image id="backdrop" anchor="stretch" color="#000000FE"/>
+
+    <Image id="dialog" sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round"
+           anchor="stretch" margin="480,160" margin.portrait="80,240">
+      <VStack anchor="stretch" margin="24" spacing="12">
+        <Text id="title" fontSize="24" height="40"/>
+        <Markdown id="markdown" width="stretch" height="stretch"/>
+      </VStack>
+      <Btn id="close" anchor="top-right" size="36x36" margin="12" sprite="">✕</Btn>
+    </Image>
+  </Screen>
+</PromptUGUI>
+```
+
+要点:
+
+- **尺寸自适应**:不学 MessageBox 的固定 `size="640x300"`,dialog 用 `anchor="stretch"` + margin(横屏左右 480/上下 160;竖屏 Variant 翻转为 80/240)。公告内容量大,自适应两种朝向比固定尺寸合理;个别调用想改尺寸用 `configure` 钩子。
+- **标题重排**:`title` 在 VStack 内,未设置时 `SetActive(false)` → VStack 自动重排,`markdown`(stretch)占满整个内容区。与 `MessageBoxRequest` 现有的隐藏模式一致。
+- **✕ 浮层**:`close` 按钮是 `dialog` 的直接子节点(不在 VStack 内),`anchor="top-right"` 浮在内容之上 —— 始终存在、与 Markdown 区重叠、不随标题移动。透明背景(`sprite=""`)+ "✕" 文字。
+
+## 3. C# API
+
+`Runtime/Application/Modals/MarkdownBoxRequest.cs`:
+
+```csharp
+public sealed class MarkdownBoxRequest : ModalRequest<bool>
+{
+    public string Text;                       // markdown 源文
+    public string Title;                      // null/空 → 隐藏标题行
+    public Action<string> OnLinkClicked;      // null → 默认 Application.OpenURL
+    public override string XmlSrc => MarkdownBox.XmlSrc;
+    public override void Bind(IScreen screen, Action<bool> close) { ... }
+    public override bool TryEscape(out bool result) { result = true; return true; }
+}
+
+public static class MarkdownBox
+{
+    public static string XmlSrc { get; set; } = "PromptUGUI/Modals/MarkdownBox.ui";
+
+    public static async Awaitable Open(
+        string markdown, string title = null,
+        Action<string> onLinkClicked = null,
+        ModalMode mode = ModalMode.Popup,
+        Action<IScreen> configure = null,
+        CancellationToken ct = default)
+        => await UI.Modal.OpenAsync(new MarkdownBoxRequest { ... }, mode, ct);
+}
+```
+
+- **返回非泛型 `Awaitable`**:无按钮 ⇒ 没有有意义的结果值,关闭即完成。`ct` 取消 → `OperationCanceledException`,同现有模态。内部 `ModalRequest<bool>` 仅为复用泛型管线,恒以 `true` 关闭。
+- **`Bind` 行为**:
+  - `markdown.Text = Text ?? ""`;
+  - `Title` 为 null/空 → `title.GameObject.SetActive(false)`,否则赋 `TextValue`;
+  - `close` Btn `OnClick` → `close(true)`;
+  - `backdrop`(`Controls.Image`)`OnPointerDown` → `close(true)`;
+  - `markdown.OnLinkClicked` → `OnLinkClicked ?? (url => Application.OpenURL(url))`。订阅均 `.AddTo(screen)`。
+- **ESC**:`TryEscape` 恒返回 true —— 点背景都能关,ESC 行为一致。
+- **链接默认行为**:公告/邮件里的链接最常见诉求是打开网页,默认 `Application.OpenURL`;调用方传 `onLinkClicked` 则完全接管(不叠加默认行为)。
+- **图片**:走 `<Markdown>` 控件现有的 `UI.Markdown.ImageResolver` 全局兜底,不加参数。
+
+## 4. 与现有体系的交互
+
+- `ModalDocCache` / `MaterializePump` / dialog 栈 / `ModalEscapeListener`:全部复用,零改动。
+- `Configure` 钩子:基类 `ModalRequest<T>.Configure` 已有,`Open` 透传 —— 调用方可借此改尺寸、改样式、拿 `Markdown` 控件订阅更多事件。
+- `UI.Router` Prompt 呈现:不在本次范围;`MarkdownBox` 与 `MessageBox` 一样可被调用方在 `onEnter` 里就地 `await`。
+
+## 5. 非目标(v1)
+
+- 不提供按钮/底部操作区(需求 1 明确排除;要按钮请用 `MessageBox` 或自定义模态)。
+- 不提供"从 src 加载 markdown 文件"的便捷参数 —— 调用方自行取得字符串后传入。
+- 不做打开/关闭转场动画。
+
+## 6. 测试
+
+EditMode(仿 `InputBoxModalTests` 模式,fake resolver + `ResetForTests`):
+
+1. `Open` 后栈顶 Screen 存在,`markdown` 控件 `Text` 等于传入源文;
+2. `title=null` → title GameObject inactive;`title="公告"` → active 且文本正确;
+3. 点 `close` Btn → Awaitable 完成、Screen 销毁;
+4. `backdrop.OnPointerDown` 触发 → 同上关闭;
+5. ESC(`TryEscape`)→ 关闭;
+6. `onLinkClicked` 传入自定义委托 → 链接事件路由到它(用 `Markdown.RaiseLinkClickedForTests`);
+7. `ct` 取消 → `OperationCanceledException`。
+
+## 7. SKILL 更新
+
+- `scripting-promptugui-csharp/SKILL.md`:内置模态一节新增 `MarkdownBox.Open` 条目(签名、关闭三通道、链接默认 OpenURL、`configure` 可改尺寸)。
+- `authoring-promptugui-xml`:不动(内置模态 XML 非作者可写面)。

--- a/docs~/superpowers/specs/2026-06-10-markdown-box-modal-design.md
+++ b/docs~/superpowers/specs/2026-06-10-markdown-box-modal-design.md
@@ -31,12 +31,13 @@
     <Image id="backdrop" anchor="stretch" color="#000000FE"/>
 
     <Image id="dialog" sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round"
-           anchor="stretch" margin="480,160" margin.portrait="80,240">
+           anchor="stretch" margin="160,480" margin.portrait="240,80">
       <VStack anchor="stretch" margin="24" spacing="12">
         <Text id="title" fontSize="24" height="40"/>
         <Markdown id="markdown" width="stretch" height="stretch"/>
       </VStack>
-      <Btn id="close" anchor="top-right" size="36x36" margin="12" sprite="">✕</Btn>
+      <Btn id="close" anchor="top-right" size="36x36" margin="12"
+           sprite="" color="#00000000" fontSize="28">×</Btn>
     </Image>
   </Screen>
 </PromptUGUI>
@@ -44,9 +45,9 @@
 
 要点:
 
-- **尺寸自适应**:不学 MessageBox 的固定 `size="640x300"`,dialog 用 `anchor="stretch"` + margin(横屏左右 480/上下 160;竖屏 Variant 翻转为 80/240)。公告内容量大,自适应两种朝向比固定尺寸合理;个别调用想改尺寸用 `configure` 钩子。
+- **尺寸自适应**:不学 MessageBox 的固定 `size="640x300"`,dialog 用 `anchor="stretch"` + margin。双分量 margin 语义为 `上下,左右`:横屏上下 160/左右 480;竖屏 Variant 翻转为上下 240/左右 80。公告内容量大,自适应两种朝向比固定尺寸合理;个别调用想改尺寸用 `configure` 钩子。
 - **标题重排**:`title` 在 VStack 内,未设置时 `SetActive(false)` → VStack 自动重排,`markdown`(stretch)占满整个内容区。与 `MessageBoxRequest` 现有的隐藏模式一致。
-- **✕ 浮层**:`close` 按钮是 `dialog` 的直接子节点(不在 VStack 内),`anchor="top-right"` 浮在内容之上 —— 始终存在、与 Markdown 区重叠、不随标题移动。透明背景(`sprite=""`)+ "✕" 文字。
+- **× 浮层**:`close` 按钮是 `dialog` 的直接子节点(不在 VStack 内),`anchor="top-right"` 浮在内容之上 —— 始终存在、与 Markdown 区重叠、不随标题移动。透明背景需要 `sprite=""` **加** `color="#00000000"`(只去 sprite 仍是白色实心矩形;alpha 0 的 Image 依旧接收 raycast,点击不受影响)。字形用 Latin-1 的 `×`(U+00D7)而非 `✕`(U+2715)—— 默认 TMP 字体不含后者。
 
 ## 3. C# API
 


### PR DESCRIPTION
## Summary

- 新增第 4 个内置模态 `MarkdownBox.Open(markdown, title, onLinkClicked, mode, configure, ct)` → 非泛型 `Awaitable`，关闭即完成：基于 `<Markdown>` 控件的只读富文本显示框（公告 / 邮件 / 更新日志）
- 无任何按钮、不可设置按钮；三通道关闭：右上角 ×（始终存在、浮于 Markdown 区之上）、点击暗色 backdrop（`Image.OnPointerDown`）、ESC（`TryEscape` 恒 true）
- `title` 可选：null 隐藏标题行，VStack 重排、Markdown 区自动占满；× 不受影响
- 内置 XML 用 `anchor="stretch"` + `margin="160,480"` / `margin.portrait="240,80"` 自适应横竖屏（首个携带 `margin.portrait` 的内置模态，附 ReSolve 回归测试）
- **延迟内容加载**：`MarkdownBox.Open(loader)` 先开窗显示占位 Loading（`loadingText` 可定制）、loader 完成后热替换、**关窗任何通道自动取消 loader 的 ct**（迟到/失败结果不触碰已销毁控件）；`OpenUrl(url)` 裸 GET 糖（镜像 `UseWebImageResolver` 的 ACS 模式 + `ct.Register(Abort)`，WebGL 安全）；鉴权内容走 `Open(loader)` 接游戏自己的网络栈
- **`UI.Markdown.HandleLink` 默认链接分发**：`Router.Scheme` 命中 → `Router.Navigate`（失败 LogError，不回落系统浏览器），否则 `Application.OpenURL`；MarkdownBox 默认链接行为切到它（行为修正：配置了 Router scheme 的游戏，markdown 里的深链从"弹浏览器"变为正确导航）
- C# SKILL 同步更新（cheatsheet、Modal dialogs、Quick usage、API surface、HandleLink 条目、required ids、新建 MARKDOWN cheatsheet 组）

设计文档：`docs~/superpowers/specs/2026-06-10-markdown-box-modal-design.md` + `docs~/superpowers/specs/2026-06-10-markdown-box-loader-design.md`

## Test Plan

- [x] EditMode 1519/1519（含 MarkdownBoxTests 13 + MarkdownBoxLoaderTests 8 + HandleLinkTests 4：源文、标题显隐、三通道关闭、ct 取消、builtin XML、Variant 翻转保持、占位/热替换/关窗取消加载/加载失败、链接分发三分支）
- [x] EditorOnly 183/183、PlayMode 132/132
- [x] dotnet format + UIXmlLint 双零
- [ ] 视觉 QA（用户）：横竖屏 margin、× 与滚动区重叠、链接点击、OpenUrl 真网络加载与关窗取消

🤖 Generated with [Claude Code](https://claude.com/claude-code)