### PR TITLE
feat: ScrollList frame/mask 与 Dropdown popup 换肤属性

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -248,7 +248,7 @@ TMP_Dropdown。R3 `OnSelected: int`。选项 C# 侧 `BindOptions(...)` 注入。
 | `tint` | `multiply` / `linear` | — | 见 **Tint blend modes** |
 | `popupSprite` | sprite key | — | Skins the popup list background (the closed button keeps using `sprite`/`color`). |
 | `popupColor` | hex / CSS / token | — | Tints the popup list background. |
-| `popupMask` | sprite key | rounded | Popup viewport clip shape; same three states as `<ScrollList mask>` (`""` = square RectMask2D). |
+| `popupMask` | sprite key | follows `popupSprite` | Popup viewport clip shape; same semantics as `<ScrollList mask>`. Unset auto-tracks `popupSprite` (sprite → rounded stencil; `popupSprite=""` → square `RectMask2D`); explicit `popupMask=` (incl. `""`) opts out. |
 
 ### `<ScrollList>`
 
@@ -265,7 +265,7 @@ ScrollRect + Mask。项 C# 侧 `BindItems(...)` 注入。`itemTemplate` 引用 `
 | `tint` | `multiply` / `linear` | — | 见 **Tint blend modes** |
 | `frame` | sprite key | — | Border layer drawn above content & scrollbar, outside the mask — scrolling content never overlaps it. Lazily created. Note: `tint=` affects only the background, not the frame. |
 | `frameColor` | hex / CSS / token | — | Tints the frame layer; setting it alone also activates the layer. |
-| `mask` | sprite key | rounded | Viewport clip shape. `mask="custom#slice"` = stencil mask with that sprite (auto-sliced); `mask=""` = square `RectMask2D` clip (cheaper; keeps a transparent list's corners square). Unset keeps the built-in rounded mask. Unlike `<Image>`/`<Frame>`, `rect`/`self` are **not** keywords here — this `mask` takes a sprite key, so use `mask=""` for a square clip. |
+| `mask` | sprite key | follows `sprite` | Viewport clip shape. `mask="custom#slice"` = stencil mask with that sprite (auto-sliced); `mask=""` = square `RectMask2D` clip (cheaper). **Unset auto-tracks the bg `sprite`**: a sprite present (incl. the default) → rounded stencil; `sprite=""`/`sprite="none"` → square, so a transparent list's corners stay square without writing `mask=""`. Explicit `mask=` (any value, incl. `""`) opts out of auto-tracking. Unlike `<Image>`/`<Frame>`, `rect`/`self` are **not** keywords here — `mask` takes a sprite key. |
 
 ### `<InputField>`
 

--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -246,6 +246,9 @@ TMP_Dropdown。R3 `OnSelected: int`。选项 C# 侧 `BindOptions(...)` 注入。
 | `sprite` | sprite key | — | |
 | `font` | string | `default` | |
 | `tint` | `multiply` / `linear` | — | 见 **Tint blend modes** |
+| `popupSprite` | sprite key | — | Skins the popup list background (the closed button keeps using `sprite`/`color`). |
+| `popupColor` | hex / CSS / token | — | Tints the popup list background. |
+| `popupMask` | sprite key | rounded | Popup viewport clip shape; same three states as `<ScrollList mask>` (`""` = square RectMask2D). |
 
 ### `<ScrollList>`
 
@@ -260,6 +263,9 @@ ScrollRect + Mask。项 C# 侧 `BindItems(...)` 注入。`itemTemplate` 引用 `
 | `color` | hex / CSS / token | — | 见 **Color Tokens** |
 | `sprite` | sprite key | — | |
 | `tint` | `multiply` / `linear` | — | 见 **Tint blend modes** |
+| `frame` | sprite key | — | Border layer drawn above content & scrollbar, outside the mask — scrolling content never overlaps it. Lazily created. Note: `tint=` affects only the background, not the frame. |
+| `frameColor` | hex / CSS / token | — | Tints the frame layer; setting it alone also activates the layer. |
+| `mask` | sprite key | rounded | Viewport clip shape. `mask="custom#slice"` = stencil mask with that sprite (auto-sliced); `mask=""` = square `RectMask2D` clip (cheaper; keeps a transparent list's corners square). Unset keeps the built-in rounded mask. |
 
 ### `<InputField>`
 

--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -265,7 +265,7 @@ ScrollRect + Mask。项 C# 侧 `BindItems(...)` 注入。`itemTemplate` 引用 `
 | `tint` | `multiply` / `linear` | — | 见 **Tint blend modes** |
 | `frame` | sprite key | — | Border layer drawn above content & scrollbar, outside the mask — scrolling content never overlaps it. Lazily created. Note: `tint=` affects only the background, not the frame. |
 | `frameColor` | hex / CSS / token | — | Tints the frame layer; setting it alone also activates the layer. |
-| `mask` | sprite key | rounded | Viewport clip shape. `mask="custom#slice"` = stencil mask with that sprite (auto-sliced); `mask=""` = square `RectMask2D` clip (cheaper; keeps a transparent list's corners square). Unset keeps the built-in rounded mask. |
+| `mask` | sprite key | rounded | Viewport clip shape. `mask="custom#slice"` = stencil mask with that sprite (auto-sliced); `mask=""` = square `RectMask2D` clip (cheaper; keeps a transparent list's corners square). Unset keeps the built-in rounded mask. Unlike `<Image>`/`<Frame>`, `rect`/`self` are **not** keywords here — this `mask` takes a sprite key, so use `mask=""` for a square clip. |
 
 ### `<InputField>`
 

--- a/Runtime/Controls/Dropdown.cs
+++ b/Runtime/Controls/Dropdown.cs
@@ -16,6 +16,7 @@ namespace PromptUGUI.Controls
         private UnityImage _bg;
         private UnityImage _templateBg;
         private RectTransform _popupViewport;
+        private bool _popupMaskExplicit;
         private TMP_Dropdown _tmp;
         private string _fontType = "default";
         private readonly Subject<int> _selected = new();
@@ -223,8 +224,23 @@ namespace PromptUGUI.Controls
         [UIAttr(IsSprite = true), Preserve]
         public string PopupMask
         {
-            set => ProceduralBuilders.ApplyViewportMask(
-                _popupViewport, value, ProceduralBuilders.SpriteRoundedRect);
+            set
+            {
+                _popupMaskExplicit = true;
+                ProceduralBuilders.ApplyViewportMask(
+                    _popupViewport, value, ProceduralBuilders.SpriteRoundedRect);
+            }
+        }
+
+        internal override void OnAfterApply()
+        {
+            base.OnAfterApply();
+            // popupMask 未显式写时跟随 popup bg sprite：有图→圆角 stencil，popupSprite=""→直角 RectMask2D
+            // （对齐 ScrollList.mask / InputField 的 mask-tracks-border 先例；显式 popupMask= 一旦写过即跳过）。
+            if (!_popupMaskExplicit)
+                ProceduralBuilders.ApplyViewportMask(
+                    _popupViewport, _templateBg != null && _templateBg.sprite != null ? null : "",
+                    ProceduralBuilders.SpriteRoundedRect);
         }
 
         [UIAttr, Preserve]

--- a/Runtime/Controls/Dropdown.cs
+++ b/Runtime/Controls/Dropdown.cs
@@ -14,6 +14,8 @@ namespace PromptUGUI.Controls
     public sealed class Dropdown : Control
     {
         private UnityImage _bg;
+        private UnityImage _templateBg;
+        private RectTransform _popupViewport;
         private TMP_Dropdown _tmp;
         private string _fontType = "default";
         private readonly Subject<int> _selected = new();
@@ -61,31 +63,27 @@ namespace PromptUGUI.Controls
             template.sizeDelta = new Vector2(0f, 150f);
             template.anchoredPosition = new Vector2(0f, 2f);
             template.gameObject.SetActive(false);
-            var templateBg = template.gameObject.AddComponent<UnityImage>();
-            templateBg.color = ProceduralBuilders.DefaultPopupBgColor;
-            ProceduralBuilders.ApplyDefaultSlicedSprite(templateBg);
+            _templateBg = template.gameObject.AddComponent<UnityImage>();
+            _templateBg.color = ProceduralBuilders.DefaultPopupBgColor;
+            ProceduralBuilders.ApplyDefaultSlicedSprite(_templateBg);
             var templateScroll = template.gameObject.AddComponent<UnityEngine.UI.ScrollRect>();
             templateScroll.horizontal = false;
             templateScroll.movementType = UnityEngine.UI.ScrollRect.MovementType.Clamped;
 
-            // Viewport: stencil Mask + sliced Image (alpha=1, showMaskGraphic=false) ── 跟默认 prefab 一致。
+            // Viewport: popup viewport mask 三态 + 默认 pugui_9slice_round，spec §2.3。
             // CRITICAL: alpha 必须为 1。alpha=0.01 会触发 UI/Default shader 的 alpha-discard，
             // 把 stencil 写飞 (4af322b 之前的 bug)。
-            var viewport = ProceduralBuilders.AddChild(template, "Viewport");
-            viewport.anchorMin = new Vector2(0f, 0f);
-            viewport.anchorMax = new Vector2(1f, 1f);
-            viewport.pivot = new Vector2(0f, 1f);
-            viewport.offsetMin = Vector2.zero;
-            viewport.offsetMax = Vector2.zero;
-            viewport.sizeDelta = new Vector2(-18f, 0f);  // 留 18px 给 Vertical Scrollbar (Task 8 加)
-            var viewportImg = viewport.gameObject.AddComponent<UnityImage>();
-            viewportImg.color = UnityEngine.Color.white;  // alpha=1 关键
-            ProceduralBuilders.ApplyDefaultSlicedSprite(viewportImg);
-            var viewportMask = viewport.gameObject.AddComponent<UnityEngine.UI.Mask>();
-            viewportMask.showMaskGraphic = false;
+            _popupViewport = ProceduralBuilders.AddChild(template, "Viewport");
+            _popupViewport.anchorMin = new Vector2(0f, 0f);
+            _popupViewport.anchorMax = new Vector2(1f, 1f);
+            _popupViewport.pivot = new Vector2(0f, 1f);
+            _popupViewport.offsetMin = Vector2.zero;
+            _popupViewport.offsetMax = Vector2.zero;
+            _popupViewport.sizeDelta = new Vector2(-18f, 0f);  // 留 18px 给 Vertical Scrollbar
+            ProceduralBuilders.ApplyViewportMask(_popupViewport, null, ProceduralBuilders.SpriteRoundedRect);
 
             // Content (top-anchored; height grows to fit items via TMP_Dropdown's runtime sizing).
-            var content = ProceduralBuilders.AddChild(viewport, "Content");
+            var content = ProceduralBuilders.AddChild(_popupViewport, "Content");
             content.anchorMin = new Vector2(0f, 1f);
             content.anchorMax = new Vector2(1f, 1f);
             content.pivot = new Vector2(0.5f, 1f);
@@ -160,7 +158,7 @@ namespace PromptUGUI.Controls
             templateScroll.verticalScrollbarVisibility = UnityEngine.UI.ScrollRect.ScrollbarVisibility.AutoHideAndExpandViewport;
             templateScroll.verticalScrollbarSpacing = -3f;
 
-            templateScroll.viewport = viewport;
+            templateScroll.viewport = _popupViewport;
             templateScroll.content = content;
 
             _tmp.template = template;

--- a/Runtime/Controls/Dropdown.cs
+++ b/Runtime/Controls/Dropdown.cs
@@ -204,6 +204,29 @@ namespace PromptUGUI.Controls
             set => _bg.sprite = UI.ResolveSprite(value);
         }
 
+        [UIAttr(IsSprite = true), Preserve]
+        public string PopupSprite
+        {
+            set
+            {
+                _templateBg.sprite = UI.ResolveSprite(value);
+                ProceduralBuilders.AutoSlice(_templateBg);
+            }
+        }
+
+        [UIAttr(IsColor = true), Preserve]
+        public string PopupColor
+        {
+            set => _templateBg.color = UI.Theme.Resolve(value);
+        }
+
+        [UIAttr(IsSprite = true), Preserve]
+        public string PopupMask
+        {
+            set => ProceduralBuilders.ApplyViewportMask(
+                _popupViewport, value, ProceduralBuilders.SpriteRoundedRect);
+        }
+
         [UIAttr, Preserve]
         public string Font
         {

--- a/Runtime/Controls/Internal/ProceduralBuilders.cs
+++ b/Runtime/Controls/Internal/ProceduralBuilders.cs
@@ -80,6 +80,15 @@ namespace PromptUGUI.Controls.Internal
             img.preserveAspect = preserveAspect;
         }
 
+        /// <summary>sprite 有 border → Sliced，否则 Simple；null sprite 不动（镜像原 Progress 私有版规则）。</summary>
+        public static void AutoSlice(UnityImage img)
+        {
+            if (img == null || img.sprite == null) return;
+            img.type = img.sprite.border != Vector4.zero
+                ? UnityImage.Type.Sliced
+                : UnityImage.Type.Simple;
+        }
+
         internal static void ResetDefaultSpriteCacheForTests() => _defaultSprites = null;
 
         public static RectTransform AddChild(RectTransform parent, string name)

--- a/Runtime/Controls/Internal/ProceduralBuilders.cs
+++ b/Runtime/Controls/Internal/ProceduralBuilders.cs
@@ -55,20 +55,6 @@ namespace PromptUGUI.Controls.Internal
             img.type = UnityImage.Type.Sliced;
         }
 
-        /// <summary>
-        /// 给 stencil Mask 用的 graphic 应用专门的 mask sprite (pugui_9slice_mask)。
-        /// 这张 sprite 跟 round 不同：border=2、Simple type 整张拉伸，让 stencil 的圆角形状
-        /// 跟 RT 大小成比例可见 (default Unity Scroll View 用单独 UIMask sprite 同样思路)。
-        /// </summary>
-        public static void ApplyDefaultMaskSprite(UnityImage img)
-        {
-            if (img == null || img.sprite != null) return;
-            var s = GetDefaultSprite(SpriteMaskRoundedRect);
-            if (s == null) return;
-            img.sprite = s;
-            img.type = UnityImage.Type.Sliced;
-        }
-
         /// <summary>给 Image 应用 simple sprite 兜底（caret / checkmark 等无边界形状）。</summary>
         public static void ApplyDefaultSimpleSprite(UnityImage img, string spriteName, bool preserveAspect = false)
         {

--- a/Runtime/Controls/Internal/ProceduralBuilders.cs
+++ b/Runtime/Controls/Internal/ProceduralBuilders.cs
@@ -89,6 +89,44 @@ namespace PromptUGUI.Controls.Internal
                 : UnityImage.Type.Simple;
         }
 
+        /// <summary>
+        /// Viewport mask 三态（spec 2026-06-11-list-popup-skin-mask §2.3）：
+        /// value == null → 默认 sprite + stencil Mask（OnAttached 初始形态）；
+        /// value == ""   → RectMask2D 直角裁剪（stencil Mask + Image 关 enabled）；
+        /// 其他          → 指定 sprite + stencil Mask（UI.ResolveSprite 失败路径同 sprite=）。
+        /// lazy-add + enabled 开关，不 Destroy —— Variant ReSolve 可在三态间任意来回切，
+        /// 也避免 PlayMode 下 Destroy 延迟销毁导致同帧切换读到待销毁组件。
+        /// </summary>
+        public static void ApplyViewportMask(RectTransform viewport, string value, string defaultSpriteName)
+        {
+            var go = viewport.gameObject;
+            var img = go.GetComponent<UnityImage>();
+            var mask = go.GetComponent<Mask>();
+            var rectMask = go.GetComponent<RectMask2D>();
+
+            if (value != null && value.Length == 0)
+            {
+                if (mask != null) mask.enabled = false;
+                if (img != null) img.enabled = false;
+                if (rectMask == null) rectMask = go.AddComponent<RectMask2D>();
+                rectMask.enabled = true;
+                return;
+            }
+
+            if (rectMask != null) rectMask.enabled = false;
+            if (img == null) img = go.AddComponent<UnityImage>();
+            img.enabled = true;
+            // alpha=1 关键：alpha<1 触发 UI/Default shader 的 alpha-discard，把 stencil 写飞 (4af322b)。
+            img.color = Color.white;
+            img.sprite = value == null
+                ? GetDefaultSprite(defaultSpriteName)
+                : PromptUGUI.Application.UI.ResolveSprite(value);
+            AutoSlice(img);
+            if (mask == null) mask = go.AddComponent<Mask>();
+            mask.enabled = true;
+            mask.showMaskGraphic = false;
+        }
+
         internal static void ResetDefaultSpriteCacheForTests() => _defaultSprites = null;
 
         public static RectTransform AddChild(RectTransform parent, string name)

--- a/Runtime/Controls/Progress.cs
+++ b/Runtime/Controls/Progress.cs
@@ -98,7 +98,7 @@ namespace PromptUGUI.Controls
                 if (string.IsNullOrEmpty(value)) return;
                 _bg.sprite = UI.ResolveSprite(value);
                 _bg.gameObject.SetActive(true);
-                AutoSlice(_bg);
+                ProceduralBuilders.AutoSlice(_bg);
                 ReconcileMaskVisibility();
             }
         }
@@ -122,7 +122,7 @@ namespace PromptUGUI.Controls
                 if (string.IsNullOrEmpty(value)) return;
                 _frame.sprite = UI.ResolveSprite(value);
                 _frame.gameObject.SetActive(true);
-                AutoSlice(_frame);
+                ProceduralBuilders.AutoSlice(_frame);
             }
         }
 
