### PR TITLE
fix(scale): BindItems/Markdown 动态子树的 scale 不生效

### DIFF
--- a/Runtime/Application/Screen.cs
+++ b/Runtime/Application/Screen.cs
@@ -37,6 +37,18 @@ namespace PromptUGUI.Application
 
         internal Controls.Internal.ToggleGroupRegistry ToggleGroups { get; private set; }
 
+        // BindItems / Markdown 等经 ScreenInstantiator.InstantiateNode 动态实例化的子树。
+        // 它们不能进 _nodeMap（同一 ElementNode 会对应 N 个卡片实例），但 scale 仍须由
+        // Screen 统一应用——Nx / <r>r 依赖 _canvasFactor，且 resize / Variant ReSolve 要重算。
+        // 只登记含 scale 声明（base 或 variant）的子树；卡片被 BindItems 重建销毁后由
+        // PruneDeadDynamicSubtrees 按 Root.GameObject == null 剔除。
+        private sealed class DynamicSubtree
+        {
+            public Control Root;
+            public Dictionary<ElementNode, Control> Nodes;
+        }
+        private readonly List<DynamicSubtree> _dynamicSubtrees = new();
+
         // 已实例化的 Add 块（不论当前是否可见）。Strategy C：首次进入激活才实例化；
         // 之后 toggle 仅切根 GameObject 的 SetActive，永不 Destroy/移除字典项；
         // 只在 Close 时随 RootGameObject 整体销毁。
