### PR TITLE
feat: .pxl 像素网格文本资产 — LLM 直接生成 UI 小件 Sprite

### DIFF
--- a/.claude/skills/authoring-promptugui-pxl/SKILL.md
+++ b/.claude/skills/authoring-promptugui-pxl/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: authoring-promptugui-pxl
+description: Use when creating or editing PromptUGUI .pxl pixel-grid sprite files — LLM-authored pixel art (9-slice borders, button skins, icons) that imports directly as Unity Sprites. For referencing the resulting sprites from XML see authoring-promptugui-xml.
+---
+
+# Authoring PromptUGUI `.pxl` pixel sprites
+
+`.pxl` is a plain-text pixel-grid format: a palette plus character grid, one character per pixel. Drop a `.pxl` file into a SpriteSet `sourceFolder` and Unity's ScriptedImporter turns it into point-filtered Sprite(s) — with 9-slice border and PPU declared in-file — that the existing **Sync Atlases** pipeline packs exactly like PNGs. The result is referenced from `.ui.xml` as `set:key` via `<Icon name=>`, `<Image sprite=>`, `<Btn sprite=>`, etc.
+
+Sweet spot: **UI chrome ≤48×48** — 9-slice frames, button skins, icons, badges, small decorations. NOT for large illustrations; a big grid is unmanageable text and pixel art quality drops with size anyway.
+
+The text IS the image: you can re-read your own output row by row and fix individual pixels. Import errors carry line numbers, so the loop is write → check Console → revise.
+
+## File format
+
+A complete two-state 9-slice button (`Buttons/ok.pxl`):
+
+```
+# 12x8 button skin, two states sharing one palette
+palette: @ui
+ppu: 16
+chars:
+  K: night
+  H: cloud
+  M: steel
+  S: slate
+  D: #3a4466
+
+[normal]
+border: 3,3,3,3
+grid:
+  .KKKKKKKKKK.
+  KHHHHHHHHHHK
+  KHMMMMMMMMSK
+  KHMMMMMMMMSK
+  KHMMMMMMMMSK
+  KHMMMMMMMMSK
+  KSSSSSSSSSSK
+  .KKKKKKKKKK.
+
+[pressed]
+border: 3,3,3,3
+grid:
+  .KKKKKKKKKK.
+  KSSSSSSSSSSK
+  KSDDDDDDDDHK
+  KSDDDDDDDDHK
+  KSDDDDDDDDHK
+  KSDDDDDDDDHK
+  KHHHHHHHHHHK
+  .KKKKKKKKKK.
+```
+
+### Header directives (file-level, shared by all sections)
+
+- `palette: @<name>` — optional. References a project `.gpl` palette by file basename (`@ui` → `ui.gpl`). Name charset: `[A-Za-z0-9_-]+`. Omit it for pure inline-hex mode.
+- `ppu: <n>` — optional, pixels-per-unit for the created Sprites; positive number, **default 100**. For pixel art you usually want a small value (e.g. `ppu: 16`) or to rely on PromptUGUI's own scaling on the XML side.
+- `chars:` — starts the character→color block. Each entry is one line: `X: value` (single character, colon, space, value). Values:
+  - `transparent`
+  - a palette color name (only valid in `palette: @...` mode)
+  - `#RRGGBB` or `#RRGGBBAA` (exact 6 or 8 hex digits, no spaces)
+
+  `.` is **always transparent and reserved** — you never need to declare it, and redefining it to anything but `transparent` is an error. Duplicate keys are errors. Don't use `[`, `]`, `#`, `.`, or whitespace as chars keys (`#` lines are comments; `[x]`-shaped grid rows would parse as section headers).
+
+### Comments
+
+A line whose **first non-whitespace character is `#`** is a comment, anywhere in the file (header, chars block, between sections, even between grid rows). There are **no trailing comments** — `K: night  # outline` would make the color name literally `night  # outline` and fail. Put comments on their own lines.
+
+### Sections
+
+- `[name]` starts a section; names match `[A-Za-z0-9_-]+`; duplicates are errors. Each section becomes one independent Sprite (sections may have different sizes).
+- **Implicit single section**: a file with no `[name]` header at all may put `border:`/`grid:` directly after the header — one anonymous sprite. You **cannot mix** implicit content with explicit `[section]` headers in one file.
+
+### Per-section directives
+
+- `border: L,B,R,T` — optional 9-slice border, four non-negative ints in **Unity sprite-border order: left, bottom, right, top**. Must appear **before** `grid:`. Constraints: `L+R ≤ width`, `B+T ≤ height`. Omit for a non-sliced sprite.
+- `grid:` — the pixel rows follow, one line per row, one character per pixel, **top-down**. Rules:
+  - Every row must have **exactly the same width** as the first row (the #1 authoring error — count characters).
+  - Every non-`.` character must already be declared in `chars:`.
+  - Leading/trailing whitespace is trimmed, so uniform indentation is fine; spaces cannot be pixels.
+  - A **blank line ENDS the grid**. Don't split a grid with an empty line — the rows after the blank become "unrecognized line" errors. One `grid:` per section.
+
+## Sprite keys (how XML refers to the result)
+
+Keys follow the same SpriteSet rules as PNGs (see the **authoring-promptugui-xml** skill, `reference/icons.md`):
+
+| File | Section | Key |
+|---|---|---|
+| `Buttons/ok.pxl` (implicit single section) | — | `Buttons/ok` |
+| `Buttons/ok.pxl` | `[pressed]` | `Buttons/ok/pressed` |
+| `Buttons/ok.pxl` | `[ok]` (same as file basename) | `Buttons/ok` (collapses to the plain path key) |
+
+So in XML: `<Btn sprite="ui:Buttons/ok" pressedSprite="ui:Buttons/ok/pressed"/>`. The bare last segment (`pressed`) also works as an alias when it's unambiguous across the whole source folder — same shortcut rule as PNG basenames. Inline TMP sprites (`<sprite name=...>` in text) only ever see **bare names** (the section name, or the file basename for an implicit section).
+
+## Palette workflow (`.gpl`)
+
+Palettes use the **GIMP Palette** format — the community standard: Lospec palettes download as `.gpl`, Aseprite reads/writes it natively. Format: a `GIMP Palette` first line, then `R G B name` entries (name optional).
+
+- `palette: @ui` finds `ui.gpl` by file basename **anywhere in the project**; zero matches or more than one is an import error (the error lists candidates when ambiguous).
+- **Palette mode enforces project-wide color consistency**: every `#hex` chars value must exactly match some palette entry's RGB (alpha is free — `#1a1c2c80` is fine if `26 28 44` is on the palette). An off-palette hex fails the import with an "off-palette" error: pick a palette color or add it to the `.gpl`.
+- Color **names are normalized** for lookup: case, spaces, hyphens and underscores are ignored (`Dark Blue` ≡ `dark-blue` ≡ `darkblue`).
+- **Unnamed palette entries** (lines with only `R G B`) can only be referenced by hex.
+- Editing a `.gpl` auto-reimports every `.pxl` that references it — a project-wide recolor is one file edit. Adding, deleting, or moving a `.gpl` also re-triggers `.pxl` imports (so a previously broken "palette not found" file heals itself when the palette appears).
+
+## Pixel-art craft rules
+
+You are drawing, not just encoding. Apply these when composing a grid:
+
+- **1px outline** around the shape, usually the darkest palette color. It's what makes a small sprite read against any background.
+- **Limited ramp**: 2–4 shades per material (highlight / base / shadow). More shades at this size = mud.
+- **9-slice design**: the **corners carry all the detail** (rounded corners, rivets, notches). The **edge strips between the borders must tile** — keep each edge uniform along its axis (a horizontal edge strip should have identical columns; a vertical strip identical rows). The **center must tile or be flat** — a flat fill is safest and lets the button stretch to any size.
+- **Button states**: pressed = swap the highlight and shadow edges (bevel inverts) and/or darken the face; optionally shift the content 1px down. Hover = lighter face. Keep the outline identical across states so the silhouette doesn't jump.
+- **Centered glyphs want odd dimensions** (e.g. 9×9, 13×13) so there's a true center pixel.
+- **Design at the smallest size that reads**; let PPU / PromptUGUI scaling handle display size. A crisp 12×12 scaled up beats a fuzzy 48×48.
+- Use `.` (transparent) for *outside the silhouette* only — don't fake glow/anti-aliasing with semi-transparent pixels inside the shape; pixel art stays hard-edged (the importer is point-filtered for a reason).
+
+## Errors & self-verification
+
+Import errors land in the **Unity Console with line numbers** and fail the asset — no Sprite is produced (and Sync Atlases / `<Icon>` resolution will then miss the key). After writing a file, check the Console; after fixing, the reimport is automatic on save.
+
+| Error | Cause / fix |
+|---|---|
+| `row width N != first row width M` | Ragged grid row — count characters; every row in a section must be identical length. |
+| `unknown grid char 'X' (not in chars:)` | Pixel char not declared — add it to `chars:` (before the grid). |
+| `... is not on palette '@name' (off-palette color ...)` | Hex doesn't match any palette RGB — use a palette color or extend the `.gpl`. |
+| `color name '...' not found in palette` / `requires a 'palette: @<name>' declaration` | Typo'd name, or used a name without declaring `palette:`. |
+| `palette '@name' not found` / `is ambiguous` | No (or multiple) `<name>.gpl` in the project. |
+| `border (...) exceeds grid size WxH` | `L+R > width` or `B+T > height` — shrink the border or grow the grid. |
+| `unrecognized line '...' (note: a blank line ends a grid: block)` | Usually a blank line inside a grid — grid rows must be contiguous. |
+| `cannot mix implicit (headerless) content with [section] headers` | Started drawing before the first `[section]` — add a header to the first sprite too. |
+| `'.' is reserved for transparent` / `duplicate chars key` / `duplicate section name` | Self-explanatory — rename. |
+
+**Self-verify before reporting done**: the grid is the image. Re-read your own output row by row — check the outline is closed, edge strips are uniform (9-slice), every row is the same width, and there are no stray pixels. Then confirm the Unity Console is clean and the sprite shows up under the expected `set:key`.

--- a/.claude/skills/authoring-promptugui-xml/reference/icons.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/icons.md
@@ -54,3 +54,11 @@ Anything else inside a Template body (`{{a}}:{{b}}`, `solar:{{a}}-{{b}}`, multi-
 - Names must be **unique across all flagged sets**. A collision aborts the sync with an error (`[InlineSprite] glyph name collision ...`) — rename the offending sprite.
 - The baked sheet is point-filtered and uncompressed (crisp for pixel-art).
 - Independent of the per-set `.spriteatlas` (which still serves `<Image>` / `<Icon>`): a flagged set does not need its icons referenced anywhere to be baked. The generated asset lives at `Assets/PromptUGUI.Generated/InlineSprites.asset`.
+
+## `.pxl` text sprites
+
+A SpriteSet `sourceFolder` may also contain `.pxl` files — LLM-authored pixel-grid
+text that imports directly as point-filtered Sprites (with 9-slice border / PPU
+declared in-file). Multi-section files contribute `path/section` keys (unique bare
+section names work as aliases). Full format and drawing guidance: the
+**authoring-promptugui-pxl** skill.

--- a/Editor/Pxl.meta
+++ b/Editor/Pxl.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4e3a6df78ca3e764c906fbc3d060d5f8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Pxl/GplPalette.cs
+++ b/Editor/Pxl/GplPalette.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PromptUGUI.Editor
+{
+    /// <summary>GIMP Palette (.gpl) 文本解析。社区标准格式：Aseprite 原生读写、
+    /// Lospec 全站可下载。条目 = "R G B [name]"，name 可缺省（缺省条目只能被 hex 命中）。</summary>
+    internal sealed class GplPalette
+    {
+        public readonly List<(Color32 color, string name)> Entries = new List<(Color32 color, string name)>();
+        private readonly Dictionary<string, Color32> _byName = new Dictionary<string, Color32>(StringComparer.Ordinal);
+
+        public static GplPalette Parse(string text)
+        {
+            var palette = new GplPalette();
+            var lines = text.Replace("\r\n", "\n").Split('\n');
+            var headerSeen = false;
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i].Trim();
+                if (line.Length == 0) continue;
+                if (!headerSeen)
+                {
+                    if (line != "GIMP Palette")
+                        throw new FormatException(
+                            $"line {i + 1}: not a GIMP Palette file (expected 'GIMP Palette' header)");
+                    headerSeen = true;
+                    continue;
+                }
+                if (line.StartsWith("#", StringComparison.Ordinal)) continue;
+                if (line.StartsWith("Name:", StringComparison.Ordinal)) continue;
+                if (line.StartsWith("Columns:", StringComparison.Ordinal)) continue;
+
+                var parts = line.Split((char[])null, 4, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length < 3 ||
+                    !byte.TryParse(parts[0], out var r) ||
+                    !byte.TryParse(parts[1], out var g) ||
+                    !byte.TryParse(parts[2], out var b))
+                {
+                    throw new FormatException($"line {i + 1}: expected 'R G B [name]', got '{line}'");
+                }
+                var name = parts.Length == 4 ? parts[3].Trim() : null;
+                if (string.IsNullOrEmpty(name)) name = null;
+                var color = new Color32(r, g, b, 255);
+                palette.Entries.Add((color, name));
+                if (name != null) palette._byName[Normalize(name)] = color;
+            }
+            if (!headerSeen)
+                throw new FormatException("line 1: not a GIMP Palette file (expected 'GIMP Palette' header)");
+            return palette;
+        }
+
+        public bool TryGetByName(string token, out Color32 color) =>
+            _byName.TryGetValue(Normalize(token), out color);
+
+        public bool ContainsRgb(Color32 c)
+        {
+            foreach (var (e, _) in Entries)
+                if (e.r == c.r && e.g == c.g && e.b == c.b) return true;
+            return false;
+        }
+
+        /// <summary>色名比较忽略大小写与空格/连字符/下划线差异（"Dark Blue" ≡ "dark-blue"）。</summary>
+        public static string Normalize(string name) =>
+            name.ToLowerInvariant().Replace(" ", "").Replace("-", "").Replace("_", "");
+    }
+}

