### PR TITLE
fix: ReSolve crash on resize after BindItems replaced static cards

### DIFF
--- a/Runtime/Application/Screen.cs
+++ b/Runtime/Application/Screen.cs
@@ -529,6 +529,9 @@ namespace PromptUGUI.Application
                 var node = kv.Key;
                 if (inactiveNodes.Contains(node)) continue;
                 var control = kv.Value;
+                // BindItems 重建（Carousel/TabBar）会销毁静态 XML 卡的 GameObject，
+                // 但其 ElementNode 仍留在 _nodeMap —— 跳过已销毁的控件（同 ApplyScales 的 rt==null 防御）。
+                if (control.GameObject == null) continue;
                 var entry = _registry.Resolve(node.Tag);
                 ControlAttributeApplier.Apply(node, control, entry, Variants, initial: false);
             }

--- a/Runtime/Controls/TabBar.cs
+++ b/Runtime/Controls/TabBar.cs
@@ -31,6 +31,10 @@ namespace PromptUGUI.Controls
         // both on dynamic Rebuild and on static OnAfterApply so reapply replaces them.
         private CompositeDisposable _tabSubs;
 
+        // BindItems 接管卡片来源后置位：之后 ReSolve 触发的 CollectStaticTabs 不得把
+        // 已 Dispose 的静态 Tab 收回 _tabs（镜像 CarouselView._bound）。
+        private bool _bound;
+
         public override void OnAttached()
         {
             _group = GameObject.AddComponent<ToggleGroup>();
@@ -129,6 +133,7 @@ namespace PromptUGUI.Controls
 
         private void ClearTabs()
         {
+            _bound = true;
             _tabSubs?.Dispose();
             _tabSubs = null;
             foreach (var t in _tabs) t.Dispose();
@@ -216,6 +221,7 @@ namespace PromptUGUI.Controls
 
         private void CollectStaticTabs()
         {
+            if (_bound) return;
             _tabs.Clear();
             foreach (var child in Children)
             {

--- a/Tests/EditMode/Controls/CarouselBindItemsTests.cs
+++ b/Tests/EditMode/Controls/CarouselBindItemsTests.cs
@@ -68,6 +68,26 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
+        public void ReSolve_After_BindItems_Replaced_Static_Cards_Does_Not_Throw()
+        {
+            // 静态 XML 卡被 BindItems 重建销毁后，其 ElementNode 仍留在 Screen._nodeMap；
+            // resize / Variant / Theme 触发的 ReSolve 不得对已销毁的 RectTransform 重新 Apply。
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Carousel id='car' size='200x100'><Frame id='banner0'/><Frame id='banner1'/></Carousel>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            var car = screen.Get<Carousel>("car");
+            using var sub = car.BindItems(
+                Observable.Return<IReadOnlyList<string>>(new[] { "a" }),
+                (IControl card, string s) => { });
+
+            Assert.DoesNotThrow(() => screen.ReSolve());
+            Assert.AreEqual(1, car.Count, "dynamic cards survive the ReSolve");
+        }
+
+        [Test]
         public void BindItems_Rebuild_That_Clamps_Current_Fires_OnCurrentChanged()
         {
             var car = Open("<Carousel id='car' size='200x100'><Image/><Image/><Image/></Carousel>");

--- a/Tests/EditMode/Controls/TabBarBindItemsTests.cs
+++ b/Tests/EditMode/Controls/TabBarBindItemsTests.cs
@@ -56,6 +56,29 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
+        public void ReSolve_After_BindItems_Replaced_Static_Tabs_Keeps_Dynamic_Tabs()
+        {
+            // 与 Carousel 同构：静态 <Tab> 被 BindItems 重建销毁后 ReSolve 不得崩溃；
+            // 且 OnAfterApply 的 CollectStaticTabs 不得把已销毁的静态 Tab 收回 _tabs、
+            // 丢掉动态建的 Tab。
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'><Tab text='static1'/><Tab text='static2'/></TabBar>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            var bar = screen.Get<TabBar>("bar");
+            using var sub = bar.BindItems(
+                Observable.Return<IReadOnlyList<string>>(new[] { "dyn1", "dyn2" }),
+                (Tab tab, string s) => tab.Text = s);
+
+            Assert.DoesNotThrow(() => screen.ReSolve());
+            Assert.AreEqual(2, bar.Count, "dynamic tabs survive the ReSolve");
+            Assert.AreEqual("dyn1", bar.GetAt(0).GameObject.transform.Find("Label")
+                .GetComponent<TMPro.TMP_Text>().text);
+        }
+
+        [Test]
         public void BindItems_With_Custom_Template_Resolves_Tab_Via_GetComponentInChildren()
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>


### PR DESCRIPTION
## 问题

动态绑定（`BindItems`）替换掉 `<Carousel>` / `<TabBar>` 的静态 XML 子卡后，窗口 resize（以及 Variant / Theme 切换）触发的 `Screen.ReSolve` 崩溃：

```
ParseException: <Frame id='banner0'>: The object of type 'UnityEngine.RectTransform'
has been destroyed but you are still trying to access it.
  at ControlAttributeApplier.Apply (...) ControlAttributeApplier.cs:119
  at Screen.ReSolve () Screen.cs:533
```

## 根因

1. 静态 XML 卡在 `Open` 时被注册进 `Screen._nodeMap`（`InstantiateRecursive`）。
2. `BindItems` 重建 → `ClearCards()` / `ClearTabs()` 把旧卡 `Dispose()`，GameObject 被销毁——但 `_nodeMap` 里的 `ElementNode` 条目没有任何路径移除。
3. `ReSolve` 遍历 `_nodeMap` 逐节点重新 Apply → 撞已销毁的 RectTransform。

`CarouselView.SetStaticCards` 的 `_bound` 标志说明库本来就预期这条销毁流程，只是漏了 `_nodeMap` 这一侧。

## 修复

- **`Screen.ReSolve`**：跳过 `control.GameObject == null`（已销毁）的 `_nodeMap` 条目——与 `ApplyScales` 已有的 `rt == null` 防御同一惯例。
- **`TabBar`**：补 `_bound` 标志（`ClearTabs()` 置位），`CollectStaticTabs` 在动态绑定接管后不再回收——否则 ReSolve 会把已销毁的静态 Tab 收回 `_tabs`、丢掉动态 Tab，崩在 `Cannot access a disposed object`（与 Carousel 同族的第二条路径；镜像 `CarouselView._bound`）。

## 测试

- 新增红测试（修前逐字复现原报错）：
  - `CarouselBindItemsTests.ReSolve_After_BindItems_Replaced_Static_Cards_Does_Not_Throw`
  - `TabBarBindItemsTests.ReSolve_After_BindItems_Replaced_Static_Tabs_Keeps_Dynamic_Tabs`
- EditMode **1522/1522** + PlayMode **132/132** 全绿，`dotnet format --verify-no-changes` 干净。
- 用户已在实际项目确认 resize 不再报错。

纯内部行为修复，无 XML / 公开 API 变化，无需 SKILL 更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)