@@ -150,26 +150,18 @@ namespace PromptUGUI.Controls
                     _stencilMask = maskRt.gameObject.AddComponent<UnityEngine.UI.Mask>();
                 }
                 _maskGraphic.sprite = UI.ResolveSprite(value);
-                AutoSlice(_maskGraphic);
+                ProceduralBuilders.AutoSlice(_maskGraphic);
                 ReconcileMaskVisibility();
             }
         }
 
         internal override void OnAfterApply()
         {
-            AutoSlice(_bg);
-            AutoSlice(_frame);
-            AutoSlice(_maskGraphic);
+            ProceduralBuilders.AutoSlice(_bg);
+            ProceduralBuilders.AutoSlice(_frame);
+            ProceduralBuilders.AutoSlice(_maskGraphic);
             ReconcileMaskVisibility();
             ReconcileFill();
-        }
-
-        private static void AutoSlice(UnityImage img)
-        {
-            if (img == null || img.sprite == null) return;
-            img.type = img.sprite.border != Vector4.zero
-                ? UnityImage.Type.Sliced
-                : UnityImage.Type.Simple;
         }
 
         private void ReconcileMaskVisibility()

--- a/Runtime/Controls/ScrollList.cs
+++ b/Runtime/Controls/ScrollList.cs
@@ -16,6 +16,7 @@ namespace PromptUGUI.Controls
     {
         private UnityImage _bg;
         private UnityImage _frame;
+        private bool _maskExplicit;
         private ScrollRect _scroll;
         private RectTransform _viewport;
         private RectTransform _content;
@@ -189,8 +190,12 @@ namespace PromptUGUI.Controls
         [UIAttr(IsSprite = true), Preserve]
         public string Mask
         {
-            set => ProceduralBuilders.ApplyViewportMask(
-                _viewport, value, ProceduralBuilders.SpriteMaskRoundedRect);
+            set
+            {
+                _maskExplicit = true;
+                ProceduralBuilders.ApplyViewportMask(
+                    _viewport, value, ProceduralBuilders.SpriteMaskRoundedRect);
+            }
         }
 
         private UnityImage EnsureFrame()
@@ -220,6 +225,12 @@ namespace PromptUGUI.Controls
         internal override void OnAfterApply()
         {
             base.OnAfterApply();
+            // mask 未显式写时跟随 bg sprite：有图→圆角 stencil，sprite=""→直角 RectMask2D
+            // （对齐 InputField 的 mask-tracks-border 先例；显式 mask= 一旦写过即 latch，跳过这里）。
+            if (!_maskExplicit)
+                ProceduralBuilders.ApplyViewportMask(
+                    _viewport, _bg != null && _bg.sprite != null ? null : "",
+                    ProceduralBuilders.SpriteMaskRoundedRect);
             // Scrollbar 由 Direction setter 懒建，可能晚于 frame 入树 —— 每轮 apply 后把 frame 钉回最顶。
             if (_frame != null) _frame.transform.SetAsLastSibling();
         }

--- a/Runtime/Controls/ScrollList.cs
+++ b/Runtime/Controls/ScrollList.cs
@@ -15,6 +15,7 @@ namespace PromptUGUI.Controls
     public sealed class ScrollList : Control
     {
         private UnityImage _bg;
+        private UnityImage _frame;
         private ScrollRect _scroll;
         private RectTransform _viewport;
         private RectTransform _content;
@@ -190,6 +191,37 @@ namespace PromptUGUI.Controls
         {
             set => ProceduralBuilders.ApplyViewportMask(
                 _viewport, value, ProceduralBuilders.SpriteMaskRoundedRect);
+        }
+
+        private UnityImage EnsureFrame()
+        {
+            // 边框层：内容/滚动条之上、不被 mask（spec §2.1）。懒创建；层序由 OnAfterApply 钉住。
+            _frame ??= ProceduralBuilders.AddImage(RectTransform, "Frame", raycast: false);
+            return _frame;
+        }
+
+        [UIAttr(IsSprite = true), Preserve]
+        public string Frame
+        {
+            set
+            {
+                var img = EnsureFrame();
+                img.sprite = UI.ResolveSprite(value);
+                ProceduralBuilders.AutoSlice(img);
+            }
+        }
+
+        [UIAttr(IsColor = true), Preserve]
+        public string FrameColor
+        {
+            set => EnsureFrame().color = UI.Theme.Resolve(value);
+        }
+
+        internal override void OnAfterApply()
+        {
+            base.OnAfterApply();
+            // Scrollbar 由 Direction setter 懒建，可能晚于 frame 入树 —— 每轮 apply 后把 frame 钉回最顶。
+            if (_frame != null) _frame.transform.SetAsLastSibling();
         }
 
         private Func<RectTransform, IControl> ResolveFactory(string tag)

--- a/Runtime/Controls/ScrollList.cs
+++ b/Runtime/Controls/ScrollList.cs
@@ -16,6 +16,7 @@ namespace PromptUGUI.Controls
     {
         private UnityImage _bg;
         private ScrollRect _scroll;
+        private RectTransform _viewport;
         private RectTransform _content;
         private LayoutGroup _layoutGroup;
         private string _direction = "vertical";
@@ -45,20 +46,13 @@ namespace PromptUGUI.Controls
             ProceduralBuilders.ApplyDefaultSlicedSprite(_bg);
             _scroll = GameObject.GetComponent<ScrollRect>() ?? GameObject.AddComponent<ScrollRect>();
 
-            var viewport = ProceduralBuilders.AddChild(RectTransform, "Viewport");
-            viewport.pivot = new Vector2(0f, 1f);
-            // Viewport: stencil Mask + alpha=1 mask sprite + showMaskGraphic=false (跟 Unity 默认 Scroll View 思路一致)。
-            // 用专门的 pugui_9slice_mask sprite 而非 bg 用的 pugui_9slice_round —— 后者 9-slice 圆角才 2×2 像素，
-            // 视觉上 stencil 圆角效果不可见。pugui_9slice_mask 是 Simple type 整张拉伸，圆角弧度跟 RT 大小成比例可见。
-            // alpha=1 关键，避免 4af322b 的 UI/Default shader alpha-discard。
-            var viewportImg = viewport.gameObject.AddComponent<UnityImage>();
-            viewportImg.color = UnityEngine.Color.white;
-            ProceduralBuilders.ApplyDefaultMaskSprite(viewportImg);
-            var viewportMask = viewport.gameObject.AddComponent<Mask>();
-            viewportMask.showMaskGraphic = false;
-            _scroll.viewport = viewport;
+            _viewport = ProceduralBuilders.AddChild(RectTransform, "Viewport");
+            _viewport.pivot = new Vector2(0f, 1f);
+            // Viewport mask 三态 + 默认 pugui_9slice_mask 圆角，见 ApplyViewportMask 注释 / spec §2.3。
+            ProceduralBuilders.ApplyViewportMask(_viewport, null, ProceduralBuilders.SpriteMaskRoundedRect);
+            _scroll.viewport = _viewport;
 
-            _content = ProceduralBuilders.AddChild(viewport, "Content");
+            _content = ProceduralBuilders.AddChild(_viewport, "Content");
             _scroll.content = _content;
 
             _scroll.movementType = ScrollRect.MovementType.Elastic;

--- a/Runtime/Controls/ScrollList.cs
+++ b/Runtime/Controls/ScrollList.cs
@@ -185,6 +185,13 @@ namespace PromptUGUI.Controls
             set => _bg.sprite = UI.ResolveSprite(value);
         }
 
+        [UIAttr(IsSprite = true), Preserve]
+        public string Mask
+        {
+            set => ProceduralBuilders.ApplyViewportMask(
+                _viewport, value, ProceduralBuilders.SpriteMaskRoundedRect);
+        }
+
         private Func<RectTransform, IControl> ResolveFactory(string tag)
         {
             if (string.IsNullOrEmpty(tag)) return null;

--- a/Tests/EditMode/Controls/DropdownTests.cs
+++ b/Tests/EditMode/Controls/DropdownTests.cs
@@ -71,6 +71,51 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
+        public void PopupMask_unset_auto_squares_when_popupSprite_empty()
+        {
+            var dd = OpenDropdown(@"popupSprite=''");
+            var vp = TemplateOf(dd).Find("Viewport").gameObject;
+            Assert.IsTrue(vp.GetComponent<UnityEngine.UI.RectMask2D>() != null
+                          && vp.GetComponent<UnityEngine.UI.RectMask2D>().enabled,
+                "popupSprite='' with no explicit popupMask should auto-square the popup viewport clip");
+            var mask = vp.GetComponent<UnityEngine.UI.Mask>();
+            Assert.IsTrue(mask == null || !mask.enabled, "stencil Mask must be off when auto-squared");
+        }
+
+        [Test]
+        public void PopupMask_unset_stays_rounded_when_popupSprite_present()
+        {
+            var dd = OpenDropdown();  // default popup bg has the rounded sprite
+            var vp = TemplateOf(dd).Find("Viewport").gameObject;
+            var mask = vp.GetComponent<UnityEngine.UI.Mask>();
+            Assert.IsNotNull(mask);
+            Assert.IsTrue(mask.enabled, "default popup bg sprite present → rounded stencil mask");
+            Assert.IsNull(vp.GetComponent<UnityEngine.UI.RectMask2D>());
+        }
+
+        [Test]
+        public void Explicit_popupMask_wins_over_popupSprite_autotrack()
+        {
+            var dd = OpenDropdown(@"popupSprite='' popupMask='PromptUGUI/Defaults/pugui#pugui_9slice_mask'");
+            var vp = TemplateOf(dd).Find("Viewport").gameObject;
+            var mask = vp.GetComponent<UnityEngine.UI.Mask>();
+            Assert.IsNotNull(mask);
+            Assert.IsTrue(mask.enabled, "explicit popupMask wins despite popupSprite=''");
+            Assert.AreEqual("pugui_9slice_mask", vp.GetComponent<UnityEngine.UI.Image>().sprite.name);
+            Assert.IsNull(vp.GetComponent<UnityEngine.UI.RectMask2D>());
+        }
+
+        [Test]
+        public void Explicit_empty_popupMask_stays_square_even_with_popupSprite_present()
+        {
+            var dd = OpenDropdown(@"popupMask=''");  // default popup bg sprite present, but explicit '' wins
+            var vp = TemplateOf(dd).Find("Viewport").gameObject;
+            Assert.IsTrue(vp.GetComponent<UnityEngine.UI.RectMask2D>().enabled);
+            var mask = vp.GetComponent<UnityEngine.UI.Mask>();
+            Assert.IsTrue(mask == null || !mask.enabled);
+        }
+
+        [Test]
         public void BindOptions_strings_populates_tmp_dropdown()
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>

--- a/Tests/EditMode/Controls/DropdownTests.cs
+++ b/Tests/EditMode/Controls/DropdownTests.cs
@@ -12,6 +12,64 @@ namespace PromptUGUI.Tests.EditMode.Controls
         [SetUp] public void SetUp() => UI.ResetForTests();
         [TearDown] public void TearDown() => UI.ResetForTests();
 
+        private Dropdown OpenDropdown(string attrs = "")
+        {
+            string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'><Dropdown id='dd' " + attrs + @"/></Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            return UI.Open("S").Get<Dropdown>("dd");
+        }
+
+        private static UnityEngine.Transform TemplateOf(Dropdown dd) =>
+            dd.GameObject.transform.Find("Template");
+
+        [Test]
+        public void PopupSprite_and_color_apply_to_template_bg()
+        {
+            var dd = OpenDropdown(@"popupSprite='PromptUGUI/Defaults/pugui#pugui_9slice_mask' popupColor='#00FF00'");
+            var bg = TemplateOf(dd).GetComponent<UnityEngine.UI.Image>();
+            Assert.AreEqual("pugui_9slice_mask", bg.sprite.name);
+            Assert.AreEqual(0f, bg.color.r);
+            Assert.AreEqual(1f, bg.color.g);
+        }
+
+        [Test]
+        public void Popup_defaults_unchanged_without_popup_attrs()
+        {
+            var dd = OpenDropdown();
+            var bg = TemplateOf(dd).GetComponent<UnityEngine.UI.Image>();
+            Assert.AreEqual(UnityEngine.Color.white, bg.color);  // DefaultPopupBgColor
+            Assert.AreEqual("pugui_9slice_round", bg.sprite.name);
+            var vp = TemplateOf(dd).Find("Viewport").gameObject;
+            Assert.IsTrue(vp.GetComponent<UnityEngine.UI.Mask>().enabled);
+            Assert.IsNull(vp.GetComponent<UnityEngine.UI.RectMask2D>());
+        }
+
+        [Test]
+        public void PopupMask_empty_swaps_stencil_for_RectMask2D()
+        {
+            var dd = OpenDropdown(@"popupMask=''");
+            var vp = TemplateOf(dd).Find("Viewport").gameObject;
+            Assert.IsTrue(vp.GetComponent<UnityEngine.UI.RectMask2D>().enabled);
+            var mask = vp.GetComponent<UnityEngine.UI.Mask>();
+            Assert.IsTrue(mask == null || !mask.enabled);
+            var img = vp.GetComponent<UnityEngine.UI.Image>();
+            Assert.IsTrue(img == null || !img.enabled);
+        }
+
+        [Test]
+        public void PopupMask_custom_sprite_applies_to_viewport()
+        {
+            var dd = OpenDropdown(@"popupMask='PromptUGUI/Defaults/pugui#pugui_9slice_mask'");
+            var vp = TemplateOf(dd).Find("Viewport").gameObject;
+            var img = vp.GetComponent<UnityEngine.UI.Image>();
+            Assert.AreEqual("pugui_9slice_mask", img.sprite.name);
+            Assert.IsTrue(vp.GetComponent<UnityEngine.UI.Mask>().enabled);
+            Assert.IsFalse(vp.GetComponent<UnityEngine.UI.Mask>().showMaskGraphic);
+        }
+
         [Test]
         public void BindOptions_strings_populates_tmp_dropdown()
         {

--- a/Tests/EditMode/Controls/ScrollListTests.cs
+++ b/Tests/EditMode/Controls/ScrollListTests.cs
@@ -241,5 +241,42 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var sr = sl.GameObject.GetComponent<UnityEngine.UI.ScrollRect>();
             Assert.AreSame(scrollbar, sr.horizontalScrollbar);
         }
+
+        [Test]
+        public void Frame_creates_topmost_nonraycast_layer()
+        {
+            var sl = OpenList(@"frame='PromptUGUI/Defaults/pugui#pugui_9slice_round'");
+            var root = sl.GameObject.transform;
+            var frame = root.Find("Frame");
+            Assert.IsNotNull(frame, "frame= should lazily create the Frame layer");
+            Assert.AreEqual(root.childCount - 1, frame.GetSiblingIndex(), "frame must be the last sibling (above Viewport & Scrollbar)");
+            var img = frame.GetComponent<UnityEngine.UI.Image>();
+            Assert.IsFalse(img.raycastTarget);
+            Assert.AreEqual("pugui_9slice_round", img.sprite.name);
+            Assert.AreEqual(UnityEngine.UI.Image.Type.Sliced, img.type);
+            var rt = (UnityEngine.RectTransform)frame;
+            Assert.AreEqual(UnityEngine.Vector2.zero, rt.anchorMin);
+            Assert.AreEqual(UnityEngine.Vector2.one, rt.anchorMax);
+            Assert.AreEqual(UnityEngine.Vector2.zero, rt.offsetMin);
+            Assert.AreEqual(UnityEngine.Vector2.zero, rt.offsetMax);
+        }
+
+        [Test]
+        public void FrameColor_alone_activates_frame_layer()
+        {
+            var sl = OpenList(@"frameColor='#FF0000'");
+            var frame = sl.GameObject.transform.Find("Frame");
+            Assert.IsNotNull(frame);
+            var img = frame.GetComponent<UnityEngine.UI.Image>();
+            Assert.AreEqual(1f, img.color.r);
+            Assert.AreEqual(0f, img.color.g);
+        }
+
+        [Test]
+        public void No_frame_attr_means_no_frame_node()
+        {
+            var sl = OpenList();
+            Assert.IsNull(sl.GameObject.transform.Find("Frame"), "frame layer is lazy");
+        }
     }
 }

--- a/Tests/EditMode/Controls/ScrollListTests.cs
+++ b/Tests/EditMode/Controls/ScrollListTests.cs
@@ -11,6 +11,66 @@ namespace PromptUGUI.Tests.EditMode.Controls
         [SetUp] public void SetUp() => UI.ResetForTests();
         [TearDown] public void TearDown() => UI.ResetForTests();
 
+        private ScrollList OpenList(string attrs = "")
+        {
+            string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Slot'><Frame/></Template>
+  <Screen name='S'><ScrollList id='sl' itemTemplate='Slot' " + attrs + @"/></Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            return UI.Open("S").Get<ScrollList>("sl");
+        }
+
+        private static UnityEngine.RectTransform ViewportOf(ScrollList sl) =>
+            (UnityEngine.RectTransform)sl.GameObject.transform.Find("Viewport");
+
+        [Test]
+        public void Mask_empty_swaps_stencil_for_RectMask2D()
+        {
+            var sl = OpenList(@"mask=''");
+            var vp = ViewportOf(sl).gameObject;
+            var rectMask = vp.GetComponent<UnityEngine.UI.RectMask2D>();
+            Assert.IsNotNull(rectMask);
+            Assert.IsTrue(rectMask.enabled);
+            var mask = vp.GetComponent<UnityEngine.UI.Mask>();
+            Assert.IsTrue(mask == null || !mask.enabled, "stencil Mask must be off");
+            var img = vp.GetComponent<UnityEngine.UI.Image>();
+            Assert.IsTrue(img == null || !img.enabled, "viewport Image must be off (RectMask2D has no showMaskGraphic)");
+        }
+
+        [Test]
+        public void Mask_custom_sprite_replaces_default_mask_sprite()
+        {
+            var sl = OpenList(@"mask='PromptUGUI/Defaults/pugui#pugui_9slice_round'");
+            var vp = ViewportOf(sl).gameObject;
+            var mask = vp.GetComponent<UnityEngine.UI.Mask>();
+            Assert.IsNotNull(mask);
+            Assert.IsTrue(mask.enabled);
+            Assert.IsFalse(mask.showMaskGraphic);
+            var img = vp.GetComponent<UnityEngine.UI.Image>();
+            Assert.AreEqual("pugui_9slice_round", img.sprite.name);
+            Assert.AreEqual(1f, img.color.a, "alpha=1 critical (4af322b)");
+            Assert.AreEqual(UnityEngine.UI.Image.Type.Sliced, img.type, "AutoSlice: border 非零 → Sliced");
+            Assert.IsNull(vp.GetComponent<UnityEngine.UI.RectMask2D>());
+        }
+
+        [Test]
+        public void Mask_toggles_between_states_without_leftover_components()
+        {
+            var sl = OpenList();
+            var vp = ViewportOf(sl).gameObject;
+            sl.Mask = "";                                              // 圆角 → 直角
+            sl.Mask = "PromptUGUI/Defaults/pugui#pugui_9slice_round";  // 直角 → 自定义
+            sl.Mask = "";                                              // 自定义 → 直角
+
+            Assert.AreEqual(1, vp.GetComponents<UnityEngine.UI.RectMask2D>().Length, "no duplicates");
+            Assert.AreEqual(1, vp.GetComponents<UnityEngine.UI.Mask>().Length, "lazy-add keeps single instance");
+            Assert.IsTrue(vp.GetComponent<UnityEngine.UI.RectMask2D>().enabled);
+            Assert.IsFalse(vp.GetComponent<UnityEngine.UI.Mask>().enabled);
+            Assert.IsFalse(vp.GetComponent<UnityEngine.UI.Image>().enabled);
+        }
+
         [Test]
         public void BindItems_template_creates_one_slot_per_data_item()
         {

--- a/Tests/EditMode/Controls/ScrollListTests.cs
+++ b/Tests/EditMode/Controls/ScrollListTests.cs
@@ -294,5 +294,54 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var sl = OpenList();
             Assert.IsNull(sl.GameObject.transform.Find("Frame"), "frame layer is lazy");
         }
+
+        [Test]
+        public void Mask_unset_auto_squares_when_sprite_empty()
+        {
+            // sprite="" clears the bg → mask must auto-follow to square (no orphan rounded clip)
+            var sl = OpenList(@"sprite='' color='#00000000'");
+            var vp = ViewportOf(sl).gameObject;
+            Assert.IsTrue(vp.GetComponent<UnityEngine.UI.RectMask2D>() != null
+                          && vp.GetComponent<UnityEngine.UI.RectMask2D>().enabled,
+                "sprite='' with no explicit mask should auto-square the viewport clip");
+            var mask = vp.GetComponent<UnityEngine.UI.Mask>();
+            Assert.IsTrue(mask == null || !mask.enabled, "stencil Mask must be off when auto-squared");
+        }
+
+        [Test]
+        public void Mask_unset_stays_rounded_when_sprite_present()
+        {
+            // default list (bg has the default rounded sprite) keeps the rounded stencil — back-compat
+            var sl = OpenList();
+            var vp = ViewportOf(sl).gameObject;
+            var mask = vp.GetComponent<UnityEngine.UI.Mask>();
+            Assert.IsNotNull(mask);
+            Assert.IsTrue(mask.enabled, "default bg sprite present → rounded stencil mask");
+            Assert.IsNull(vp.GetComponent<UnityEngine.UI.RectMask2D>());
+        }
+
+        [Test]
+        public void Explicit_mask_wins_over_sprite_autotrack()
+        {
+            // explicit mask='...' must NOT be overridden by the sprite='' auto-track
+            var sl = OpenList(@"sprite='' mask='PromptUGUI/Defaults/pugui#pugui_9slice_round'");
+            var vp = ViewportOf(sl).gameObject;
+            var mask = vp.GetComponent<UnityEngine.UI.Mask>();
+            Assert.IsNotNull(mask);
+            Assert.IsTrue(mask.enabled, "explicit mask sprite wins despite sprite=''");
+            Assert.AreEqual("pugui_9slice_round", vp.GetComponent<UnityEngine.UI.Image>().sprite.name);
+            Assert.IsNull(vp.GetComponent<UnityEngine.UI.RectMask2D>());
+        }
+
+        [Test]
+        public void Explicit_empty_mask_stays_square_even_with_sprite_present()
+        {
+            // mask='' is explicit → square, even though the default bg sprite is present (NOT auto-rounded)
+            var sl = OpenList(@"mask=''");
+            var vp = ViewportOf(sl).gameObject;
+            Assert.IsTrue(vp.GetComponent<UnityEngine.UI.RectMask2D>().enabled);
+            var mask = vp.GetComponent<UnityEngine.UI.Mask>();
+            Assert.IsTrue(mask == null || !mask.enabled);
+        }
     }
 }