@@ -243,55 +255,110 @@ namespace PromptUGUI.Application
         // variant override are still tracked (resolves to null → identity reset).
         private void ApplyScales()
         {
-            if (_nodeMap.Count == 0) return;
             foreach (var kv in _nodeMap)
+                ApplyScaleToNode(kv.Key, kv.Value, dynamicBaseline: false);
+            PruneDeadDynamicSubtrees();
+            foreach (var subtree in _dynamicSubtrees)
+                ApplyScalesTo(subtree.Nodes);
+        }
+
+        private void ApplyScalesTo(Dictionary<ElementNode, Control> nodes)
+        {
+            foreach (var kv in nodes)
+                ApplyScaleToNode(kv.Key, kv.Value, dynamicBaseline: true);
+        }
+
+        // dynamicBaseline: 静态节点（_nodeMap）靠 ReSolve 的 ApplyCommon 把 RectTransform
+        // 重置到 margin-resolved 基线，box-preserving 补偿才幂等；动态子树节点属性只在
+        // 实例化时 Apply 一次，没有这个重置——首次应用前捕获基线，之后每次先还原。
+        private void ApplyScaleToNode(ElementNode node, Control control, bool dynamicBaseline)
+        {
+            var declaredBase = node.Attributes.ContainsKey("scale");
+            var declaredVariant = node.VariantOverrides.ContainsKey("scale");
+            if (!declaredBase && !declaredVariant) return;
+
+            var raw = PromptUGUI.Variants.VariantResolver.ResolveAttribute(
+                node, "scale", Variants);
+            var rt = control.RectTransform;
+            if (rt == null) return;
+
+            if (dynamicBaseline)
             {
-                var node = kv.Key;
-                var declaredBase = node.Attributes.ContainsKey("scale");
-                var declaredVariant = node.VariantOverrides.ContainsKey("scale");
-                if (!declaredBase && !declaredVariant) continue;
-
-                var raw = PromptUGUI.Variants.VariantResolver.ResolveAttribute(
-                    node, "scale", Variants);
-                var rt = kv.Value.RectTransform;
-                if (rt == null) continue;
-
-                if (TryParseDeviceScale(raw, out var devN))
+                if (control._dynamicScaleBaseline is { } b)
                 {
-                    var f = _canvasFactor > 0f ? _canvasFactor : 1f;
-                    var dv = devN / f;
-                    rt.localScale = new Vector3(dv, dv, 1f);
-                    ApplyBoxPreservingCompensation(rt, dv);
-                    continue;
+                    rt.anchorMin = b.AnchorMin;
+                    rt.anchorMax = b.AnchorMax;
+                    rt.sizeDelta = b.SizeDelta;
+                    rt.anchoredPosition = b.AnchoredPosition;
                 }
-
-                if (TryParseRelativeScale(raw, out var relR))
+                else
                 {
-                    var f = _canvasFactor > 0f ? _canvasFactor : 1f;
-                    // round-half-up to the nearest integer effective (>= 1), then divide the
-                    // factor back out: net physical-px/unit = effective (integer → pixel-aligned),
-                    // and grows with f (responds to window size). See CRS-D3/D4/D5.
-                    var eff = Mathf.Max(1f, Mathf.Floor(f * relR + 0.5f));
-                    var dv = eff / f;
-                    rt.localScale = new Vector3(dv, dv, 1f);
-                    ApplyBoxPreservingCompensation(rt, dv);
-                    continue;
+                    control._dynamicScaleBaseline =
+                        (rt.anchorMin, rt.anchorMax, rt.sizeDelta, rt.anchoredPosition);
                 }
-
-                if (string.IsNullOrEmpty(raw)
-                    || !float.TryParse(raw, System.Globalization.NumberStyles.Float,
-                                       System.Globalization.CultureInfo.InvariantCulture, out var v)
-                    || v <= 0f)
-                {
-                    // Unresolved / non-numeric (e.g. <Animation scale="1:0.5">) → identity.
-                    // ApplyCommon already restored the baseline geometry, so leave it untouched.
-                    rt.localScale = Vector3.one;
-                    continue;
-                }
-
-                rt.localScale = new Vector3(v, v, 1f);
-                ApplyBoxPreservingCompensation(rt, v);
             }
+
+            if (TryParseDeviceScale(raw, out var devN))
+            {
+                var f = _canvasFactor > 0f ? _canvasFactor : 1f;
+                var dv = devN / f;
+                rt.localScale = new Vector3(dv, dv, 1f);
+                ApplyBoxPreservingCompensation(rt, dv);
+                return;
+            }
+
+            if (TryParseRelativeScale(raw, out var relR))
+            {
+                var f = _canvasFactor > 0f ? _canvasFactor : 1f;
+                // round-half-up to the nearest integer effective (>= 1), then divide the
+                // factor back out: net physical-px/unit = effective (integer → pixel-aligned),
+                // and grows with f (responds to window size). See CRS-D3/D4/D5.
+                var eff = Mathf.Max(1f, Mathf.Floor(f * relR + 0.5f));
+                var dv = eff / f;
+                rt.localScale = new Vector3(dv, dv, 1f);
+                ApplyBoxPreservingCompensation(rt, dv);
+                return;
+            }
+
+            if (string.IsNullOrEmpty(raw)
+                || !float.TryParse(raw, System.Globalization.NumberStyles.Float,
+                                   System.Globalization.CultureInfo.InvariantCulture, out var v)
+                || v <= 0f)
+            {
+                // Unresolved / non-numeric (e.g. <Animation scale="1:0.5">) → identity.
+                // The baseline geometry was restored above (dynamic) or by ApplyCommon (static).
+                rt.localScale = Vector3.one;
+                return;
+            }
+
+            rt.localScale = new Vector3(v, v, 1f);
+            ApplyBoxPreservingCompensation(rt, v);
+        }
+
+        // ScreenInstantiator.InstantiateNode（BindItems / Markdown 动态实例化）完成后调用。
+        // 无 scale 声明的子树不登记（绝大多数列表卡片），零额外开销。
+        internal void RegisterDynamicSubtree(Control root, Dictionary<ElementNode, Control> nodes)
+        {
+            PruneDeadDynamicSubtrees();
+            var hasScale = false;
+            foreach (var node in nodes.Keys)
+            {
+                if (!hasScale && (node.Attributes.ContainsKey("scale")
+                                  || node.VariantOverrides.ContainsKey("scale")))
+                    hasScale = true;
+                // 动态子树可能是 Screen 里唯一的 factor scale 来源；resize 门控必须看到它。
+                if (DeclaresFactorScale(node)) _hasFactorScale = true;
+            }
+            if (!hasScale) return;
+            _dynamicSubtrees.Add(new DynamicSubtree { Root = root, Nodes = nodes });
+            ApplyScalesTo(nodes);
+        }
+
+        private void PruneDeadDynamicSubtrees()
+        {
+            for (var i = _dynamicSubtrees.Count - 1; i >= 0; i--)
+                if (_dynamicSubtrees[i].Root.GameObject == null)
+                    _dynamicSubtrees.RemoveAt(i);
         }
 
         // Sets _hasFactorScale if any currently-instantiated node uses a factor-dependent scale
