### PR TITLE
feat: flow=\"false\" 出流子节点 — Stack 内背景层/角标不占排版流

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -454,6 +454,7 @@ Other notes:
 | `pivot="x,y"`               | `RectTransform.pivot`（不写则从 anchor 推）                                                                                                                                                                                                                                                                         |
 | `hidden="true"`             | `GameObject.SetActive(false)`                                                                                                                                                                                                                                                                                       |
 | `interactable="false"`      | `CanvasGroup.interactable=false` + `blocksRaycasts=false`（首次访问按需 add `CanvasGroup`；级联到所有后代，比 `Selectable.interactable` 范围更大）                                                                                                                                                                  |
+| `flow="false"`              | `LayoutElement.ignoreLayout=true`（仅父级是 LayoutGroup 时有意义）—— LayoutGroup 收集 rectChildren 时跳过该子节点，`anchor` / `margin` / `size` 改走自由定位分支写 RectTransform                                                                                                                                       |
 
 **不变量与易踩坑**
 
@@ -477,6 +478,7 @@ Other notes:
 | `hidden="true"` | bool | Initial `SetActive(false)`. |
 | `interactable="false"` | bool | Initial `CanvasGroup.interactable=false` + `blocksRaycasts=false`. On `<Btn>` it **also** sets `Button.interactable=false` → the Btn enters its Disabled state (see `reference/states.md`). |
 | `stateReact="false"` | bool (default `true`) | Opts this node **and its whole subtree** out of an ancestor `<Btn>` / `<Tab>` / `<Toggle>`'s `*Modulate` fan-out. Has no effect on `*Color` (absolute — bg only, never fanned out). See `reference/states.md`. |