--- a/Editor/Pxl/GplPalette.cs
+++ b/Editor/Pxl/GplPalette.cs
@@ -5,11 +5,12 @@ using UnityEngine;
 namespace PromptUGUI.Editor
 {
     /// <summary>GIMP Palette (.gpl) 文本解析。社区标准格式：Aseprite 原生读写、
-    /// Lospec 全站可下载。条目 = "R G B [name]"，name 可缺省（缺省条目只能被 hex 命中）。</summary>
+    /// Lospec 全站可下载。条目 = "R G B [name]"，name 可缺省（缺省条目只能被 hex 命中）。
+    /// 同名条目 last-wins（Entries 保留全部，按名查找取最后一个）。</summary>
     internal sealed class GplPalette
     {
-        public readonly List<(Color32 color, string name)> Entries = new List<(Color32 color, string name)>();
-        private readonly Dictionary<string, Color32> _byName = new Dictionary<string, Color32>(StringComparer.Ordinal);
+        public readonly List<(Color32 color, string name)> Entries = new();
+        private readonly Dictionary<string, Color32> _byName = new(StringComparer.Ordinal);
 
         public static GplPalette Parse(string text)
         {

--- a/Editor/Pxl/GplPalette.cs.meta
+++ b/Editor/Pxl/GplPalette.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ff4169f7a1c578448b643df276f8e4c7

--- a/Editor/Pxl/PxlColorResolver.cs
+++ b/Editor/Pxl/PxlColorResolver.cs
@@ -8,7 +8,8 @@ namespace PromptUGUI.Editor
     /// <summary>chars 映射 → 具体颜色。palette 模式（doc.PaletteRef != null）下
     /// hex 的 RGB 必须命中色板（忽略 alpha）——把全项目调色板一致性从 LLM 自觉
     /// 变成管线强制（spec §3）。错误用 PxlParseException(line=0)：此阶段无行号，
-    /// 消息携带 char 键与值上下文足以定位。</summary>
+    /// 消息携带 char 键与值上下文足以定位。
+    /// 调用方契约：palette 参数当且仅当 doc.PaletteRef != null 时非 null（由 PxlImporter 保证）。</summary>
     internal static class PxlColorResolver
     {
         public static Dictionary<char, Color32> Resolve(PxlDocument doc, GplPalette palette)
@@ -45,12 +46,12 @@ namespace PromptUGUI.Editor
         {
             var hex = value.Substring(1);
             if ((hex.Length != 6 && hex.Length != 8) ||
-                !uint.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out _))
+                !uint.TryParse(hex, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out _))
             {
                 throw new PxlParseException(0,
                     $"chars '{key}': '{value}' is not #RRGGBB / #RRGGBBAA");
             }
-            byte P(int i) => byte.Parse(hex.Substring(i, 2), NumberStyles.HexNumber,
+            byte P(int i) => byte.Parse(hex.Substring(i, 2), NumberStyles.AllowHexSpecifier,
                 CultureInfo.InvariantCulture);
             return new Color32(P(0), P(2), P(4), hex.Length == 8 ? P(6) : (byte)255);
         }

--- a/Editor/Pxl/PxlColorResolver.cs
+++ b/Editor/Pxl/PxlColorResolver.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using UnityEngine;
+
+namespace PromptUGUI.Editor
+{
+    /// <summary>chars 映射 → 具体颜色。palette 模式（doc.PaletteRef != null）下
+    /// hex 的 RGB 必须命中色板（忽略 alpha）——把全项目调色板一致性从 LLM 自觉
+    /// 变成管线强制（spec §3）。错误用 PxlParseException(line=0)：此阶段无行号，
+    /// 消息携带 char 键与值上下文足以定位。</summary>
+    internal static class PxlColorResolver
+    {
+        public static Dictionary<char, Color32> Resolve(PxlDocument doc, GplPalette palette)
+        {
+            var map = new Dictionary<char, Color32> { ['.'] = new Color32(0, 0, 0, 0) };
+            foreach (var kv in doc.Chars)
+            {
+                var key = kv.Key;
+                var value = kv.Value;
+                if (value == "transparent") { map[key] = new Color32(0, 0, 0, 0); continue; }
+                if (value.StartsWith("#", StringComparison.Ordinal))
+                {
+                    var c = ParseHex(key, value);
+                    if (palette != null && !palette.ContainsRgb(c))
+                        throw new PxlParseException(0,
+                            $"chars '{key}': {value} is not on palette '@{doc.PaletteRef}' " +
+                            $"(off-palette color; pick a palette color or add it to the .gpl)");
+                    map[key] = c;
+                    continue;
+                }
+                // 色名
+                if (palette == null)
+                    throw new PxlParseException(0,
+                        $"chars '{key}': color name '{value}' requires a 'palette: @<name>' declaration");
+                if (!palette.TryGetByName(value, out var named))
+                    throw new PxlParseException(0,
+                        $"chars '{key}': color name '{value}' not found in palette '@{doc.PaletteRef}'");
+                map[key] = named;
+            }
+            return map;
+        }
+
+        private static Color32 ParseHex(char key, string value)
+        {
+            var hex = value.Substring(1);
+            if ((hex.Length != 6 && hex.Length != 8) ||
+                !uint.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out _))
+            {
+                throw new PxlParseException(0,
+                    $"chars '{key}': '{value}' is not #RRGGBB / #RRGGBBAA");
+            }
+            byte P(int i) => byte.Parse(hex.Substring(i, 2), NumberStyles.HexNumber,
+                CultureInfo.InvariantCulture);
+            return new Color32(P(0), P(2), P(4), hex.Length == 8 ? P(6) : (byte)255);
+        }
+    }
+}

--- a/Editor/Pxl/PxlColorResolver.cs.meta
+++ b/Editor/Pxl/PxlColorResolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c249f820b74d876499cf5696d060d1b9

--- a/Editor/Pxl/PxlImporter.cs
+++ b/Editor/Pxl/PxlImporter.cs
@@ -1,0 +1,118 @@
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.AssetImporters;
+using UnityEngine;
+
+namespace PromptUGUI.Editor
+{
+    /// <summary>.pxl（像素网格文本，spec 2026-06-11-pxl-pixel-sprite-importer）→
+    /// 每节一张 point-filter Texture2D + Sprite sub-asset。main asset = 首节
+    /// Texture2D，保证 SpriteAtlasSyncer 的 FindAssets("t:Texture2D") 能发现。
+    /// Texture 保持 readable：InlineSpriteAssetBuilder 烘焙图文混排时要读像素。</summary>
+    [ScriptedImporter(1, "pxl")]
+    internal sealed class PxlImporter : ScriptedImporter
+    {
+        public override void OnImportAsset(AssetImportContext ctx)
+        {
+            string text;
+            try { text = File.ReadAllText(ctx.assetPath); }
+            catch (IOException ex)
+            {
+                ctx.LogImportError($"{ctx.assetPath}: cannot read: {ex.Message}");
+                return;
+            }
+
+            PxlDocument doc;
+            try { doc = PxlParser.Parse(text); }
+            catch (PxlParseException ex)
+            {
+                ctx.LogImportError($"{ctx.assetPath}: {ex.Message}");
+                return;
+            }
+
+            GplPalette palette = null;
+            if (doc.PaletteRef != null)
+            {
+                var gplPath = FindPalettePath(doc.PaletteRef, out var error);
+                if (gplPath == null)
+                {
+                    ctx.LogImportError($"{ctx.assetPath}: {error}");
+                    return;
+                }
+                // 色板改动 → 所有引用它的 .pxl 自动重导入（全项目换色一次完成）。
+                ctx.DependsOnSourceAsset(gplPath);
+                try { palette = GplPalette.Parse(File.ReadAllText(gplPath)); }
+                catch (System.FormatException ex)
+                {
+                    ctx.LogImportError($"{gplPath}: {ex.Message}");
+                    return;
+                }
+            }
+
+            System.Collections.Generic.Dictionary<char, Color32> colors;
+            try { colors = PxlColorResolver.Resolve(doc, palette); }
+            catch (PxlParseException ex)
+            {
+                ctx.LogImportError($"{ctx.assetPath}: {ex.Message}");
+                return;
+            }
+
+            var basename = Path.GetFileNameWithoutExtension(ctx.assetPath);
+            Texture2D main = null;
+            foreach (var section in doc.Sections)
+            {
+                var name = section.Name ?? basename;
+                var tex = BuildTexture(section, colors, name);
+                var sprite = Sprite.Create(tex,
+                    new Rect(0, 0, section.Width, section.Height),
+                    new Vector2(0.5f, 0.5f), doc.Ppu, 0,
+                    SpriteMeshType.FullRect, section.Border);
+                sprite.name = name;
+                ctx.AddObjectToAsset($"tex:{name}", tex);
+                ctx.AddObjectToAsset($"sprite:{name}", sprite);
+                if (main == null) main = tex;
+            }
+            ctx.SetMainObject(main);
+        }
+
+        private static Texture2D BuildTexture(PxlSection section,
+            System.Collections.Generic.IReadOnlyDictionary<char, Color32> colors, string name)
+        {
+            var w = section.Width;
+            var h = section.Height;
+            var tex = new Texture2D(w, h, TextureFormat.RGBA32, false)
+            {
+                name = name,
+                filterMode = FilterMode.Point,
+                wrapMode = TextureWrapMode.Clamp,
+                alphaIsTransparency = true,
+            };
+            var px = new Color32[w * h];
+            for (var row = 0; row < h; row++)        // grid top-down → texture bottom-up
+                for (var col = 0; col < w; col++)
+                    px[(h - 1 - row) * w + col] = colors[section.Rows[row][col]];
+            tex.SetPixels32(px);
+            tex.Apply(updateMipmaps: false, makeNoLongerReadable: false);
+            return tex;
+        }
+
+        /// <summary>按文件名（去扩展名）全项目找 &lt;name&gt;.gpl。0 个或多个都报错
+        /// （error out 参数带候选列表）。</summary>
+        private static string FindPalettePath(string paletteRef, out string error)
+        {
+            var matches = AssetDatabase.FindAssets(paletteRef)
+                .Select(AssetDatabase.GUIDToAssetPath)
+                .Where(p => string.Equals(Path.GetFileName(p), paletteRef + ".gpl",
+                    System.StringComparison.Ordinal))
+                .Distinct()
+                .OrderBy(p => p, System.StringComparer.Ordinal)
+                .ToList();
+            if (matches.Count == 1) { error = null; return matches[0]; }
+            error = matches.Count == 0
+                ? $"palette '@{paletteRef}' not found (no '{paletteRef}.gpl' in project)"
+                : $"palette '@{paletteRef}' is ambiguous: {string.Join(", ", matches)}";
+            return null;
+        }
+    }
+}

--- a/Editor/Pxl/PxlImporter.cs
+++ b/Editor/Pxl/PxlImporter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using UnityEditor;
@@ -43,6 +44,11 @@ namespace PromptUGUI.Editor
                 // 色板改动 → 所有引用它的 .pxl 自动重导入（全项目换色一次完成）。
                 ctx.DependsOnSourceAsset(gplPath);
                 try { palette = GplPalette.Parse(File.ReadAllText(gplPath)); }
+                catch (IOException ex)
+                {
+                    ctx.LogImportError($"{gplPath}: cannot read: {ex.Message}");
+                    return;
+                }
                 catch (System.FormatException ex)
                 {
                     ctx.LogImportError($"{gplPath}: {ex.Message}");
@@ -50,7 +56,7 @@ namespace PromptUGUI.Editor
                 }
             }
 
-            System.Collections.Generic.Dictionary<char, Color32> colors;
+            Dictionary<char, Color32> colors;
             try { colors = PxlColorResolver.Resolve(doc, palette); }
             catch (PxlParseException ex)
             {
@@ -77,7 +83,7 @@ namespace PromptUGUI.Editor
         }
 
         private static Texture2D BuildTexture(PxlSection section,
-            System.Collections.Generic.IReadOnlyDictionary<char, Color32> colors, string name)
+            IReadOnlyDictionary<char, Color32> colors, string name)
         {
             var w = section.Width;
             var h = section.Height;
@@ -98,7 +104,8 @@ namespace PromptUGUI.Editor
         }
 
         /// <summary>按文件名（去扩展名）全项目找 &lt;name&gt;.gpl。0 个或多个都报错
-        /// （error out 参数带候选列表）。</summary>
+        /// （error out 参数带候选列表）。
+        /// 查找本身无依赖边——.gpl 新增/删除/移动由 GplPostprocessor 兜底重导入。</summary>
         private static string FindPalettePath(string paletteRef, out string error)
         {
             var matches = AssetDatabase.FindAssets(paletteRef)
@@ -113,6 +120,48 @@ namespace PromptUGUI.Editor
                 ? $"palette '@{paletteRef}' not found (no '{paletteRef}.gpl' in project)"
                 : $"palette '@{paletteRef}' is ambiguous: {string.Join(", ", matches)}";
             return null;
+        }
+    }
+
+    /// <summary>FindAssets-based palette lookup has no asset-dependency edge for the
+    /// lookup itself: a .gpl appearing (fixing a missing-palette error), disappearing,
+    /// or moving would otherwise leave dependent .pxl assets stale until a manual
+    /// reimport. Force-reimport every .pxl whenever any .gpl changes shape.
+    /// (.gpl content edits are already covered by ctx.DependsOnSourceAsset.)
+    /// Note: when a .gpl content edit reimports dependents via DependsOnSourceAsset,
+    /// the .gpl itself appears in importedAssets → this postprocessor re-queues all
+    /// .pxl once more; that is an idempotent no-op import storm only on palette
+    /// changes, acceptable for Editor tooling.</summary>
+    internal sealed class GplPostprocessor : UnityEditor.AssetPostprocessor
+    {
+        private static void OnPostprocessAllAssets(
+            string[] importedAssets, string[] deletedAssets,
+            string[] movedAssets, string[] movedFromAssetPaths)
+        {
+            if (!AnyGpl(importedAssets) && !AnyGpl(deletedAssets) &&
+                !AnyGpl(movedAssets) && !AnyGpl(movedFromAssetPaths))
+            {
+                return;
+            }
+            // Use GetAllAssetPaths instead of FindAssets("t:Texture2D") so that
+            // broken .pxl files (failed import → DefaultAsset, not Texture2D) are
+            // also re-queued — exactly the case we must recover when a missing palette
+            // reappears.
+            foreach (var path in AssetDatabase.GetAllAssetPaths())
+            {
+                if (!path.EndsWith(".pxl", System.StringComparison.Ordinal)) continue;
+                AssetDatabase.ImportAsset(path);
+            }
+        }
+
+        private static bool AnyGpl(string[] paths)
+        {
+            foreach (var p in paths)
+            {
+                if (p != null && p.EndsWith(".gpl", System.StringComparison.Ordinal))
+                    return true;
+            }
+            return false;
         }
     }
 }

--- a/Editor/Pxl/PxlImporter.cs.meta
+++ b/Editor/Pxl/PxlImporter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 52005a060a4e54a40b77f1ca5c4deaa4

--- a/Editor/Pxl/PxlParser.cs
+++ b/Editor/Pxl/PxlParser.cs
@@ -9,7 +9,7 @@ namespace PromptUGUI.Editor
     {
         public readonly int Line;
         public PxlParseException(int line, string message)
-            : base($"line {line}: {message}") { Line = line; }
+            : base(line > 0 ? $"line {line}: {message}" : message) { Line = line; }
     }
 
     internal sealed class PxlDocument

--- a/Editor/Pxl/PxlParser.cs
+++ b/Editor/Pxl/PxlParser.cs
@@ -104,7 +104,15 @@ namespace PromptUGUI.Editor
                     if (!v.StartsWith("@", StringComparison.Ordinal) || v.Length < 2)
                         throw new PxlParseException(lineNo,
                             $"palette must be '@<name>' (a project .gpl reference), got '{v}'");
-                    doc.PaletteRef = v.Substring(1);
+                    var name = v.Substring(1);
+                    foreach (var c in name)
+                    {
+                        if (!((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                              (c >= '0' && c <= '9') || c == '_' || c == '-'))
+                            throw new PxlParseException(lineNo,
+                                $"palette name '@{name}' may only contain [A-Za-z0-9_-]");
+                    }
+                    doc.PaletteRef = name;
                     continue;
                 }
                 if (line.StartsWith("ppu:", StringComparison.Ordinal))

--- a/Editor/Pxl/PxlParser.cs
+++ b/Editor/Pxl/PxlParser.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+namespace PromptUGUI.Editor
+{
+    internal sealed class PxlParseException : Exception
+    {
+        public readonly int Line;
+        public PxlParseException(int line, string message)
+            : base($"line {line}: {message}") { Line = line; }
+    }
+
+    internal sealed class PxlDocument
+    {
+        public string PaletteRef;                              // "main" ← `palette: @main`; null = 纯内联
+        public float Ppu = 100f;
+        public readonly Dictionary<char, string> Chars = new(); // char → "transparent" | 色名 | #hex
+        public readonly List<PxlSection> Sections = new();
+    }
+
+    internal sealed class PxlSection
+    {
+        public string Name;                  // null = 隐式单节
+        public Vector4 Border;               // L,B,R,T（Unity Sprite border 序）
+        public int Width, Height;
+        public readonly List<string> Rows = new(); // top-down，已 trim
+    }
+
+    /// <summary>.pxl 文本 → IR。网格语法沿 XPM 惯用法：单字符=色板项、'.'=透明、
+    /// 一行=一行像素。结构校验（行宽、border 越界、重名）在这里；颜色解析在
+    /// PxlColorResolver（Task 3）。</summary>
+    internal static class PxlParser
+    {
+        private static readonly Regex SectionHeader =
+            new(@"^\[([A-Za-z0-9_-]+)\]$", RegexOptions.Compiled);
+        private static readonly Regex CharsEntry =
+            new(@"^(.): (.+)$", RegexOptions.Compiled);
+
+        public static PxlDocument Parse(string text)
+        {
+            var doc = new PxlDocument();
+            var lines = text.Replace("\r\n", "\n").Split('\n');
+
+            PxlSection section = null;
+            var inChars = false;
+            var inGrid = false;
+            var sawImplicitContent = false;
+            var names = new HashSet<string>(StringComparer.Ordinal);
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var lineNo = i + 1;
+                var line = lines[i].Trim();
+                if (line.Length == 0) { inGrid = false; continue; }
+                if (line[0] == '#') continue; // 整行注释；'#' 因此禁作 chars key
+
+                var m = SectionHeader.Match(line);
+                if (m.Success)
+                {
+                    if (sawImplicitContent)
+                        throw new PxlParseException(lineNo,
+                            "cannot mix implicit (headerless) content with [section] headers");
+                    FinishSection(section, lineNo);
+                    var name = m.Groups[1].Value;
+                    if (!names.Add(name))
+                        throw new PxlParseException(lineNo, $"duplicate section name '[{name}]'");
+                    section = new PxlSection { Name = name };
+                    doc.Sections.Add(section);
+                    inChars = false; inGrid = false;
+                    continue;
+                }
+
+                if (inGrid)
+                {
+                    ValidateRow(line, doc, section, lineNo);
+                    continue;
+                }
+
+                if (inChars)
+                {
+                    var cm = CharsEntry.Match(line);
+                    if (cm.Success)
+                    {
+                        var key = cm.Groups[1].Value[0];
+                        var value = cm.Groups[2].Value.Trim();
+                        if (key == '#')
+                            throw new PxlParseException(lineNo, "'#' is reserved for comments");
+                        if (key == '.' && value != "transparent")
+                            throw new PxlParseException(lineNo,
+                                "'.' is reserved for transparent and cannot be redefined");
+                        if (key != '.' && !doc.Chars.TryAdd(key, value))
+                            throw new PxlParseException(lineNo, $"duplicate chars key '{key}'");
+                        continue;
+                    }
+                    inChars = false; // 掉出 chars 块，按普通行继续解析
+                }
+
+                if (line.StartsWith("palette:", StringComparison.Ordinal))
+                {
+                    var v = line.Substring("palette:".Length).Trim();
+                    if (!v.StartsWith("@", StringComparison.Ordinal) || v.Length < 2)
+                        throw new PxlParseException(lineNo,
+                            $"palette must be '@<name>' (a project .gpl reference), got '{v}'");
+                    doc.PaletteRef = v.Substring(1);
+                    continue;
+                }
+                if (line.StartsWith("ppu:", StringComparison.Ordinal))
+                {
+                    var v = line.Substring("ppu:".Length).Trim();
+                    if (!float.TryParse(v, System.Globalization.NumberStyles.Float,
+                            System.Globalization.CultureInfo.InvariantCulture, out var ppu) || ppu <= 0)
+                        throw new PxlParseException(lineNo, $"ppu must be a positive number, got '{v}'");
+                    doc.Ppu = ppu;
+                    continue;
+                }
+                if (line == "chars:") { inChars = true; continue; }
+
+                if (line.StartsWith("border:", StringComparison.Ordinal))
+                {
+                    section = EnsureSection(doc, section, ref sawImplicitContent);
+                    if (section.Rows.Count > 0)
+                        throw new PxlParseException(lineNo, "border must come before grid");
+                    section.Border = ParseBorder(line.Substring("border:".Length).Trim(), lineNo);
+                    continue;
+                }
+                if (line == "grid:")
+                {
+                    section = EnsureSection(doc, section, ref sawImplicitContent);
+                    if (section.Rows.Count > 0)
+                        throw new PxlParseException(lineNo, "section already has a grid");
+                    inGrid = true;
+                    continue;
+                }
+
+                throw new PxlParseException(lineNo, $"unrecognized line '{line}'");
+            }
+
+            FinishSection(section, lines.Length);
+            if (doc.Sections.Count == 0)
+                throw new PxlParseException(lines.Length, "file declares no grid");
+            return doc;
+        }
+
+        // 段头出现前的 border:/grid: → 隐式单节
+        private static PxlSection EnsureSection(PxlDocument doc, PxlSection current,
+            ref bool sawImplicit)
+        {
+            if (current != null) return current;
+            var s = new PxlSection { Name = null };
+            doc.Sections.Add(s);
+            sawImplicit = true;
+            return s;
+        }
+
+        private static void ValidateRow(string row, PxlDocument doc, PxlSection section, int lineNo)
+        {
+            if (section.Rows.Count > 0 && row.Length != section.Width)
+                throw new PxlParseException(lineNo,
+                    $"row width {row.Length} != first row width {section.Width}");
+            foreach (var c in row)
+            {
+                if (c == '.') continue;
+                if (!doc.Chars.ContainsKey(c))
+                    throw new PxlParseException(lineNo, $"unknown grid char '{c}' (not in chars:)");
+            }
+            if (section.Rows.Count == 0) section.Width = row.Length;
+            section.Rows.Add(row);
+            section.Height = section.Rows.Count;
+        }
+
+        private static Vector4 ParseBorder(string v, int lineNo)
+        {
+            var parts = v.Split(',');
+            if (parts.Length != 4)
+                throw new PxlParseException(lineNo, $"border must be 'L,B,R,T' (4 ints), got '{v}'");
+            var n = new int[4];
+            for (var i = 0; i < 4; i++)
+            {
+                if (!int.TryParse(parts[i].Trim(), out n[i]) || n[i] < 0)
+                    throw new PxlParseException(lineNo, $"border component '{parts[i].Trim()}' must be a non-negative int");
+            }
+            return new Vector4(n[0], n[1], n[2], n[3]);
+        }
+
+        private static void FinishSection(PxlSection s, int lineNo)
+        {
+            if (s == null) return;
+            if (s.Rows.Count == 0)
+                throw new PxlParseException(lineNo, $"section '[{s.Name}]' has no grid");
+            if (s.Border.x + s.Border.z > s.Width || s.Border.y + s.Border.w > s.Height)
+                throw new PxlParseException(lineNo,
+                    $"border ({s.Border.x},{s.Border.y},{s.Border.z},{s.Border.w}) exceeds " +
+                    $"grid size {s.Width}x{s.Height}");
+        }
+    }
+}