@@ -300,11 +367,17 @@ namespace PromptUGUI.Application
         // nodes stay in _nodeMap, so the flag is effectively sticky once any such node exists.
         private void RecomputeFactorScale()
         {
-            _hasFactorScale = false;
+            _hasFactorScale = HasFactorScaleNode();
+        }
+
+        private bool HasFactorScaleNode()
+        {
             foreach (var node in _nodeMap.Keys)
-            {
-                if (DeclaresFactorScale(node)) { _hasFactorScale = true; break; }
-            }
+                if (DeclaresFactorScale(node)) return true;
+            foreach (var subtree in _dynamicSubtrees)
+                foreach (var node in subtree.Nodes.Keys)
+                    if (DeclaresFactorScale(node)) return true;
+            return false;
         }
 
         // Whether a node declares a factor-dependent scale (Nx or <r>r) in its base attribute
@@ -468,6 +541,7 @@ namespace PromptUGUI.Application
             _byId.Clear();
             _nodeMap.Clear();
             _addInstances.Clear();
+            _dynamicSubtrees.Clear();
             ToggleGroups?.Clear();
             ToggleGroups = null;
         }

--- a/Runtime/Application/ScreenInstantiator.cs
+++ b/Runtime/Application/ScreenInstantiator.cs
@@ -40,7 +40,6 @@ namespace PromptUGUI.Application
         /// </summary>
         public IControl InstantiateNode(ElementNode node, RectTransform parent, Screen owner)
         {
-            _ = owner; // 保留参数：未来可注入 owner-scoped lookups
             var scope = new Dictionary<string, IControl>();
             var nodeMap = new Dictionary<ElementNode, Control>();
             var parentIsLayoutGroup = parent.GetComponent<UnityEngine.UI.LayoutGroup>() != null;
@@ -60,6 +59,10 @@ namespace PromptUGUI.Application
             // 让 caller (ScrollList BindItems 回调) 能 root.Get<T>("id") 命中子节点。
             // 若根本身的 id 出现在 scope 中（与自己同名场景），不影响——ScopedIds 是 IControl 的查询面。
             rootControl.ReplaceScopedIds(scope);
+            // 动态子树登记到 owner Screen：scale（尤其 Nx / <r>r 依赖 canvasFactor）由
+            // Screen.ApplyScales 统一应用，并参与 resize / Variant ReSolve 重算。
+            // owner 为 null（裸用 instantiator 的调用方）时跳过，scale 不生效。
+            owner?.RegisterDynamicSubtree(rootControl, nodeMap);
             return rootControl;
         }
 

--- a/Runtime/Controls/Control.cs
+++ b/Runtime/Controls/Control.cs
@@ -89,6 +89,17 @@ namespace PromptUGUI.Controls
         internal string _lastAppliedRuntimeState;
 
         /// <summary>