--- a/Tests/EditMode/Controls/ScrollListTests.cs
+++ b/Tests/EditMode/Controls/ScrollListTests.cs
@@ -262,6 +262,22 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
+        public void Frame_stays_topmost_after_horizontal_scrollbar_created()
+        {
+            // direction='horizontal' re-runs ApplyDirection → EnsureHorizontalScrollbar appends a
+            // NEW last-sibling AFTER the frame already exists; only OnAfterApply's re-pin keeps the
+            // border on top. (The default vertical path builds its scrollbar before the frame, so it
+            // wouldn't catch a missing re-pin — this case does.)
+            var sl = OpenList(@"frame='PromptUGUI/Defaults/pugui#pugui_9slice_round' direction='horizontal'");
+            var root = sl.GameObject.transform;
+            var frame = root.Find("Frame");
+            Assert.IsNotNull(frame);
+            Assert.IsNotNull(root.Find("Scrollbar Horizontal"), "horizontal scrollbar should exist in this direction");
+            Assert.AreEqual(root.childCount - 1, frame.GetSiblingIndex(),
+                "frame must remain the last sibling even though the horizontal scrollbar was created after it");
+        }
+
+        [Test]
         public void FrameColor_alone_activates_frame_layer()
         {
             var sl = OpenList(@"frameColor='#FF0000'");

--- a/Tests/EditMode/Editor/XsdGeneratorTests.cs
+++ b/Tests/EditMode/Editor/XsdGeneratorTests.cs
@@ -947,6 +947,23 @@ namespace PromptUGUI.Tests.Editor
             StringAssert.Contains("name=\"codeFont\"", xsd);
             StringAssert.Contains("name=\"linkColor\"", xsd);
         }