--- a/Editor/Pxl/PxlParser.cs
+++ b/Editor/Pxl/PxlParser.cs
@@ -40,6 +40,7 @@ namespace PromptUGUI.Editor
 
         public static PxlDocument Parse(string text)
         {
+            text = text.TrimStart('﻿'); // 容错裸 BOM（StreamReader 会剥，但字符串入口不保证）
             var doc = new PxlDocument();
             var lines = text.Replace("\r\n", "\n").Split('\n');
 
@@ -54,8 +55,9 @@ namespace PromptUGUI.Editor
                 var lineNo = i + 1;
                 var line = lines[i].Trim();
                 if (line.Length == 0) { inGrid = false; continue; }
-                if (line[0] == '#') continue; // 整行注释；'#' 因此禁作 chars key
+                if (line[0] == '#') continue; // 整行注释（含 chars 块内：'#: x' 整行被跳过，'#' 不可能成为 chars key）
 
+                // 段头匹配优先于 grid 行收集：grid 内的 '[x]' 行会结束当前节并开新节（'['/']' 不应用作 chars key）。
                 var m = SectionHeader.Match(line);
                 if (m.Success)
                 {
@@ -85,8 +87,6 @@ namespace PromptUGUI.Editor
                     {
                         var key = cm.Groups[1].Value[0];
                         var value = cm.Groups[2].Value.Trim();
-                        if (key == '#')
-                            throw new PxlParseException(lineNo, "'#' is reserved for comments");
                         if (key == '.' && value != "transparent")
                             throw new PxlParseException(lineNo,
                                 "'.' is reserved for transparent and cannot be redefined");
@@ -97,6 +97,7 @@ namespace PromptUGUI.Editor
                     inChars = false; // 掉出 chars 块，按普通行继续解析
                 }
 
+                // palette:/ppu: 重复声明 last-wins；同节 border: 在 grid 前重复声明同样 last-wins。
                 if (line.StartsWith("palette:", StringComparison.Ordinal))
                 {
                     var v = line.Substring("palette:".Length).Trim();
@@ -134,7 +135,7 @@ namespace PromptUGUI.Editor
                     continue;
                 }
 
-                throw new PxlParseException(lineNo, $"unrecognized line '{line}'");
+                throw new PxlParseException(lineNo, $"unrecognized line '{line}' (note: a blank line ends a grid: block)");
             }
 
             FinishSection(section, lines.Length);

--- a/Editor/Pxl/PxlParser.cs.meta
+++ b/Editor/Pxl/PxlParser.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 592c11cb26978aa46b658f9314b006f0

--- a/Editor/SpriteAtlasSyncer.cs
+++ b/Editor/SpriteAtlasSyncer.cs
@@ -392,6 +392,19 @@ namespace PromptUGUI.Editor
                     throw new OperationCanceledException();
                 }
                 EnsureSpriteImporter(assetPath);
+                // .pxl（PxlImporter）：每节一个 Sprite sub-asset。隐式单节的 sprite.name
+                // == 文件 basename → key 与 PNG 规则一致（pathKey）；显式多节 → pathKey/节名。
+                if (AssetImporter.GetAtPath(assetPath) is PxlImporter)
+                {
+                    var relPxl = assetPath.Substring(folderPrefix.Length);
+                    var pxlKey = relPxl.Substring(0, relPxl.Length - Path.GetExtension(relPxl).Length);
+                    var pxlBase = Path.GetFileNameWithoutExtension(assetPath);
+                    foreach (var s in AssetDatabase.LoadAllAssetsAtPath(assetPath).OfType<Sprite>())
+                    {
+                        result.Add((s.name == pxlBase ? pxlKey : $"{pxlKey}/{s.name}", s));
+                    }
+                    continue;
+                }
 #if PROMPTUGUI_HAS_ASEPRITE
                 // MF-D4: multi-sprite Aseprite is rejected at validation time; skip it
                 // here so a stray first-sprite doesn't sneak into the SpriteSet via
@@ -895,11 +908,33 @@ namespace PromptUGUI.Editor
         private static void ApplyTemplateFilterMode(SpriteAtlas atlas, string folderAssetPath)
         {
             var firstTexture = FindFirstTexture(folderAssetPath);
-            if (firstTexture == null) return;
+            if (firstTexture == null)
+            {
+                // 纯 .pxl 文件夹：PxlImporter 贴图恒为 point-filter 像素画 → atlas 跟随。
+                if (HasPxlSource(folderAssetPath))
+                {
+                    var pxlTs = atlas.GetTextureSettings();
+                    pxlTs.filterMode = FilterMode.Point;
+                    atlas.SetTextureSettings(pxlTs);
+                }
+                return;
+            }
             if (AssetImporter.GetAtPath(firstTexture) is not TextureImporter ti) return;
             var ts = atlas.GetTextureSettings();
             ts.filterMode = ti.filterMode;
             atlas.SetTextureSettings(ts);
+        }
+
+        private static bool HasPxlSource(string folderAssetPath)
+        {
+            if (string.IsNullOrEmpty(folderAssetPath)) return false;
+            if (!AssetDatabase.IsValidFolder(folderAssetPath)) return false;
+            foreach (var g in AssetDatabase.FindAssets("t:Texture2D", new[] { folderAssetPath }))
+            {
+                if (AssetImporter.GetAtPath(AssetDatabase.GUIDToAssetPath(g)) is PxlImporter)
+                    return true;
+            }
+            return false;
         }
     }
 }

--- a/Tests/EditMode/Editor/Pxl.meta
+++ b/Tests/EditMode/Editor/Pxl.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 920a247a8de10984d92d15a55aee8a9e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Editor/Pxl/GplPaletteTests.cs
+++ b/Tests/EditMode/Editor/Pxl/GplPaletteTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using PromptUGUI.Editor;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Editor
+{
+    public class GplPaletteTests
+    {
+        private const string Sample = "GIMP Palette\nName: db8\nColumns: 4\n# comment\n" +
+            "26 28 44\tdark-blue\n244 244 244\tWhite\n177 62 83\n";
+
+        [Test]
+        public void Parse_reads_entries_with_and_without_names()
+        {
+            var p = GplPalette.Parse(Sample);
+            Assert.AreEqual(3, p.Entries.Count);
+            Assert.AreEqual(new Color32(26, 28, 44, 255), p.Entries[0].color);
+            Assert.AreEqual("dark-blue", p.Entries[0].name);
+            Assert.IsNull(p.Entries[2].name); // unnamed entry
+        }
+
+        [Test]
+        public void TryGetByName_normalizes_case_space_hyphen_underscore()
+        {
+            var p = GplPalette.Parse(Sample);
+            Assert.IsTrue(p.TryGetByName("Dark Blue", out var c));
+            Assert.AreEqual(new Color32(26, 28, 44, 255), c);
+            Assert.IsTrue(p.TryGetByName("dark_blue", out _));
+            Assert.IsTrue(p.TryGetByName("WHITE", out _));
+            Assert.IsFalse(p.TryGetByName("nope", out _));
+        }
+
+        [Test]
+        public void ContainsRgb_matches_ignoring_alpha()
+        {
+            var p = GplPalette.Parse(Sample);
+            Assert.IsTrue(p.ContainsRgb(new Color32(177, 62, 83, 128)));
+            Assert.IsFalse(p.ContainsRgb(new Color32(1, 2, 3, 255)));
+        }
+
+        [Test]
+        public void Parse_missing_header_throws()
+        {
+            var ex = Assert.Throws<System.FormatException>(() => GplPalette.Parse("26 28 44\tx\n"));
+            StringAssert.Contains("GIMP Palette", ex.Message);
+        }
+
+        [Test]
+        public void Parse_malformed_entry_line_throws_with_line_number()
+        {
+            var ex = Assert.Throws<System.FormatException>(
+                () => GplPalette.Parse("GIMP Palette\n26 28\tshort\n"));
+            StringAssert.Contains("line 2", ex.Message);
+        }
+    }
+}

--- a/Tests/EditMode/Editor/Pxl/GplPaletteTests.cs.meta
+++ b/Tests/EditMode/Editor/Pxl/GplPaletteTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a77a02e27215cc34f8e09ab88c6c4774

--- a/Tests/EditMode/Editor/Pxl/PxlColorResolverTests.cs
+++ b/Tests/EditMode/Editor/Pxl/PxlColorResolverTests.cs
@@ -1,0 +1,87 @@
+using NUnit.Framework;
+using PromptUGUI.Editor;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Editor
+{
+    public class PxlColorResolverTests
+    {
+        private static GplPalette Palette() => GplPalette.Parse(
+            "GIMP Palette\n26 28 44\tdark-blue\n244 244 244\twhite\n100 100 100\n");
+
+        private static PxlDocument Doc(params (char, string)[] chars)
+        {
+            var d = new PxlDocument();
+            foreach (var (k, v) in chars) d.Chars[k] = v;
+            return d;
+        }
+
+        [Test]
+        public void Resolve_inline_hex_and_transparent()
+        {
+            var map = PxlColorResolver.Resolve(Doc(('K', "#1a1c2c"), ('T', "transparent")), null);
+            Assert.AreEqual(new Color32(0x1a, 0x1c, 0x2c, 255), map['K']);
+            Assert.AreEqual(new Color32(0, 0, 0, 0), map['T']);
+            Assert.AreEqual(new Color32(0, 0, 0, 0), map['.']);
+        }
+
+        [Test]
+        public void Resolve_hex_with_alpha()
+        {
+            var map = PxlColorResolver.Resolve(Doc(('S', "#1a1c2c80")), null);
+            Assert.AreEqual(new Color32(0x1a, 0x1c, 0x2c, 0x80), map['S']);
+        }
+
+        [Test]
+        public void Resolve_palette_name()
+        {
+            var doc = Doc(('K', "dark-blue"));
+            doc.PaletteRef = "main";
+            var map = PxlColorResolver.Resolve(doc, Palette());
+            Assert.AreEqual(new Color32(26, 28, 44, 255), map['K']);
+        }
+
+        [Test]
+        public void Resolve_palette_mode_hex_must_be_on_palette()
+        {
+            var doc = Doc(('K', "#1a1c2c"), ('X', "#010203"));
+            doc.PaletteRef = "main";
+            var ex = Assert.Throws<PxlParseException>(() => PxlColorResolver.Resolve(doc, Palette()));
+            StringAssert.Contains("'X'", ex.Message);
+            StringAssert.Contains("#010203", ex.Message);
+        }
+
+        [Test]
+        public void Resolve_palette_hex_alpha_variant_allowed()
+        {
+            var doc = Doc(('S', "#1a1c2c80")); // RGB 在板上，alpha 自由
+            doc.PaletteRef = "main";
+            var map = PxlColorResolver.Resolve(doc, Palette());
+            Assert.AreEqual((byte)0x80, map['S'].a);
+        }
+
+        [Test]
+        public void Resolve_name_without_palette_throws()
+        {
+            var ex = Assert.Throws<PxlParseException>(
+                () => PxlColorResolver.Resolve(Doc(('K', "dark-blue")), null));
+            StringAssert.Contains("palette:", ex.Message);
+        }
+
+        [Test]
+        public void Resolve_unknown_name_throws()
+        {
+            var doc = Doc(('K', "magenta"));
+            doc.PaletteRef = "main";
+            var ex = Assert.Throws<PxlParseException>(() => PxlColorResolver.Resolve(doc, Palette()));
+            StringAssert.Contains("magenta", ex.Message);
+        }
+
+        [Test]
+        public void Resolve_bad_hex_throws()
+        {
+            Assert.Throws<PxlParseException>(
+                () => PxlColorResolver.Resolve(Doc(('K', "#12345")), null));
+        }
+    }
+}

--- a/Tests/EditMode/Editor/Pxl/PxlColorResolverTests.cs
+++ b/Tests/EditMode/Editor/Pxl/PxlColorResolverTests.cs
@@ -83,5 +83,30 @@ namespace PromptUGUI.Tests.Editor
             Assert.Throws<PxlParseException>(
                 () => PxlColorResolver.Resolve(Doc(('K', "#12345")), null));
         }
+
+        [Test]
+        public void Resolve_hex_with_inner_whitespace_throws()
+        {
+            Assert.Throws<PxlParseException>(
+                () => PxlColorResolver.Resolve(Doc(('K', "# a1c2c")), null));
+        }
+
+        [Test]
+        public void Resolve_palette_hex_matches_unnamed_entry()
+        {
+            var doc = Doc(('G', "#646464")); // 100,100,100 无名条目，只能被 hex 命中
+            doc.PaletteRef = "main";
+            var map = PxlColorResolver.Resolve(doc, Palette());
+            Assert.AreEqual(new Color32(100, 100, 100, 255), map['G']);
+        }
+
+        [Test]
+        public void Resolve_palette_name_is_normalized()
+        {
+            var doc = Doc(('K', "Dark Blue")); // .gpl 里是 dark-blue
+            doc.PaletteRef = "main";
+            var map = PxlColorResolver.Resolve(doc, Palette());
+            Assert.AreEqual(new Color32(26, 28, 44, 255), map['K']);
+        }
     }
 }

--- a/Tests/EditMode/Editor/Pxl/PxlColorResolverTests.cs.meta
+++ b/Tests/EditMode/Editor/Pxl/PxlColorResolverTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 82d2a5ad426534e4093b585ed7afcf46

--- a/Tests/EditMode/Editor/Pxl/PxlImporterTests.cs
+++ b/Tests/EditMode/Editor/Pxl/PxlImporterTests.cs
@@ -1,0 +1,129 @@
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Editor;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.Editor
+{
+    public class PxlImporterTests
+    {
+        private const string TmpDir = "Assets/__test_pxl__";
+
+        [SetUp]
+        public void Setup()
+        {
+            if (!AssetDatabase.IsValidFolder(TmpDir))
+                AssetDatabase.CreateFolder("Assets", "__test_pxl__");
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            AssetDatabase.DeleteAsset(TmpDir);
+        }
+
+        private static string Write(string fileName, string content)
+        {
+            var abs = Path.Combine(UnityEngine.Application.dataPath, "__test_pxl__", fileName);
+            File.WriteAllText(abs, content);
+            var assetPath = $"{TmpDir}/{fileName}";
+            AssetDatabase.ImportAsset(assetPath,
+                ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+            return assetPath;
+        }
+
+        [Test]
+        public void Import_single_implicit_section_pixels_and_filter()
+        {
+            var path = Write("dot.pxl", "chars:\n  K: #102030\ngrid:\n  K.\n  ..\n");
+            var tex = AssetDatabase.LoadAssetAtPath<Texture2D>(path);
+            Assert.IsNotNull(tex);
+            Assert.AreEqual("dot", tex.name);
+            Assert.AreEqual(FilterMode.Point, tex.filterMode);
+            // grid 第 1 行是顶行 → texture y=1（bottom-up 翻转）
+            Assert.AreEqual(new Color32(0x10, 0x20, 0x30, 255), (Color32)tex.GetPixel(0, 1));
+            Assert.AreEqual(0, ((Color32)tex.GetPixel(1, 1)).a);
+            var sprite = AssetDatabase.LoadAssetAtPath<Sprite>(path);
+            Assert.IsNotNull(sprite);
+            Assert.AreEqual("dot", sprite.name);
+        }
+
+        [Test]
+        public void Import_border_and_ppu_land_on_sprite()
+        {
+            var path = Write("framed.pxl",
+                "ppu: 16\nchars:\n  K: #000000\n[bg]\nborder: 1,1,1,1\ngrid:\n  KKK\n  KKK\n  KKK\n");
+            var sprite = AssetDatabase.LoadAllAssetsAtPath(path).OfType<Sprite>().Single();
+            Assert.AreEqual("bg", sprite.name);
+            Assert.AreEqual(new Vector4(1, 1, 1, 1), sprite.border);
+            Assert.AreEqual(16f, sprite.pixelsPerUnit);
+        }
+
+        [Test]
+        public void Import_multi_section_produces_sub_sprites_main_is_first_texture()
+        {
+            var path = Write("btn.pxl",
+                "chars:\n  K: #000000\n  W: #ffffff\n" +
+                "[normal]\ngrid:\n  KW\n[pressed]\ngrid:\n  WK\n");
+            var sprites = AssetDatabase.LoadAllAssetsAtPath(path).OfType<Sprite>()
+                .Select(s => s.name).OrderBy(n => n).ToArray();
+            Assert.AreEqual(new[] { "normal", "pressed" }, sprites);
+            var main = AssetDatabase.LoadMainAssetAtPath(path);
+            Assert.IsInstanceOf<Texture2D>(main);
+            // Unity 强制把 main object 改名为文件名（"btn"），所以按身份断言：
+            // main 必须是首节 "normal" 那张贴图。
+            var normal = AssetDatabase.LoadAllAssetsAtPath(path).OfType<Sprite>()
+                .Single(s => s.name == "normal");
+            Assert.AreSame(main, normal.texture);
+        }
+
+        [Test]
+        public void Import_palette_ref_resolves_and_offpalette_fails()
+        {
+            Write("main.gpl", "GIMP Palette\n26 28 44\tdark-blue\n");
+            var ok = Write("ok.pxl", "palette: @main\nchars:\n  K: dark-blue\ngrid:\n  K\n");
+            Assert.IsNotNull(AssetDatabase.LoadAssetAtPath<Sprite>(ok));
+
+            LogAssert.ignoreFailingMessages = true;
+            var bad = Write("bad.pxl", "palette: @main\nchars:\n  K: #010203\ngrid:\n  K\n");
+            LogAssert.ignoreFailingMessages = false;
+            Assert.IsNull(AssetDatabase.LoadAssetAtPath<Sprite>(bad), "off-palette must fail import");
+        }
+
+        [Test]
+        public void Import_gpl_edit_triggers_dependent_reimport()
+        {
+            Write("pal.gpl", "GIMP Palette\n255 0 0\tred\n");
+            var path = Write("dep.pxl", "palette: @pal\nchars:\n  R: red\ngrid:\n  R\n");
+            Assert.AreEqual(new Color32(255, 0, 0, 255),
+                (Color32)AssetDatabase.LoadAssetAtPath<Texture2D>(path).GetPixel(0, 0));
+
+            // 改色板 → 依赖的 .pxl 自动重导入，颜色跟着变
+            Write("pal.gpl", "GIMP Palette\n0 255 0\tred\n");
+            AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+            Assert.AreEqual(new Color32(0, 255, 0, 255),
+                (Color32)AssetDatabase.LoadAssetAtPath<Texture2D>(path).GetPixel(0, 0));
+        }
+
+        [Test]
+        public void Import_parse_error_fails_import_with_logged_error()
+        {
+            LogAssert.ignoreFailingMessages = true;
+            var path = Write("broken.pxl", "chars:\n  K: #000000\ngrid:\n  KK\n  K\n");
+            LogAssert.ignoreFailingMessages = false;
+            Assert.IsNull(AssetDatabase.LoadAssetAtPath<Texture2D>(path));
+        }
+
+        [Test]
+        public void Import_missing_palette_fails_import()
+        {
+            LogAssert.ignoreFailingMessages = true;
+            var path = Write("orphan.pxl", "palette: @nosuch\nchars:\n  K: #000000\ngrid:\n  K\n");
+            LogAssert.ignoreFailingMessages = false;
+            Assert.IsNull(AssetDatabase.LoadAssetAtPath<Texture2D>(path));
+        }
+    }
+}

--- a/Tests/EditMode/Editor/Pxl/PxlImporterTests.cs
+++ b/Tests/EditMode/Editor/Pxl/PxlImporterTests.cs
@@ -88,9 +88,12 @@ namespace PromptUGUI.Tests.Editor
             Assert.IsNotNull(AssetDatabase.LoadAssetAtPath<Sprite>(ok));
 
             LogAssert.ignoreFailingMessages = true;
-            var bad = Write("bad.pxl", "palette: @main\nchars:\n  K: #010203\ngrid:\n  K\n");
-            LogAssert.ignoreFailingMessages = false;
-            Assert.IsNull(AssetDatabase.LoadAssetAtPath<Sprite>(bad), "off-palette must fail import");
+            try
+            {
+                var bad = Write("bad.pxl", "palette: @main\nchars:\n  K: #010203\ngrid:\n  K\n");
+                Assert.IsNull(AssetDatabase.LoadAssetAtPath<Sprite>(bad), "off-palette must fail import");
+            }
+            finally { LogAssert.ignoreFailingMessages = false; }
         }
 
         [Test]