+        /// 动态子树（BindItems / Markdown 经 ScreenInstantiator.InstantiateNode 实例化）里
+        /// 声明了 scale 的节点的几何基线。静态节点每次 ReSolve 先经 ApplyCommon 重置
+        /// RectTransform 再做 box-preserving 补偿；动态节点属性只在实例化时 Apply 一次,
+        /// 所以 Screen.ApplyScales 首次应用前捕获基线、之后每次先还原, 保证补偿不跨
+        /// resize / Variant 切换累积。仅 <see cref="PromptUGUI.Application.Screen"/> 读写。
+        /// </summary>
+        internal (UnityEngine.Vector2 AnchorMin, UnityEngine.Vector2 AnchorMax,
+                  UnityEngine.Vector2 SizeDelta, UnityEngine.Vector2 AnchoredPosition)?
+            _dynamicScaleBaseline;
+
+        /// <summary>
         /// 返回 control 当前运行时独占状态值的归一化字符串 (e.g. Tab.isOn → "true"/"false",
         /// Slider.value → invariant float)。没有 RuntimeStateAttr 的控件返回 null。
         /// 仅 <see cref="ControlAttributeApplier"/> 用于检测 runtime 覆写。

--- a/Tests/EditMode/Application/DynamicSubtreeScaleTests.cs
+++ b/Tests/EditMode/Application/DynamicSubtreeScaleTests.cs
@@ -1,0 +1,223 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using R3;
+
+namespace PromptUGUI.Tests.Application
+{
+    // BindItems / itemTemplate 动态实例化的子树（ScrollList / Carousel / TabBar / Markdown
+    // 共用 ScreenInstantiator.InstantiateNode）不进 Screen._nodeMap —— scale 必须仍由
+    // Screen 统一应用（Nx / <r>r 依赖 _canvasFactor），并参与 resize / Variant 重算。
+    public class DynamicSubtreeScaleTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static IControl BindOne(IScreen screen, out ScrollList list)
+        {
+            list = screen.Get<ScrollList>("list");
+            IControl captured = null;
+            list.BindItems(
+                Observable.Return<IReadOnlyList<string>>(new[] { "a" }),
+                (IControl slot, string s) => captured = slot);
+            Assert.IsNotNull(captured, "BindItems should instantiate one slot");
+            return captured;
+        }
+
+        [Test]
+        public void BindItems_card_plain_scale_applied_on_instantiation()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Row'>
+    <Frame width='200' height='50'><Text id='label' scale='0.5'>x</Text></Frame>
+  </Template>
+  <Screen name='S' scale-mode='auto' reference='1920x1080'>
+    <ScrollList id='list' itemTemplate='Row'/>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var slot = BindOne(screen, out _);
+
+            var rt = slot.Get<Text>("label").RectTransform;
+            Assert.AreEqual(0.5f, rt.localScale.x, 1e-5f);
+            Assert.AreEqual(0.5f, rt.localScale.y, 1e-5f);
+        }
+
+        [Test]
+        public void BindItems_card_device_scale_uses_canvas_factor()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(5760f, 3240f); // /1920x1080 = factor 3
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Row'>
+    <Frame width='200' height='50'><Text id='label' scale='2x'>x</Text></Frame>
+  </Template>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <ScrollList id='list' itemTemplate='Row'/>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var slot = BindOne(screen, out _);
+
+            var rt = slot.Get<Text>("label").RectTransform;
+            Assert.AreEqual(2f / 3f, rt.localScale.x, 1e-5f);
+        }
+
+        [Test]
+        public void BindItems_card_relative_scale_uses_canvas_factor()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(5760f, 3240f); // factor 3
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Row'>
+    <Frame width='200' height='50'><Text id='label' scale='0.5r'>x</Text></Frame>
+  </Template>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <ScrollList id='list' itemTemplate='Row'/>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var slot = BindOne(screen, out _);
+
+            // round(3*0.5)=2 → 2/3 — same math as the static-node RelativeScale tests.
+            var rt = slot.Get<Text>("label").RectTransform;
+            Assert.AreEqual(2f / 3f, rt.localScale.x, 1e-5f);
+        }
+
+        [Test]
+        public void BindItems_card_factor_scale_recomputes_on_resize()
+        {
+            // Factor scale exists ONLY in the dynamic template — the _hasFactorScale resize
+            // gate must discover it from the dynamic subtree, not just _nodeMap.
+            UnityEngine.Vector2 size = new(5760f, 3240f); // factor 3
+            UI.CanvasSizeOverride = () => size;
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Row'>
+    <Frame width='200' height='50'><Text id='label' scale='1x'>x</Text></Frame>
+  </Template>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <ScrollList id='list' itemTemplate='Row'/>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var slot = BindOne(screen, out _);
+            var rt = slot.Get<Text>("label").RectTransform;
+            Assert.AreEqual(1f / 3f, rt.localScale.x, 1e-5f);
+
+            size = new UnityEngine.Vector2(3840f, 2160f); // factor 2
+            var relay = screen.RootGameObject.GetComponent<RectDimensionsRelay>();
+            relay.OnDimensionsChanged?.Invoke();
+
+            Assert.AreEqual(0.5f, rt.localScale.x, 1e-5f);
+        }
+
+        [Test]
+        public void BindItems_card_box_preserving_does_not_accumulate_across_resizes()
+        {
+            UnityEngine.Vector2 size = new(5760f, 3240f); // factor 3
+            UI.CanvasSizeOverride = () => size;
+            // The scaled node is INSIDE the card root (Frame), not a direct LayoutGroup
+            // child — box-preserving compensation runs and must stay idempotent without
+            // the ApplyCommon baseline reset that static nodes get from ReSolve.
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Row'>
+    <Frame width='200' height='50'>
+      <Frame id='inner' anchor='stretch' margin='10,10,10,10' scale='1x'/>
+    </Frame>
+  </Template>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <ScrollList id='list' itemTemplate='Row'/>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var slot = BindOne(screen, out _);
+            var rt = slot.Get("inner").RectTransform;
+            var relay = screen.RootGameObject.GetComponent<RectDimensionsRelay>();
+
+            // factor 3: localScale 1/3, inv 3 → span 3 about 0.5 → [-1, 2]; sizeDelta -20*3 = -60.
+            Assert.AreEqual(1f / 3f, rt.localScale.x, 1e-5f);
+            Assert.AreEqual(-1f, rt.anchorMin.x, 1e-4f);
+            Assert.AreEqual(-60f, rt.sizeDelta.x, 1e-3f);
+
+            // → factor 2: localScale 1/2, inv 2 → [-0.5, 1.5]; sizeDelta -40.
+            size = new UnityEngine.Vector2(3840f, 2160f);
+            relay.OnDimensionsChanged?.Invoke();
+            Assert.AreEqual(0.5f, rt.localScale.x, 1e-5f);
+            Assert.AreEqual(-0.5f, rt.anchorMin.x, 1e-4f);
+            Assert.AreEqual(-40f, rt.sizeDelta.x, 1e-3f);
+
+            // → back to factor 3: must equal first reading, NOT compounded.
+            size = new UnityEngine.Vector2(5760f, 3240f);
+            relay.OnDimensionsChanged?.Invoke();
+            Assert.AreEqual(1f / 3f, rt.localScale.x, 1e-5f);
+            Assert.AreEqual(-1f, rt.anchorMin.x, 1e-4f);
+            Assert.AreEqual(-60f, rt.sizeDelta.x, 1e-3f);
+        }
+
+        [Test]
+        public void BindItems_rebuild_gives_new_cards_scale_too()
+        {
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(5760f, 3240f); // factor 3
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Row'>
+    <Frame width='200' height='50'><Text id='label' scale='1x'>x</Text></Frame>
+  </Template>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <ScrollList id='list' itemTemplate='Row'/>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var list = screen.Get<ScrollList>("list");
+
+            var src = new ReactiveProperty<IReadOnlyList<string>>(new[] { "a", "b" });
+            IControl last = null;
+            list.BindItems(src, (IControl slot, string s) => last = slot);
+            Assert.AreEqual(1f / 3f, last.Get<Text>("label").RectTransform.localScale.x, 1e-5f);
+
+            // Rebuild destroys the old cards; the replacement cards must get scale as well.
+            src.Value = new[] { "x" };
+            Assert.AreEqual(1, list.SlotCount);
+            Assert.AreEqual(1f / 3f, last.Get<Text>("label").RectTransform.localScale.x, 1e-5f);
+        }
+
+        [Test]
+        public void BindItems_card_variant_scale_applies_on_ReSolve()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Row'>
+    <Frame width='200' height='50'><Text id='label' scale.portrait='0.5'>x</Text></Frame>
+  </Template>
+  <Screen name='S' scale-mode='auto' reference='1920x1080'>
+    <ScrollList id='list' itemTemplate='Row'/>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var slot = BindOne(screen, out _);
+            var rt = slot.Get<Text>("label").RectTransform;
+
+            // landscape (default): variant inactive → identity.
+            Assert.AreEqual(1f, rt.localScale.x, 1e-5f);
+
+            UI.Orientation.AutoTrack = false;
+            UI.Orientation.Set(isPortrait: true);
+            Assert.AreEqual(0.5f, rt.localScale.x, 1e-5f);
+
+            UI.Orientation.Set(isPortrait: false);
+            // back to landscape: baseline restored, identity again.
+            Assert.AreEqual(1f, rt.localScale.x, 1e-5f);
+        }
+    }
+}