+| `flow="false"` | bool (default `true`) | **Layout-group children only** (direct child of `<VStack>` / `<HStack>` / `<Grid>`). Opts the child **out of the layout flow**: the group neither positions it nor counts it toward its own preferred size, and `anchor` / `margin` / `N%` regain full free-positioning semantics against the group's rect. Use for a 9-slice background layer / badge / overlay inside a hug-sized stack — see **Out-of-flow children** below. Inert under a free-positioning parent (`PUI-FLOW-OUTSIDE-GROUP`). Variant-overridable (`flow.portrait="false"`). |
 | `scale="N"` / `scale="Nx"` / `scale="<r>r"` | float `N` / `Nx` (int) / `<r>r` (float) | Three forms: `N` = box-preserving (a render-density knob, **not** a resize knob); `Nx` = N physical px per design-unit (constant across factors, **doesn't grow with the window**); `<r>r` = `r×` the canvas factor **snapped to an integer** (**grows with the window yet stays pixel-aligned**). `scale="2"` ≠ `scale="2x"`. Full formulas / examples / caveats: see **Relative scale** / **Device-density** / **Canvas-relative snapped** below. |
 
 **margin & consumed sides.** A margin only offsets from a side the `anchor` **consumes**: a **stretched** axis reads both its slots, a **point** anchor (`top` / `bottom` / `left` / `right`) reads only its own side, a **centered** axis reads neither. So `anchor="bottom-right" margin="60,_,_,_"` puts 60 in the **top** slot → silently dropped (a `bottom` anchor reads only the bottom slot; write `margin="_,_,60,_"` to push it up). The lint CLI flags a non-zero value on an unconsumed side as **`PUI-MARGIN-INERT-SIDE`** (CLI-only; 4-component + explicit-`anchor` form only — symmetric 1-/2-component shorthands always land on the consumed side and are not flagged).
@@ -527,6 +529,28 @@ Vertical: same idea (`top` → upper, `bottom` → lower, `center` → middle).
 **Inside `<Grid>`**, the parent's `cellSize` is authoritative — a child's `size` is silently ignored.
 
 **Cross-axis alignment** of layout-group children is set on the parent via `childAlign` (defaults: VStack `upper-center`, HStack `middle-left`). Override the whole group, not per child — uGUI LayoutGroup doesn't support per-child cross-axis alignment.
+
+**Out-of-flow children (`flow="false"`)** — a `<VStack>` / `<HStack>` / `<Grid>` child with `flow="false"` opts out of the layout flow entirely: the group skips it when positioning children **and** when computing its own preferred size (`LayoutElement.ignoreLayout` under the hood). The child positions itself against the group's rect with normal free-positioning semantics — `anchor` / `margin` / `N%` are legal again (no `PUI-LAYOUT-ANCHOR` / `PUI-LAYOUT-MARGIN`; `PUI-MARGIN-INERT-SIDE` applies again instead). `width="stretch"` stays forbidden — out of flow there is no flex weight; use `anchor="stretch"`.
+
+The killer use case: a **hug-width stack with a 9-slice skin**. Nested stacks hug for free — a width-less `<HStack>` inside a `<VStack>` is sized to padding + spacing + the sum of its children's preferred widths (no ContentSizeFitter needed) — so put the skin **inside** the stack as out-of-flow stretch layers:
+
+```xml
+<VStack anchor="stretch" margin="8,8,_,8" spacing="4" childAlign="upper-left">
+  <!-- timeBox hugs: width = padding + icon 12 + spacing 4 + scaled text width, live -->
+  <HStack id="timeBox" height="18" spacing="4" padding="3,6,3,3">
+    <Image anchor="stretch" flow="false" sprite="UI:Box-Secondary-Frame" color="primary-dark" tint="linear"/>
+    <Image anchor="stretch" flow="false" sprite="UI:Box-Secondary-Bg" mask="self" color="primary-darken/0.5" tint="linear"/>
+    <Icon name="Solar16Bold:Time/Clock Circle" color="on-primary" size="12x12"/>
+    <Text id="time" fontSize="12" color="on-primary" scale="0.5r" tr="false">18天 05:26:45</Text>
+  </HStack>
+</VStack>
+```
+
+When the countdown text changes (or the locale swaps), the text's preferred width re-reports and `timeBox` re-hugs automatically; both background layers stretch over whatever that is without inflating it.
+
+- `flow="false"` under a free-positioning parent (`<Frame>` / `<Screen>` / `<Image>`) is inert → `PUI-FLOW-OUTSIDE-GROUP` (CLI error / runtime warning). anchor/margin already work there — just drop the attribute.
+- Variant-overridable: `flow.portrait="false"` pulls a child out of flow in one variant only; flipping back re-enters the flow (geometry re-resolves on the normal ReSolve path).
+- A `<Text scale=...>` child that is statically `flow="false"` (no variant override) skips the scale-host measuring wrapper — it isn't measured by the group; free-positioning scale semantics apply instead.
 
 ## Layout group 放置配方（HStack / VStack）
 
@@ -1033,6 +1057,7 @@ STATE         stateReact="false"  opt node+subtree out of *Modulate fan-out (no 
               详见 reference/states.md（状态化视觉）· reference/animations.md（Trigger/Animation）
 
 COMMON ATTRS  id  anchor  size|width|height  margin  pivot  hidden  interactable  stateReact
+STACK-CHILD   flow="false"  → out of layout flow (ignoreLayout; anchor/margin legal again)
 STACK-ONLY    padding  spacing                                    (VStack/HStack/Grid)
 
 ANCHOR        "<v>-<h>"     v ∈ {top, center, bottom, stretch}

--- a/Editor/XsdGenerator.cs
+++ b/Editor/XsdGenerator.cs
@@ -217,7 +217,7 @@ namespace PromptUGUI.Editor
         // XmlSchemaSet rejects with "The attribute 'X' already exists.").
         private static readonly string[] _commonAttrNames = {
             "id","anchor","size","width","height","margin","pivot",
-            "padding","spacing","hidden","interactable","scale",
+            "padding","spacing","hidden","interactable","scale","flow",
             // Control.StateReact ([UIAttr] on the base) — opts a graphic out of a parent
             // Btn's state-tint fan-out; applies to every control, so it's a common attr.
             "stateReact" };

--- a/Runtime/Application/ControlAttributeApplier.cs
+++ b/Runtime/Application/ControlAttributeApplier.cs
@@ -104,12 +104,14 @@ namespace PromptUGUI.Application
             var pivot = VariantResolver.ResolveAttribute(node, "pivot", variants);
             var hiddenStr = VariantResolver.ResolveAttribute(node, "hidden", variants);
             var interactableStr = VariantResolver.ResolveAttribute(node, "interactable", variants);
+            var flowStr = VariantResolver.ResolveAttribute(node, "flow", variants);
             bool? hidden = hiddenStr == null ? null : hiddenStr == "true";
             var interactable = interactableStr != "false";
+            var flow = flowStr != "false";
 
             try
             {
-                control.ApplyCommon(anchor, size, width, height, margin, pivot, hidden, interactable);
+                control.ApplyCommon(anchor, size, width, height, margin, pivot, hidden, interactable, flow);
                 control.OnAfterApply();
             }
             catch (Exception ex) when (!(ex is ParseException))
@@ -149,7 +151,7 @@ namespace PromptUGUI.Application
         {
             return name switch
             {
-                "anchor" or "size" or "width" or "height" or "margin" or "pivot" or "hidden" or "interactable" => true,
+                "anchor" or "size" or "width" or "height" or "margin" or "pivot" or "hidden" or "interactable" or "flow" => true,
                 // 'scale' deliberately NOT listed: it is applied by Screen.ApplyScales (independent
                 // of the ApplyCommon path) for controls without their own setter, and dispatched
                 // through the normal [UIAttr("scale")] loop for controls that handle it themselves

--- a/Runtime/Application/ScreenInstantiator.cs
+++ b/Runtime/Application/ScreenInstantiator.cs
@@ -185,6 +185,12 @@ namespace PromptUGUI.Application
                 foreach (var issue in LayoutGroupChildRules.CheckChild(node))
                     Debug.LogWarning(issue.Message);
             }
+            else
+            {
+                // 运行时父级已确凿（按组件判断）：非 layout-group 下的 'flow' 是 inert 属性。
+                foreach (var issue in LayoutGroupChildRules.CheckNonLayoutChild(node))
+                    Debug.LogWarning(issue.Message);
+            }
 
             // Per-tag self-checks (mirror of IRWalker dispatch; runtime warns)
             if (node.Tag == "Frame")
@@ -237,8 +243,11 @@ namespace PromptUGUI.Application
             // 条件 3 看 base 或任意 variant 覆盖——variant 运行期才激活而 GO 永不重建，
             // 创建期必须备好；scale 未解析时桥 ×1 透传（≡ 裸 TMP）。Grid 不在内
             // （GetComponent<HorizontalOrVerticalLayoutGroup> 对 GridLayoutGroup 返回 null）。
+            // flow="false"（且没有 variant 能翻回流内）的 Text 不被 LayoutGroup 量算，
+            // wrapper 反而会变成一个没人定位的中间层（自由定位写的是内层 RT）—— 跳过。
             if (control is Text textControl
                 && parent.GetComponent<UnityEngine.UI.HorizontalOrVerticalLayoutGroup>() != null
+                && !LayoutGroupChildRules.AlwaysOutOfFlow(node)
                 && (node.Attributes.ContainsKey("scale")
                     || node.VariantOverrides.ContainsKey("scale")))
             {

--- a/Runtime/Controls/Control.cs
+++ b/Runtime/Controls/Control.cs
@@ -197,7 +197,7 @@ namespace PromptUGUI.Controls
         // 通用属性应用（由 ScreenInstantiator 在子类自身属性应用之后调用）
         public void ApplyCommon(string anchor, string size, string width, string height,
                                 string margin, string pivot,
-                                bool? hidden, bool interactable)
+                                bool? hidden, bool interactable, bool flow = true)
         {
             var sizeSpec = SizeSpec.Parse(size, width, height);
 
@@ -222,11 +222,29 @@ namespace PromptUGUI.Controls
             var parentIsGrid = parentLg is UnityEngine.UI.GridLayoutGroup;
             var parentIsAutoLayout = parentLg != null && !parentIsGrid;
 
+            // flow="false"：子节点退出排版流。LayoutGroup（含 Grid）收集 rectChildren 时跳过
+            // ignoreLayout 的子节点 → 它既不占排版空间也不贡献 preferred，anchor / margin /
+            // size 走下面的自由定位分支，恢复完整语义（典型：Stack 里铺满的背景层 / 角标）。
+            // 回流时清回 false（不摘组件），保 Variant 切换 / ReSolve 幂等。
+            if (parentLg != null)
+            {
+                var flowLe = LayoutHost.gameObject.GetComponent<UnityEngine.UI.LayoutElement>();
+                if (!flow)
+                {
+                    flowLe ??= LayoutHost.gameObject.AddComponent<UnityEngine.UI.LayoutElement>();
+                    flowLe.ignoreLayout = true;
+                }
+                else if (flowLe != null)
+                {
+                    flowLe.ignoreLayout = false;
+                }
+            }
+
             // 百分比 ('%') 在任何 LayoutGroup 容器（V/HStack 或 Grid）里都无法表达：
             // - V/HStack 用的是 flex 权重，不是父尺寸百分比；
             // - Grid 用的是 cellSize，子节点的 anchor 直接被 GridLayoutGroup 覆写。
             // 给出可操作的提示：用加权 stretch + spacer 兄弟，或者移到自由定位父级。
-            if ((parentIsAutoLayout || parentIsGrid)
+            if ((parentIsAutoLayout || parentIsGrid) && flow
                 && (sizeSpec.IsFractionalWidth || sizeSpec.IsFractionalHeight))
             {
                 throw new System.ArgumentException(
@@ -238,7 +256,7 @@ namespace PromptUGUI.Controls
                     "Or move the child to a free-positioning parent (Frame/Screen) where '%' maps to anchor fractions.");
             }
 
-            if (parentIsAutoLayout)
+            if (parentIsAutoLayout && flow)
             {
                 ApplyLayoutElement(sizeSpec, preset);
                 // anchor / pivot / sizeDelta / anchoredPosition: LayoutGroup 接管几何。

--- a/Runtime/Core/Lint/IRWalker.cs
+++ b/Runtime/Core/Lint/IRWalker.cs
@@ -74,7 +74,9 @@ namespace PromptUGUI.Lint
             // dropped (spec §6.2). Self-relative — about the node's own anchor + margin.
             // Skipped under a layout group: margin is wholly ignored there and PUI-LAYOUT-MARGIN
             // already owns that message, so an inert-side error would be a redundant second hit.
-            if (!parentIsLayoutGroup)
+            // Exception: a flow="false" child is back in free-positioning semantics — margin is
+            // meaningful again, so the inert-side check applies after all.
+            if (!parentIsLayoutGroup || LayoutGroupChildRules.MightBeOutOfFlow(node))
                 foreach (var issue in MarginAnchorRules.Check(node))
                     yield return issue;
 
@@ -98,6 +100,13 @@ namespace PromptUGUI.Lint
             {
                 if (isLayoutGroup)
                     foreach (var issue in LayoutGroupChildRules.CheckChild(child))
+                        yield return issue;
+                else
+                    // 'flow' under a non-layout-group parent is inert — flag it. Dispatched
+                    // from the child loop only (parent tag truly known): template-body roots,
+                    // <Add> roots and screen roots are exempt automatically — their real
+                    // parent is resolved at invocation/runtime and may well be an HStack.
+                    foreach (var issue in LayoutGroupChildRules.CheckNonLayoutChild(child))
                         yield return issue;
                 if (node.Tag == "Carousel")
                     foreach (var issue in CarouselRules.CheckCard(child))

--- a/Runtime/Core/Lint/LayoutGroupChildRules.cs
+++ b/Runtime/Core/Lint/LayoutGroupChildRules.cs
@@ -13,9 +13,47 @@ namespace PromptUGUI.Lint
     {
         public const string AnchorCode = "PUI-LAYOUT-ANCHOR";
         public const string MarginCode = "PUI-LAYOUT-MARGIN";
+        public const string FlowOutsideCode = "PUI-FLOW-OUTSIDE-GROUP";
+
+        /// <summary>
+        /// True when this child opts out of the layout flow in at least one configuration:
+        /// base <c>flow="false"</c>, or any variant override on <c>flow</c> (the author has
+        /// explicitly taken over in/out-of-flow switching — anchor/margin may serve the
+        /// out-of-flow shape, so static checks stay conservative and let them pass).
+        /// </summary>
+        public static bool MightBeOutOfFlow(ElementNode child) =>
+            (child.Attributes.TryGetValue("flow", out var f) && f == "false")
+            || child.VariantOverrides.ContainsKey("flow");
+
+        /// <summary>
+        /// True when this child is out of flow in every configuration: base
+        /// <c>flow="false"</c> with no variant override that could flip it back.
+        /// Used by ScreenInstantiator to skip in-flow-only plumbing (scale-host wrapper).
+        /// </summary>
+        public static bool AlwaysOutOfFlow(ElementNode child) =>
+            child.Attributes.TryGetValue("flow", out var f) && f == "false"
+            && !child.VariantOverrides.ContainsKey("flow");
+
+        /// <summary>
+        /// Child of a NON-layout-group parent: <c>flow</c> is inert there (free-positioning
+        /// parents have no layout flow to opt out of) — flag any usage.
+        /// </summary>
+        public static IEnumerable<LintIssue> CheckNonLayoutChild(ElementNode child)
+        {
+            if (child.Attributes.ContainsKey("flow")
+                || child.VariantOverrides.ContainsKey("flow"))
+                yield return new LintIssue(
+                    FlowOutsideCode, child.Tag, child.Id,
+                    $"<{child.Tag} id='{child.Id}'>: 'flow' has no effect because the parent is not a layout group (VStack/HStack/Grid) — free-positioning parents have no layout flow to opt out of. " +
+                    $"Fix: remove the 'flow' attribute; anchor/margin already position this element freely.");
+        }
 
         public static IEnumerable<LintIssue> CheckChild(ElementNode child)
         {
+            // flow="false"（或任一 variant 接管 flow）：子节点（可能）退出排版流，
+            // anchor / margin 恢复自由定位语义 —— 不再是误用。
+            if (MightBeOutOfFlow(child)) yield break;
+
             if (child.Attributes.ContainsKey("anchor")
                 || child.VariantOverrides.ContainsKey("anchor"))
                 yield return new LintIssue(

--- a/Tests/EditMode/Controls/FlowAttributeTests.cs
+++ b/Tests/EditMode/Controls/FlowAttributeTests.cs
@@ -1,0 +1,184 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Parser;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    /// <summary>
+    /// flow="false"：layout-group（V/HStack/Grid）子节点退出排版流 —— 挂
+    /// LayoutElement.ignoreLayout=true 让 LayoutGroup 跳过它，anchor / margin / size
+    /// 恢复自由定位语义。典型用途：Stack 里铺满的 9-slice 背景层、角标、装饰 overlay。
+    /// </summary>
+    public class FlowAttributeTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Flow_false_child_of_HStack_gets_ignoreLayout_and_stretch_anchors()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <HStack id='stack' width='200' height='18'>
+    <Image id='bg' anchor='stretch' flow='false'/>
+    <Btn id='b' size='64x16'/>
+  </HStack>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var bg = screen.Get<PromptUGUI.Controls.Image>("bg");
+            var le = bg.GameObject.GetComponent<LayoutElement>();
+            Assert.IsNotNull(le, "flow=false child must get a LayoutElement (ignoreLayout carrier)");
+            Assert.IsTrue(le.ignoreLayout, "flow=false → LayoutElement.ignoreLayout=true");
+            Assert.AreEqual(Vector2.zero, bg.RectTransform.anchorMin,
+                "flow=false: anchor='stretch' applies (free-positioning path)");
+            Assert.AreEqual(Vector2.one, bg.RectTransform.anchorMax);
+            Assert.AreEqual(Vector2.zero, bg.RectTransform.sizeDelta);
+        }
+
+        [Test]
+        public void Flow_false_child_margin_applies_offsets()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <HStack id='stack' width='200' height='100'>
+    <Image id='bg' anchor='stretch' margin='10,10,10,10' flow='false'/>
+    <Btn id='b' size='64x16'/>
+  </HStack>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var bg = screen.Get<PromptUGUI.Controls.Image>("bg");
+            Assert.AreEqual(new Vector2(-20f, -20f), bg.RectTransform.sizeDelta,
+                "flow=false: margin drives sizeDelta like any free-positioned stretch child");
+        }
+
+        [Test]
+        public void Flow_false_child_excluded_from_HStack_preferred_width()
+        {
+            // 核心需求：背景层不得撑大 Stack 的 hug 宽度。bg 若在流内，其 500 宽
+            // 会进 preferred 总和；ignoreLayout 后 preferred 只看 Btn 的 64。
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <VStack id='v' width='300' height='100'>
+    <HStack id='stack' height='18'>
+      <Image id='bg' width='500' height='18' flow='false'/>
+      <Btn id='b' size='64x16'/>
+    </HStack>
+  </VStack>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var stack = screen.Get<HStack>("stack");
+            var lg = stack.GameObject.GetComponent<HorizontalLayoutGroup>();
+            lg.CalculateLayoutInputHorizontal();
+            Assert.AreEqual(64f, lg.preferredWidth,
+                "flow=false child must not contribute to the layout group's preferred width");
+        }
+
+        [Test]
+        public void Flow_false_allows_fractional_width()
+        {
+            // '%' 在流内是硬错误（flex 权重无法表达父百分比）；流外恢复自由定位语义 → 合法。
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <HStack id='stack' width='200' height='100'>
+    <Image id='bg' width='50%' height='10' flow='false'/>
+    <Btn id='b' size='64x16'/>
+  </HStack>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var bg = screen.Get<PromptUGUI.Controls.Image>("bg");
+            Assert.AreEqual(0f, bg.RectTransform.anchorMin.x, 1e-4f);
+            Assert.AreEqual(0.5f, bg.RectTransform.anchorMax.x, 1e-4f,
+                "flow=false: width='50%' maps to anchor sub-range like under a Frame");
+        }
+
+        [Test]
+        public void Flow_false_with_width_stretch_throws()
+        {
+            // 流外没有 flex 权重概念，'stretch' 关键字无意义 —— 与 Frame 子节点同样响亮报错。
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <HStack id='stack' width='200' height='100'>
+    <Image id='bg' width='stretch' flow='false'/>
+  </HStack>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            Assert.Throws<ParseException>(() => UI.Open("S"));
+        }
+
+        [Test]
+        public void Flow_variant_toggle_flips_ignoreLayout_both_ways()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <HStack id='stack' width='200' height='100'>
+    <Image id='bg' anchor='stretch' flow.deco='false'/>
+    <Btn id='b' size='64x16'/>
+  </HStack>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            UI.Variants.Set("deco", false);
+            var screen = UI.Open("S");
+            var bg = screen.Get<PromptUGUI.Controls.Image>("bg");
+            var le0 = bg.GameObject.GetComponent<LayoutElement>();
+            Assert.IsTrue(le0 == null || !le0.ignoreLayout, "base: in flow");
+
+            UI.Variants.Set("deco", true);
+            var le = bg.GameObject.GetComponent<LayoutElement>();
+            Assert.IsNotNull(le);
+            Assert.IsTrue(le.ignoreLayout, "variant deco: out of flow");
+            Assert.AreEqual(Vector2.zero, bg.RectTransform.anchorMin);
+            Assert.AreEqual(Vector2.one, bg.RectTransform.anchorMax);
+
+            UI.Variants.Set("deco", false);
+            Assert.IsFalse(le.ignoreLayout,
+                "back to base: ignoreLayout must reset to false (ReSolve idempotency)");
+        }
+
+        [Test]
+        public void Flow_false_under_Grid_gets_ignoreLayout_and_free_anchors()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Grid id='grid' columns='2' cellSize='40x40' width='200' height='200'>
+    <Image id='bg' anchor='stretch' flow='false'/>
+    <Btn id='b'/>
+  </Grid>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var bg = screen.Get<PromptUGUI.Controls.Image>("bg");
+            var le = bg.GameObject.GetComponent<LayoutElement>();
+            Assert.IsNotNull(le);
+            Assert.IsTrue(le.ignoreLayout, "GridLayoutGroup also honors ignoreLayout");
+            Assert.AreEqual(Vector2.zero, bg.RectTransform.anchorMin);
+            Assert.AreEqual(Vector2.one, bg.RectTransform.anchorMax);
+        }
+
+        [Test]
+        public void Scaled_text_with_flow_false_skips_layout_bridge_wrapper()
+        {
+            // STW-D8 wrapper 只为"被 LayoutGroup 量算"服务；流外的 Text 不被量算，
+            // wrapper 反而会变成一个没人定位的中间层 —— 必须跳过。
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <HStack id='stack' width='200' height='40'>
+    <Text id='t' scale='2x' flow='false' anchor='top-left' width='50' height='20' tr='false'>hi</Text>
+    <Btn id='b' size='64x16'/>
+  </HStack>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var t = screen.Get<PromptUGUI.Controls.Text>("t");
+            var stack = screen.Get<HStack>("stack");
+            Assert.AreSame(stack.GameObject.transform, t.GameObject.transform.parent,
+                "flow=false <Text scale> must NOT get a [scale-host] wrapper");
+        }
+    }
+}

--- a/Tests/EditMode/Controls/FlowAttributeTests.cs.meta
+++ b/Tests/EditMode/Controls/FlowAttributeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 010c864f319c992419c75ff8de7fb047

--- a/Tests/EditMode/Lint/FlowLintTests.cs
+++ b/Tests/EditMode/Lint/FlowLintTests.cs
@@ -1,0 +1,153 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.IR;
+using PromptUGUI.Lint;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.EditMode.Lint
+{
+    /// <summary>
+    /// flow="false" 的 lint 面：
+    /// - layout-group 子节点声明 flow=false 后，anchor / margin 恢复合法 → PUI-LAYOUT-ANCHOR /
+    ///   PUI-LAYOUT-MARGIN 放行，PUI-MARGIN-INERT-SIDE（自由定位语义的检查）恢复生效；
+    /// - 非 layout-group 父级下写 flow 是 inert 属性 → PUI-FLOW-OUTSIDE-GROUP。
+    /// </summary>
+    public class FlowLintTests
+    {
+        // ---- LayoutGroupChildRules.CheckChild：flow=false 放行 anchor/margin ----
+
+        [Test]
+        public void CheckChild_AnchorAndMargin_Suppressed_WhenFlowFalse()
+        {
+            var child = new ElementNode("Image") { Id = "bg" };
+            child.Attributes["flow"] = "false";
+            child.Attributes["anchor"] = "stretch";
+            child.Attributes["margin"] = "8";
+            Assert.IsEmpty(LayoutGroupChildRules.CheckChild(child),
+                "flow=false: anchor/margin are meaningful again — no PUI-LAYOUT-* issue");
+        }
+
+        [Test]
+        public void CheckChild_Anchor_StillFlagged_WhenFlowTrue()
+        {
+            var child = new ElementNode("Image") { Id = "bg" };
+            child.Attributes["flow"] = "true";
+            child.Attributes["anchor"] = "stretch";
+            var issues = LayoutGroupChildRules.CheckChild(child).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(LayoutGroupChildRules.AnchorCode, issues[0].Code);
+        }
+
+        [Test]
+        public void CheckChild_Suppressed_WhenFlowHasVariantOverride()
+        {
+            // flow 只在某 variant 下为 false：作者明确接管了流内/流外切换，
+            // anchor 是为流外形态准备的 —— 静态检查放行（保守不误报）。
+            var child = new ElementNode("Image") { Id = "bg" };
+            child.VariantOverrides["flow"] =
+                new List<(string Variant, string Value)> { ("deco", "false") };
+            child.Attributes["anchor"] = "stretch";
+            Assert.IsEmpty(LayoutGroupChildRules.CheckChild(child));
+        }
+
+        // ---- 非 layout-group 父级下的 flow：inert → PUI-FLOW-OUTSIDE-GROUP ----
+
+        [Test]
+        public void CheckNonLayoutChild_Flow_Flagged()
+        {
+            var child = new ElementNode("Image") { Id = "bg" };
+            child.Attributes["flow"] = "false";
+            var issues = LayoutGroupChildRules.CheckNonLayoutChild(child).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(LayoutGroupChildRules.FlowOutsideCode, issues[0].Code);
+            StringAssert.Contains("'flow'", issues[0].Message);
+        }
+
+        [Test]
+        public void CheckNonLayoutChild_NoFlow_NoIssue()
+        {
+            var child = new ElementNode("Image") { Id = "bg" };
+            child.Attributes["anchor"] = "stretch";
+            Assert.IsEmpty(LayoutGroupChildRules.CheckNonLayoutChild(child));
+        }
+
+        // ---- IRWalker 集成 ----
+
+        [Test]
+        public void Walk_FlowUnderFrame_Flagged()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <Frame>
+      <Image id='bg' flow='false' anchor='stretch'/>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+            var doc = UIDocumentParser.Parse(xml);
+            var issues = IRWalker.Walk(doc)
+                .Where(i => i.Code == LayoutGroupChildRules.FlowOutsideCode).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual("bg", issues[0].Id);
+        }
+
+        [Test]
+        public void Walk_FlowInsideHStack_NotFlagged_AndLayoutAnchorSuppressed()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <HStack>
+      <Image id='bg' flow='false' anchor='stretch'/>
+      <Btn id='b' size='64x16'/>
+    </HStack>
+  </Screen>
+</PromptUGUI>";
+            var doc = UIDocumentParser.Parse(xml);
+            var all = IRWalker.Walk(doc).ToList();
+            Assert.IsFalse(all.Any(i => i.Code == LayoutGroupChildRules.FlowOutsideCode));
+            Assert.IsFalse(all.Any(i => i.Code == LayoutGroupChildRules.AnchorCode));
+        }
+
+        [Test]
+        public void Walk_InertSideMargin_Restored_ForFlowFalseChild()
+        {
+            // 流内子节点的 inert-side 检查让位给 PUI-LAYOUT-MARGIN；流外恢复自由定位
+            // 语义后 margin 重新有意义，写在 anchor 不消费的边上要重新报。
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <HStack>
+      <Text id='val' flow='false' anchor='bottom-right' margin='60,_,_,_'>x</Text>
+    </HStack>
+  </Screen>
+</PromptUGUI>";
+            var doc = UIDocumentParser.Parse(xml);
+            var issues = IRWalker.Walk(doc)
+                .Where(i => i.Code == MarginAnchorRules.InertSideCode).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual("val", issues[0].Id);
+        }
+
+        [Test]
+        public void Walk_TemplateBody_FlowNotFlagged()
+        {
+            // Template body 的根节点活在声明空间，真实父级要到 invocation 处才知道
+            // （可能就是个 HStack）—— FLOW-OUTSIDE 只在父 tag 已知的 child loop 派发，
+            // body 根（以及 <Add> 根、Screen 根）自动豁免，宁缺毋滥。
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Deco'>
+    <Image flow='false' anchor='stretch'/>
+  </Template>
+  <Screen name='S'>
+    <Frame/>
+  </Screen>
+</PromptUGUI>";
+            var doc = UIDocumentParser.Parse(xml);
+            Assert.IsFalse(IRWalker.Walk(doc)
+                .Any(i => i.Code == LayoutGroupChildRules.FlowOutsideCode));
+        }
+    }
+}

--- a/Tests/EditMode/Lint/FlowLintTests.cs.meta
+++ b/Tests/EditMode/Lint/FlowLintTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d7144da4febfa6b428b009d216a94304

--- a/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
+++ b/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
@@ -318,6 +318,8 @@ margin="16,8,4,12"    T=16, R=8, B=4, L=12
 
 容器自身仍用 `anchor` + `size`/`margin` 在父级里定位。
 
+**例外：`flow="false"`（出流子节点，FLW）。** 子节点声明 `flow="false"` 后退出排版流：实现为 `LayoutElement.ignoreLayout=true`，布局组在定位与量算 preferred 时都跳过它；`anchor` / `margin` / `N%` 对它恢复完整自由定位语义（相对布局组自身的 rect），上述警告与 `%` 禁令一并解除。`width="stretch"` 仍非法（流外没有 flex 权重，应改用 `anchor="stretch"`）。典型用途：hug 尺寸的 Stack 内铺满的 9-slice 背景层 / 角标。在非布局组父级下 `flow` 是 inert 属性（lint `PUI-FLOW-OUTSIDE-GROUP`）。可被 Variant 覆盖（`flow.portrait="false"`），切换走标准 ReSolve 重解算。
+
 ---
 
 ## 7. Template：复用与组合


### PR DESCRIPTION
V/HStack/Grid 直接子节点声明 flow=\"false\" 后退出排版流：
- LayoutElement.ignoreLayout=true，布局组定位与 preferred 量算都跳过它
- anchor / margin / N% 恢复完整自由定位语义（相对布局组 rect）
- width=\"stretch\" 维持报错（流外无 flex 权重，用 anchor=\"stretch\"）
- Variant 可覆盖（flow.portrait=\"false\"），ReSolve 双向幂等
- 静态出流的 <Text scale> 跳过 scale-host 量算 wrapper

lint：PUI-LAYOUT-ANCHOR / PUI-LAYOUT-MARGIN 对出流子节点放行， PUI-MARGIN-INERT-SIDE 恢复生效；新增 PUI-FLOW-OUTSIDE-GROUP （非布局组父级下 flow 是 inert 属性；child-loop 派发，模板 body 根 / Add 根自动豁免）。XSD commonAttrs + XML SKILL + spec §6.5 已同步。

典型用法 — hug 宽度的 timeBox 抱紧倒计时文字，9-slice 皮肤铺满不撑宽： <HStack id=\"timeBox\" height=\"18\" spacing=\"4\" padding=\"3,6,3,3\">
    <Image anchor=\"stretch\" flow=\"false\" sprite=\"UI:Box-Frame\"/>
    <Icon .../><Text scale=\"0.5r\">18天 05:26:45</Text>
  </HStack>

EditMode 1595 + EditorOnly 184 + PlayMode 133 全绿，dotnet format verify 通过，UIXmlLint 内置 XML 无新告警。