@@ -112,18 +115,44 @@ namespace PromptUGUI.Tests.Editor
         public void Import_parse_error_fails_import_with_logged_error()
         {
             LogAssert.ignoreFailingMessages = true;
-            var path = Write("broken.pxl", "chars:\n  K: #000000\ngrid:\n  KK\n  K\n");
-            LogAssert.ignoreFailingMessages = false;
-            Assert.IsNull(AssetDatabase.LoadAssetAtPath<Texture2D>(path));
+            try
+            {
+                LogAssert.Expect(LogType.Error,
+                    new System.Text.RegularExpressions.Regex("row width"));
+                var path = Write("broken.pxl", "chars:\n  K: #000000\ngrid:\n  KK\n  K\n");
+                Assert.IsNull(AssetDatabase.LoadAssetAtPath<Texture2D>(path));
+            }
+            finally { LogAssert.ignoreFailingMessages = false; }
         }
 
         [Test]
         public void Import_missing_palette_fails_import()
         {
             LogAssert.ignoreFailingMessages = true;
-            var path = Write("orphan.pxl", "palette: @nosuch\nchars:\n  K: #000000\ngrid:\n  K\n");
-            LogAssert.ignoreFailingMessages = false;
-            Assert.IsNull(AssetDatabase.LoadAssetAtPath<Texture2D>(path));
+            try
+            {
+                var path = Write("orphan.pxl", "palette: @nosuch\nchars:\n  K: #000000\ngrid:\n  K\n");
+                Assert.IsNull(AssetDatabase.LoadAssetAtPath<Texture2D>(path));
+            }
+            finally { LogAssert.ignoreFailingMessages = false; }
+        }
+
+        [Test]
+        public void Import_gpl_added_later_recovers_broken_pxl()
+        {
+            string path;
+            LogAssert.ignoreFailingMessages = true;
+            try
+            {
+                path = Write("late.pxl", "palette: @latepal\nchars:\n  K: #1a1c2c\ngrid:\n  K\n");
+                Assert.IsNull(AssetDatabase.LoadAssetAtPath<Texture2D>(path));
+            }
+            finally { LogAssert.ignoreFailingMessages = false; }
+
+            Write("latepal.gpl", "GIMP Palette\n26 28 44\tdark-blue\n");
+            AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+            Assert.IsNotNull(AssetDatabase.LoadAssetAtPath<Texture2D>(path),
+                "adding the missing .gpl must re-trigger the broken .pxl import");
         }
     }
 }

--- a/Tests/EditMode/Editor/Pxl/PxlImporterTests.cs.meta
+++ b/Tests/EditMode/Editor/Pxl/PxlImporterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0f70a1d5a66eafa47ba351d741ee9042

--- a/Tests/EditMode/Editor/Pxl/PxlParserTests.cs
+++ b/Tests/EditMode/Editor/Pxl/PxlParserTests.cs
@@ -1,0 +1,115 @@
+using NUnit.Framework;
+using PromptUGUI.Editor;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Editor
+{
+    public class PxlParserTests
+    {
+        [Test]
+        public void Parse_implicit_single_section()
+        {
+            var doc = PxlParser.Parse(
+                "chars:\n  K: #1a1c2c\ngrid:\n  .KK.\n  K..K\n");
+            Assert.IsNull(doc.PaletteRef);
+            Assert.AreEqual(100f, doc.Ppu);
+            Assert.AreEqual(1, doc.Sections.Count);
+            Assert.IsNull(doc.Sections[0].Name);
+            Assert.AreEqual(4, doc.Sections[0].Width);
+            Assert.AreEqual(2, doc.Sections[0].Height);
+            Assert.AreEqual(".KK.", doc.Sections[0].Rows[0]);
+        }
+
+        [Test]
+        public void Parse_full_header_and_two_sections()
+        {
+            var doc = PxlParser.Parse(
+                "palette: @main\nppu: 16\nchars:\n  K: dark-blue\n  W: #f4f4f4\n" +
+                "# a comment\n" +
+                "[normal]\nborder: 1,1,1,1\ngrid:\n  KKK\n  KWK\n  KKK\n\n" +
+                "[pressed]\ngrid:\n  WW\n  WW\n");
+            Assert.AreEqual("main", doc.PaletteRef);
+            Assert.AreEqual(16f, doc.Ppu);
+            Assert.AreEqual(2, doc.Chars.Count);
+            Assert.AreEqual("dark-blue", doc.Chars['K']);
+            Assert.AreEqual(2, doc.Sections.Count);
+            Assert.AreEqual("normal", doc.Sections[0].Name);
+            Assert.AreEqual(new Vector4(1, 1, 1, 1), doc.Sections[0].Border);
+            Assert.AreEqual("pressed", doc.Sections[1].Name);
+            Assert.AreEqual(Vector4.zero, doc.Sections[1].Border);
+        }
+
+        [Test]
+        public void Parse_unknown_grid_char_reports_line()
+        {
+            var ex = Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  K: #000000\ngrid:\n  KK\n  KX\n"));
+            Assert.AreEqual(5, ex.Line);
+            StringAssert.Contains("'X'", ex.Message);
+        }
+
+        [Test]
+        public void Parse_ragged_rows_reports_line()
+        {
+            var ex = Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  K: #000000\ngrid:\n  KKK\n  KK\n"));
+            Assert.AreEqual(5, ex.Line);
+        }
+
+        [Test]
+        public void Parse_duplicate_section_name_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  K: #000000\n[a]\ngrid:\n  K\n[a]\ngrid:\n  K\n"));
+        }
+
+        [Test]
+        public void Parse_duplicate_char_key_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  K: #000000\n  K: #ffffff\ngrid:\n  K\n"));
+        }
+
+        [Test]
+        public void Parse_dot_redefined_to_color_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  .: #000000\ngrid:\n  .\n"));
+        }
+
+        [Test]
+        public void Parse_border_exceeding_size_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  K: #000000\n[a]\nborder: 2,0,2,0\ngrid:\n  KKK\n"));
+        }
+
+        [Test]
+        public void Parse_empty_grid_section_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  K: #000000\n[a]\ngrid:\n[b]\ngrid:\n  K\n"));
+        }
+
+        [Test]
+        public void Parse_palette_without_at_prefix_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "palette: main\nchars:\n  K: #000000\ngrid:\n  K\n"));
+        }
+
+        [Test]
+        public void Parse_implicit_then_explicit_section_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  K: #000000\ngrid:\n  K\n[late]\ngrid:\n  K\n"));
+        }
+
+        [Test]
+        public void Parse_unrecognized_line_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  K: #000000\nbogus directive\ngrid:\n  K\n"));
+        }
+    }
+}

--- a/Tests/EditMode/Editor/Pxl/PxlParserTests.cs
+++ b/Tests/EditMode/Editor/Pxl/PxlParserTests.cs
@@ -99,6 +99,13 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
+        public void Parse_palette_name_with_space_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "palette: @my pal\nchars:\n  K: #000000\ngrid:\n  K\n"));
+        }
+
+        [Test]
         public void Parse_implicit_then_explicit_section_throws()
         {
             Assert.Throws<PxlParseException>(() => PxlParser.Parse(

--- a/Tests/EditMode/Editor/Pxl/PxlParserTests.cs
+++ b/Tests/EditMode/Editor/Pxl/PxlParserTests.cs
@@ -111,5 +111,22 @@ namespace PromptUGUI.Tests.Editor
             Assert.Throws<PxlParseException>(() => PxlParser.Parse(
                 "chars:\n  K: #000000\nbogus directive\ngrid:\n  K\n"));
         }
+
+        [Test]
+        public void Parse_invalid_ppu_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "ppu: 0\nchars:\n  K: #000000\ngrid:\n  K\n"));
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "ppu: abc\nchars:\n  K: #000000\ngrid:\n  K\n"));
+        }
+
+        [Test]
+        public void Parse_border_after_grid_throws()
+        {
+            var ex = Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  K: #000000\ngrid:\n  K\n\nborder: 0,0,0,0\n"));
+            StringAssert.Contains("border must come before grid", ex.Message);
+        }
     }
 }

--- a/Tests/EditMode/Editor/Pxl/PxlParserTests.cs.meta
+++ b/Tests/EditMode/Editor/Pxl/PxlParserTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: acdfb01f8896be742b15645f0ce6641d

--- a/Tests/EditMode/Editor/Pxl/PxlSyncerTests.cs
+++ b/Tests/EditMode/Editor/Pxl/PxlSyncerTests.cs
@@ -1,0 +1,117 @@
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Editor;
+using UnityEditor;
+using UnityEditor.U2D;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Editor
+{
+    public class PxlSyncerTests
+    {
+        private const string TestRoot = "Assets/__test_pxlsync__";
+
+        [SetUp]
+        public void Setup()
+        {
+            if (!AssetDatabase.IsValidFolder(TestRoot))
+                AssetDatabase.CreateFolder("Assets", "__test_pxlsync__");
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            AssetDatabase.DeleteAsset(TestRoot);
+        }
+
+        private static void WritePxl(string relPath, string content)
+        {
+            var abs = Path.Combine(UnityEngine.Application.dataPath, "__test_pxlsync__",
+                relPath.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(abs));
+            File.WriteAllText(abs, content);
+        }
+
+        private static void ImportAll() =>
+            AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+
+        private const string SinglePxl = "chars:\n  K: #000000\ngrid:\n  K\n";
+        private const string MultiPxl =
+            "chars:\n  K: #000000\n  W: #ffffff\n[normal]\ngrid:\n  K\n[pressed]\ngrid:\n  W\n";
+
+        [Test]
+        public void Enumerate_single_section_key_is_pathkey()
+        {
+            WritePxl("icon.pxl", SinglePxl);
+            ImportAll();
+            var entries = SpriteAtlasSyncer.EnumerateSpriteSources(TestRoot);
+            Assert.AreEqual(1, entries.Count);
+            Assert.AreEqual("icon", entries[0].pathKey);
+        }
+
+        [Test]
+        public void Enumerate_multi_section_keys_append_section_name()
+        {
+            WritePxl("Buttons/ok.pxl", MultiPxl);
+            ImportAll();
+            var keys = SpriteAtlasSyncer.EnumerateSpriteSources(TestRoot)
+                .Select(e => e.pathKey).OrderBy(k => k).ToArray();
+            Assert.AreEqual(new[] { "Buttons/ok/normal", "Buttons/ok/pressed" }, keys);
+        }
+
+        [Test]
+        public void Enumerate_mixed_png_and_pxl()
+        {
+            WritePxl("a.pxl", SinglePxl);
+            var png = new Texture2D(1, 1);
+            png.SetPixel(0, 0, Color.red);
+            File.WriteAllBytes(
+                Path.Combine(UnityEngine.Application.dataPath, "__test_pxlsync__", "b.png"),
+                png.EncodeToPNG());
+            Object.DestroyImmediate(png);
+            ImportAll();
+            var keys = SpriteAtlasSyncer.EnumerateSpriteSources(TestRoot)
+                .Select(e => e.pathKey).OrderBy(k => k).ToArray();
+            Assert.AreEqual(new[] { "a", "b" }, keys);
+        }
+
+        [Test]
+        public void BuildLookup_promotes_unique_bare_alias_for_section_key()
+        {
+            WritePxl("Buttons/ok.pxl", MultiPxl);
+            ImportAll();
+            var entries = SpriteAtlasSyncer.EnumerateSpriteSources(TestRoot);
+            var lookup = SpriteAtlasSyncer.BuildLookup(entries, out _);
+            Assert.IsTrue(lookup.ContainsKey("Buttons/ok/pressed"));
+            Assert.IsTrue(lookup.ContainsKey("pressed"), "unique bare alias promoted");
+        }
+
+        [Test]
+        public void ResetTextureImportSettings_skips_pxl()
+        {
+            WritePxl("icon.pxl", SinglePxl);
+            ImportAll();
+            Assert.AreEqual(0, SpriteAtlasSyncer.ResetTextureImportSettings(TestRoot),
+                ".pxl has no TextureImporter; reset must skip it");
+        }
+
+        [Test]
+        public void EnsureAtlas_pxl_only_folder_gets_point_filter()
+        {
+            WritePxl("icon.pxl", SinglePxl);
+            ImportAll();
+            var set = ScriptableObject.CreateInstance<PromptUGUI.Application.SpriteSet>();
+            var so = new SerializedObject(set);
+            so.FindProperty("setName").stringValue = "pxltest";
+            so.FindProperty("sourceFolder").objectReferenceValue =
+                AssetDatabase.LoadAssetAtPath<DefaultAsset>(TestRoot);
+            so.ApplyModifiedPropertiesWithoutUndo();
+            AssetDatabase.CreateAsset(set, $"{TestRoot}/pxltest.asset");
+
+            var atlas = SpriteAtlasSyncer.EnsureAtlasAsset(set);
+            Assert.IsNotNull(atlas);
+            Assert.AreEqual(FilterMode.Point, atlas.GetTextureSettings().filterMode);
+        }
+    }
+}

--- a/Tests/EditMode/Editor/Pxl/PxlSyncerTests.cs.meta
+++ b/Tests/EditMode/Editor/Pxl/PxlSyncerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a50b5837513fbca4b8fb8a0e168b6566