--- a/Tests/EditMode/Application/DynamicSubtreeScaleTests.cs.meta
+++ b/Tests/EditMode/Application/DynamicSubtreeScaleTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 670901b94f4a0c049843da1aba6d93d9


### PR DESCRIPTION
## 问题

运行时经 `ScreenInstantiator.InstantiateNode` 动态实例化的模板子树（ScrollList / Carousel / TabBar 的 BindItems 卡片、Markdown 渲染树），`scale` 属性完全不生效，`localScale` 永远停在 1。

根因链：

1. `scale` 被刻意排除在普通 `[UIAttr]` 应用流程之外，只由 `Screen.ApplyScales` 统一应用（`Nx` / `<r>r` 依赖 `_canvasFactor`，还要做 box-preserving 补偿）。
2. `ApplyScales` 只遍历 Screen 的 `_nodeMap`。
3. `InstantiateNode` 创建的是局部 nodeMap，从不进 owner Screen 的 `_nodeMap` —— 也不能进：同一个 itemTemplate `ElementNode` 对应 N 个卡实例，字典键会冲突。
4. 连带问题：`_hasFactorScale` resize 门控也看不到只存在于 itemTemplate 里的 factor scale，即使首次应用了，resize 后也会失效。

## 修复

- `InstantiateNode` 末尾把 `(rootControl, nodeMap)` 注册进 owner Screen（`RegisterDynamicSubtree`），四个动态路径一次覆盖。
- `Screen` 新增 `_dynamicSubtrees` 并行列表：只登记含 `scale` 声明的子树（普通列表卡零开销）；注册时立即用当前 `_canvasFactor` 应用；`ApplyScales`（ReSolve / resize）末尾遍历重算；`_hasFactorScale` 门控纳入动态节点；BindItems 重建销毁的卡按 `Root.GameObject == null` 剔除（与 #65 的防御一致）。
- 幂等性：动态节点没有 ReSolve 的 `ApplyCommon` 基线重置，首次应用前在 `Control._dynamicScaleBaseline` 捕获实例化几何，之后每次先还原 —— box-preserving 补偿不跨 resize / Variant 切换累积。

## 测试

新增 `DynamicSubtreeScaleTests` 7 用例（TDD 先红后绿）：实例化即应用（普通 / `2x` / `0.5r`）、factor scale 仅在模板内时 resize 重算门控、box-preserving 跨 resize 不累积、rebuild 后新卡仍有 scale、variant 切换经 ReSolve 生效并还原。

EditMode 1529/1529 + PlayMode 132/132 绿，lint clean。用户已视觉验证（ChatMessage / EventCard / Announcement 动态卡 `scale="0.5r"`）。

SKILL 无需更新：恢复的是文档已承诺的行为，无旧 caveat。

🤖 Generated with [Claude Code](https://claude.com/claude-code)