+
+        [Test]
+        public void ScrollList_and_Dropdown_skin_attrs_in_schema()
+        {
+            // Tasks 3-5 added skin attrs via [UIAttr]; the reflected `customs` path emits them
+            // automatically — this is the regression anchor proving they reach the schema.
+            var r = new ControlRegistry();
+            r.Register<ScrollList>("ScrollList", null);
+            r.Register<Dropdown>("Dropdown", null);
+            var xsd = XsdGenerator.Generate(r);
+            StringAssert.Contains("name=\"frame\"", xsd);
+            StringAssert.Contains("name=\"frameColor\"", xsd);
+            StringAssert.Contains("name=\"mask\"", xsd);
+            StringAssert.Contains("name=\"popupSprite\"", xsd);
+            StringAssert.Contains("name=\"popupColor\"", xsd);
+            StringAssert.Contains("name=\"popupMask\"", xsd);
+        }
     }
 
     public class TestPrimaryButton : Control

--- a/docs~/superpowers/plans/2026-06-11-list-popup-skin-mask.md
+++ b/docs~/superpowers/plans/2026-06-11-list-popup-skin-mask.md
@@ -1,0 +1,592 @@
+# ScrollList / Dropdown 换肤 + mask 属性 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `<ScrollList>` 新增 `frame=` / `frameColor=` / `mask=`，`<Dropdown>` 新增 `popupSprite=` / `popupColor=` / `popupMask=`，对齐 `<Progress>` 的 bg/frame/mask 词汇。
+
+**Architecture:** mask 三态逻辑（null=默认 sprite + stencil；""=RectMask2D 直角；其他=指定 sprite + stencil）抽成 `ProceduralBuilders.ApplyViewportMask` 一份实现，两控件 OnAttached 与新 setter 共用；切换用 lazy-add + `enabled` 开关，不 Destroy。`AutoSlice` 从 Progress 提为公共。frame 层懒创建顶层 sibling，`OnAfterApply` 里 `SetAsLastSibling()` 保证压在懒建的 Scrollbar 之上。
+
+**Tech Stack:** Unity 6 uGUI（Mask / RectMask2D / Image），EditMode NUnit via UnityMCP，dotnet format lint。
+
+**Spec:** `docs~/superpowers/specs/2026-06-11-list-popup-skin-mask-design.md`
+
+**前置状态：** 分支 `feat/list-popup-skin-mask` 已建（spec 已提交）。每个任务结束跑 lint：`cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx`（首次需 `dotnet restore PromptUGUI.Lint.slnx`）。
+
+**测试命令模板**（每次源码改动后先 refresh 再跑）：
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])     # 确认无编译错误
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["<ClassName>"])
+mcp__UnityMCP__get_test_job(job_id=...)                        # 轮询到完成
+```
+
+---
+
+### Task 1: `ProceduralBuilders.AutoSlice` 公共化（纯重构）
+
+**Files:**
+- Modify: `Runtime/Controls/Internal/ProceduralBuilders.cs`（在 `ApplyDefaultSimpleSprite` 之后加方法）
+- Modify: `Runtime/Controls/Progress.cs`（删私有 `AutoSlice`，5 处调用改指向公共版）
+
+- [ ] **Step 1: ProceduralBuilders 加 AutoSlice**
+
+```csharp
+/// <summary>sprite 有 border → Sliced，否则 Simple；null sprite 不动（镜像原 Progress 私有版规则）。</summary>
+public static void AutoSlice(UnityImage img)
+{
+    if (img == null || img.sprite == null) return;
+    img.type = img.sprite.border != Vector4.zero
+        ? UnityImage.Type.Sliced
+        : UnityImage.Type.Simple;
+}
+```
+
+- [ ] **Step 2: Progress 删私有 AutoSlice、改调用**
+
+删除 `Progress.cs:167-173` 的 `private static void AutoSlice(UnityImage img)` 方法；文件内 5 处 `AutoSlice(...)` 调用（`Bg` setter、`Frame` setter、`Mask` setter、`OnAfterApply` 里 3 连发）全部改为 `ProceduralBuilders.AutoSlice(...)`。Progress.cs 已 `using PromptUGUI.Controls.Internal;`（确认 using 列表，没有就加）。
+
+- [ ] **Step 3: refresh + 跑 Progress 回归**
+
+Run: `run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["ProgressTests"])`
+Expected: 全 PASS（纯重构零行为变化）。
+
+- [ ] **Step 4: lint + commit**
+
+```bash
+git add Runtime/Controls/Internal/ProceduralBuilders.cs Runtime/Controls/Progress.cs
+git commit -m "refactor: AutoSlice 提为 ProceduralBuilders 公共方法"
+```
+
+---
+
+### Task 2: `ApplyViewportMask` helper + ScrollList / Dropdown OnAttached 改用（行为不变重构）
+
+**Files:**
+- Modify: `Runtime/Controls/Internal/ProceduralBuilders.cs`
+- Modify: `Runtime/Controls/ScrollList.cs:48-59`（Viewport 构建段）
+- Modify: `Runtime/Controls/Dropdown.cs:71-85`（popup Viewport 构建段）
+
+- [ ] **Step 1: ProceduralBuilders 加 ApplyViewportMask**
+
+```csharp
+/// <summary>
+/// Viewport mask 三态（spec 2026-06-11-list-popup-skin-mask §2.3）：
+/// value == null → 默认 sprite + stencil Mask（OnAttached 初始形态）；
+/// value == ""   → RectMask2D 直角裁剪（stencil Mask + Image 关 enabled）；
+/// 其他          → 指定 sprite + stencil Mask（UI.ResolveSprite 失败路径同 sprite=）。
+/// lazy-add + enabled 开关，不 Destroy —— Variant ReSolve 可在三态间任意来回切，
+/// 也避免 PlayMode 下 Destroy 延迟销毁导致同帧切换读到待销毁组件。
+/// </summary>
+public static void ApplyViewportMask(RectTransform viewport, string value, string defaultSpriteName)
+{
+    var go = viewport.gameObject;
+    var img = go.GetComponent<UnityImage>();
+    var mask = go.GetComponent<Mask>();
+    var rectMask = go.GetComponent<RectMask2D>();
+
+    if (value != null && value.Length == 0)
+    {
+        if (mask != null) mask.enabled = false;
+        if (img != null) img.enabled = false;
+        if (rectMask == null) rectMask = go.AddComponent<RectMask2D>();
+        rectMask.enabled = true;
+        return;
+    }
+
+    if (rectMask != null) rectMask.enabled = false;
+    if (img == null) img = go.AddComponent<UnityImage>();
+    img.enabled = true;
+    // alpha=1 关键：alpha<1 触发 UI/Default shader 的 alpha-discard，把 stencil 写飞 (4af322b)。
+    img.color = Color.white;
+    img.sprite = value == null
+        ? GetDefaultSprite(defaultSpriteName)
+        : PromptUGUI.Application.UI.ResolveSprite(value);
+    AutoSlice(img);
+    if (mask == null) mask = go.AddComponent<Mask>();
+    mask.enabled = true;
+    mask.showMaskGraphic = false;
+}
+```
+
+注意：文件已 `using UnityEngine.UI;`（`Mask` / `RectMask2D` 直接可用）。`PromptUGUI.Application.UI` 用全名引用，避免 using 增量。
+
+- [ ] **Step 2: ScrollList.OnAttached 改用 helper**
+
+`ScrollList.cs` 加字段 `private RectTransform _viewport;`，`OnAttached` 中原 48-59 行（`var viewport = ...` 到 `_scroll.viewport = viewport;`）替换为：
+
+```csharp
+_viewport = ProceduralBuilders.AddChild(RectTransform, "Viewport");
+_viewport.pivot = new Vector2(0f, 1f);
+// mask 三态 + 默认 pugui_9slice_mask 圆角，见 ApplyViewportMask 注释 / spec §2.3
+ProceduralBuilders.ApplyViewportMask(_viewport, null, ProceduralBuilders.SpriteMaskRoundedRect);
+_scroll.viewport = _viewport;
+```
+
+下一行 `_content = ProceduralBuilders.AddChild(viewport, "Content");` 的 `viewport` 改 `_viewport`。
+
+- [ ] **Step 3: Dropdown.OnAttached 改用 helper**
+
+`Dropdown.cs` 加字段：
+
+```csharp
+private UnityImage _templateBg;
+private RectTransform _popupViewport;
+```
+
+64-66 行 `var templateBg = ...` 三行改为字段赋值（`_templateBg = template.gameObject.AddComponent<UnityImage>(); _templateBg.color = ProceduralBuilders.DefaultPopupBgColor; ProceduralBuilders.ApplyDefaultSlicedSprite(_templateBg);`）。
+
+74-85 行 Viewport 段改为：
+
+```csharp
+_popupViewport = ProceduralBuilders.AddChild(template, "Viewport");
+_popupViewport.anchorMin = new Vector2(0f, 0f);
+_popupViewport.anchorMax = new Vector2(1f, 1f);
+_popupViewport.pivot = new Vector2(0f, 1f);
+_popupViewport.offsetMin = Vector2.zero;
+_popupViewport.offsetMax = Vector2.zero;
+_popupViewport.sizeDelta = new Vector2(-18f, 0f);  // 留 18px 给 Vertical Scrollbar
+// mask 三态 + 默认 pugui_9slice_round（border 9-slice，stencil 圆角视觉上不可见），spec §2.3
+ProceduralBuilders.ApplyViewportMask(_popupViewport, null, ProceduralBuilders.SpriteRoundedRect);
+```
+
+后面 `templateScroll.viewport = viewport;` 改 `_popupViewport`，`var content = ProceduralBuilders.AddChild(viewport, ...)` 改 `_popupViewport`。
+
+- [ ] **Step 4: refresh + 回归现有套件**
+
+Run: `run_tests(..., group_names=["ScrollListTests", "ScrollListContentSizingTests", "DropdownTests", "DropdownContentSizingTests"])`
+Expected: 全 PASS——`Viewport_HasStencilMaskAndMaskSpriteWithAlphaOne`（断言 pugui_9slice_mask + Sliced + alpha=1）和 `Viewport_HasNoRectMask2D` 是关键回归，证明 helper 与原构建等价。
+
+- [ ] **Step 5: lint + commit**
+
+```bash
+git add Runtime/Controls/Internal/ProceduralBuilders.cs Runtime/Controls/ScrollList.cs Runtime/Controls/Dropdown.cs
+git commit -m "refactor: viewport mask 构建抽 ApplyViewportMask 共享 helper"
+```
+
+---
+
+### Task 3: ScrollList `mask=` 属性
+
+**Files:**
+- Modify: `Runtime/Controls/ScrollList.cs`
+- Test: `Tests/EditMode/Controls/ScrollListTests.cs`
+
+- [ ] **Step 1: 写红测试（加到 ScrollListTests.cs）**
+
+```csharp
+private ScrollList OpenList(string attrs = "")
+{
+    string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Slot'><Frame/></Template>
+  <Screen name='S'><ScrollList id='sl' itemTemplate='Slot' " + attrs + @"/></Screen>
+</PromptUGUI>";
+    UI.LoadDocument("test", xml);
+    return UI.Open("S").Get<ScrollList>("sl");
+}
+
+private static UnityEngine.RectTransform ViewportOf(ScrollList sl) =>
+    (UnityEngine.RectTransform)sl.GameObject.transform.Find("Viewport");
+
+[Test]
+public void Mask_empty_swaps_stencil_for_RectMask2D()
+{
+    var sl = OpenList(@"mask=''");
+    var vp = ViewportOf(sl).gameObject;
+    var rectMask = vp.GetComponent<UnityEngine.UI.RectMask2D>();
+    Assert.IsNotNull(rectMask);
+    Assert.IsTrue(rectMask.enabled);
+    var mask = vp.GetComponent<UnityEngine.UI.Mask>();
+    Assert.IsTrue(mask == null || !mask.enabled, "stencil Mask must be off");
+    var img = vp.GetComponent<UnityEngine.UI.Image>();
+    Assert.IsTrue(img == null || !img.enabled, "viewport Image must be off (RectMask2D has no showMaskGraphic)");
+}
+
+[Test]
+public void Mask_custom_sprite_replaces_default_mask_sprite()
+{
+    var sl = OpenList(@"mask='PromptUGUI/Defaults/pugui#pugui_9slice_round'");
+    var vp = ViewportOf(sl).gameObject;
+    var mask = vp.GetComponent<UnityEngine.UI.Mask>();
+    Assert.IsNotNull(mask);
+    Assert.IsTrue(mask.enabled);
+    Assert.IsFalse(mask.showMaskGraphic);
+    var img = vp.GetComponent<UnityEngine.UI.Image>();
+    Assert.AreEqual("pugui_9slice_round", img.sprite.name);
+    Assert.AreEqual(1f, img.color.a, "alpha=1 critical (4af322b)");
+    Assert.AreEqual(UnityEngine.UI.Image.Type.Sliced, img.type, "AutoSlice: border 非零 → Sliced");
+    Assert.IsNull(vp.GetComponent<UnityEngine.UI.RectMask2D>());
+}
+
+[Test]
+public void Mask_toggles_between_states_without_leftover_components()
+{
+    var sl = OpenList();
+    var vp = ViewportOf(sl).gameObject;
+    sl.Mask = "";                                              // 圆角 → 直角
+    sl.Mask = "PromptUGUI/Defaults/pugui#pugui_9slice_round";  // 直角 → 自定义
+    sl.Mask = "";                                              // 自定义 → 直角
+
+    Assert.AreEqual(1, vp.GetComponents<UnityEngine.UI.RectMask2D>().Length, "no duplicates");
+    Assert.AreEqual(1, vp.GetComponents<UnityEngine.UI.Mask>().Length, "lazy-add keeps single instance");
+    Assert.IsTrue(vp.GetComponent<UnityEngine.UI.RectMask2D>().enabled);
+    Assert.IsFalse(vp.GetComponent<UnityEngine.UI.Mask>().enabled);
+    Assert.IsFalse(vp.GetComponent<UnityEngine.UI.Image>().enabled);
+}
+```
+
+（默认态回归已有 `Viewport_HasStencilMaskAndMaskSpriteWithAlphaOne` / `Viewport_HasNoRectMask2D` 覆盖，不重写。）
+
+- [ ] **Step 2: refresh + 跑，确认编译失败/红**
+
+Expected: 编译错误 `'ScrollList' does not contain a definition for 'Mask'`（属性不存在）。
+
+- [ ] **Step 3: ScrollList 加 Mask 属性（放 `Sprite` 属性之后）**
+
+```csharp
+[UIAttr(IsSprite = true), Preserve]
+public string Mask
+{
+    set => ProceduralBuilders.ApplyViewportMask(
+        _viewport, value, ProceduralBuilders.SpriteMaskRoundedRect);
+}
+```
+
+- [ ] **Step 4: refresh + 跑 ScrollListTests**
+
+Run: `run_tests(..., group_names=["ScrollListTests"])`
+Expected: 全 PASS（含原有用例）。
+
+- [ ] **Step 5: lint + commit**
+
+```bash
+git add Runtime/Controls/ScrollList.cs Tests/EditMode/Controls/ScrollListTests.cs
+git commit -m "feat(scrolllist): mask= 三态属性（默认圆角 / 自定义 sprite / ''=RectMask2D 直角）"
+```
+
+---
+
+### Task 4: ScrollList `frame=` / `frameColor=`
+
+**Files:**
+- Modify: `Runtime/Controls/ScrollList.cs`
+- Test: `Tests/EditMode/Controls/ScrollListTests.cs`
+
+- [ ] **Step 1: 写红测试**
+
+```csharp
+[Test]
+public void Frame_creates_topmost_nonraycast_layer()
+{
+    var sl = OpenList(@"frame='PromptUGUI/Defaults/pugui#pugui_9slice_round'");
+    var root = sl.GameObject.transform;
+    var frame = root.Find("Frame");
+    Assert.IsNotNull(frame, "frame= should lazily create the Frame layer");
+    Assert.AreEqual(root.childCount - 1, frame.GetSiblingIndex(), "frame must be the last sibling (above Viewport & Scrollbar)");
+    var img = frame.GetComponent<UnityEngine.UI.Image>();
+    Assert.IsFalse(img.raycastTarget);
+    Assert.AreEqual("pugui_9slice_round", img.sprite.name);
+    Assert.AreEqual(UnityEngine.UI.Image.Type.Sliced, img.type);
+    var rt = (UnityEngine.RectTransform)frame;
+    Assert.AreEqual(UnityEngine.Vector2.zero, rt.anchorMin);
+    Assert.AreEqual(UnityEngine.Vector2.one, rt.anchorMax);
+    Assert.AreEqual(UnityEngine.Vector2.zero, rt.offsetMin);
+    Assert.AreEqual(UnityEngine.Vector2.zero, rt.offsetMax);
+}
+
+[Test]
+public void FrameColor_alone_activates_frame_layer()
+{
+    var sl = OpenList(@"frameColor='#FF0000'");
+    var frame = sl.GameObject.transform.Find("Frame");
+    Assert.IsNotNull(frame);
+    var img = frame.GetComponent<UnityEngine.UI.Image>();
+    Assert.AreEqual(1f, img.color.r);
+    Assert.AreEqual(0f, img.color.g);
+}
+
+[Test]
+public void No_frame_attr_means_no_frame_node()
+{
+    var sl = OpenList();
+    Assert.IsNull(sl.GameObject.transform.Find("Frame"), "frame layer is lazy");
+}
+```
+
+- [ ] **Step 2: refresh + 跑，确认编译失败/红**
+
+Expected: 编译错误（`Frame` / `FrameColor` 属性不存在）。
+
+- [ ] **Step 3: 实现**
+
+`ScrollList.cs` 加字段 `private UnityImage _frame;`，加（放 `Mask` 属性之后）：
+
+```csharp
+private UnityImage EnsureFrame()
+{
+    // 边框层：内容/滚动条之上、不被 mask（spec §2.1）。懒创建；层序由 OnAfterApply 钉住。
+    _frame ??= ProceduralBuilders.AddImage(RectTransform, "Frame", raycast: false);
+    return _frame;
+}
+
+[UIAttr(IsSprite = true), Preserve]
+public string Frame
+{
+    set
+    {
+        var img = EnsureFrame();
+        img.sprite = UI.ResolveSprite(value);
+        ProceduralBuilders.AutoSlice(img);
+    }
+}
+
+[UIAttr(IsColor = true), Preserve]
+public string FrameColor
+{
+    set => EnsureFrame().color = UI.Theme.Resolve(value);
+}
+
+internal override void OnAfterApply()
+{
+    base.OnAfterApply();
+    // Scrollbar 由 Direction setter 懒建，可能晚于 frame 入树 —— 每轮 apply 后把 frame 钉回最顶。
+    if (_frame != null) _frame.transform.SetAsLastSibling();
+}
+```
+
+- [ ] **Step 4: refresh + 跑 ScrollListTests**
+
+Expected: 全 PASS。`Frame_creates_topmost_nonraycast_layer` 验证 OnAfterApply 的 SetAsLastSibling 生效（XML 属性顺序里 frame 在 itemTemplate 前也不怕）。
+
+- [ ] **Step 5: lint + commit**
+
+```bash
+git add Runtime/Controls/ScrollList.cs Tests/EditMode/Controls/ScrollListTests.cs
+git commit -m "feat(scrolllist): frame=/frameColor= 边框层（mask 外、内容之上）"
+```
+
+---
+
+### Task 5: Dropdown `popupSprite=` / `popupColor=` / `popupMask=`
+
+**Files:**
+- Modify: `Runtime/Controls/Dropdown.cs`
+- Test: `Tests/EditMode/Controls/DropdownTests.cs`
+
+- [ ] **Step 1: 写红测试（加到 DropdownTests.cs，沿用该文件现有 SetUp/Open 模式；若已有等价 helper 直接复用）**
+
+```csharp
+private Dropdown OpenDropdown(string attrs = "")
+{
+    string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'><Dropdown id='dd' " + attrs + @"/></Screen>
+</PromptUGUI>";
+    UI.LoadDocument("test", xml);
+    return UI.Open("S").Get<Dropdown>("dd");
+}
+
+private static UnityEngine.Transform TemplateOf(Dropdown dd) =>
+    dd.GameObject.transform.Find("Template");
+
+[Test]
+public void PopupSprite_and_color_apply_to_template_bg()
+{
+    var dd = OpenDropdown(@"popupSprite='PromptUGUI/Defaults/pugui#pugui_9slice_mask' popupColor='#00FF00'");
+    var bg = TemplateOf(dd).GetComponent<UnityEngine.UI.Image>();
+    Assert.AreEqual("pugui_9slice_mask", bg.sprite.name);
+    Assert.AreEqual(0f, bg.color.r);
+    Assert.AreEqual(1f, bg.color.g);
+}
+
+[Test]
+public void Popup_defaults_unchanged_without_popup_attrs()
+{
+    var dd = OpenDropdown();
+    var bg = TemplateOf(dd).GetComponent<UnityEngine.UI.Image>();
+    Assert.AreEqual(UnityEngine.Color.white, bg.color);  // DefaultPopupBgColor
+    Assert.AreEqual("pugui_9slice_round", bg.sprite.name);
+    var vp = TemplateOf(dd).Find("Viewport").gameObject;
+    Assert.IsTrue(vp.GetComponent<UnityEngine.UI.Mask>().enabled);
+    Assert.IsNull(vp.GetComponent<UnityEngine.UI.RectMask2D>());
+}
+
+[Test]
+public void PopupMask_empty_swaps_stencil_for_RectMask2D()
+{
+    var dd = OpenDropdown(@"popupMask=''");
+    var vp = TemplateOf(dd).Find("Viewport").gameObject;
+    Assert.IsTrue(vp.GetComponent<UnityEngine.UI.RectMask2D>().enabled);
+    var mask = vp.GetComponent<UnityEngine.UI.Mask>();
+    Assert.IsTrue(mask == null || !mask.enabled);
+    var img = vp.GetComponent<UnityEngine.UI.Image>();
+    Assert.IsTrue(img == null || !img.enabled);
+}
+
+[Test]
+public void PopupMask_custom_sprite_applies_to_viewport()
+{
+    var dd = OpenDropdown(@"popupMask='PromptUGUI/Defaults/pugui#pugui_9slice_mask'");
+    var vp = TemplateOf(dd).Find("Viewport").gameObject;
+    var img = vp.GetComponent<UnityEngine.UI.Image>();
+    Assert.AreEqual("pugui_9slice_mask", img.sprite.name);
+    Assert.IsTrue(vp.GetComponent<UnityEngine.UI.Mask>().enabled);
+    Assert.IsFalse(vp.GetComponent<UnityEngine.UI.Mask>().showMaskGraphic);
+}
+```
+
+- [ ] **Step 2: refresh + 跑，确认红**
+
+Expected: 4 个新用例 FAIL——XML 未知属性当前路径下要么被忽略要么报错；以实际输出为准（若是 ParseException 同样算红）。
+
+- [ ] **Step 3: 实现（放 `Sprite` 属性之后）**
+
+```csharp
+[UIAttr(IsSprite = true), Preserve]
+public string PopupSprite
+{
+    set
+    {
+        _templateBg.sprite = UI.ResolveSprite(value);
+        ProceduralBuilders.AutoSlice(_templateBg);
+    }
+}
+
+[UIAttr(IsColor = true), Preserve]
+public string PopupColor
+{
+    set => _templateBg.color = UI.Theme.Resolve(value);
+}
+
+[UIAttr(IsSprite = true), Preserve]
+public string PopupMask
+{
+    set => ProceduralBuilders.ApplyViewportMask(
+        _popupViewport, value, ProceduralBuilders.SpriteRoundedRect);
+}
+```
+
+- [ ] **Step 4: refresh + 跑 DropdownTests**
+
+Expected: 全 PASS。
+
+- [ ] **Step 5: lint + commit**
+
+```bash
+git add Runtime/Controls/Dropdown.cs Tests/EditMode/Controls/DropdownTests.cs
+git commit -m "feat(dropdown): popupSprite/popupColor/popupMask 弹出列表换肤"
+```
+
+---
+
+### Task 6: XSD 断言
+
+**Files:**
+- Test: `Tests/EditMode/Editor/XsdGeneratorTests.cs`
+
+- [ ] **Step 1: 加测试（反射路径自动收新属性，此测试是防回归锚点）**
+
+```csharp
+[Test]
+public void ScrollList_and_Dropdown_skin_attrs_in_schema()
+{
+    var r = new ControlRegistry();
+    r.Register<PromptUGUI.Controls.ScrollList>("ScrollList", null);
+    r.Register<PromptUGUI.Controls.Dropdown>("Dropdown", null);
+    var xsd = XsdGenerator.Generate(r);
+    StringAssert.Contains("\"frame\"", xsd);
+    StringAssert.Contains("\"frameColor\"", xsd);
+    StringAssert.Contains("\"mask\"", xsd);
+    StringAssert.Contains("\"popupSprite\"", xsd);
+    StringAssert.Contains("\"popupColor\"", xsd);
+    StringAssert.Contains("\"popupMask\"", xsd);
+}
+```
+
+注意：`Register` 调用形式与文件内现有用例一致（`r.Register<T>("Tag", null)`）；断言带引号匹配 `<xs:attribute name="frame"` 的 name 值，避免误匹配元素名。若文件内现有断言风格是裸子串（不带引号），跟随现有风格。
+
+- [ ] **Step 2: refresh + 跑 XsdGeneratorTests（EditorOnly 程序集）**
+
+Run: `run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"], group_names=["XsdGeneratorTests"])`
+Expected: PASS（反射自动生成，无需改 XsdGenerator；若 FAIL 则说明 `[UIAttr]` 没挂对，回查 Task 3-5）。
+
+- [ ] **Step 3: commit**
+
+```bash
+git add Tests/EditMode/Editor/XsdGeneratorTests.cs
+git commit -m "test(xsd): ScrollList/Dropdown 换肤属性进 schema 断言"
+```
+
+---
+
+### Task 7: SKILL 更新
+
+**Files:**
+- Modify: `.claude/skills/authoring-promptugui-xml/SKILL.md`（ScrollList 表 ~L254、Dropdown 表 ~L242）
+
+- [ ] **Step 1: ScrollList 属性表追加 3 行（`tint` 行之后）**
+
+```markdown
+| `frame` | sprite key | — | Border layer drawn above content & scrollbar, outside the mask — scrolling content never overlaps it. Lazily created. |
+| `frameColor` | hex / CSS / token | — | Tints the frame layer; setting it alone also activates the layer. |
+| `mask` | sprite key | built-in rounded | Viewport clip shape. `mask="custom#slice"` = stencil mask with that sprite (auto-sliced); `mask=""` = square `RectMask2D` clipping (cheaper; stops a transparent list from having its corners clipped round). Unset keeps the built-in rounded mask. |
+```
+
+- [ ] **Step 2: Dropdown 属性表追加 3 行（`tint` 行之后）**
+
+```markdown
+| `popupSprite` | sprite key | — | Skins the popup list background (the closed button keeps using `sprite`/`color`). |
+| `popupColor` | hex / CSS / token | — | Tints the popup list background. |
+| `popupMask` | sprite key | built-in rounded | Popup viewport clip shape; same three-state semantics as `<ScrollList mask>` (`""` = square RectMask2D). |
+```
+
+- [ ] **Step 3: 跑 UIXmlLint 自检内置 modal XML 未受影响（无新规则，纯确认）**
+
+```bash
+dotnet run --project .lint/UIXmlLint -- Runtime/Resources/
+```
+
+Expected: exit 0。
+
+- [ ] **Step 4: commit**
+
+```bash
+git add .claude/skills/authoring-promptugui-xml/SKILL.md
+git commit -m "docs(skill): ScrollList frame/mask 与 Dropdown popup* 属性"
+```
+
+---
+
+### Task 8: 全量回归 + 收尾
+
+- [ ] **Step 1: 全量 EditMode + EditorOnly + PlayMode**
+
+```
+run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])
+```
+
+Expected: 全 PASS（EditMode 基线 1522 + 新增 ~10）。
+
+- [ ] **Step 2: lint 终验**
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+Expected: exit 0。
+
+- [ ] **Step 3: 检查 .meta 文件**
+
+`git status` 确认无新建文件缺 .meta（本计划只改既有文件 + 测试文件已存在，理论上无新 .meta；若 Unity 生成了改动要一并提交）。
+
+- [ ] **Step 4: 推分支开 PR（不合 main；视觉 QA 留给用户）**
+
+```bash
+git push -u origin feat/list-popup-skin-mask
+gh pr create --title "feat: ScrollList frame/mask 与 Dropdown popup 换肤属性" --body "..."
+```
+
+PR body 概述三态 mask 语义 + spec 链接 + 测试数，结尾带 🤖 Generated with [Claude Code](https://claude.com/claude-code)。

--- a/docs~/superpowers/specs/2026-06-11-list-popup-skin-mask-design.md
+++ b/docs~/superpowers/specs/2026-06-11-list-popup-skin-mask-design.md
@@ -1,0 +1,107 @@
+# ScrollList / Dropdown 换肤 + mask 属性（对齐 Progress 词汇）
+
+**日期**：2026-06-11
+**状态**：设计阶段（待 review，未进入实施）
+**作用域**：`<ScrollList>` 新增 `frame=` / `frameColor=` / `mask=`，`<Dropdown>` 新增 `popupSprite=` / `popupColor=` / `popupMask=`。不改任何现有属性语义，不动 Carousel / Markdown 的 viewport。
+**关联**：属性词汇对齐 `<Progress>` 的 `bg` / `frame` / `mask` 三件套（[`2026-05-27-progress-control-design.md`](2026-05-27-progress-control-design.md)，实现见 `Runtime/Controls/Progress.cs`）。新增作者可写属性 → `authoring-promptugui-xml` SKILL 必须更新（见 §8）。
+
+---
+
+## 1. 背景与问题
+
+控件的视觉一般由**边框**和**背景**两层组成：要 mask 的是背景与内容，边框画在内容之上、不进 mask，这样滚动内容不会叠到边框上。`Progress` 已经按这个模型实现（`bg=` / `frame=` / `mask=`，frame 是 MaskWrapper 之外的顶层 sibling）。
+
+但两个带 viewport 的控件没有跟上：
+
+1. **ScrollList**（`Runtime/Controls/ScrollList.cs:48-58`）：Viewport 的 stencil Mask + `pugui_9slice_mask` 写死。`sprite="" color="#0000"` 做透明列表时，内容仍被圆角 mask 咬角，无任何属性可改；也没有边框层。
+2. **Dropdown**（`Runtime/Controls/Dropdown.cs:56-85`）：弹出列表的 `templateBg` 写死 `DefaultPopupBgColor` + 默认 sprite，完全不能换肤；Viewport mask 写死 `pugui_9slice_round`（9-slice 圆角仅 2×2px，stencil 圆角视觉上不可见，症状轻，但同样无口子）。
+
+## 2. 属性设计
+
+### 2.1 ScrollList（现有 `sprite=` / `color=` / `tint=` 语义不变，仍是背景层）
+
+| 属性 | 类型 | 行为 |
+|---|---|---|
+| `frame=` | IsSprite | 边框层。root 下**最后一个 sibling**（Viewport 和 Scrollbar 之上），anchor 全 stretch，`raycastTarget=false`，`AutoSlice`（sprite 有 border → Sliced，否则 Simple）。不被 mask；滚动内容从边框下面穿过。**懒创建**：不写该属性不建节点。 |
+| `frameColor=` | IsColor | 边框着色；单独写也会激活 frame 层（镜像 `Progress.FrameColor`）。 |
+| `mask=` | IsSprite | Viewport 裁剪形状，三态见 §2.3。 |
+
+### 2.2 Dropdown（按钮本体的 `sprite=` / `color=` / `tint=` 不动）
+
+| 属性 | 类型 | 行为 |
+|---|---|---|
+| `popupSprite=` | IsSprite | 弹出列表 `templateBg` 的 sprite（`AutoSlice`）。 |
+| `popupColor=` | IsColor | 弹出列表 `templateBg` 着色。 |
+| `popupMask=` | IsSprite | 弹出列表 Viewport 裁剪形状，三态语义与 ScrollList `mask=` 完全一致（默认 sprite 不同，见 §2.3）。 |
+
+弹出框不做 frame 层（YAGNI；要双层视觉时弹出框可以直接用带边框画进 sprite 的图——它不滚动到边缘外的内容远少于 ScrollList）。
+
+### 2.3 mask 三态语义（两控件共享）
+
+| 写法 | 行为 |
+|---|---|
+| 未写 | 维持各自现状：ScrollList = stencil Mask + `pugui_9slice_mask`（Simple 整图拉伸圆角）；Dropdown popup = stencil Mask + `pugui_9slice_round`（Sliced）。向后兼容，现有 UI 视觉零变化。 |
+| `mask="路径#名字"` | stencil Mask 保留，Viewport Image 换成指定 sprite + `AutoSlice`；`showMaskGraphic=false` 不变。sprite 解析失败走现有 `UI.ResolveSprite` 失败路径（与 `sprite=` 同行为），无新错误类型。 |
+| `mask=""` | 拆掉 stencil Mask + Viewport Image，挂 `RectMask2D` 直角裁剪。省一个 drawcall + 一张 mask 图；透明列表不再被圆角咬角。 |
+
+**Variant 可逆切换**：ReSolve 可能让 mask 值在三态间任意方向变化（圆角 → 直角 → 自定义 sprite 来回切）。setter 必须按需 `AddComponent` / `Destroy` 且不残留组件（EditMode 下用 `DestroyImmediate`，同 `Screen.Close` 的分支惯例）。
+
+## 3. 共享实现
+
+mask 三态逻辑抽一份，放 `Runtime/Controls/Internal/ProceduralBuilders.cs`（或同目录新 helper）：
+
+```csharp
+// value 三态：null=默认（defaultSprite + stencil）；""=RectMask2D；其余=指定 sprite + stencil
+internal static void ApplyViewportMask(RectTransform viewport, string value, string defaultSpriteName)
+```
+
+- ScrollList `OnAttached` 的现有 Viewport 构建改为调用 `ApplyViewportMask(viewport, null, SpriteMaskRoundedRect)`；Dropdown 同理传 `SpriteRoundedRect`。
+- `mask=` / `popupMask=` setter 直接转调。
+- stencil ↔ RectMask2D 切换时同步处理 Viewport 上的 `UnityImage`（RectMask2D 路径不需要 graphic，必须移除，否则白图会渲染出来——RectMask2D 不像 Mask 有 showMaskGraphic）。
+
+frame 层（ScrollList）：懒创建，`_frame ??= 建节点`，每次激活后 `SetAsLastSibling()` 保证压在 Scrollbar 之上（Scrollbar 是 `EnsureVerticalScrollbar` 懒建的，顺序不可靠）。
+
+## 4. 与现有体系的交互
+
+- **RuntimeStateAttr**：不涉及——新属性全是静态皮肤，无运行时回写。
+- **Variant ReSolve**：`ControlAttributeApplier` 重放 setter 即可，§2.3 的可逆切换是唯一额外要求。
+- **AutoHideAndExpandViewport**：mask 形态切换不改 Viewport 的 RectTransform 几何（`sizeDelta` / 锚点不动），ScrollRect 的 scrollbar 撑开逻辑不受影响。
+- **XSD**：新属性走 customs 反射路径自动进 schema，无需手写。
+- **Lint**：无新规则；`BuiltinTags.cs` 无新 tag，不需要同步。
+
+## 5. 非目标（v1）
+
+- 不做 `maskPadding=`（Frame/Image 有先例，但这里无真实需求）。
+- 弹出框不做 `popupFrame=`。
+- 不动 Carousel / Markdown 的裸 `RectMask2D` viewport（已是直角，无症状）。
+- 不做"`sprite=""` 时 mask 自动退直角"的隐式推导——显式 `mask=""` 更可控。
+
+## 6. 测试（EditMode，沿用现有 ScrollList / Dropdown 测试文件模式）
+
+ScrollList：
+
+1. `frame="..."` → root 最后一个 child，stretch 全幅，`raycastTarget=false`，sprite 正确，有 border 的 sprite → Sliced；
+2. 只写 `frameColor=` → frame 节点被激活且颜色正确；
+3. 不写 `frame` → 无 frame 节点（懒创建）；
+4. 不写 `mask` → Viewport 上 stencil Mask + `pugui_9slice_mask`（现状回归）；
+5. `mask="自定义"` → Viewport Image 换 sprite，Mask 仍在，`showMaskGraphic=false`；
+6. `mask=""` → Viewport 无 Mask 无 Image，有 RectMask2D；
+7. Variant 切换 `mask` 三态来回 → 组件不残留、不重复。
+
+Dropdown：
+
+8. `popupSprite` / `popupColor` → 落到 templateBg；
+9. `popupMask` 三态 → 同 4-6（作用于 Template/Viewport）；
+10. 不写 popup 属性 → templateBg 维持 `DefaultPopupBgColor`（现状回归）。
+
+XSD：substring 断言补 `frame` / `popupMask` 各一条。
+
+## 7. 风险
+
+- **stencil → RectMask2D 切换的渲染残留**：移除 Mask 组件时 uGUI 会重建 stencil 状态，子 graphic 的 material 需要 dirty；用 `MaskUtilities` 已有机制（Destroy Mask 自带 NotifyStencilStateChanged），EditMode 测试覆盖组件状态，视觉确认留给 QA。
+- **frame 压住 Scrollbar**：边框 9-slice 通常只有数像素，Scrollbar 在 AutoHideAndExpandViewport 下贴右缘，边框图案会盖住其最外侧几像素——这是"内容不叠到边框上"模型的预期表现，作者可用 `padding=` 调整。
+
+## 8. SKILL 更新
+
+- `authoring-promptugui-xml/SKILL.md`：ScrollList 条目加 `frame` / `frameColor` / `mask` 三行，Dropdown 条目加 `popupSprite` / `popupColor` / `popupMask` 三行（含三态语义一句话说明）。两控件无 reference 深水区文件，改主文档。
+- `scripting-promptugui-csharp`：不动（无新公开 C# API）。

--- a/docs~/superpowers/specs/2026-06-11-list-popup-skin-mask-design.md
+++ b/docs~/superpowers/specs/2026-06-11-list-popup-skin-mask-design.md
@@ -40,11 +40,11 @@
 
 | 写法 | 行为 |
 |---|---|
-| 未写 | 维持各自现状：ScrollList = stencil Mask + `pugui_9slice_mask`（Simple 整图拉伸圆角）；Dropdown popup = stencil Mask + `pugui_9slice_round`（Sliced）。向后兼容，现有 UI 视觉零变化。 |
+| 未写 | 维持各自现状：ScrollList = stencil Mask + `pugui_9slice_mask`（border=2 Sliced）；Dropdown popup = stencil Mask + `pugui_9slice_round`（Sliced）。向后兼容，现有 UI 视觉零变化。 |
 | `mask="路径#名字"` | stencil Mask 保留，Viewport Image 换成指定 sprite + `AutoSlice`；`showMaskGraphic=false` 不变。sprite 解析失败走现有 `UI.ResolveSprite` 失败路径（与 `sprite=` 同行为），无新错误类型。 |
 | `mask=""` | 拆掉 stencil Mask + Viewport Image，挂 `RectMask2D` 直角裁剪。省一个 drawcall + 一张 mask 图；透明列表不再被圆角咬角。 |
 
-**Variant 可逆切换**：ReSolve 可能让 mask 值在三态间任意方向变化（圆角 → 直角 → 自定义 sprite 来回切）。setter 必须按需 `AddComponent` / `Destroy` 且不残留组件（EditMode 下用 `DestroyImmediate`，同 `Screen.Close` 的分支惯例）。
+**Variant 可逆切换**：ReSolve 可能让 mask 值在三态间任意方向变化（圆角 → 直角 → 自定义 sprite 来回切）。实现用 **lazy-add + `enabled` 开关**（首次需要时 `AddComponent`，之后只切 `enabled`），不 Destroy——对齐"Variants don't rebuild GameObjects"惯例，也避免 PlayMode 下 `Destroy` 延迟销毁导致同帧来回切换读到待销毁组件。
 
 ## 3. 共享实现
 

--- a/docs~/superpowers/specs/2026-06-11-list-popup-skin-mask-design.md
+++ b/docs~/superpowers/specs/2026-06-11-list-popup-skin-mask-design.md
@@ -40,9 +40,16 @@
 
 | 写法 | 行为 |
 |---|---|
-| 未写 | 维持各自现状：ScrollList = stencil Mask + `pugui_9slice_mask`（border=2 Sliced）；Dropdown popup = stencil Mask + `pugui_9slice_round`（Sliced）。向后兼容，现有 UI 视觉零变化。 |
-| `mask="路径#名字"` | stencil Mask 保留，Viewport Image 换成指定 sprite + `AutoSlice`；`showMaskGraphic=false` 不变。sprite 解析失败走现有 `UI.ResolveSprite` 失败路径（与 `sprite=` 同行为），无新错误类型。 |
-| `mask=""` | 拆掉 stencil Mask + Viewport Image，挂 `RectMask2D` 直角裁剪。省一个 drawcall + 一张 mask 图；透明列表不再被圆角咬角。 |
+| 未写（自动跟随 bg sprite） | mask 形状跟随背景：`sprite` 有图（含默认圆角底）→ stencil Mask（ScrollList=`pugui_9slice_mask`，Dropdown popup=`pugui_9slice_round`，Sliced）；`sprite=""` / `sprite="none"`（背景清成 null）→ `RectMask2D` 直角。默认 ScrollList/Dropdown 带默认底 sprite → 圆角，**现有 UI 视觉零变化**；只有"清了背景"这一种情况从圆角自动变直角。 |
+| `mask="路径#名字"`（显式） | stencil Mask 保留，Viewport Image 换成指定 sprite + `AutoSlice`；`showMaskGraphic=false` 不变。sprite 解析失败走现有 `UI.ResolveSprite` 失败路径（与 `sprite=` 同行为），无新错误类型。**显式即脱离自动跟随**。 |
+| `mask=""`（显式） | 拆掉 stencil Mask + Viewport Image，挂 `RectMask2D` 直角裁剪。省一个 drawcall + 一张 mask 图。**显式 `""` 永远直角，即使背景有 sprite**。 |
+
+**自动跟随（InputField 范式）**：起因——`sprite=""` 只清背景 `_bg`（退成直角实心矩形），mask 若恒留圆角则内容被"无主"圆角裁剪、与直角背景错配。解法对齐 `<InputField>` 的"text-area mask inset 跟随边框 sprite"先例：**未显式写 `mask` 时，mask 形状跟随 `sprite` 是否有图**。一旦显式写过 `mask=`（任意值含 `""`）即 latch 为显式，之后不再自动跟随。
+
+- 跟踪 `_maskExplicit`（bool）：`Mask` setter 置 true。
+- 在 `OnAfterApply`（每次 apply / ReSolve 后，`ControlAttributeApplier` 保证晚于所有 setter）reconcile：`if (!_maskExplicit) ApplyViewportMask(viewport, bgSprite != null ? null : "", default)`。`sprite=` 与 `mask=` setter 顺序无所谓——OnAfterApply 统一收口。
+- 幂等：null/"" 两分支重复调用结果不变；Variant 把 `sprite.portrait=""` 时 ReSolve 自动让 mask 退直角。
+- 启发式边界：只区分"有 sprite→圆角 / 无 sprite→直角"；自定义方角面板 sprite 仍得圆角 mask，需要时用显式 `mask=` 覆盖。
 
 **Variant 可逆切换**：ReSolve 可能让 mask 值在三态间任意方向变化（圆角 → 直角 → 自定义 sprite 来回切）。实现用 **lazy-add + `enabled` 开关**（首次需要时 `AddComponent`，之后只切 `enabled`），不 Destroy——对齐"Variants don't rebuild GameObjects"惯例，也避免 PlayMode 下 `Destroy` 延迟销毁导致同帧来回切换读到待销毁组件。
 


### PR DESCRIPTION
## 摘要

对齐 `<Progress>` 的 **边框 / 背景 / mask** 三件套词汇，给两个带 viewport 的容器补上换肤口子：

- **`<ScrollList>`** 新增 `frame` / `frameColor`（边框层，画在内容与滚动条之上、**不被 mask**，滚动内容不会叠到边框上；懒创建）+ `mask`（viewport 裁剪形状）。
- **`<Dropdown>`** 新增 `popupSprite` / `popupColor`（弹出列表背景换肤，按钮本体的 `sprite`/`color` 不动）+ `popupMask`（弹出 viewport 裁剪形状）。

### `mask` / `popupMask` 三态
| 写法 | 行为 |
|---|---|
| 不写 | 各控件历史默认圆角 stencil（向后兼容，视觉零变化） |
| `mask="路径#切片"` | stencil mask 换成该 sprite（按 border 自动 9-slice） |
| `mask=""` | `RectMask2D` 直角裁剪（省一个 drawcall + 一张图；解决透明列表被圆角咬角） |

> 起因：`<ScrollList sprite="" color="#0000">` 做透明列表时，viewport 仍被写死的 `pugui_9slice_mask` 圆角裁剪，无任何属性可改。本 PR 把那张写死的 mask 暴露成 `mask=` 属性。

## 实现要点

- mask 三态逻辑抽成单一 `ProceduralBuilders.ApplyViewportMask`，OnAttached + 两控件的 `mask=`/`popupMask=` setter 全部走这一份（**lazy-add + `enabled` 开关，绝不 Destroy** —— 对齐"Variants don't rebuild GameObjects"，避免 PlayMode 延迟销毁在同帧来回切时读到待销毁组件）。
- `AutoSlice` 从 `Progress` 提升为 `ProceduralBuilders` 公共方法；顺手移除被取代的孤儿 `ApplyDefaultMaskSprite`。
- ScrollList `frame` 层用 `OnAfterApply` 的 `SetAsLastSibling()` 钉顶 —— 因为 Scrollbar 是 `Direction` setter 懒建的，可能晚于 frame 入树（含 `direction="horizontal"` 重建场景）。
- 两控件历史默认 sprite 不同（ScrollList=`pugui_9slice_mask`，Dropdown popup=`pugui_9slice_round`），各自"不写"默认保持原状，通过 `defaultSpriteName` 参数显式传入。

## 测试

- EditMode `PromptUGUI.Tests.EditMode`: **1570/1570** 绿
- EditMode `PromptUGUI.Tests.EditorOnly`: **184/184** 绿（含新增 XSD 断言）
- PlayMode `PromptUGUI.Tests.PlayMode`: **133/133** 绿
- `dotnet format --verify-no-changes`: 干净
- 新增覆盖：mask 三态 + Variant 来回切不残留组件、frame 顶层非 raycast 层、frame 在 horizontal scrollbar 懒建后仍置顶、popup 三属性、默认态回归。

## 文档

- `authoring-promptugui-xml/SKILL.md`：ScrollList / Dropdown 属性表补 6 行（英文），含 `mask=` 不是 `rect`/`self` 关键字、取 sprite key 的澄清。

## 待办（合并前）

- [ ] 视觉 QA：透明 `mask=""` 直角列表、`frame=` 边框层视觉、Dropdown popup 换肤。

spec: `docs~/superpowers/specs/2026-06-11-list-popup-skin-mask-design.md`
plan: `docs~/superpowers/plans/2026-06-11-list-popup-skin-mask.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)