--- a/docs~/superpowers/plans/2026-06-11-pxl-pixel-sprite-importer.md
+++ b/docs~/superpowers/plans/2026-06-11-pxl-pixel-sprite-importer.md
@@ -1,0 +1,1392 @@
+# `.pxl` 像素网格文本资产 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增 `.pxl` 文本格式（XPM 惯用法字符网格 + GIMP `.gpl` 项目级调色板）和 Editor ScriptedImporter，让 LLM 以文本直接产出带 9-slice/PPU 的 Unity Sprite，接入现有 SpriteSet → Sync Atlases 管线。
+
+**Architecture:** 纯 C# 解析三件套（`GplPalette` / `PxlParser` / `PxlColorResolver`，全部 `Editor/Pxl/`，EditorOnly 直测）+ `PxlImporter`（ScriptedImporter，每节一张 point-filter Texture2D + Sprite sub-asset）+ `SpriteAtlasSyncer.EnumerateSpriteSources` 的 PxlImporter 分支（多节 key 派生）。消费端（SpriteSet entries / `<Icon>` / `<Image>` / 9-slice / InlineSpriteAssetBuilder）零改动。
+
+**Tech Stack:** Unity 6 `UnityEditor.AssetImporters.ScriptedImporter`、NUnit（`PromptUGUI.Tests.EditorOnly`）、Unity MCP 跑测、`.lint` dotnet format。
+
+**Spec:** `docs~/superpowers/specs/2026-06-11-pxl-pixel-sprite-importer-design.md`（必读，含格式完整定义）
+
+**约定提醒（CLAUDE.md）：**
+- 禁止 commit 到 main——全部工作在 `feat/pxl-importer` 分支。
+- 测试一律走 Unity MCP（先 `refresh_unity` 等编译、`read_console` 查错，再 `run_tests` + `get_test_job` 轮询）。
+- 每个源文件改动后跑 `.lint` 的 dotnet format 校验。
+- 新建 `.cs` 文件后让 Unity refresh 生成 `.meta`，**`.meta` 必须随源文件一起 commit**（host 工程在 `C:\xsoft\PromptUGUIDev`，本仓库以 UPM file:// 引用）。
+
+---
+
+## File Structure
+
+| 文件 | 职责 |
+|---|---|
+| Create `Editor/Pxl/GplPalette.cs` | GIMP `.gpl` 文本解析 + 色名/RGB 查询（纯 C#） |
+| Create `Editor/Pxl/PxlParser.cs` | `.pxl` 文本 → `PxlDocument`/`PxlSection` IR + `PxlParseException`（纯 C#，含结构校验） |
+| Create `Editor/Pxl/PxlColorResolver.cs` | chars 映射 → `char→Color32`（透明/hex/色名 + 越板校验，纯 C#） |
+| Create `Editor/Pxl/PxlImporter.cs` | ScriptedImporter：调上面三件套 → Texture2D + Sprite sub-assets |
+| Modify `Editor/SpriteAtlasSyncer.cs` | `EnumerateSpriteSources` 加 PxlImporter 分支（多节 key）；`ApplyTemplateFilterMode` pxl-only 文件夹 Point 兜底 |
+| Test `Tests/EditMode/Editor/Pxl/GplPaletteTests.cs` | .gpl 解析全集 |
+| Test `Tests/EditMode/Editor/Pxl/PxlParserTests.cs` | 格式全集 + 错误路径（带行号断言） |
+| Test `Tests/EditMode/Editor/Pxl/PxlColorResolverTests.cs` | 颜色解析 + 越板/缺名错误 |
+| Test `Tests/EditMode/Editor/Pxl/PxlImporterTests.cs` | AssetDatabase 集成：资产结构 / border / PPU / .gpl 依赖重导入 |
+| Test `Tests/EditMode/Editor/Pxl/PxlSyncerTests.cs` | key 派生（单/多节）、与 PNG 混放、Reset 跳过 `.pxl`、atlas Point 兜底 |
+| Create `.claude/skills/authoring-promptugui-pxl/SKILL.md` | LLM authoring 指南 |
+| Modify `.claude/skills/authoring-promptugui-xml/reference/icons.md` | `.pxl` 来源指针 |
+
+**关键既有代码事实**（实现前自查，防止接错）：
+- `SpriteAtlasSyncer.EnumerateSpriteSources`（`Editor/SpriteAtlasSyncer.cs:368`）：key = 相对 sourceFolder 路径去扩展名（`Path.GetExtension` 通用剥除，`.pxl` 天然适用）；目前 `LoadAssetAtPath<Sprite>` 只取一个 Sprite——多节 `.pxl` 必须改走 `LoadAllAssetsAtPath().OfType<Sprite>()`。
+- `EnsureSpriteImporter`（`:473`）：非 TextureImporter/AsepriteImporter 静默跳过 → `PxlImporter` 资产不被改设置，零改动。
+- `ResetTextureImportSettings`（`:514`）/ `ApplyImportSettingsToFolder`（`:573`）/ `FindFirstTexture`（`:637`）：均有 `is (not) TextureImporter` guard → `.pxl` 自然跳过，只补测试。
+- `BuildLookup`（`:440`）：裸名别名 = pathKey 最后一段，唯一时才提升——多节 key `Buttons/ok/pressed` 的裸名 `pressed` 撞名时自动不提升，零改动。
+- `SpriteAtlasAutoSync.AnyUnder` 扩展名无关 → sourceFolder 下 `.pxl` 重导入（含 .gpl 依赖触发的）已会触发 repack，零改动。
+- `InlineSpriteAssetBuilder.cs:72` 复用 `EnumerateSpriteSources` → 图文混排烘焙免费生效，**前提 importer 的 Texture2D 保持 readable**（`tex.Apply(false, false)`，不要 makeNoLongerReadable）。
+- `PoFileImporter.cs` 是本仓库 ScriptedImporter 先例；`.pxl` 无原生 importer 抢注，用普通 `[ScriptedImporter(1, "pxl")]` 即可，不需要 override + postprocessor。
+- 测试惯例照 `PoFileImporterTests.cs` / `SpriteAtlasSyncerTests.cs`：temp 文件夹 `Assets/__test_pxl__`，`File.WriteAllText` 用 `Application.dataPath` 绝对路径，`AssetDatabase.ImportAsset(path, ForceUpdate | ForceSynchronousImport)`，TearDown `DeleteAsset`。
+
+**MCP 测试命令模板**（每个 Task 的"跑测试"步骤都指这里，`<Group>` 换成该 Task 的测试类名）：
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])        # 必须无编译错误再继续
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"], group_names=["<Group>"])
+mcp__UnityMCP__get_test_job(job_id=...)                            # 轮询到完成，读 pass/fail
+```
+
+**Lint 命令模板**（每个 commit 前）：
+
+```bash
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx && dotnet format style PromptUGUI.Lint.slnx && cd ..
+```
+
+---
+
+### Task 0: 分支 + spec/plan 入库
+
+**Files:** 无代码。
+
+- [ ] **Step 1: 建分支**
+
+```bash
+git checkout -b feat/pxl-importer
+```
+
+- [ ] **Step 2: commit spec + plan**
+
+```bash
+git add docs~/superpowers/specs/2026-06-11-pxl-pixel-sprite-importer-design.md \
+        docs~/superpowers/plans/2026-06-11-pxl-pixel-sprite-importer.md
+git commit -m "docs: .pxl pixel sprite importer spec + plan
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 1: `GplPalette`（.gpl 解析）
+
+**Files:**
+- Create: `Editor/Pxl/GplPalette.cs`
+- Test: `Tests/EditMode/Editor/Pxl/GplPaletteTests.cs`
+
+.gpl 格式：首个非空行必须是 `GIMP Palette`；随后 `Name:` / `Columns:` 头、`#` 注释行、空行均跳过；条目行 = `R G B [名字...]`（空白分隔，名字为行剩余部分，可缺省）。
+
+- [ ] **Step 1: 写失败测试**
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Editor;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Editor
+{
+    public class GplPaletteTests
+    {
+        private const string Sample = "GIMP Palette\nName: db8\nColumns: 4\n# comment\n" +
+            "26 28 44\tdark-blue\n244 244 244\tWhite\n177 62 83\n";
+
+        [Test]
+        public void Parse_reads_entries_with_and_without_names()
+        {
+            var p = GplPalette.Parse(Sample);
+            Assert.AreEqual(3, p.Entries.Count);
+            Assert.AreEqual(new Color32(26, 28, 44, 255), p.Entries[0].color);
+            Assert.AreEqual("dark-blue", p.Entries[0].name);
+            Assert.IsNull(p.Entries[2].name); // unnamed entry
+        }
+
+        [Test]
+        public void TryGetByName_normalizes_case_space_hyphen_underscore()
+        {
+            var p = GplPalette.Parse(Sample);
+            Assert.IsTrue(p.TryGetByName("Dark Blue", out var c));
+            Assert.AreEqual(new Color32(26, 28, 44, 255), c);
+            Assert.IsTrue(p.TryGetByName("dark_blue", out _));
+            Assert.IsTrue(p.TryGetByName("WHITE", out _));
+            Assert.IsFalse(p.TryGetByName("nope", out _));
+        }
+
+        [Test]
+        public void ContainsRgb_matches_ignoring_alpha()
+        {
+            var p = GplPalette.Parse(Sample);
+            Assert.IsTrue(p.ContainsRgb(new Color32(177, 62, 83, 128)));
+            Assert.IsFalse(p.ContainsRgb(new Color32(1, 2, 3, 255)));
+        }
+
+        [Test]
+        public void Parse_missing_header_throws()
+        {
+            var ex = Assert.Throws<System.FormatException>(() => GplPalette.Parse("26 28 44\tx\n"));
+            StringAssert.Contains("GIMP Palette", ex.Message);
+        }
+
+        [Test]
+        public void Parse_malformed_entry_line_throws_with_line_number()
+        {
+            var ex = Assert.Throws<System.FormatException>(
+                () => GplPalette.Parse("GIMP Palette\n26 28\tshort\n"));
+            StringAssert.Contains("line 2", ex.Message);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+MCP 模板，`group_names=["GplPaletteTests"]`。Expected: 编译错误（GplPalette 不存在）——`read_console` 看到 CS0246 即算 Red 确认，先写实现再跑。
+
+- [ ] **Step 3: 实现**
+
+```csharp
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PromptUGUI.Editor
+{
+    /// <summary>GIMP Palette (.gpl) 文本解析。社区标准格式：Aseprite 原生读写、
+    /// Lospec 全站可下载。条目 = "R G B [name]"，name 可缺省（缺省条目只能被 hex 命中）。</summary>
+    internal sealed class GplPalette
+    {
+        public readonly List<(Color32 color, string name)> Entries = new();
+        private readonly Dictionary<string, Color32> _byName = new(StringComparer.Ordinal);
+
+        public static GplPalette Parse(string text)
+        {
+            var palette = new GplPalette();
+            var lines = text.Replace("\r\n", "\n").Split('\n');
+            var headerSeen = false;
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i].Trim();
+                if (line.Length == 0) continue;
+                if (!headerSeen)
+                {
+                    if (line != "GIMP Palette")
+                        throw new FormatException(
+                            $"line {i + 1}: not a GIMP Palette file (expected 'GIMP Palette' header)");
+                    headerSeen = true;
+                    continue;
+                }
+                if (line.StartsWith("#", StringComparison.Ordinal)) continue;
+                if (line.StartsWith("Name:", StringComparison.Ordinal)) continue;
+                if (line.StartsWith("Columns:", StringComparison.Ordinal)) continue;
+
+                var parts = line.Split((char[])null, 4, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length < 3 ||
+                    !byte.TryParse(parts[0], out var r) ||
+                    !byte.TryParse(parts[1], out var g) ||
+                    !byte.TryParse(parts[2], out var b))
+                {
+                    throw new FormatException($"line {i + 1}: expected 'R G B [name]', got '{line}'");
+                }
+                var name = parts.Length == 4 ? parts[3].Trim() : null;
+                if (string.IsNullOrEmpty(name)) name = null;
+                var color = new Color32(r, g, b, 255);
+                palette.Entries.Add((color, name));
+                if (name != null) palette._byName[Normalize(name)] = color;
+            }
+            if (!headerSeen)
+                throw new FormatException("line 1: not a GIMP Palette file (expected 'GIMP Palette' header)");
+            return palette;
+        }
+
+        public bool TryGetByName(string token, out Color32 color) =>
+            _byName.TryGetValue(Normalize(token), out color);
+
+        public bool ContainsRgb(Color32 c)
+        {
+            foreach (var (e, _) in Entries)
+                if (e.r == c.r && e.g == c.g && e.b == c.b) return true;
+            return false;
+        }
+
+        /// <summary>色名比较忽略大小写与空格/连字符/下划线差异（"Dark Blue" ≡ "dark-blue"）。</summary>
+        public static string Normalize(string name) =>
+            name.ToLowerInvariant().Replace(" ", "").Replace("-", "").Replace("_", "");
+    }
+}
+```
+
+- [ ] **Step 4: refresh + 跑测试确认通过**
+
+MCP 模板，`group_names=["GplPaletteTests"]`。Expected: 5/5 PASS。
+
+- [ ] **Step 5: lint + commit**
+
+```bash
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx && dotnet format style PromptUGUI.Lint.slnx && cd ..
+git add Editor/Pxl/ Tests/EditMode/Editor/Pxl/
+git commit -m "feat(pxl): GplPalette — GIMP .gpl text palette parser
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+（`Editor/Pxl/` 和 `Tests/.../Pxl/` 是新目录——确认 Unity refresh 已生成目录与文件的 `.meta` 并一并 add。）
+
+---
+
+### Task 2: `PxlParser`（.pxl 文本 → IR）
+
+**Files:**
+- Create: `Editor/Pxl/PxlParser.cs`
+- Test: `Tests/EditMode/Editor/Pxl/PxlParserTests.cs`
+
+格式细节（spec §2 的实现裁决，以此为准）：
+
+- 行级语法。整行注释 = trim 后以 `#` 开头（任何位置，含 grid 块内；因此 `#` 禁作 chars key）。空行跳过（grid 块内空行 = grid 结束）。
+- 文件头（首个 `[section]` 或隐式 grid 内容之前）：`palette: @<name>`（必须 `@` 前缀）、`ppu: <float>`（>0）、`chars:` 起 chars 块——后续每行 `<单字符>: <值>`（trim 后第 2 字符是 `:`），直到首个不匹配行。
+- chars key 重复 = error；`.` 可显式声明但值必须 `transparent`；`#` 禁作 key。
+- `[name]` 段头，名字限 `[A-Za-z0-9_-]+`；重名 = error。隐式单节 = 段头出现前就有 `border:`/`grid:`；隐式内容与显式段头混用 = error。
+- 节内：`border: L,B,R,T`（4 个 ≥0 整数，须在 `grid:` 前）；`grid:` 起网格块，每行 trim 后即一行像素，直到空行/段头/EOF。grid 行字符必须 ∈ chars ∪ {`.`}（error 带行号与字符）；各行宽必须一致；节必须有非空 grid；border 须满足 L+R ≤ width 且 B+T ≤ height。
+- 节外/头部出现无法识别的行 = error。
+
+- [ ] **Step 1: 写失败测试**
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Editor;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Editor
+{
+    public class PxlParserTests
+    {
+        [Test]
+        public void Parse_implicit_single_section()
+        {
+            var doc = PxlParser.Parse(
+                "chars:\n  K: #1a1c2c\ngrid:\n  .KK.\n  K..K\n");
+            Assert.IsNull(doc.PaletteRef);
+            Assert.AreEqual(100f, doc.Ppu);
+            Assert.AreEqual(1, doc.Sections.Count);
+            Assert.IsNull(doc.Sections[0].Name);
+            Assert.AreEqual(4, doc.Sections[0].Width);
+            Assert.AreEqual(2, doc.Sections[0].Height);
+            Assert.AreEqual(".KK.", doc.Sections[0].Rows[0]);
+        }
+
+        [Test]
+        public void Parse_full_header_and_two_sections()
+        {
+            var doc = PxlParser.Parse(
+                "palette: @main\nppu: 16\nchars:\n  K: dark-blue\n  W: #f4f4f4\n" +
+                "# a comment\n" +
+                "[normal]\nborder: 1,1,1,1\ngrid:\n  KKK\n  KWK\n  KKK\n\n" +
+                "[pressed]\ngrid:\n  WW\n  WW\n");
+            Assert.AreEqual("main", doc.PaletteRef);
+            Assert.AreEqual(16f, doc.Ppu);
+            Assert.AreEqual(2, doc.Chars.Count);
+            Assert.AreEqual("dark-blue", doc.Chars['K']);
+            Assert.AreEqual(2, doc.Sections.Count);
+            Assert.AreEqual("normal", doc.Sections[0].Name);
+            Assert.AreEqual(new Vector4(1, 1, 1, 1), doc.Sections[0].Border);
+            Assert.AreEqual("pressed", doc.Sections[1].Name);
+            Assert.AreEqual(Vector4.zero, doc.Sections[1].Border);
+        }
+
+        [Test]
+        public void Parse_unknown_grid_char_reports_line()
+        {
+            var ex = Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  K: #000000\ngrid:\n  KK\n  KX\n"));
+            Assert.AreEqual(5, ex.Line);
+            StringAssert.Contains("'X'", ex.Message);
+        }
+
+        [Test]
+        public void Parse_ragged_rows_reports_line()
+        {
+            var ex = Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  K: #000000\ngrid:\n  KKK\n  KK\n"));
+            Assert.AreEqual(5, ex.Line);
+        }
+
+        [Test]
+        public void Parse_duplicate_section_name_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  K: #000000\n[a]\ngrid:\n  K\n[a]\ngrid:\n  K\n"));
+        }
+
+        [Test]
+        public void Parse_duplicate_char_key_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  K: #000000\n  K: #ffffff\ngrid:\n  K\n"));
+        }
+
+        [Test]
+        public void Parse_dot_redefined_to_color_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  .: #000000\ngrid:\n  .\n"));
+        }
+
+        [Test]
+        public void Parse_border_exceeding_size_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  K: #000000\n[a]\nborder: 2,0,2,0\ngrid:\n  KKK\n"));
+        }
+
+        [Test]
+        public void Parse_empty_grid_section_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  K: #000000\n[a]\ngrid:\n[b]\ngrid:\n  K\n"));
+        }
+
+        [Test]
+        public void Parse_palette_without_at_prefix_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "palette: main\nchars:\n  K: #000000\ngrid:\n  K\n"));
+        }
+
+        [Test]
+        public void Parse_implicit_then_explicit_section_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  K: #000000\ngrid:\n  K\n[late]\ngrid:\n  K\n"));
+        }
+
+        [Test]
+        public void Parse_unrecognized_line_throws()
+        {
+            Assert.Throws<PxlParseException>(() => PxlParser.Parse(
+                "chars:\n  K: #000000\nbogus directive\ngrid:\n  K\n"));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: refresh，确认 CS0246（Red）**
+
+- [ ] **Step 3: 实现**
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+namespace PromptUGUI.Editor
+{
+    internal sealed class PxlParseException : Exception
+    {
+        public readonly int Line;
+        public PxlParseException(int line, string message)
+            : base($"line {line}: {message}") { Line = line; }
+    }
+
+    internal sealed class PxlDocument
+    {
+        public string PaletteRef;                              // "main" ← `palette: @main`; null = 纯内联
+        public float Ppu = 100f;
+        public readonly Dictionary<char, string> Chars = new(); // char → "transparent" | 色名 | #hex
+        public readonly List<PxlSection> Sections = new();
+    }
+
+    internal sealed class PxlSection
+    {
+        public string Name;                  // null = 隐式单节
+        public Vector4 Border;               // L,B,R,T（Unity Sprite border 序）
+        public int Width, Height;
+        public readonly List<string> Rows = new(); // top-down，已 trim
+    }
+
+    /// <summary>.pxl 文本 → IR。网格语法沿 XPM 惯用法：单字符=色板项、'.'=透明、
+    /// 一行=一行像素。结构校验（行宽、border 越界、重名）在这里；颜色解析在
+    /// <see cref="PxlColorResolver"/>。</summary>
+    internal static class PxlParser
+    {
+        private static readonly Regex SectionHeader =
+            new(@"^\[([A-Za-z0-9_-]+)\]$", RegexOptions.Compiled);
+        private static readonly Regex CharsEntry =
+            new(@"^(.): (.+)$", RegexOptions.Compiled);
+
+        public static PxlDocument Parse(string text)
+        {
+            var doc = new PxlDocument();
+            var lines = text.Replace("\r\n", "\n").Split('\n');
+
+            PxlSection section = null;       // 当前节（含隐式）
+            var sectionExplicit = false;
+            var inChars = false;
+            var inGrid = false;
+            var sawImplicitContent = false;
+            var names = new HashSet<string>(StringComparer.Ordinal);
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var lineNo = i + 1;
+                var line = lines[i].Trim();
+                if (line.Length == 0) { inGrid = false; continue; }
+                if (line[0] == '#') continue; // 整行注释；'#' 因此禁作 chars key
+
+                var m = SectionHeader.Match(line);
+                if (m.Success)
+                {
+                    if (sawImplicitContent)
+                        throw new PxlParseException(lineNo,
+                            "cannot mix implicit (headerless) content with [section] headers");
+                    FinishSection(section, lineNo);
+                    var name = m.Groups[1].Value;
+                    if (!names.Add(name))
+                        throw new PxlParseException(lineNo, $"duplicate section name '[{name}]'");
+                    section = new PxlSection { Name = name };
+                    doc.Sections.Add(section);
+                    sectionExplicit = true;
+                    inChars = false; inGrid = false;
+                    continue;
+                }
+
+                if (inGrid)
+                {
+                    ValidateRow(line, doc, section, lineNo);
+                    continue;
+                }
+
+                if (inChars)
+                {
+                    var cm = CharsEntry.Match(line);
+                    if (cm.Success)
+                    {
+                        var key = cm.Groups[1].Value[0];
+                        var value = cm.Groups[2].Value.Trim();
+                        if (key == '#')
+                            throw new PxlParseException(lineNo, "'#' is reserved for comments");
+                        if (key == '.' && value != "transparent")
+                            throw new PxlParseException(lineNo,
+                                "'.' is reserved for transparent and cannot be redefined");
+                        if (key != '.' && !doc.Chars.TryAdd(key, value))
+                            throw new PxlParseException(lineNo, $"duplicate chars key '{key}'");
+                        continue;
+                    }
+                    inChars = false; // 掉出 chars 块，按普通行继续解析
+                }
+
+                if (line.StartsWith("palette:", StringComparison.Ordinal))
+                {
+                    var v = line.Substring("palette:".Length).Trim();
+                    if (!v.StartsWith("@", StringComparison.Ordinal) || v.Length < 2)
+                        throw new PxlParseException(lineNo,
+                            $"palette must be '@<name>' (a project .gpl reference), got '{v}'");
+                    doc.PaletteRef = v.Substring(1);
+                    continue;
+                }
+                if (line.StartsWith("ppu:", StringComparison.Ordinal))
+                {
+                    var v = line.Substring("ppu:".Length).Trim();
+                    if (!float.TryParse(v, System.Globalization.NumberStyles.Float,
+                            System.Globalization.CultureInfo.InvariantCulture, out var ppu) || ppu <= 0)
+                        throw new PxlParseException(lineNo, $"ppu must be a positive number, got '{v}'");
+                    doc.Ppu = ppu;
+                    continue;
+                }
+                if (line == "chars:") { inChars = true; continue; }
+
+                if (line.StartsWith("border:", StringComparison.Ordinal))
+                {
+                    section = EnsureSection(doc, section, ref sectionExplicit,
+                        ref sawImplicitContent, names, lineNo);
+                    if (section.Rows.Count > 0)
+                        throw new PxlParseException(lineNo, "border must come before grid");
+                    section.Border = ParseBorder(line.Substring("border:".Length).Trim(), lineNo);
+                    continue;
+                }
+                if (line == "grid:")
+                {
+                    section = EnsureSection(doc, section, ref sectionExplicit,
+                        ref sawImplicitContent, names, lineNo);
+                    if (section.Rows.Count > 0)
+                        throw new PxlParseException(lineNo, "section already has a grid");
+                    inGrid = true;
+                    continue;
+                }
+
+                throw new PxlParseException(lineNo, $"unrecognized line '{line}'");
+            }
+
+            FinishSection(section, lines.Length);
+            if (doc.Sections.Count == 0)
+                throw new PxlParseException(lines.Length, "file declares no grid");
+            return doc;
+        }
+
+        private static PxlSection EnsureSection(PxlDocument doc, PxlSection current,
+            ref bool isExplicit, ref bool sawImplicit, HashSet<string> names, int lineNo)
+        {
+            if (current != null) return current;
+            // 段头出现前的 border:/grid: → 隐式单节
+            var s = new PxlSection { Name = null };
+            doc.Sections.Add(s);
+            isExplicit = false;
+            sawImplicit = true;
+            return s;
+        }
+
+        private static void ValidateRow(string row, PxlDocument doc, PxlSection section, int lineNo)
+        {
+            if (section.Rows.Count > 0 && row.Length != section.Width)
+                throw new PxlParseException(lineNo,
+                    $"row width {row.Length} != first row width {section.Width}");
+            foreach (var c in row)
+            {
+                if (c == '.') continue;
+                if (!doc.Chars.ContainsKey(c))
+                    throw new PxlParseException(lineNo, $"unknown grid char '{c}' (not in chars:)");
+            }
+            if (section.Rows.Count == 0) section.Width = row.Length;
+            section.Rows.Add(row);
+            section.Height = section.Rows.Count;
+        }
+
+        private static Vector4 ParseBorder(string v, int lineNo)
+        {
+            var parts = v.Split(',');
+            if (parts.Length != 4)
+                throw new PxlParseException(lineNo, $"border must be 'L,B,R,T' (4 ints), got '{v}'");
+            var n = new int[4];
+            for (var i = 0; i < 4; i++)
+            {
+                if (!int.TryParse(parts[i].Trim(), out n[i]) || n[i] < 0)
+                    throw new PxlParseException(lineNo, $"border component '{parts[i].Trim()}' must be a non-negative int");
+            }
+            return new Vector4(n[0], n[1], n[2], n[3]);
+        }
+
+        private static void FinishSection(PxlSection s, int lineNo)
+        {
+            if (s == null) return;
+            if (s.Rows.Count == 0)
+                throw new PxlParseException(lineNo, $"section '[{s.Name}]' has no grid");
+            if (s.Border.x + s.Border.z > s.Width || s.Border.y + s.Border.w > s.Height)
+                throw new PxlParseException(lineNo,
+                    $"border ({s.Border.x},{s.Border.y},{s.Border.z},{s.Border.w}) exceeds " +
+                    $"grid size {s.Width}x{s.Height}");
+        }
+    }
+}
+```
+
+注意：`EnsureSection` 里 `isExplicit` 参数当前实现未读——如 lint 报 IDE0060，去掉该参数并同步调用点（两处）。
+
+- [ ] **Step 4: refresh + 跑测试确认通过**
+
+MCP 模板，`group_names=["PxlParserTests"]`。Expected: 12/12 PASS。
+
+- [ ] **Step 5: lint + commit**
+
+```bash
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx && dotnet format style PromptUGUI.Lint.slnx && cd ..
+git add Editor/Pxl/ Tests/EditMode/Editor/Pxl/
+git commit -m "feat(pxl): PxlParser — .pxl text to IR with line-numbered errors
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `PxlColorResolver`（chars → Color32 + 越板校验）
+
+**Files:**
+- Create: `Editor/Pxl/PxlColorResolver.cs`
+- Test: `Tests/EditMode/Editor/Pxl/PxlColorResolverTests.cs`
+
+规则（spec §2/§3）：`transparent` → `(0,0,0,0)`；`#RRGGBB`/`#RRGGBBAA` → 直解，**palette 模式下 RGB 必须命中色板**（忽略 alpha），否则 error（越板色）；色名 → 仅 palette 模式可用（内联模式给色名 = error），normalized 查找，查不到 = error。`.` 恒透明。错误用 `PxlParseException`（line=0，消息带 char 与值上下文——resolve 阶段无行号，char 足以定位）。
+
+- [ ] **Step 1: 写失败测试**
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Editor;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Editor
+{
+    public class PxlColorResolverTests
+    {
+        private static GplPalette Palette() => GplPalette.Parse(
+            "GIMP Palette\n26 28 44\tdark-blue\n244 244 244\twhite\n100 100 100\n");
+
+        private static PxlDocument Doc(params (char, string)[] chars)
+        {
+            var d = new PxlDocument();
+            foreach (var (k, v) in chars) d.Chars[k] = v;
+            return d;
+        }
+
+        [Test]
+        public void Resolve_inline_hex_and_transparent()
+        {
+            var map = PxlColorResolver.Resolve(Doc(('K', "#1a1c2c"), ('T', "transparent")), null);
+            Assert.AreEqual(new Color32(0x1a, 0x1c, 0x2c, 255), map['K']);
+            Assert.AreEqual(new Color32(0, 0, 0, 0), map['T']);
+            Assert.AreEqual(new Color32(0, 0, 0, 0), map['.']);
+        }
+
+        [Test]
+        public void Resolve_hex_with_alpha()
+        {
+            var map = PxlColorResolver.Resolve(Doc(('S', "#1a1c2c80")), null);
+            Assert.AreEqual(new Color32(0x1a, 0x1c, 0x2c, 0x80), map['S']);
+        }
+
+        [Test]
+        public void Resolve_palette_name()
+        {
+            var doc = Doc(('K', "dark-blue"));
+            doc.PaletteRef = "main";
+            var map = PxlColorResolver.Resolve(doc, Palette());
+            Assert.AreEqual(new Color32(26, 28, 44, 255), map['K']);
+        }
+
+        [Test]
+        public void Resolve_palette_mode_hex_must_be_on_palette()
+        {
+            var doc = Doc(('K', "#1a1c2c"), ('X', "#010203"));
+            doc.PaletteRef = "main";
+            var ex = Assert.Throws<PxlParseException>(() => PxlColorResolver.Resolve(doc, Palette()));
+            StringAssert.Contains("'X'", ex.Message);
+            StringAssert.Contains("#010203", ex.Message);
+        }
+
+        [Test]
+        public void Resolve_palette_hex_alpha_variant_allowed()
+        {
+            var doc = Doc(('S', "#1a1c2c80")); // RGB 在板上，alpha 自由
+            doc.PaletteRef = "main";
+            var map = PxlColorResolver.Resolve(doc, Palette());
+            Assert.AreEqual((byte)0x80, map['S'].a);
+        }
+
+        [Test]
+        public void Resolve_name_without_palette_throws()
+        {
+            var ex = Assert.Throws<PxlParseException>(
+                () => PxlColorResolver.Resolve(Doc(('K', "dark-blue")), null));
+            StringAssert.Contains("palette:", ex.Message);
+        }
+
+        [Test]
+        public void Resolve_unknown_name_throws()
+        {
+            var doc = Doc(('K', "magenta"));
+            doc.PaletteRef = "main";
+            var ex = Assert.Throws<PxlParseException>(() => PxlColorResolver.Resolve(doc, Palette()));
+            StringAssert.Contains("magenta", ex.Message);
+        }
+
+        [Test]
+        public void Resolve_bad_hex_throws()
+        {
+            Assert.Throws<PxlParseException>(
+                () => PxlColorResolver.Resolve(Doc(('K', "#12345")), null));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: refresh，确认 CS0246（Red）**
+
+- [ ] **Step 3: 实现**
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using UnityEngine;
+
+namespace PromptUGUI.Editor
+{
+    /// <summary>chars 映射 → 具体颜色。palette 模式（doc.PaletteRef != null）下
+    /// hex 的 RGB 必须命中色板（忽略 alpha）——把全项目调色板一致性从 LLM 自觉
+    /// 变成管线强制（spec §3）。</summary>
+    internal static class PxlColorResolver
+    {
+        public static Dictionary<char, Color32> Resolve(PxlDocument doc, GplPalette palette)
+        {
+            var map = new Dictionary<char, Color32> { ['.'] = new Color32(0, 0, 0, 0) };
+            foreach (var kv in doc.Chars)
+            {
+                var (key, value) = (kv.Key, kv.Value);
+                if (value == "transparent") { map[key] = new Color32(0, 0, 0, 0); continue; }
+                if (value.StartsWith("#", StringComparison.Ordinal))
+                {
+                    var c = ParseHex(key, value);
+                    if (palette != null && !palette.ContainsRgb(c))
+                        throw new PxlParseException(0,
+                            $"chars '{key}': {value} is not on palette '@{doc.PaletteRef}' " +
+                            $"(off-palette color; pick a palette color or add it to the .gpl)");
+                    map[key] = c;
+                    continue;
+                }
+                // 色名
+                if (palette == null)
+                    throw new PxlParseException(0,
+                        $"chars '{key}': color name '{value}' requires a 'palette: @<name>' declaration");
+                if (!palette.TryGetByName(value, out var named))
+                    throw new PxlParseException(0,
+                        $"chars '{key}': color name '{value}' not found in palette '@{doc.PaletteRef}'");
+                map[key] = named;
+            }
+            return map;
+        }
+
+        private static Color32 ParseHex(char key, string value)
+        {
+            var hex = value.Substring(1);
+            if ((hex.Length != 6 && hex.Length != 8) ||
+                !uint.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out _))
+            {
+                throw new PxlParseException(0,
+                    $"chars '{key}': '{value}' is not #RRGGBB / #RRGGBBAA");
+            }
+            byte P(int i) => byte.Parse(hex.Substring(i, 2), NumberStyles.HexNumber,
+                CultureInfo.InvariantCulture);
+            return new Color32(P(0), P(2), P(4), hex.Length == 8 ? P(6) : (byte)255);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: refresh + 跑测试确认通过**
+
+MCP 模板，`group_names=["PxlColorResolverTests"]`。Expected: 8/8 PASS。
+
+- [ ] **Step 5: lint + commit**
+
+```bash
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx && dotnet format style PromptUGUI.Lint.slnx && cd ..
+git add Editor/Pxl/ Tests/EditMode/Editor/Pxl/
+git commit -m "feat(pxl): PxlColorResolver — palette enforcement + hex/name resolution
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `PxlImporter`（ScriptedImporter）
+
+**Files:**
+- Create: `Editor/Pxl/PxlImporter.cs`
+- Test: `Tests/EditMode/Editor/Pxl/PxlImporterTests.cs`
+
+要点：每节一张 RGBA32 Texture2D（Point、Clamp、`alphaIsTransparency`、**保持 readable**——InlineSpriteAssetBuilder 要读像素）+ `Sprite.Create(..., FullRect, border)` sub-asset；节名 = 段名，隐式单节 = 文件 basename；main asset = 首节 Texture2D（保证 `FindAssets("t:Texture2D")` 可发现）。grid 行序 top-down，texture 像素行序 bottom-up——写像素时翻转。`palette: @name` 经 `AssetDatabase.FindAssets` 找 `<name>.gpl`（0 个/多个都报错），并 `ctx.DependsOnSourceAsset` 注册依赖。所有错误 `ctx.LogImportError` 后 return（资产保持失败态）。
+
+- [ ] **Step 1: 写失败测试**
+
+```csharp
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Editor;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.Editor
+{
+    public class PxlImporterTests
+    {
+        private const string TmpDir = "Assets/__test_pxl__";
+
+        [SetUp]
+        public void Setup()
+        {
+            if (!AssetDatabase.IsValidFolder(TmpDir))
+                AssetDatabase.CreateFolder("Assets", "__test_pxl__");
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            AssetDatabase.DeleteAsset(TmpDir);
+        }
+
+        private static string Write(string fileName, string content)
+        {
+            var abs = Path.Combine(UnityEngine.Application.dataPath, "__test_pxl__", fileName);
+            File.WriteAllText(abs, content);
+            var assetPath = $"{TmpDir}/{fileName}";
+            AssetDatabase.ImportAsset(assetPath,
+                ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+            return assetPath;
+        }
+
+        [Test]
+        public void Import_single_implicit_section_pixels_and_filter()
+        {
+            var path = Write("dot.pxl", "chars:\n  K: #102030\ngrid:\n  K.\n  ..\n");
+            var tex = AssetDatabase.LoadAssetAtPath<Texture2D>(path);
+            Assert.IsNotNull(tex);
+            Assert.AreEqual("dot", tex.name);
+            Assert.AreEqual(FilterMode.Point, tex.filterMode);
+            // grid 第 1 行是顶行 → texture y=1（bottom-up 翻转）
+            Assert.AreEqual(new Color32(0x10, 0x20, 0x30, 255), (Color32)tex.GetPixel(0, 1));
+            Assert.AreEqual(0, ((Color32)tex.GetPixel(1, 1)).a);
+            var sprite = AssetDatabase.LoadAssetAtPath<Sprite>(path);
+            Assert.IsNotNull(sprite);
+            Assert.AreEqual("dot", sprite.name);
+        }
+
+        [Test]
+        public void Import_border_and_ppu_land_on_sprite()
+        {
+            var path = Write("framed.pxl",
+                "ppu: 16\nchars:\n  K: #000000\n[bg]\nborder: 1,1,1,1\ngrid:\n  KKK\n  KKK\n  KKK\n");
+            var sprite = AssetDatabase.LoadAllAssetsAtPath(path).OfType<Sprite>().Single();
+            Assert.AreEqual("bg", sprite.name);
+            Assert.AreEqual(new Vector4(1, 1, 1, 1), sprite.border);
+            Assert.AreEqual(16f, sprite.pixelsPerUnit);
+        }
+
+        [Test]
+        public void Import_multi_section_produces_sub_sprites_main_is_first_texture()
+        {
+            var path = Write("btn.pxl",
+                "chars:\n  K: #000000\n  W: #ffffff\n" +
+                "[normal]\ngrid:\n  KW\n[pressed]\ngrid:\n  WK\n");
+            var sprites = AssetDatabase.LoadAllAssetsAtPath(path).OfType<Sprite>()
+                .Select(s => s.name).OrderBy(n => n).ToArray();
+            Assert.AreEqual(new[] { "normal", "pressed" }, sprites);
+            var main = AssetDatabase.LoadMainAssetAtPath(path);
+            Assert.IsInstanceOf<Texture2D>(main);
+            Assert.AreEqual("normal", main.name);
+        }
+
+        [Test]
+        public void Import_palette_ref_resolves_and_offpalette_fails()
+        {
+            Write("main.gpl", "GIMP Palette\n26 28 44\tdark-blue\n");
+            var ok = Write("ok.pxl", "palette: @main\nchars:\n  K: dark-blue\ngrid:\n  K\n");
+            Assert.IsNotNull(AssetDatabase.LoadAssetAtPath<Sprite>(ok));
+
+            LogAssert.ignoreFailingMessages = true;
+            var bad = Write("bad.pxl", "palette: @main\nchars:\n  K: #010203\ngrid:\n  K\n");
+            LogAssert.ignoreFailingMessages = false;
+            Assert.IsNull(AssetDatabase.LoadAssetAtPath<Sprite>(bad), "off-palette must fail import");
+        }
+
+        [Test]
+        public void Import_gpl_edit_triggers_dependent_reimport()
+        {
+            Write("pal.gpl", "GIMP Palette\n255 0 0\tred\n");
+            var path = Write("dep.pxl", "palette: @pal\nchars:\n  R: red\ngrid:\n  R\n");
+            Assert.AreEqual(new Color32(255, 0, 0, 255),
+                (Color32)AssetDatabase.LoadAssetAtPath<Texture2D>(path).GetPixel(0, 0));
+
+            // 改色板 → 依赖的 .pxl 自动重导入，颜色跟着变
+            Write("pal.gpl", "GIMP Palette\n0 255 0\tred\n");
+            AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+            Assert.AreEqual(new Color32(0, 255, 0, 255),
+                (Color32)AssetDatabase.LoadAssetAtPath<Texture2D>(path).GetPixel(0, 0));
+        }
+
+        [Test]
+        public void Import_parse_error_fails_import_with_logged_error()
+        {
+            LogAssert.ignoreFailingMessages = true;
+            var path = Write("broken.pxl", "chars:\n  K: #000000\ngrid:\n  KK\n  K\n");
+            LogAssert.ignoreFailingMessages = false;
+            Assert.IsNull(AssetDatabase.LoadAssetAtPath<Texture2D>(path));
+        }
+
+        [Test]
+        public void Import_missing_palette_fails_import()
+        {
+            LogAssert.ignoreFailingMessages = true;
+            var path = Write("orphan.pxl", "palette: @nosuch\nchars:\n  K: #000000\ngrid:\n  K\n");
+            LogAssert.ignoreFailingMessages = false;
+            Assert.IsNull(AssetDatabase.LoadAssetAtPath<Texture2D>(path));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: refresh，跑 `group_names=["PxlImporterTests"]` 确认全 FAIL（.pxl 无 importer → Load 返回 null/非 Sprite）**
+
+注意第一个测试 `Import_single_implicit_section_pixels_and_filter` 此时 `LoadAssetAtPath<Texture2D>` 返回 null → FAIL，符合 Red。
+
+- [ ] **Step 3: 实现**
+
+```csharp
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.AssetImporters;
+using UnityEngine;
+
+namespace PromptUGUI.Editor
+{
+    /// <summary>.pxl（像素网格文本，spec 2026-06-11-pxl-pixel-sprite-importer）→
+    /// 每节一张 point-filter Texture2D + Sprite sub-asset。main asset = 首节
+    /// Texture2D，保证 SpriteAtlasSyncer 的 FindAssets("t:Texture2D") 能发现。
+    /// Texture 保持 readable：InlineSpriteAssetBuilder 烘焙图文混排时要读像素。</summary>
+    [ScriptedImporter(1, "pxl")]
+    internal sealed class PxlImporter : ScriptedImporter
+    {
+        public override void OnImportAsset(AssetImportContext ctx)
+        {
+            string text;
+            try { text = File.ReadAllText(ctx.assetPath); }
+            catch (IOException ex)
+            {
+                ctx.LogImportError($"{ctx.assetPath}: cannot read: {ex.Message}");
+                return;
+            }
+
+            PxlDocument doc;
+            try { doc = PxlParser.Parse(text); }
+            catch (PxlParseException ex)
+            {
+                ctx.LogImportError($"{ctx.assetPath}: {ex.Message}");
+                return;
+            }
+
+            GplPalette palette = null;
+            if (doc.PaletteRef != null)
+            {
+                var gplPath = FindPalettePath(doc.PaletteRef, out var error);
+                if (gplPath == null)
+                {
+                    ctx.LogImportError($"{ctx.assetPath}: {error}");
+                    return;
+                }
+                // 色板改动 → 所有引用它的 .pxl 自动重导入（全项目换色一次完成）。
+                ctx.DependsOnSourceAsset(gplPath);
+                try { palette = GplPalette.Parse(File.ReadAllText(gplPath)); }
+                catch (System.FormatException ex)
+                {
+                    ctx.LogImportError($"{gplPath}: {ex.Message}");
+                    return;
+                }
+            }
+
+            System.Collections.Generic.Dictionary<char, Color32> colors;
+            try { colors = PxlColorResolver.Resolve(doc, palette); }
+            catch (PxlParseException ex)
+            {
+                ctx.LogImportError($"{ctx.assetPath}: {ex.Message}");
+                return;
+            }
+
+            var basename = Path.GetFileNameWithoutExtension(ctx.assetPath);
+            Texture2D main = null;
+            foreach (var section in doc.Sections)
+            {
+                var name = section.Name ?? basename;
+                var tex = BuildTexture(section, colors, name);
+                var sprite = Sprite.Create(tex,
+                    new Rect(0, 0, section.Width, section.Height),
+                    new Vector2(0.5f, 0.5f), doc.Ppu, 0,
+                    SpriteMeshType.FullRect, section.Border);
+                sprite.name = name;
+                ctx.AddObjectToAsset($"tex:{name}", tex);
+                ctx.AddObjectToAsset($"sprite:{name}", sprite);
+                if (main == null) main = tex;
+            }
+            ctx.SetMainObject(main);
+        }
+
+        private static Texture2D BuildTexture(PxlSection section,
+            System.Collections.Generic.IReadOnlyDictionary<char, Color32> colors, string name)
+        {
+            var w = section.Width;
+            var h = section.Height;
+            var tex = new Texture2D(w, h, TextureFormat.RGBA32, false)
+            {
+                name = name,
+                filterMode = FilterMode.Point,
+                wrapMode = TextureWrapMode.Clamp,
+                alphaIsTransparency = true,
+            };
+            var px = new Color32[w * h];
+            for (var row = 0; row < h; row++)        // grid top-down → texture bottom-up
+                for (var col = 0; col < w; col++)
+                    px[(h - 1 - row) * w + col] = colors[section.Rows[row][col]];
+            tex.SetPixels32(px);
+            tex.Apply(updateMipmaps: false, makeNoLongerReadable: false);
+            return tex;
+        }
+
+        /// <summary>按文件名（去扩展名）全项目找 &lt;name&gt;.gpl。0 个或多个都报错
+        /// （error out 参数带候选列表）。</summary>
+        private static string FindPalettePath(string paletteRef, out string error)
+        {
+            var matches = AssetDatabase.FindAssets(paletteRef)
+                .Select(AssetDatabase.GUIDToAssetPath)
+                .Where(p => string.Equals(Path.GetFileName(p), paletteRef + ".gpl",
+                    System.StringComparison.Ordinal))
+                .Distinct()
+                .OrderBy(p => p, System.StringComparer.Ordinal)
+                .ToList();
+            if (matches.Count == 1) { error = null; return matches[0]; }
+            error = matches.Count == 0
+                ? $"palette '@{paletteRef}' not found (no '{paletteRef}.gpl' in project)"
+                : $"palette '@{paletteRef}' is ambiguous: {string.Join(", ", matches)}";
+            return null;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: refresh + 跑测试确认通过**
+
+MCP 模板，`group_names=["PxlImporterTests"]`。Expected: 7/7 PASS。
+若 `Import_gpl_edit_triggers_dependent_reimport` 失败：检查 `DependsOnSourceAsset` 的路径是否与 `.gpl` 实际 assetPath 一致（大小写/分隔符）。
+
+- [ ] **Step 5: 顺跑全量 EditorOnly，确认无连带回归**
+
+`run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])`。Expected: 全绿（基线 184 + 本计划新增）。
+
+- [ ] **Step 6: lint + commit**
+
+```bash
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx && dotnet format style PromptUGUI.Lint.slnx && cd ..
+git add Editor/Pxl/ Tests/EditMode/Editor/Pxl/
+git commit -m "feat(pxl): PxlImporter — ScriptedImporter, per-section Texture2D+Sprite, .gpl dependency
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `SpriteAtlasSyncer` 对接（key 派生 + Point 兜底）
+
+**Files:**
+- Modify: `Editor/SpriteAtlasSyncer.cs:383-415`（`EnumerateSpriteSources` 循环体）、`:895-903`（`ApplyTemplateFilterMode`）
+- Test: `Tests/EditMode/Editor/Pxl/PxlSyncerTests.cs`
+
+key 规则（spec §2 的实现裁决）：`PxlImporter` 资产按 Sprite sub-asset 枚举；`sprite.name == 文件 basename` → key = pathKey（隐式单节，与 PNG 规则一致；顺带让 `ok.pxl` 里的 `[ok]` 也折叠为 `Buttons/ok`），否则 key = `pathKey/sprite.name`。裸名别名交给既有 `BuildLookup`（`pressed` 撞名时自动不提升）。
+
+- [ ] **Step 1: 写失败测试**
+
+```csharp
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Editor;
+using UnityEditor;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Editor
+{
+    public class PxlSyncerTests
+    {
+        private const string TestRoot = "Assets/__test_pxlsync__";
+
+        [SetUp]
+        public void Setup()
+        {
+            if (!AssetDatabase.IsValidFolder(TestRoot))
+                AssetDatabase.CreateFolder("Assets", "__test_pxlsync__");
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            AssetDatabase.DeleteAsset(TestRoot);
+        }
+
+        private static void WritePxl(string relPath, string content)
+        {
+            var abs = Path.Combine(UnityEngine.Application.dataPath, "__test_pxlsync__",
+                relPath.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(abs));
+            File.WriteAllText(abs, content);
+        }
+
+        private static void ImportAll() =>
+            AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+
+        private const string SinglePxl = "chars:\n  K: #000000\ngrid:\n  K\n";
+        private const string MultiPxl =
+            "chars:\n  K: #000000\n  W: #ffffff\n[normal]\ngrid:\n  K\n[pressed]\ngrid:\n  W\n";
+
+        [Test]
+        public void Enumerate_single_section_key_is_pathkey()
+        {
+            WritePxl("icon.pxl", SinglePxl);
+            ImportAll();
+            var entries = SpriteAtlasSyncer.EnumerateSpriteSources(TestRoot);
+            Assert.AreEqual(1, entries.Count);
+            Assert.AreEqual("icon", entries[0].pathKey);
+        }
+
+        [Test]
+        public void Enumerate_multi_section_keys_append_section_name()
+        {
+            WritePxl("Buttons/ok.pxl", MultiPxl);
+            ImportAll();
+            var keys = SpriteAtlasSyncer.EnumerateSpriteSources(TestRoot)
+                .Select(e => e.pathKey).OrderBy(k => k).ToArray();
+            Assert.AreEqual(new[] { "Buttons/ok/normal", "Buttons/ok/pressed" }, keys);
+        }
+
+        [Test]
+        public void Enumerate_mixed_png_and_pxl()
+        {
+            WritePxl("a.pxl", SinglePxl);
+            var png = new Texture2D(1, 1);
+            png.SetPixel(0, 0, Color.red);
+            File.WriteAllBytes(
+                Path.Combine(UnityEngine.Application.dataPath, "__test_pxlsync__", "b.png"),
+                png.EncodeToPNG());
+            Object.DestroyImmediate(png);
+            ImportAll();
+            var keys = SpriteAtlasSyncer.EnumerateSpriteSources(TestRoot)
+                .Select(e => e.pathKey).OrderBy(k => k).ToArray();
+            Assert.AreEqual(new[] { "a", "b" }, keys);
+        }
+
+        [Test]
+        public void BuildLookup_promotes_unique_bare_alias_for_section_key()
+        {
+            WritePxl("Buttons/ok.pxl", MultiPxl);
+            ImportAll();
+            var entries = SpriteAtlasSyncer.EnumerateSpriteSources(TestRoot);
+            var lookup = SpriteAtlasSyncer.BuildLookup(entries, out _);
+            Assert.IsTrue(lookup.ContainsKey("Buttons/ok/pressed"));
+            Assert.IsTrue(lookup.ContainsKey("pressed"), "unique bare alias promoted");
+        }
+
+        [Test]
+        public void ResetTextureImportSettings_skips_pxl()
+        {
+            WritePxl("icon.pxl", SinglePxl);
+            ImportAll();
+            Assert.AreEqual(0, SpriteAtlasSyncer.ResetTextureImportSettings(TestRoot),
+                ".pxl has no TextureImporter; reset must skip it");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: refresh + 跑 `group_names=["PxlSyncerTests"]`，确认 key 相关测试 FAIL**
+
+预期失败形态：`Enumerate_multi_section_keys` 只得到 1 个 entry（`LoadAssetAtPath<Sprite>` 任取其一、key 无节名段）。`ResetTextureImportSettings_skips_pxl` 应已 PASS（guard 既有）——它是钉死回归的。
+
+- [ ] **Step 3: 修改 `EnumerateSpriteSources`**
+
+在 `Editor/SpriteAtlasSyncer.cs` 的 `EnumerateSpriteSources` 循环里，`EnsureSpriteImporter(assetPath);` 之后、`#if PROMPTUGUI_HAS_ASEPRITE` 之前插入：
+
+```csharp
+                // .pxl（PxlImporter）：每节一个 Sprite sub-asset。隐式单节的 sprite.name
+                // == 文件 basename → key 与 PNG 规则一致（pathKey）；显式多节 → pathKey/节名。
+                if (AssetImporter.GetAtPath(assetPath) is PxlImporter)
+                {
+                    var relPxl = assetPath.Substring(folderPrefix.Length);
+                    var pxlKey = relPxl.Substring(0, relPxl.Length - Path.GetExtension(relPxl).Length);
+                    var pxlBase = Path.GetFileNameWithoutExtension(assetPath);
+                    foreach (var s in AssetDatabase.LoadAllAssetsAtPath(assetPath).OfType<Sprite>())
+                    {
+                        result.Add((s.name == pxlBase ? pxlKey : $"{pxlKey}/{s.name}", s));
+                    }
+                    continue;
+                }
+```
+
+（文件已 `using System.Linq;`，无需新增。）
+
+- [ ] **Step 4: 修改 `ApplyTemplateFilterMode`（pxl-only 文件夹 atlas Point 兜底）**
+
+`FindFirstTexture` 排除非 TextureImporter → 纯 `.pxl` 的 sourceFolder 拿不到模板，atlas 会落默认 Bilinear，把像素画糊掉。替换 `ApplyTemplateFilterMode`：
+
+```csharp
+        private static void ApplyTemplateFilterMode(SpriteAtlas atlas, string folderAssetPath)
+        {
+            var firstTexture = FindFirstTexture(folderAssetPath);
+            if (firstTexture == null)
+            {
+                // 纯 .pxl 文件夹：PxlImporter 贴图恒为 point-filter 像素画 → atlas 跟随。
+                if (HasPxlSource(folderAssetPath))
+                {
+                    var pxlTs = atlas.GetTextureSettings();
+                    pxlTs.filterMode = FilterMode.Point;
+                    atlas.SetTextureSettings(pxlTs);
+                }
+                return;
+            }
+            if (AssetImporter.GetAtPath(firstTexture) is not TextureImporter ti) return;
+            var ts = atlas.GetTextureSettings();
+            ts.filterMode = ti.filterMode;
+            atlas.SetTextureSettings(ts);
+        }
+
+        private static bool HasPxlSource(string folderAssetPath)
+        {
+            if (string.IsNullOrEmpty(folderAssetPath)) return false;
+            if (!AssetDatabase.IsValidFolder(folderAssetPath)) return false;
+            foreach (var g in AssetDatabase.FindAssets("t:Texture2D", new[] { folderAssetPath }))
+            {
+                if (AssetImporter.GetAtPath(AssetDatabase.GUIDToAssetPath(g)) is PxlImporter)
+                    return true;
+            }
+            return false;
+        }
+```
+
+并在 `PxlSyncerTests` 补一条（写在 Step 1 文件里也可，此处列全）：
+
+```csharp
+        [Test]
+        public void EnsureAtlas_pxl_only_folder_gets_point_filter()
+        {
+            WritePxl("icon.pxl", SinglePxl);
+            ImportAll();
+            var set = ScriptableObject.CreateInstance<PromptUGUI.Application.SpriteSet>();
+            var so = new SerializedObject(set);
+            so.FindProperty("setName").stringValue = "pxltest";
+            so.FindProperty("sourceFolder").objectReferenceValue =
+                AssetDatabase.LoadAssetAtPath<DefaultAsset>(TestRoot);
+            so.ApplyModifiedPropertiesWithoutUndo();
+            AssetDatabase.CreateAsset(set, $"{TestRoot}/pxltest.asset");
+
+            var atlas = SpriteAtlasSyncer.EnsureAtlasAsset(set);
+            Assert.IsNotNull(atlas);
+            Assert.AreEqual(FilterMode.Point, atlas.GetTextureSettings().filterMode);
+        }
+```
+
+（`SerializedObject` 需 `using UnityEditor;` 已有；`SpriteSet` 字段名 `setName`/`sourceFolder` 见 `Runtime/Application/SpriteSet.cs:18,40`。atlas 资产会建在 `TestRoot` 下，TearDown 的 `DeleteAsset(TestRoot)` 一并清掉。）
+
+- [ ] **Step 5: refresh + 跑 `group_names=["PxlSyncerTests"]` 确认全 PASS（6/6）**
+
+- [ ] **Step 6: 全量回归**
+
+`run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])` 与 `assembly_names=["PromptUGUI.Tests.EditMode"]` 都跑。Expected: 全绿（EditMode 基线 1570）。
+
+- [ ] **Step 7: lint + commit**
+
+```bash
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx && dotnet format style PromptUGUI.Lint.slnx && cd ..
+git add Editor/SpriteAtlasSyncer.cs Tests/EditMode/Editor/Pxl/
+git commit -m "feat(pxl): syncer integration — per-section keys + point-filter atlas fallback
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: SKILL 文档
+
+**Files:**
+- Create: `.claude/skills/authoring-promptugui-pxl/SKILL.md`
+- Modify: `.claude/skills/authoring-promptugui-xml/reference/icons.md`（来源指针）
+
+- [ ] **Step 1: 写 `SKILL.md`**（英文，结构如下，写作时对照 spec §2/§3 与最终实现核对每条语法）
+
+```markdown
+---
+name: authoring-promptugui-pxl
+description: Use when creating or editing PromptUGUI .pxl pixel-grid sprite files — LLM-authored pixel art (9-slice borders, button skins, icons) that imports directly as Unity Sprites. For referencing the resulting sprites from XML see authoring-promptugui-xml.
+---
+
+# Authoring PromptUGUI `.pxl` pixel sprites
+
+(sections:)
+## When to use / pipeline overview
+- .pxl in a SpriteSet sourceFolder → auto-imports as Sprite(s) → reference as `set:key` from <Icon>/<Image sprite=>; Sync Atlases packs them like PNGs.
+- Sweet spot ≤48×48 UI chrome; NOT for large illustrations.
+## File format (full grammar + one complete multi-section example)
+- header: palette/ppu/chars; sections [name]; border L,B,R,T before grid; grid rows; '.'=transparent; '#'-comments; error behaviors (line-numbered import errors).
+- key derivation: file path key + /section for multi-section; bare-name aliases.
+## Palette workflow (.gpl)
+- GIMP Palette format, Lospec download, @name resolution, off-palette = import error, palette edit → auto reimport.
+- caveat: renaming/moving the .gpl does not auto-reimport dependents; reimport manually.
+## Pixel-art craft rules for LLMs
+- 1px outline, limited ramp per material, 9-slice corner design (corners hold the detail, edges must tile), button state ladder (normal/hover lighter/pressed darker+shifted), odd sizes for centered icons, etc.
+## Verifying your output
+- import errors land in the Unity console (and fail the asset); re-read your grid — text IS the image.
+```
+
+- [ ] **Step 2: 在 `icons.md` 文末加指针小节**
+
+```markdown
+## `.pxl` text sprites
+
+A SpriteSet `sourceFolder` may also contain `.pxl` files — LLM-authored pixel-grid
+text that imports directly as point-filtered Sprites (with 9-slice border / PPU
+declared in-file). Multi-section files contribute `path/section` keys. Full format
+and drawing guidance: the **authoring-promptugui-pxl** skill.
+```
+
+- [ ] **Step 3: commit**
+
+```bash
+git add .claude/skills/authoring-promptugui-pxl/ .claude/skills/authoring-promptugui-xml/reference/icons.md
+git commit -m "docs(skill): authoring-promptugui-pxl + icons.md pointer
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: 端到端验证 + 收尾
+
+- [ ] **Step 1: 端到端冒烟（host 工程）**
+
+在 host 工程任一 SpriteSet sourceFolder 写一个真实 `.pxl`（带 `[normal]`/`[pressed]` 的 9-slice 按钮皮肤 + `main.gpl`），在某个 `.ui.xml` 里 `<Image sprite="<set>:<key>"/>` 引用，跑 `Tools → PromptUGUI → Sprite → Sync Atlases (All Sets)`（或 MCP `execute_menu_item`，注意不是 Reimport All），用 `read_console` 确认无错误、SpriteSet entries 出现新 key。
+
+- [ ] **Step 2: 三套全量测试**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])     # 基线 1570
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])   # 基线 184 + 新增 ~32
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])     # 基线 133
+```
+
+Expected: 全绿。
+
+- [ ] **Step 3: lint 终验**
+
+```bash
+cd .lint && dotnet restore PromptUGUI.Lint.slnx && \
+dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+Expected: exit 0。
+
+- [ ] **Step 4: 确认 `.meta` 完整**
+
+```bash
+git status --short   # 不应有未跟踪的 .cs/.md 缺 .meta 伴生
+```
+
+- [ ] **Step 5: push + PR（走 superpowers:finishing-a-development-branch）**
+
+PR 描述引用 spec 路径；提醒用户做视觉 QA（Unity 里看导入的 .pxl 按钮皮肤 9-slice 拉伸效果）。
+
+---
+
+## Self-Review 记录
+
+- **Spec coverage**：§2 格式（Task 2/3）、§3 .gpl（Task 1/4）、§4 importer（Task 4）、§5 改动面五行（Task 5 前两行 + guard 测试；AutoSync 行经代码核实零改动，Task 7 冒烟覆盖；消费端零改动）、§6 测试（Task 1–5）、§7 SKILL（Task 6）。无缺口。
+- **Spec 偏差（已回写 spec）**：默认 PPU = 100（项目无"项目默认 PPU"设置）。
+- **实现裁决（spec 未细化处，以本计划为准）**：单显式节 `[x]` 在 `x.pxl` 中折叠为 pathKey；`#` 整行注释、禁作 chars key；空行终止 grid 块；rows 取 trim 后内容（空格不是合法网格字符）。
+- **类型一致性**：`PxlDocument.Chars`/`Sections`/`PaletteRef`/`Ppu`、`PxlSection.Name/Border/Width/Height/Rows`、`GplPalette.Entries/TryGetByName/ContainsRgb` 在 Task 2/3/4/5 间已交叉核对一致。

--- a/docs~/superpowers/specs/2026-06-11-pxl-pixel-sprite-importer-design.md
+++ b/docs~/superpowers/specs/2026-06-11-pxl-pixel-sprite-importer-design.md
@@ -1,0 +1,112 @@
+# `.pxl` 像素网格文本资产（LLM 生成 UI 小件）设计
+
+**日期**：2026-06-11
+**状态**：设计阶段（待 review，未进入实施）
+**作用域**：新增 `.pxl` 文本格式 + Editor `ScriptedImporter`，让 LLM 以"调色板 + 字符网格"文本直接产出 Unity Sprite 资产（含 9-slice border / PPU），落进现有 SpriteSet → Sync Atlases 管线；调色板用社区标准 GIMP `.gpl` 做项目级共享。覆盖 UI chrome 小件（9-slice 边框、按钮皮肤、图标、小装饰，经验上限 ≤48×48）。
+**依赖**：
+- [`2026-05-07-promptugui-description-language-design.md`](2026-05-07-promptugui-description-language-design.md) §7.6（`<Icon>` / SpriteSet）
+- `Editor/SpriteAtlasSyncer.cs`（发现/打包/key 派生）、`Runtime/Application/SpriteSet.cs`（entries 消费端）
+
+---
+
+## 1. 背景与目标
+
+### 1.1 问题
+
+PromptUGUI 已让 LLM 通过 `.ui.xml` 生成界面结构，但界面的**图像资产**（9-slice 边框、按钮皮肤、图标）仍需用户手工绘制——这是"LLM 生成完整 UI"链路上最后一段断点。
+
+### 1.2 为什么不是 SVG → Sprite
+
+- **表示错配**：SVG 是连续坐标 + 抗锯齿光栅化；像素艺术是离散网格 + 限色调色板 + 逐像素控制。SVG 光栅化再降采样/量化得到的是"缩小的平面矢量图"，做不出 1px 勾线、selective outline、手工 AA。
+- **精度错配**：LLM 写 SVG 控制得了拓扑，控制不了最终光栅化到 24×24 时每个像素的明暗——像素画的质量恰恰全在这一层。
+- **工具链负担**：`com.unity.vectorgraphics` 维护停滞，否则需引外部 rasterizer。
+
+### 1.3 为什么是网格文本
+
+像素画天生是小型离散数据：24×24 的 9-slice 边框只有 576 格、<10 色——正是 LLM 文本输出能精确控制的形式，且**文本即所见**，LLM 能看着自己的输出自我修订。网格语法沿用 XPM 惯用法（单字符=色板项、`.`=透明、一行字符串=一行像素）——LLM 训练数据里大量存在；XPM 本身因 C 语法噪音且缺 9-slice/多 sprite/PPU 元数据而不直接采用。调研确认（2026-06）不存在满足此场景的社区标准格式；调色板层面则有标准：GIMP Palette（`.gpl`），Aseprite 原生读写、Lospec 全站提供下载，直接采用。
+
+### 1.4 目标
+
+LLM 写下一个 `.pxl` 文件放进 SpriteSet sourceFolder → Unity 自动导入为 Sprite（point filter、带 border）→ 现有 Sync Atlases / `<Icon>` / `<Image sprite=>` 零改动消费。错误（语法、行宽、越板色）在 import 时以行号报出，LLM 据此修订。
+
+---
+
+## 2. `.pxl` 文件格式
+
+```
+palette: @main              # 可选；引用项目级 main.gpl。省略 = 纯内联模式
+ppu: 16                     # 可选；缺省 100（Unity TextureImporter 惯例值）
+chars:
+  .: transparent
+  K: dark-blue              # @palette 模式：按 .gpl 内颜色名引用
+  W: #f4f4f4                # 内联 hex；palette 模式下 hex 必须存在于色板，否则 import error
+
+[normal]
+border: 4,4,4,4             # 可选，9-slice（L,B,R,T 同 Unity Sprite border 序）；每节独立
+grid:
+  ..KKKKKK..
+  .KWWWWWWK.
+  .KW....WK.
+  ..KKKKKK..
+
+[pressed]
+border: 4,4,4,4
+grid:
+  ..KKKKKK..
+  .KGGGGGGK.
+  ...
+```
+
+规则：
+
+- **网格**：单字符 = `chars` 中一项；`.` 固定为透明（保留字符）；每行宽度必须一致（不一致 = import error 报行号）；各节尺寸可不同。grid 行允许统一缩进（取首行缩进为基准剥除）。
+- **分节**：`[节名]` 起一节，节名限 `[A-Za-z0-9_-]+`。**单 sprite 文件可整体省略 `[节名]`**（隐式单节）。
+- **key 派生**（icon 名 / atlas key）：
+  - 单节文件：`相对 sourceFolder 路径去扩展名`——与现有 PNG 规则一致（`Buttons/ok.pxl` → `Buttons/ok`，不冲突时另补裸名别名 `ok`）。
+  - 多节文件：`路径/节名`（`Buttons/ok.pxl` 的 `[pressed]` → `Buttons/ok/pressed`，裸名别名 `pressed` 按既有唯一性规则）。
+- **颜色**：`chars` 值三种写法——`transparent`、`.gpl` 颜色名（仅 `@palette` 模式）、`#RRGGBB` / `#RRGGBBAA`。`@palette` 模式下 hex 写法须精确命中色板某项（忽略 alpha 通道比较 RGB），否则 import error（"越板色"），把全项目风格一致性从 LLM 自觉变成管线强制。
+- **多节共享**：`palette` / `ppu` / `chars` 是文件级头部，所有节共享——按钮三态放同一文件、共享调色板，LLM 一屏看全整套皮肤，是风格一致性的主要收益点。
+
+## 3. 调色板：`.gpl`（GIMP Palette）
+
+- 标准文本格式：`GIMP Palette` 头 + 每行 `R G B<TAB>名字`。美术可从 Lospec 直接下载落盘，Aseprite 同步编辑。
+- `palette: @main` 按**文件名去扩展名**全项目 `FindAssets` 查找 `main.gpl`；找不到或重名 = import error。
+- `PxlImporter` 通过 `ctx.DependsOnSourceAsset(gplPath)` 注册依赖：**改色板自动重导入所有引用它的 `.pxl`**，全项目换色一次完成。
+- `.gpl` 本身不需要成为自定义资产类型——importer 直接读文件文本；无 `.gpl` ScriptedImporter（Unity 默认把它当 DefaultAsset，无碍）。
+- 色名解析：忽略大小写与空格/连字符差异（`Dark Blue` ≡ `dark-blue`）；无名条目只能被 hex 命中。
+
+## 4. PxlImporter（`Editor/` asmdef，ScriptedImporter）
+
+- `[ScriptedImporter(1, "pxl")]`。解析 → 每节构建 `Texture2D`（`FilterMode.Point`、RGBA32、不压缩、`alphaIsTransparency`）→ `Sprite.Create(tex, rect, pivot:center, ppu, extrude:0, FullRect, border)` 挂为 sub-asset。
+- **资产结构**：每节一张独立 Texture2D（节间尺寸可异，不拼 sheet）。单节文件 main asset = 该 Texture2D；多节文件 main asset = 首节 Texture2D，其余节的 Texture2D + Sprite 全部 `ctx.AddObjectToAsset`。这样 `FindAssets("t:Texture2D", folders)` 必然可发现（main asset 类型）。
+- **解析器**与 importer 同置 `Editor/`（纯 C# 内部类，便于 EditorOnly 单测直测）；错误用 `ctx.LogImportError` 携带行号 + 期望/实际描述，LLM 读 Console/lint 输出可直接定位修订。
+- 导入产物随 Library 进 Player 构建（同 Aseprite importer 模式），**运行时零新增代码**。
+
+## 5. 现有管线对接（改动面）
+
+| 处 | 改动 |
+|---|---|
+| `SpriteAtlasSyncer` key 派生 | "去 `.png`" 泛化为"去扩展名"；`.pxl` 多节文件按 sub-asset Sprite 枚举，key 加 `/节名` 段 |
+| `SpriteAtlasSyncer` 收集 | 既有 `FindAssets("t:Texture2D", folders)` 天然命中 `.pxl` main asset；多节需补 `LoadAllAssetsAtPath` 取全部 Sprite sub-assets |
+| `ResetTextureImportSettings` 等 TextureImporter-only 操作 | 已有 importer 类型 guard（MF-D1b 同款，`is not TextureImporter` 跳过）——预计零改动，补测试钉死 |
+| `SpriteSet.entries` / `<Icon>` / `<Image>` / 9-slice 消费端 | 零改动（只认 Sprite 引用） |
+| `SpriteAtlasAutoSync` | `.pxl` 重导入产生的 Sprite 变化应触发既有 auto-sync 路径；验证 + 必要时把 `.pxl` 扩展名加进监听 |
+
+## 6. 测试
+
+- **解析器**（EditorOnly，直测内部类）：格式全集（单/多节、palette 引用/内联/混合、border、ppu 缺省）+ 错误路径（行宽不齐、未知字符、越板 hex、重复节名、palette 缺失/重名、保留字符 `.` 被重定义）。
+- **Importer 集成**（EditorOnly，temp 文件夹 + AssetDatabase）：资产结构（main/sub）、Sprite border/PPU 正确、`.gpl` 修改触发依赖重导入。
+- **Syncer**（EditorOnly）：`.pxl` 单/多节 key 派生、与 PNG 混放同一 sourceFolder、`ResetTextureImportSettings` 跳过 `.pxl`。
+
+## 7. 文档（SKILL）
+
+- 新增 LLM authoring skill：`.claude/skills/authoring-promptugui-pxl/SKILL.md`——格式语法 + 像素画作画守则（1px 勾线、限色、9-slice 角区设计、按钮三态明度阶梯等）+ `.gpl` 调色板约定。
+- `authoring-promptugui-xml/reference/icons.md` 加指针（`.pxl` 也是 SpriteSet 的合法来源）。
+
+## 8. 范围外（本次不做）
+
+- **大图对齐修正工具**（生图模型输出的"假像素图"网格检测 + 主导色重采样 + 调色板量化）——独立 milestone，与本设计仅共享"落盘进 sourceFolder"约定。
+- PNG 导出逃生口（右键 Export as PNG，供美术接手精修）。
+- 动画 / 多帧 / sprite sheet。
+- SVG 路线（已否决，见 §1.2）。
+- 运行时动态解析 `.pxl`（importer 是 Editor-only，运行时只见成品 Sprite）。

--- a/docs~/superpowers/specs/2026-06-11-pxl-pixel-sprite-importer-design.md
+++ b/docs~/superpowers/specs/2026-06-11-pxl-pixel-sprite-importer-design.md
@@ -34,15 +34,19 @@ LLM 写下一个 `.pxl` 文件放进 SpriteSet sourceFolder → Unity 自动导�
 ## 2. `.pxl` 文件格式
 
 ```
-palette: @main              # 可选；引用项目级 main.gpl。省略 = 纯内联模式
-ppu: 16                     # 可选；缺省 100（Unity TextureImporter 惯例值）
+# 注释仅支持整行（trim 后以 # 开头）；行尾注释不可用
+# palette: 可选；引用项目级 main.gpl。省略 = 纯内联模式
+palette: @main
+# ppu: 可选；缺省 100（Unity TextureImporter 惯例值）
+ppu: 16
 chars:
   .: transparent
-  K: dark-blue              # @palette 模式：按 .gpl 内颜色名引用
-  W: #f4f4f4                # 内联 hex；palette 模式下 hex 必须存在于色板，否则 import error
+  K: dark-blue
+  W: #f4f4f4
 
 [normal]
-border: 4,4,4,4             # 可选，9-slice（L,B,R,T 同 Unity Sprite border 序）；每节独立
+# border: 可选，9-slice（L,B,R,T 同 Unity Sprite border 序）；每节独立；须在 grid 前
+border: 4,4,4,4
 grid:
   ..KKKKKK..
   .KWWWWWWK.
@@ -59,7 +63,7 @@ grid:
 
 规则：
 
-- **网格**：单字符 = `chars` 中一项；`.` 固定为透明（保留字符）；每行宽度必须一致（不一致 = import error 报行号）；各节尺寸可不同。grid 行允许统一缩进（取首行缩进为基准剥除）。
+- **网格**：单字符 = `chars` 中一项；`.` 固定为透明（保留字符）；每行宽度必须一致（不一致 = import error 报行号）；各节尺寸可不同。grid 行首尾空白一律 trim（缩进随意，空格不是合法网格字符）；空行结束 grid 块。
 - **分节**：`[节名]` 起一节，节名限 `[A-Za-z0-9_-]+`。**单 sprite 文件可整体省略 `[节名]`**（隐式单节）。
 - **key 派生**（icon 名 / atlas key）：
   - 单节文件：`相对 sourceFolder 路径去扩展名`——与现有 PNG 规则一致（`Buttons/ok.pxl` → `Buttons/ok`，不冲突时另补裸名别名 `ok`）。

--- a/install_for_claude.md
+++ b/install_for_claude.md
@@ -31,10 +31,11 @@
 
 ## 步骤 2：复制 LLM Skills 到用户项目
 
-包内自带三个给 LLM 读的 skill，路径：
+包内自带四个给 LLM 读的 skill，路径：
 
 ```
 <project root>/Library/PackageCache/com.promptugui.core@<hash>/.claude/skills/authoring-promptugui-xml/SKILL.md      # XML 编写
+<project root>/Library/PackageCache/com.promptugui.core@<hash>/.claude/skills/authoring-promptugui-pxl/SKILL.md      # .pxl 像素图（9-slice 边框 / 按钮皮肤 / 图标的网格文本格式）
 <project root>/Library/PackageCache/com.promptugui.core@<hash>/.claude/skills/scripting-promptugui-csharp/SKILL.md   # C# bridge（UI.Open / Get<T> / R3 / BindItems / 自定义 Control）
 <project root>/Library/PackageCache/com.promptugui.core@<hash>/.claude/skills/using-promptugui-addressables/SKILL.md # Addressables 集成（.ui.xml / .po / IconSet）
 ```
@@ -59,7 +60,7 @@ Copy-Item -Recurse -Force `
 
 > 备选：如果用户希望这些 skill 跨所有项目可用，复制到 `~/.claude/skills/` 而不是项目内 `.claude/skills/`。默认推荐项目作用域。
 
-**验证**：确认 `.claude/skills/` 下 `authoring-promptugui-xml/`、`scripting-promptugui-csharp/`、`using-promptugui-addressables/` 三个目录都存在，每个目录里的 `SKILL.md` 第 1 行都是 `---`（YAML frontmatter 起始）。
+**验证**：确认 `.claude/skills/` 下 `authoring-promptugui-xml/`、`authoring-promptugui-pxl/`、`scripting-promptugui-csharp/`、`using-promptugui-addressables/` 四个目录都存在，每个目录里的 `SKILL.md` 第 1 行都是 `---`（YAML frontmatter 起始）。
 
 ## 步骤 3：注入项目级 CLAUDE.md 约定
 
@@ -97,13 +98,13 @@ Copy-Item -Recurse -Force `
 依次确认：
 
 1. ✓ `Library/PackageCache/com.promptugui.core@<hash>/Runtime/` 存在
-2. ✓ `.claude/skills/` 下 `authoring-promptugui-xml/`、`scripting-promptugui-csharp/`、`using-promptugui-addressables/` 三个 SKILL.md 都存在，frontmatter 完整
+2. ✓ `.claude/skills/` 下 `authoring-promptugui-xml/`、`authoring-promptugui-pxl/`、`scripting-promptugui-csharp/`、`using-promptugui-addressables/` 四个 SKILL.md 都存在，frontmatter 完整
 3. ✓ `CLAUDE.md` 含 Tr() 包裹约定章节，原内容保留
 4. ✓ 检查 `dotnet --list-sdks` 是否安装了 10 版本。
 5. ✓ （可选）`mcp__UnityMCP__refresh_unity(compile="request", mode="standard")` 后 `mcp__UnityMCP__read_console(action="get", types=["error"])` 无编译错误
 6. ✓ （可选）检查`xmllint`是否可执行，提醒用户安装
 
-全部通过即安装完成。下次会话 Claude Code 会自动加载 `CLAUDE.md`；用户编辑 `.ui.xml` 时 `authoring-promptugui-xml` 触发，写 C# 调用 `UI.*` 时 `scripting-promptugui-csharp` 触发，集成 Unity Addressables 时 `using-promptugui-addressables` 触发。
+全部通过即安装完成。下次会话 Claude Code 会自动加载 `CLAUDE.md`；用户编辑 `.ui.xml` 时 `authoring-promptugui-xml` 触发，创建/编辑 `.pxl` 像素图（9-slice 边框、按钮皮肤、图标）时 `authoring-promptugui-pxl` 触发，写 C# 调用 `UI.*` 时 `scripting-promptugui-csharp` 触发，集成 Unity Addressables 时 `using-promptugui-addressables` 触发。
 
 ## 升级 / 卸载
 
@@ -111,5 +112,5 @@ Copy-Item -Recurse -Force `
 
 **卸载**：
 1. 从 `manifest.json` 删除 `com.promptugui.core`
-2. 删除 `.claude/skills/authoring-promptugui-xml/`、`.claude/skills/scripting-promptugui-csharp/`、`.claude/skills/using-promptugui-addressables/`
+2. 删除 `.claude/skills/authoring-promptugui-xml/`、`.claude/skills/authoring-promptugui-pxl/`、`.claude/skills/scripting-promptugui-csharp/`、`.claude/skills/using-promptugui-addressables/`
 3. 从 `CLAUDE.md` 删除 `## i18n: Tr() 包裹约定` 章节（如果项目里别的库也共用同名约定，保留）


### PR DESCRIPTION
## Summary

打通"LLM 生成界面图像资产"链路的小件部分（spec: `docs~/superpowers/specs/2026-06-11-pxl-pixel-sprite-importer-design.md`）：

- **`.pxl` 文本格式**：XPM 惯用法字符网格（单字符=色板项、`.`=透明）+ 文件级 `palette/ppu/chars` 头 + `[节名]` 多 sprite 分节（按钮三态共享调色板一屏看全）；`border: L,B,R,T` 声明 9-slice。解析错误带行号，LLM 看 Console 直接修订。
- **`.gpl` 项目级调色板**（GIMP Palette 社区标准，Lospec 直接下载可用）：`palette: @main` 全项目唯一查找；palette 模式下越板 hex = import error（风格一致性管线强制）；改/增/删/移 `.gpl` 自动重导入所有依赖的 `.pxl`（`DependsOnSourceAsset` + `GplPostprocessor`）。
- **`PxlImporter`（Editor-only ScriptedImporter）**：每节一张 point-filter readable Texture2D + Sprite sub-asset（border/PPU 入 Sprite）；main asset = 首节贴图保证 `t:Texture2D` 可发现；运行时零新增代码。
- **`SpriteAtlasSyncer` 对接**：多节 key = `路径/节名`（隐式单节与 PNG 规则一致，裸名别名沿用既有唯一性提升）；纯 `.pxl` 文件夹建 atlas 自动 Point 兜底。`<Icon>`/`<Image>`/9-slice/图文混排消费端零改动。
- **新 authoring skill** `.claude/skills/authoring-promptugui-pxl/SKILL.md`（语法 + 像素画作画守则 + 错误表）+ `icons.md` 指针。

## Test Plan

- [x] EditorOnly 229/229（含新增 ~45：GplPalette 5 / PxlParser 15 / PxlColorResolver 11 / PxlImporter 8 / PxlSyncer 6）
- [x] EditMode 1595/1595、PlayMode 133/133（零回归）
- [x] host 工程端到端冒烟：`.pxl`+`.gpl` → 导入 → 像素/border/PPU/Point 断言 → `SyncAll` → entries（`panel/normal`、`panel/pressed` + 裸名别名）→ atlas Point → 清理，Console 无错误
- [x] `dotnet format --verify-no-changes` exit 0
- [ ] 用户视觉 QA：在 host 工程写一个真实 9-slice 按钮皮肤 `.pxl`，挂到界面上看拉伸效果

## 后续候选（不阻塞）

- SyncAll 重复 key（`.pxl` 节 vs 同名 PNG 路径）last-wins 静默——可加 warning/lint
- chars key 收紧硬拒 `[`/`]`（现为 SKILL 文档级约束）
- 大图对齐修正工具（生图模型"假像素图"→真低分辨率）为独立 milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)