### PR TITLE
feat: UI.Tutorial 新手引导系统 — 路径定位/挖洞遮罩/全屏拦截/断点续

### DIFF
--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -1228,6 +1228,22 @@ IReadOnlyList<string> chain = UI.Router.Chain;   // root→top, e.g. ["home","de
 UI.Router.Changed += () => Debug.Log(UI.Router.Current);  // event Action; fires after every reconcile
 ```
 
+### Navigation guards
+
+Register a predicate that vetoes navigation before it runs. Any guard returning `false` makes the next `Open` / `Navigate` / `Back` throw `NavigationRejectedException` **synchronously** — the chain is unchanged and `Changed` does not fire.
+
+```csharp
+// Block leaving the current screen while there are unsaved changes.
+Func<string, bool> guard = name => !HasUnsavedChanges;   // false → rejected
+UI.Router.AddGuard(guard);
+// ...later
+UI.Router.RemoveGuard(guard);   // removed by reference — keep the delegate instance
+```
+
+- The guard receives the **target route name**. Keep guards pure (no navigation side effects).
+- `AddGuard(null)` throws `ArgumentNullException`. Guards are cleared on `UI.ResetForTests()`.
+- The tutorial system (below) uses a guard internally to lock navigation for the duration of a `Run`.
+
 ### Four presentations
 
 | Kind | Registration | What opens | Deactivated by |
@@ -1293,6 +1309,80 @@ UI.Router.MapPrompt("confirm-delete", parent: "home", run: async (q, ct) =>
 ```
 
 Navigating away while the dialog is open cancels `ct`, the dialog throws `OperationCanceledException`, and the Prompt exits cleanly.
+
+## Tutorial (onboarding / coach marks)
+
+`UI.Tutorial.Run` plays a step-by-step coach-mark sequence. Each step spotlights a control — a translucent full-screen mask with a hole punched over the target — shows a speech bubble + pointing finger, and blocks all other input (clicks **and** deep-link navigation) until the step is satisfied. Targets use the same `"screenName/idPath"` path as Toast (`UI.TryResolvePath`), so a step can point at any control in any open screen.
+
+### Progress persistence (optional)
+
+Register load/save delegates — where progress lives is the caller's concern (same philosophy as `SourceResolver`). Without them, every `Run` starts from the beginning.
+
+```csharp
+UI.Tutorial.UseProgressStore(
+    load: id => PlayerPrefs.GetInt("tut_" + id, 0),
+    save: (id, n) => PlayerPrefs.SetInt("tut_" + id, n));
+```
+
+### Running a sequence
+
+```csharp
+await UI.Tutorial.Run("first-purchase", async t =>
+{
+    await t.Step("main/shopBtn", text: "Tap here to open the shop");
+    await t.Step("shop/items/0/buyBtn", text: "Buy this one");
+    await t.Step(null, text: "Nice work!", advance: Advance.TapAnywhere);   // caption-only page
+    await t.Step("main/bagBtn", text: "Check your bag", mode: TutorialMode.Hint,
+                 advance: Advance.When(() => bagOpened));
+});
+```
+
+- `Run(id, body)` wraps the whole session: it creates the overlay, registers a navigation guard, and on completion **or** exception tears everything down (try/finally). It is globally exclusive — a nested/concurrent `Run` throws `InvalidOperationException`.
+- **Resume:** `Run` reads `load(id)` and fast-forwards already-completed steps (they complete instantly, no visuals). Each finished step saves `index+1`; the whole run saves `int.MaxValue` on success. Advancing the *game* state to the resume point is the script's job — use `t.Navigate(...)` between steps to set the stage (deep-link reconcile makes "already there" a no-op).
+- There is no `CancellationToken` and no built-in skip button in v1: a tutorial runs to completion or the process exits (and resumes next launch via the store).
+
+### `Step` parameters
+
+```csharp
+Awaitable Step(
+    string target,                          // "screenName/idPath"; null = caption-only (no hole/finger)
+    string text = null,                     // bubble text (goes through i18n); null = no bubble
+    TutorialMode mode = TutorialMode.Block, // Block = spotlight + input lock; Hint = bubble/finger only, no lock
+    Advance advance = default,              // default: target != null → TapTarget, else → TapAnywhere
+    Side place = Side.Auto,                 // bubble/finger side: Auto avoids screen edges, or Top/Bottom/Left/Right
+    float padding = 8f,                     // hole inset beyond the target rect (design units)
+    float timeout = -1f);                   // seconds to wait for the target to appear; -1 = forever
+```
+
+**Advance modes:**
+
+| `Advance` | Step completes when… |
+|---|---|
+| `Advance.TapTarget` | the user clicks the target control (default when `target != null`) |
+| `Advance.TapAnywhere` | the user clicks anywhere (default when `target == null`; requires `Block`) |
+| `Advance.When(() => bool)` | a predicate, polled each frame, returns true |
+| `Advance.Until(() => Awaitable)` | an awaitable you supply completes |
+
+- The target need not exist yet: the step waits (full-screen mask, no hole) until the path resolves, then opens the hole. If the target is destroyed mid-step (e.g. a list rebuild), the step returns to waiting. `timeout >= 0` makes waiting fail with `TimeoutException`.
+- The overlay follows the target **every frame**, so resize / orientation change / target animation track automatically.
+- `Hint` mode shows the bubble + finger but does **not** block input (the player may ignore it); the navigation lock still holds for the whole `Run`.
+
+### Navigating during a tutorial
+
+A `Run` locks the router (an internal reject-all guard), so any direct `UI.Router.Open` / `Navigate` throws `NavigationRejectedException`. To move between screens as part of the script, use `t.Navigate(...)` — it bypasses the guard for that one call:
+
+```csharp
+await UI.Tutorial.Run("intro", async t =>
+{
+    await t.Step("home/playBtn", text: "Start a match");
+    await t.Navigate("battle");                        // scripted nav — allowed past the lock
+    await t.Step("battle/skillBtn", text: "Use your skill");
+});
+```
+
+### Skinning
+
+The overlay is a built-in `.ui.xml` you can replace wholesale (same as the modals): set `UI.Tutorial.XmlSrc` to your own Resources path. The screen must expose ids `mask` (a `<Frame>` the mask renders into), `bubbleRoot`, `bubble`, `bubbleText`, and `finger`. Also tunable: `UI.Tutorial.MaskColor` (default `"#000000B0"`) and `UI.Tutorial.SortingOrder` (default `3000`, above modals and toasts). `UI.Tutorial.IsActive` reports whether a tutorial is currently running.
 
 ## `<Trigger>` and `<Animation>` from C#
 

--- a/Runtime/Application/Router/NavigationRejectedException.cs
+++ b/Runtime/Application/Router/NavigationRejectedException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace PromptUGUI.Application
+{
+    /// <summary>导航被 UI.Router.AddGuard 注册的 guard 拒绝。</summary>
+    public sealed class NavigationRejectedException : Exception
+    {
+        public string RouteName { get; }
+        public NavigationRejectedException(string routeName)
+            : base($"navigation to '{routeName}' rejected by guard")
+            => RouteName = routeName;
+    }
+}

--- a/Runtime/Application/Router/NavigationRejectedException.cs.meta
+++ b/Runtime/Application/Router/NavigationRejectedException.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0ad3be37e06ab634e87f601a7f691328

--- a/Runtime/Application/Tutorial.meta
+++ b/Runtime/Application/Tutorial.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b6dbc28fb5ed9514eaa3f2e37774d017
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Application/Tutorial/Side.cs
+++ b/Runtime/Application/Tutorial/Side.cs
@@ -1,0 +1,5 @@
+namespace PromptUGUI.Application
+{
+    /// <summary>引导气泡/手指相对目标的方位。Auto = 自动避让选剩余空间最大的一侧。</summary>
+    public enum Side { Auto, Top, Bottom, Left, Right }
+}

--- a/Runtime/Application/Tutorial/Side.cs.meta
+++ b/Runtime/Application/Tutorial/Side.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fd5a7a5652313094ea70d09183d33d90

--- a/Runtime/Application/Tutorial/SpotlightMask.cs
+++ b/Runtime/Application/Tutorial/SpotlightMask.cs
@@ -63,6 +63,8 @@ namespace PromptUGUI.Application.Tutorial
         }
 
         // —— 测试钩子 —— //
+        internal Rect? HoleForTests => _hole;
+
         internal bool HitTestForTests(Vector2 local) => HitTest(local);
 
         internal int PopulateMeshVertexCountForTests()

--- a/Runtime/Application/Tutorial/SpotlightMask.cs
+++ b/Runtime/Application/Tutorial/SpotlightMask.cs
@@ -1,0 +1,73 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Application.Tutorial
+{
+    /// <summary>
+    /// 引导挖洞遮罩(spec §5.2):洞外四块环形带渲染遮罩色并拦截 raycast,
+    /// 洞内不渲染、IsRaycastLocationValid 返回 false → 点击穿透到下层真实控件。
+    /// 不用 shader/stencil,WebGL 安全。
+    /// </summary>
+    internal sealed class SpotlightMask : MaskableGraphic, ICanvasRaycastFilter
+    {
+        private Rect? _hole;   // 本地坐标(pivot 居中)
+
+        /// <summary>null = 无洞(整屏遮罩,纯说明页/等待目标期)。</summary>
+        public void SetHole(Rect? holeInLocalSpace)
+        {
+            _hole = holeInLocalSpace;
+            SetVerticesDirty();
+        }
+
+        public bool IsRaycastLocationValid(Vector2 screenPoint, Camera eventCamera)
+        {
+            if (!RectTransformUtility.ScreenPointToLocalPointInRectangle(
+                    rectTransform, screenPoint, eventCamera, out var local))
+                return false;
+            return HitTest(local);
+        }
+
+        private bool HitTest(Vector2 local) => !(_hole.HasValue && _hole.Value.Contains(local));
+
+        protected override void OnPopulateMesh(VertexHelper vh)
+        {
+            vh.Clear();
+            var r = GetPixelAdjustedRect();
+            if (_hole == null) { AddQuad(vh, r.xMin, r.yMin, r.xMax, r.yMax); return; }
+
+            // 洞夹紧到自身 rect,四块环形带:上、下、左、右(左右带只到洞的上下沿)
+            var h = _hole.Value;
+            float hx0 = Mathf.Max(h.xMin, r.xMin), hx1 = Mathf.Min(h.xMax, r.xMax);
+            float hy0 = Mathf.Max(h.yMin, r.yMin), hy1 = Mathf.Min(h.yMax, r.yMax);
+            if (hx1 <= hx0 || hy1 <= hy0) { AddQuad(vh, r.xMin, r.yMin, r.xMax, r.yMax); return; }
+
+            AddQuad(vh, r.xMin, hy1, r.xMax, r.yMax);   // 上
+            AddQuad(vh, r.xMin, r.yMin, r.xMax, hy0);   // 下
+            AddQuad(vh, r.xMin, hy0, hx0, hy1);         // 左
+            AddQuad(vh, hx1, hy0, r.xMax, hy1);         // 右
+        }
+
+        private void AddQuad(VertexHelper vh, float x0, float y0, float x1, float y1)
+        {
+            if (x1 <= x0 || y1 <= y0) return;   // 退化带跳过
+            int i = vh.currentVertCount;
+            var c = color;
+            vh.AddVert(new Vector3(x0, y0), c, Vector2.zero);
+            vh.AddVert(new Vector3(x0, y1), c, Vector2.zero);
+            vh.AddVert(new Vector3(x1, y1), c, Vector2.zero);
+            vh.AddVert(new Vector3(x1, y0), c, Vector2.zero);
+            vh.AddTriangle(i, i + 1, i + 2);
+            vh.AddTriangle(i + 2, i + 3, i);
+        }
+
+        // —— 测试钩子 —— //
+        internal bool HitTestForTests(Vector2 local) => HitTest(local);
+
+        internal int PopulateMeshVertexCountForTests()
+        {
+            using var vh = new VertexHelper();
+            OnPopulateMesh(vh);
+            return vh.currentVertCount;
+        }
+    }
+}

--- a/Runtime/Application/Tutorial/SpotlightMask.cs
+++ b/Runtime/Application/Tutorial/SpotlightMask.cs
@@ -27,6 +27,8 @@ namespace PromptUGUI.Application.Tutorial
             return HitTest(local);
         }
 
+        // 命中测试用未夹紧的 _hole(网格用夹紧版):洞恒为 目标 rect+padding,与本 rect 同属
+        // overlay 画布、必然相交,故不存在"完全在 rect 外"的洞 → 二者不会分歧。
         private bool HitTest(Vector2 local) => !(_hole.HasValue && _hole.Value.Contains(local));
 
         protected override void OnPopulateMesh(VertexHelper vh)

--- a/Runtime/Application/Tutorial/SpotlightMask.cs.meta
+++ b/Runtime/Application/Tutorial/SpotlightMask.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7a7c297834138a142ba4382b142a22b0

--- a/Runtime/Application/Tutorial/TutorialClickRelay.cs
+++ b/Runtime/Application/Tutorial/TutorialClickRelay.cs
@@ -1,0 +1,17 @@
+using System;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace PromptUGUI.Application.Tutorial
+{
+    /// <summary>
+    /// 临时挂到目标 GO(TapTarget)或 mask GO(TapAnywhere)的点击转发器,步骤结束移除。
+    /// 与 GO 上既有 Button 等 IPointerClickHandler 并存(uGUI 对命中 GO 上所有 handler 逐个执行)。
+    /// </summary>
+    internal sealed class TutorialClickRelay : MonoBehaviour, IPointerClickHandler
+    {
+        internal Action OnClicked;
+        public void OnPointerClick(PointerEventData _) => OnClicked?.Invoke();
+        internal void FireForTests() => OnClicked?.Invoke();
+    }
+}

--- a/Runtime/Application/Tutorial/TutorialClickRelay.cs.meta
+++ b/Runtime/Application/Tutorial/TutorialClickRelay.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 86bd1f027f7272b4fb0b75351f4adac4

--- a/Runtime/Application/Tutorial/TutorialFlow.cs
+++ b/Runtime/Application/Tutorial/TutorialFlow.cs
@@ -1,0 +1,90 @@
+using System;
+using UnityEngine;
+
+namespace PromptUGUI.Application
+{
+    public enum TutorialMode { Block, Hint }
+
+    public readonly struct Advance
+    {
+        internal enum Kind { Default = 0, TapTargetK, TapAnywhereK, WhenK, UntilK }
+        internal readonly Kind K;
+        internal readonly Func<bool> Predicate;
+        internal readonly Func<Awaitable> Condition;
+        private Advance(Kind k, Func<bool> p, Func<Awaitable> c) { K = k; Predicate = p; Condition = c; }
+        public static Advance TapTarget => new(Kind.TapTargetK, null, null);
+        public static Advance TapAnywhere => new(Kind.TapAnywhereK, null, null);
+        public static Advance When(Func<bool> predicate) =>
+            new(Kind.WhenK, predicate ?? throw new ArgumentNullException(nameof(predicate)), null);
+        public static Advance Until(Func<Awaitable> condition) =>
+            new(Kind.UntilK, null, condition ?? throw new ArgumentNullException(nameof(condition)));
+    }
+
+    /// <summary>一次 UI.Tutorial.Run 的会话句柄；Step 顺序编号，支撑断点续。</summary>
+    public sealed class TutorialFlow
+    {
+        private readonly string _id;
+        private readonly int _resume;
+        private readonly Action<string, int> _save;
+        private int _stepIndex;
+
+        internal TutorialFlow(string id, int resume, Action<string, int> save)
+        { _id = id; _resume = resume; _save = save; }
+
+        public Awaitable Step(string target, string text = null,
+            TutorialMode mode = TutorialMode.Block, Advance advance = default,
+            Side place = Side.Auto, float padding = 8f, float timeout = -1f)
+        {
+            var kind = advance.K == Advance.Kind.Default
+                ? (target != null ? Advance.Kind.TapTargetK : Advance.Kind.TapAnywhereK)
+                : advance.K;
+            if (kind == Advance.Kind.TapTargetK && target == null)
+                throw new ArgumentException("Advance.TapTarget requires a target path");
+            if (kind == Advance.Kind.TapAnywhereK && mode == TutorialMode.Hint)
+                throw new ArgumentException("Advance.TapAnywhere requires TutorialMode.Block");
+
+            int index = _stepIndex++;
+            if (index < _resume) return AwaitableHelpers.Completed();   // fast-forward
+
+            return RunStep(index, new StepConfig
+            {
+                Target = target,
+                Text = text,
+                Mode = mode,
+                AdvanceKind = kind,
+                Predicate = advance.Predicate,
+                Condition = advance.Condition,
+                Place = place,
+                Padding = padding,
+                Timeout = timeout,
+            });
+        }
+
+        private async Awaitable RunStep(int index, StepConfig cfg)
+        {
+            var view = await UI.Tutorial.EnsureOverlay();
+            var acs = new AwaitableCompletionSource();
+            view.BeginStep(cfg, acs);
+            try { await acs.Awaitable; }
+            finally { view.EndStep(); }
+            _save?.Invoke(_id, index + 1);
+        }
+
+        public Awaitable Navigate(string name, RouteQuery query = null)
+        {
+            UI.Router.BypassGuardsOnce();
+            return UI.Router.Open(name, query);
+        }
+    }
+
+    internal struct StepConfig
+    {
+        public string Target, Text;
+        public TutorialMode Mode;
+        public Advance.Kind AdvanceKind;
+        public Func<bool> Predicate;
+        public Func<Awaitable> Condition;
+        public Side Place;
+        public float Padding, Timeout;
+    }
+}

--- a/Runtime/Application/Tutorial/TutorialFlow.cs.meta
+++ b/Runtime/Application/Tutorial/TutorialFlow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f74aecd8d23fab84fb6752ef3ccf90aa

--- a/Runtime/Application/Tutorial/TutorialOverlayView.cs
+++ b/Runtime/Application/Tutorial/TutorialOverlayView.cs
@@ -1,0 +1,177 @@
+using System;
+using PromptUGUI.Controls;
+using UnityEngine;
+
+namespace PromptUGUI.Application.Tutorial
+{
+    /// <summary>
+    /// overlay 视图 + 每步状态机：WaitTarget（整屏遮罩，逐 tick 解析路径，累计超时）
+    /// → Active（开洞、摆气泡手指、装推进监听、逐 tick 跟随/检活/轮询 When）
+    /// → 完成（acs.SetResult）或超时（acs.SetException）。
+    /// LateUpdate 调 Tick(unscaledDeltaTime)；EditMode 测试经 UI.Tutorial.TickForTests 手动驱动。
+    /// </summary>
+    internal sealed class TutorialOverlayView : MonoBehaviour
+    {
+        private const float FingerGap = 60f;        // 手指 + 间距
+        private const float FingerSpriteOffset = 180f;  // pugui_caret 本身朝下 → 抵消 TutorialPlacement 的“朝上”基准
+
+        internal SpotlightMask Mask;
+        private RectTransform _overlayRect, _bubbleRootRt, _bubbleRt, _fingerRt;
+        private Text _bubbleText;
+
+        private StepConfig _cfg;
+        private AwaitableCompletionSource _acs;
+        private bool _stepActive, _targetLive, _untilStarted;
+        private float _waited;
+        private RectTransform _targetRect;
+        private TutorialClickRelay _relay;
+
+        internal void Init(Screen screen)
+        {
+            Mask = screen.Get<IControl>("mask").GameObject.AddComponent<SpotlightMask>();
+            Mask.color = UI.Theme.Resolve(UI.Tutorial.MaskColor);
+            Mask.raycastTarget = true;
+            _overlayRect = screen.RootGameObject.GetComponent<RectTransform>();
+            _bubbleRootRt = screen.Get<IControl>("bubbleRoot").RectTransform;
+            _bubbleRt = screen.Get<IControl>("bubble").RectTransform;
+            _bubbleText = screen.Get<Text>("bubbleText");
+            _fingerRt = screen.Get<IControl>("finger").RectTransform;
+            _bubbleRootRt.gameObject.SetActive(false);
+        }
+
+        internal void BeginStep(StepConfig cfg, AwaitableCompletionSource acs)
+        {
+            _cfg = cfg; _acs = acs; _stepActive = true; _targetLive = false;
+            _waited = 0f; _untilStarted = false; _targetRect = null;
+            bool block = cfg.Mode == TutorialMode.Block;
+            Mask.enabled = block; Mask.raycastTarget = block;
+            Mask.SetHole(null);
+            ApplyBubbleText(cfg.Text);
+            if (cfg.Target == null) EnterActive(null);
+        }
+
+        internal void EndStep()
+        {
+            RemoveRelay();
+            _stepActive = false; _targetLive = false; _targetRect = null;
+            if (Mask != null) Mask.SetHole(null);
+            if (_bubbleRootRt != null) _bubbleRootRt.gameObject.SetActive(false);
+        }
+
+        internal void Tick(float dt)
+        {
+            if (!_stepActive) return;
+            if (!_targetLive && _cfg.Target != null)
+            {
+                if (UI.TryResolvePath(_cfg.Target, out _, out var rect)) EnterActive(rect);
+                else
+                {
+                    _waited += dt;
+                    if (_cfg.Timeout >= 0f && _waited > _cfg.Timeout)
+                        Fail(new TimeoutException(
+                            $"tutorial step target '{_cfg.Target}' not found within {_cfg.Timeout}s"));
+                    return;
+                }
+            }
+            if (_targetLive)
+            {
+                if (_cfg.Target != null && _targetRect == null) { LeaveActive(); return; }
+                if (_cfg.Target != null) UpdateVisuals();
+                if (_cfg.AdvanceKind == Advance.Kind.WhenK && _cfg.Predicate != null && _cfg.Predicate())
+                    Complete();
+            }
+        }
+
+        private void EnterActive(RectTransform rect)
+        {
+            _targetRect = rect; _targetLive = true; _waited = 0f;
+            if (_cfg.AdvanceKind == Advance.Kind.TapTargetK && rect != null)
+                _relay = AttachRelay(rect.gameObject);
+            else if (_cfg.AdvanceKind == Advance.Kind.TapAnywhereK)
+                _relay = AttachRelay(Mask.gameObject);
+            if (_cfg.AdvanceKind == Advance.Kind.UntilK && !_untilStarted)
+            { _untilStarted = true; _ = AwaitCondition(); }
+            if (_cfg.Target != null) UpdateVisuals(); else CenterBubble();
+        }
+
+        private void LeaveActive()
+        {
+            RemoveRelay(); _targetLive = false; _targetRect = null;
+            if (Mask != null) Mask.SetHole(null);
+        }
+
+        private void UpdateVisuals()
+        {
+            var local = WorldRectToLocal(_targetRect, _overlayRect);
+            var hole = new Rect(local.xMin - _cfg.Padding, local.yMin - _cfg.Padding,
+                local.width + 2f * _cfg.Padding, local.height + 2f * _cfg.Padding);
+            if (_cfg.Mode == TutorialMode.Block) Mask.SetHole(hole);
+            if (!_bubbleRootRt.gameObject.activeSelf) return;   // 无文案 → 不摆气泡/手指
+            var r = TutorialPlacement.Choose(_overlayRect.rect, local, _bubbleRt.rect.size,
+                FingerGap, _cfg.Place);
+            _bubbleRootRt.anchoredPosition = r.BubblePos;
+            _fingerRt.gameObject.SetActive(true);
+            _fingerRt.anchoredPosition = r.FingerPos - r.BubblePos;
+            _fingerRt.localEulerAngles = new Vector3(0f, 0f, r.FingerAngle + FingerSpriteOffset);
+        }
+
+        private void CenterBubble()
+        {
+            _bubbleRootRt.anchoredPosition = Vector2.zero;
+            _fingerRt.gameObject.SetActive(false);
+        }
+
+        private void ApplyBubbleText(string text)
+        {
+            bool show = !string.IsNullOrEmpty(text);
+            _bubbleRootRt.gameObject.SetActive(show);
+            if (show) _bubbleText.TextValue = text;
+        }
+
+        private async Awaitable AwaitCondition()
+        { try { await _cfg.Condition(); Complete(); } catch (Exception ex) { Fail(ex); } }
+
+        private TutorialClickRelay AttachRelay(GameObject go)
+        {
+            var r = go.AddComponent<TutorialClickRelay>();
+            r.OnClicked = Complete;
+            return r;
+        }
+
+        private void RemoveRelay()
+        {
+            if (_relay == null) return;
+            _relay.OnClicked = null;
+            if (UnityEngine.Application.isPlaying) Destroy(_relay); else DestroyImmediate(_relay);
+            _relay = null;
+        }
+
+        private void Complete() { if (_stepActive) { _stepActive = false; _acs.TrySetResult(); } }
+        private void Fail(Exception ex) { if (_stepActive) { _stepActive = false; _acs.TrySetException(ex); } }
+
+        private void LateUpdate() => Tick(Time.unscaledDeltaTime);
+
+        internal static Rect WorldRectToLocal(RectTransform target, RectTransform overlayRect)
+        {
+            var corners = new Vector3[4];
+            target.GetWorldCorners(corners);
+            var srcCanvas = target.GetComponentInParent<Canvas>();
+            Camera srcCam = srcCanvas != null ? srcCanvas.worldCamera : null;
+            var dstCanvas = overlayRect.GetComponentInParent<Canvas>();
+            Camera dstCam = dstCanvas != null ? dstCanvas.worldCamera : null;
+            Vector2 min = new(float.MaxValue, float.MaxValue), max = new(float.MinValue, float.MinValue);
+            for (int i = 0; i < 4; i++)
+            {
+                Vector2 sp = RectTransformUtility.WorldToScreenPoint(srcCam, corners[i]);
+                RectTransformUtility.ScreenPointToLocalPointInRectangle(overlayRect, sp, dstCam, out var lp);
+                min = Vector2.Min(min, lp); max = Vector2.Max(max, lp);
+            }
+            return Rect.MinMaxRect(min.x, min.y, max.x, max.y);
+        }
+
+        internal bool IsBlockingStep => _stepActive && _cfg.Mode == TutorialMode.Block;
+        internal bool BubbleRootActiveForTests => _bubbleRootRt != null && _bubbleRootRt.gameObject.activeSelf;
+        internal string BubbleTextForTests =>
+            _bubbleText != null && _bubbleText.TmpComponent != null ? _bubbleText.TmpComponent.text : null;
+    }
+}

--- a/Runtime/Application/Tutorial/TutorialOverlayView.cs
+++ b/Runtime/Application/Tutorial/TutorialOverlayView.cs
@@ -73,12 +73,18 @@ namespace PromptUGUI.Application.Tutorial
                     return;
                 }
             }
+            // 解析成功的同一 tick 故意不 return,继续往下:让激活当帧就为真的 When 谓词即时推进。
             if (_targetLive)
             {
                 if (_cfg.Target != null && _targetRect == null) { LeaveActive(); return; }
                 if (_cfg.Target != null) UpdateVisuals();
-                if (_cfg.AdvanceKind == Advance.Kind.WhenK && _cfg.Predicate != null && _cfg.Predicate())
-                    Complete();
+                if (_cfg.AdvanceKind == Advance.Kind.WhenK && _cfg.Predicate != null)
+                {
+                    bool done;
+                    try { done = _cfg.Predicate(); }
+                    catch (Exception ex) { Fail(ex); return; }   // 作者谓词抛错 → 一次性 Fail,不逐帧刷日志(与 Until 对齐)
+                    if (done) Complete();
+                }
             }
         }
 
@@ -151,10 +157,12 @@ namespace PromptUGUI.Application.Tutorial
 
         private void LateUpdate() => Tick(Time.unscaledDeltaTime);
 
+        // 每帧调用,复用同一数组避免 GC(Tick 主线程同步,无重入)。
+        private static readonly Vector3[] s_corners = new Vector3[4];
+
         internal static Rect WorldRectToLocal(RectTransform target, RectTransform overlayRect)
         {
-            var corners = new Vector3[4];
-            target.GetWorldCorners(corners);
+            target.GetWorldCorners(s_corners);
             var srcCanvas = target.GetComponentInParent<Canvas>();
             Camera srcCam = srcCanvas != null ? srcCanvas.worldCamera : null;
             var dstCanvas = overlayRect.GetComponentInParent<Canvas>();
@@ -162,7 +170,7 @@ namespace PromptUGUI.Application.Tutorial
             Vector2 min = new(float.MaxValue, float.MaxValue), max = new(float.MinValue, float.MinValue);
             for (int i = 0; i < 4; i++)
             {
-                Vector2 sp = RectTransformUtility.WorldToScreenPoint(srcCam, corners[i]);
+                Vector2 sp = RectTransformUtility.WorldToScreenPoint(srcCam, s_corners[i]);
                 RectTransformUtility.ScreenPointToLocalPointInRectangle(overlayRect, sp, dstCam, out var lp);
                 min = Vector2.Min(min, lp); max = Vector2.Max(max, lp);
             }

--- a/Runtime/Application/Tutorial/TutorialOverlayView.cs.meta
+++ b/Runtime/Application/Tutorial/TutorialOverlayView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cae1df9f205046d4fa39d39a54518d67

--- a/Runtime/Application/Tutorial/TutorialPlacement.cs
+++ b/Runtime/Application/Tutorial/TutorialPlacement.cs
@@ -1,0 +1,80 @@
+using UnityEngine;
+
+namespace PromptUGUI.Application.Tutorial
+{
+    /// <summary>
+    /// 气泡+手指四向避让(spec §5.3),全部在 overlay 本地坐标(中心原点)。
+    /// 纯函数,EditMode 可测。gap = 手指长度 + 间距,气泡中心 = 目标边缘 + gap + 半气泡。
+    /// </summary>
+    internal static class TutorialPlacement
+    {
+        internal readonly struct Result
+        {
+            public readonly Side Side;
+            public readonly Vector2 BubblePos;   // 气泡中心
+            public readonly Vector2 FingerPos;   // 手指中心(气泡与目标之间的 gap 中点)
+            public readonly float FingerAngle;   // Z 旋转;素材默认朝上(0°=指上)
+            public Result(Side s, Vector2 b, Vector2 f, float a)
+            { Side = s; BubblePos = b; FingerPos = f; FingerAngle = a; }
+        }
+
+        internal static Result Choose(Rect overlay, Rect target, Vector2 bubbleSize,
+            float gap, Side place)
+        {
+            if (place != Side.Auto) return Build(place, target, bubbleSize, gap, overlay);
+
+            Side best = Side.Top;
+            float bestScore = float.MinValue;
+            foreach (var s in new[] { Side.Top, Side.Bottom, Side.Left, Side.Right })
+            {
+                var r = Build(s, target, bubbleSize, gap, overlay);
+                var bubble = new Rect(r.BubblePos - bubbleSize / 2f, bubbleSize);
+                float overflow = Overflow(bubble, overlay);
+                // 零溢出里选剩余空间最大;有溢出则溢出最小
+                float room = s switch
+                {
+                    Side.Top => overlay.yMax - target.yMax,
+                    Side.Bottom => target.yMin - overlay.yMin,
+                    Side.Left => target.xMin - overlay.xMin,
+                    _ => overlay.xMax - target.xMax,
+                };
+                float score = overflow > 0f ? -1000f - overflow : room;
+                if (score > bestScore) { bestScore = score; best = s; }
+            }
+            return Build(best, target, bubbleSize, gap, overlay);
+        }
+
+        private static Result Build(Side s, Rect t, Vector2 b, float gap, Rect overlay)
+        {
+            Vector2 c = t.center, bubble, finger;
+            float angle;
+            switch (s)
+            {
+                case Side.Top:
+                    bubble = new Vector2(c.x, t.yMax + gap + b.y / 2f);
+                    finger = new Vector2(c.x, t.yMax + gap / 2f);
+                    angle = 180f; break;
+                case Side.Bottom:
+                    bubble = new Vector2(c.x, t.yMin - gap - b.y / 2f);
+                    finger = new Vector2(c.x, t.yMin - gap / 2f);
+                    angle = 0f; break;
+                case Side.Left:
+                    bubble = new Vector2(t.xMin - gap - b.x / 2f, c.y);
+                    finger = new Vector2(t.xMin - gap / 2f, c.y);
+                    angle = -90f; break;
+                default:   // Right
+                    bubble = new Vector2(t.xMax + gap + b.x / 2f, c.y);
+                    finger = new Vector2(t.xMax + gap / 2f, c.y);
+                    angle = 90f; break;
+            }
+            // 沿副轴夹紧让气泡不出屏(主轴出屏由 Auto 评分排除)
+            bubble.x = Mathf.Clamp(bubble.x, overlay.xMin + b.x / 2f, overlay.xMax - b.x / 2f);
+            bubble.y = Mathf.Clamp(bubble.y, overlay.yMin + b.y / 2f, overlay.yMax - b.y / 2f);
+            return new Result(s, bubble, finger, angle);
+        }
+
+        private static float Overflow(Rect r, Rect bounds) =>
+            Mathf.Max(0f, bounds.xMin - r.xMin) + Mathf.Max(0f, r.xMax - bounds.xMax)
+            + Mathf.Max(0f, bounds.yMin - r.yMin) + Mathf.Max(0f, r.yMax - bounds.yMax);
+    }
+}

--- a/Runtime/Application/Tutorial/TutorialPlacement.cs
+++ b/Runtime/Application/Tutorial/TutorialPlacement.cs
@@ -8,6 +8,8 @@ namespace PromptUGUI.Application.Tutorial
     /// </summary>
     internal static class TutorialPlacement
     {
+        private static readonly Side[] _autoOrder = { Side.Top, Side.Bottom, Side.Left, Side.Right };
+
         internal readonly struct Result
         {
             public readonly Side Side;
@@ -23,14 +25,12 @@ namespace PromptUGUI.Application.Tutorial
         {
             if (place != Side.Auto) return Build(place, target, bubbleSize, gap, overlay);
 
+            // Build 的双轴夹紧保证任意一侧气泡都不出屏,故选边只剩一个判据:
+            // 选目标与屏幕边之间剩余空间最大的一侧(平局取 _autoOrder 在前者 → Top)。
             Side best = Side.Top;
-            float bestScore = float.MinValue;
-            foreach (var s in new[] { Side.Top, Side.Bottom, Side.Left, Side.Right })
+            float bestRoom = float.MinValue;
+            foreach (var s in _autoOrder)
             {
-                var r = Build(s, target, bubbleSize, gap, overlay);
-                var bubble = new Rect(r.BubblePos - bubbleSize / 2f, bubbleSize);
-                float overflow = Overflow(bubble, overlay);
-                // 零溢出里选剩余空间最大;有溢出则溢出最小
                 float room = s switch
                 {
                     Side.Top => overlay.yMax - target.yMax,
@@ -38,8 +38,7 @@ namespace PromptUGUI.Application.Tutorial
                     Side.Left => target.xMin - overlay.xMin,
                     _ => overlay.xMax - target.xMax,
                 };
-                float score = overflow > 0f ? -1000f - overflow : room;
-                if (score > bestScore) { bestScore = score; best = s; }
+                if (room > bestRoom) { bestRoom = room; best = s; }
             }
             return Build(best, target, bubbleSize, gap, overlay);
         }
@@ -67,14 +66,11 @@ namespace PromptUGUI.Application.Tutorial
                     finger = new Vector2(t.xMax + gap / 2f, c.y);
                     angle = 90f; break;
             }
-            // 沿副轴夹紧让气泡不出屏(主轴出屏由 Auto 评分排除)
+            // 双轴夹紧气泡中心,使气泡恒不越过 overlay(由此每侧 overflow 必为 0,
+            // 选边判据简化为剩余空间最大,见 Choose)。
             bubble.x = Mathf.Clamp(bubble.x, overlay.xMin + b.x / 2f, overlay.xMax - b.x / 2f);
             bubble.y = Mathf.Clamp(bubble.y, overlay.yMin + b.y / 2f, overlay.yMax - b.y / 2f);
             return new Result(s, bubble, finger, angle);
         }
-
-        private static float Overflow(Rect r, Rect bounds) =>
-            Mathf.Max(0f, bounds.xMin - r.xMin) + Mathf.Max(0f, r.xMax - bounds.xMax)
-            + Mathf.Max(0f, bounds.yMin - r.yMin) + Mathf.Max(0f, r.yMax - bounds.yMax);
     }
 }

--- a/Runtime/Application/Tutorial/TutorialPlacement.cs.meta
+++ b/Runtime/Application/Tutorial/TutorialPlacement.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f652db82d9193a840892cb6e7a9efb92

--- a/Runtime/Application/UI.Modal.cs
+++ b/Runtime/Application/UI.Modal.cs
@@ -164,6 +164,7 @@ namespace PromptUGUI.Application
 
             private static void OnEscapePressed(Slot slot)
             {
+                if (Tutorial.IsBlockingInput) return;   // Block 引导期间吞 ESC(不关下层模态)
                 if (_stack.Count == 0 || _stack[_stack.Count - 1] != slot) return;
                 slot.Entry.TryEscape(() => OnEntryClosed(slot));
             }

--- a/Runtime/Application/UI.Router.Reconcile.cs
+++ b/Runtime/Application/UI.Router.Reconcile.cs
@@ -238,6 +238,7 @@ namespace PromptUGUI.Application
                     var captured = def.Name;
                     esc.OnEscape = () =>
                     {
+                        if (UI.Tutorial.IsBlockingInput) return;
                         // 只栈顶 routed modal 响应;有 ad-hoc 模态在上时让位给它
                         if (IsTop(captured) && !UI.Modal.IsAnyOpen) _ = Back();
                     };

--- a/Runtime/Application/UI.Router.Reconcile.cs
+++ b/Runtime/Application/UI.Router.Reconcile.cs
@@ -60,6 +60,7 @@ namespace PromptUGUI.Application
 
             public static Awaitable Open(string name, RouteQuery query = null)
             {
+                CheckGuards(name);
                 var tcs = new AwaitableCompletionSource();
                 _waiters.Add(tcs);
                 _pending = (name, query ?? RouteQuery.Empty);
@@ -364,6 +365,8 @@ namespace PromptUGUI.Application
             {
                 CancelAllForTeardown();
                 _routes.Clear();
+                _guards.Clear();
+                _bypassGuardsOnce = false;
                 Scheme = null;
                 Changed = null;
             }

--- a/Runtime/Application/UI.Router.cs
+++ b/Runtime/Application/UI.Router.cs
@@ -24,7 +24,7 @@ namespace PromptUGUI.Application
 
             public static void RemoveGuard(Func<string, bool> guard) => _guards.Remove(guard);
 
-            /// <summary>下一次 Open 跳过整条 guard 链并复位(Tutorial 内部导航用)。</summary>
+            /// <summary>下一次 Open 调用跳过整条 guard 链并复位(无论该 Open 成功与否;Tutorial 内部导航用)。</summary>
             internal static void BypassGuardsOnce() => _bypassGuardsOnce = true;
 
             private static void CheckGuards(string name)

--- a/Runtime/Application/UI.Router.cs
+++ b/Runtime/Application/UI.Router.cs
@@ -9,8 +9,30 @@ namespace PromptUGUI.Application
         {
             private static readonly Dictionary<string, RouteNode> _routes = new();
 
+            private static readonly List<Func<string, bool>> _guards = new();
+            private static bool _bypassGuardsOnce;
+
             /// <summary>Navigate(url) 校验的 scheme;null = 不校验(接受任意 scheme 或无 scheme)。</summary>
             public static string Scheme { get; set; }
+
+            /// <summary>导航前置守卫:任一返回 false → Open/Navigate/Back 抛 NavigationRejectedException。</summary>
+            public static void AddGuard(Func<string, bool> guard)
+            {
+                if (guard == null) throw new ArgumentNullException(nameof(guard));
+                _guards.Add(guard);
+            }
+
+            public static void RemoveGuard(Func<string, bool> guard) => _guards.Remove(guard);
+
+            /// <summary>下一次 Open 跳过整条 guard 链并复位(Tutorial 内部导航用)。</summary>
+            internal static void BypassGuardsOnce() => _bypassGuardsOnce = true;
+
+            private static void CheckGuards(string name)
+            {
+                if (_bypassGuardsOnce) { _bypassGuardsOnce = false; return; }
+                foreach (var g in _guards)
+                    if (!g(name)) throw new NavigationRejectedException(name);
+            }
 
             public static void Map(string name, string src, string screen = null,
                 RoutePresent present = RoutePresent.Page, string parent = null,

--- a/Runtime/Application/UI.Tutorial.cs
+++ b/Runtime/Application/UI.Tutorial.cs
@@ -21,6 +21,7 @@ namespace PromptUGUI.Application
             internal static TutorialFlow Active;
             private static TutorialOverlayView _view;
             private static string _overlayKey;
+            private static readonly Func<string, bool> _rejectAll = _ => false;
 
             public static bool IsActive => Active != null;
             internal static bool IsBlockingInput => _view != null && _view.IsBlockingStep;
@@ -43,6 +44,34 @@ namespace PromptUGUI.Application
             {
                 if (_overlayKey != null) UI.CloseModalScreen(_overlayKey);
                 _overlayKey = null; _view = null;
+            }
+
+            /// <summary>
+            /// 跑一段引导:body 内一步一 await。id 用于断点续(load/save 委托)。
+            /// 整段独占(重入抛 InvalidOperationException);try/finally 保证 guard 注销 + overlay 销毁。
+            /// </summary>
+            public static async Awaitable Run(string id, Func<TutorialFlow, Awaitable> body)
+            {
+                if (id == null) throw new ArgumentNullException(nameof(id));
+                if (body == null) throw new ArgumentNullException(nameof(body));
+                if (Active != null)
+                    throw new InvalidOperationException("UI.Tutorial.Run: a tutorial is already running");
+
+                int resume = _load?.Invoke(id) ?? 0;
+                var flow = new TutorialFlow(id, resume, _save);
+                Active = flow;
+                Router.AddGuard(_rejectAll);
+                try
+                {
+                    await body(flow);
+                    _save?.Invoke(id, int.MaxValue);   // 整段完成哨兵
+                }
+                finally
+                {
+                    Router.RemoveGuard(_rejectAll);
+                    DestroyOverlay();
+                    Active = null;
+                }
             }
 
             internal static void ResetForTestsInternal()

--- a/Runtime/Application/UI.Tutorial.cs
+++ b/Runtime/Application/UI.Tutorial.cs
@@ -18,9 +18,6 @@ namespace PromptUGUI.Application
             public static void UseProgressStore(Func<string, int> load, Action<string, int> save)
             { _load = load; _save = save; }
 
-            internal static Func<string, int> Load => _load;
-            internal static Action<string, int> Save => _save;
-
             internal static TutorialFlow Active;
             private static TutorialOverlayView _view;
             private static string _overlayKey;

--- a/Runtime/Application/UI.Tutorial.cs
+++ b/Runtime/Application/UI.Tutorial.cs
@@ -74,9 +74,18 @@ namespace PromptUGUI.Application
                 }
             }
 
+            // UI.UnloadAll 调用:抹掉进行中的 Run —— 注销内部 guard + 清状态(镜像 Run 的 finally)。
+            // overlay Screen 在 _open 里,由 UnloadAll/ResetForTests 的 _open 循环统一关。
+            internal static void CancelAllForTeardown()
+            {
+                Router.RemoveGuard(_rejectAll);   // 幂等:不在表里则 no-op
+                Active = null; _view = null; _overlayKey = null;
+            }
+
             internal static void ResetForTestsInternal()
             {
-                Active = null; _view = null; _overlayKey = null; _load = null; _save = null;
+                CancelAllForTeardown();
+                _load = null; _save = null;
                 // 复位作者可改的换肤静态,避免跨测试泄漏(同 MessageBox.XmlSrc 那类陷阱)。
                 XmlSrc = "PromptUGUI/Tutorial/TutorialOverlay.ui";
                 SortingOrder = 3000;

--- a/Runtime/Application/UI.Tutorial.cs
+++ b/Runtime/Application/UI.Tutorial.cs
@@ -1,0 +1,61 @@
+using System;
+using PromptUGUI.Application.Modals;
+using PromptUGUI.Application.Tutorial;
+using UnityEngine;
+
+namespace PromptUGUI.Application
+{
+    public static partial class UI
+    {
+        public static class Tutorial
+        {
+            public static string XmlSrc { get; set; } = "PromptUGUI/Tutorial/TutorialOverlay.ui";
+            public static int SortingOrder { get; set; } = 3000;   // > Toast(2000) > Modal(1000)
+            public static string MaskColor { get; set; } = "#000000B0";
+
+            private static Func<string, int> _load;
+            private static Action<string, int> _save;
+            public static void UseProgressStore(Func<string, int> load, Action<string, int> save)
+            { _load = load; _save = save; }
+
+            internal static Func<string, int> Load => _load;
+            internal static Action<string, int> Save => _save;
+
+            internal static TutorialFlow Active;
+            private static TutorialOverlayView _view;
+            private static string _overlayKey;
+
+            public static bool IsActive => Active != null;
+            internal static bool IsBlockingInput => _view != null && _view.IsBlockingStep;
+
+            internal static async Awaitable<TutorialOverlayView> EnsureOverlay()
+            {
+                if (_view != null) return _view;
+                await ModalDocCache.EnsureLoaded(XmlSrc);
+                var (screen, key) = UI.OpenModalScreen(XmlSrc);
+                _overlayKey = key;
+                var canvas = screen.RootGameObject.GetComponent<UnityEngine.Canvas>();
+                canvas.overrideSorting = true;
+                canvas.sortingOrder = SortingOrder;
+                _view = screen.RootGameObject.AddComponent<TutorialOverlayView>();
+                _view.Init(screen);
+                return _view;
+            }
+
+            internal static void DestroyOverlay()
+            {
+                if (_overlayKey != null) UI.CloseModalScreen(_overlayKey);
+                _overlayKey = null; _view = null;
+            }
+
+            internal static void ResetForTestsInternal()
+            { Active = null; _view = null; _overlayKey = null; _load = null; _save = null; }
+
+            // —— 测试钩子 —— //
+            internal static TutorialFlow BeginSessionForTests()
+            { var f = new TutorialFlow("test", 0, null); Active = f; return f; }
+            internal static void TickForTests(float dt) => _view?.Tick(dt);
+            internal static TutorialOverlayView ViewForTests => _view;
+        }
+    }
+}

--- a/Runtime/Application/UI.Tutorial.cs
+++ b/Runtime/Application/UI.Tutorial.cs
@@ -48,7 +48,7 @@ namespace PromptUGUI.Application
 
             /// <summary>
             /// 跑一段引导:body 内一步一 await。id 用于断点续(load/save 委托)。
-            /// 整段独占(重入抛 InvalidOperationException);try/finally 保证 guard 注销 + overlay 销毁。
+            /// 整段独占(重入抛 InvalidOperationException);try/finally 保证 guard 注销 + overlay 销毁 + Active 复位。
             /// </summary>
             public static async Awaitable Run(string id, Func<TutorialFlow, Awaitable> body)
             {
@@ -75,7 +75,13 @@ namespace PromptUGUI.Application
             }
 
             internal static void ResetForTestsInternal()
-            { Active = null; _view = null; _overlayKey = null; _load = null; _save = null; }
+            {
+                Active = null; _view = null; _overlayKey = null; _load = null; _save = null;
+                // 复位作者可改的换肤静态,避免跨测试泄漏(同 MessageBox.XmlSrc 那类陷阱)。
+                XmlSrc = "PromptUGUI/Tutorial/TutorialOverlay.ui";
+                SortingOrder = 3000;
+                MaskColor = "#000000B0";
+            }
 
             // —— 测试钩子 —— //
             internal static TutorialFlow BeginSessionForTests()

--- a/Runtime/Application/UI.Tutorial.cs.meta
+++ b/Runtime/Application/UI.Tutorial.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4493c556eeab92349b50a75cfe62611b

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -853,6 +853,7 @@ namespace PromptUGUI.Application
             Modal.CancelAllForTeardown();
             Modals.LoadingOverlay.CancelAllForTeardown();
             Toasts.ToastOverlay.CancelAllForTeardown();
+            Tutorial.CancelAllForTeardown();
             Modals.ModalDocCache.Clear();
             foreach (var s in _open.Values) s.Close();
             _open.Clear();

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -1017,6 +1017,7 @@ namespace PromptUGUI.Application
             Markdown.ResetForTestsInternal();
             TranslationStore.Instance.UnloadAll();
             Router.ResetForTestsInternal();
+            Tutorial.ResetForTestsInternal();
             Modal.CancelAllForTeardown();
             Modals.LoadingOverlay.CancelAllForTeardown();
             Toasts.ToastOverlay.CancelAllForTeardown();

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -784,8 +784,13 @@ namespace PromptUGUI.Application
         /// idPath 为空 → 该 Screen root。任一步未命中 → false（Toast 控件定位据此退回默认位）。
         /// </summary>
         internal static bool TryResolvePath(string path, out UnityEngine.RectTransform rect)
+            => TryResolvePath(path, out _, out rect);
+
+        /// <summary>同 TryResolvePath，但回传 IControl（path==screen 名时 control=null、rect=root）。</summary>
+        internal static bool TryResolvePath(string path, out PromptUGUI.Controls.IControl control,
+            out UnityEngine.RectTransform rect)
         {
-            rect = null;
+            control = null; rect = null;
             if (string.IsNullOrEmpty(path)) return false;
 
             string bestKey = null;
@@ -808,8 +813,8 @@ namespace PromptUGUI.Application
             string idPath = path.Substring(bestKey.Length + 1);
             try
             {
-                var ctl = screen.Get(idPath);
-                rect = ctl?.RectTransform;
+                control = screen.Get(idPath);
+                rect = control?.RectTransform;
                 return rect != null;
             }
             catch (System.Collections.Generic.KeyNotFoundException) { return false; }

--- a/Runtime/Resources/PromptUGUI/Tutorial.meta
+++ b/Runtime/Resources/PromptUGUI/Tutorial.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e508faac4d6618348bbee8dd6ea9f867
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Resources/PromptUGUI/Tutorial/TutorialOverlay.ui.xml
+++ b/Runtime/Resources/PromptUGUI/Tutorial/TutorialOverlay.ui.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PromptUGUI version="1">
+  <Screen name="PromptUGUI/Tutorial/TutorialOverlay.ui" reference="1920x1080" reference.portrait="1080x1920">
+    <!-- mask: 纯 RectTransform 容器(Frame 无 Graphic);C# 在其 GameObject 上挂 SpotlightMask
+         并按 UI.Tutorial.MaskColor 应用遮罩色。 -->
+    <Frame id="mask" anchor="stretch"/>
+    <!-- bubbleRoot: 气泡+手指容器,锚点居中(对齐 TutorialPlacement 的中心原点坐标系);C# 每帧摆位。 -->
+    <Frame id="bubbleRoot" anchor="center" size="0x0">
+      <Image id="bubble" anchor="center" size="300x100"
+             sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round" color="#222222EE">
+        <Text id="bubbleText" anchor="stretch" margin="16" fontSize="22" align="center" color="white"/>
+      </Image>
+      <!-- finger: 复用内置 caret(本身朝下);Task 5 视图按 FingerAngle+180 旋转使其指向目标。 -->
+      <Image id="finger" anchor="center" size="48x48"
+             sprite="PromptUGUI/Defaults/pugui.png#pugui_caret"/>
+    </Frame>
+  </Screen>
+</PromptUGUI>

--- a/Runtime/Resources/PromptUGUI/Tutorial/TutorialOverlay.ui.xml.meta
+++ b/Runtime/Resources/PromptUGUI/Tutorial/TutorialOverlay.ui.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d659736bcb8fd944badacf15d04de60a
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Router/RouterGuardTests.cs
+++ b/Tests/EditMode/Router/RouterGuardTests.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+
+namespace PromptUGUI.Tests.Router
+{
+    public class RouterGuardTests
+    {
+        private static string Xml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'>
+  <Image id='bg' anchor='stretch'/>
+</Screen></PromptUGUI>";
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            var files = new Dictionary<string, string>
+            { ["home"] = Xml("home"), ["shop"] = Xml("shop") };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+            UI.Router.Map("shop", "shop", parent: "home");
+        }
+
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Guard_ReturnsFalse_OpenThrows_ChainUnchanged_ChangedNotFired()
+        {
+            UI.Router.Open("home").GetAwaiter().GetResult();
+            int changed = 0;
+            UI.Router.Changed += () => changed++;
+            UI.Router.AddGuard(_ => false);
+
+            Assert.Throws<NavigationRejectedException>(
+                () => UI.Router.Open("shop").GetAwaiter().GetResult());
+            CollectionAssert.AreEqual(new[] { "home" }, UI.Router.Chain);
+            Assert.AreEqual(0, changed);
+        }
+
+        [Test]
+        public void Guard_ReceivesTargetName()
+        {
+            string seen = null;
+            UI.Router.AddGuard(n => { seen = n; return true; });
+            UI.Router.Open("shop").GetAwaiter().GetResult();
+            Assert.AreEqual("shop", seen);
+        }
+
+        [Test]
+        public void Guard_AllTrue_NavigationProceeds()
+        {
+            UI.Router.AddGuard(_ => true);
+            UI.Router.AddGuard(_ => true);
+            UI.Router.Open("shop").GetAwaiter().GetResult();
+            Assert.AreEqual("shop", UI.Router.Current);
+        }
+
+        [Test]
+        public void RemoveGuard_RestoresNavigation()
+        {
+            System.Func<string, bool> g = _ => false;
+            UI.Router.AddGuard(g);
+            UI.Router.RemoveGuard(g);
+            UI.Router.Open("shop").GetAwaiter().GetResult();
+            Assert.AreEqual("shop", UI.Router.Current);
+        }
+
+        [Test]
+        public void Guard_AlsoBlocks_NavigateUrl()
+        {
+            UI.Router.AddGuard(_ => false);
+            Assert.Throws<NavigationRejectedException>(
+                () => UI.Router.Navigate("shop").GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public void BypassGuardsOnce_AllowsExactlyOneNavigation()
+        {
+            UI.Router.AddGuard(_ => false);
+            UI.Router.BypassGuardsOnce();
+            UI.Router.Open("shop").GetAwaiter().GetResult();   // 放行一次
+            Assert.AreEqual("shop", UI.Router.Current);
+            Assert.Throws<NavigationRejectedException>(
+                () => UI.Router.Open("home").GetAwaiter().GetResult());   // 标记已复位
+        }
+
+        [Test]
+        public void ResetForTests_ClearsGuardsAndBypass()
+        {
+            UI.Router.AddGuard(_ => false);
+            UI.Router.BypassGuardsOnce();
+            UI.ResetForTests();
+            SetUp();   // 重建路由表
+            UI.Router.Open("shop").GetAwaiter().GetResult();   // 不再被拦
+            Assert.AreEqual("shop", UI.Router.Current);
+        }
+    }
+}

--- a/Tests/EditMode/Router/RouterGuardTests.cs
+++ b/Tests/EditMode/Router/RouterGuardTests.cs
@@ -59,6 +59,21 @@ namespace PromptUGUI.Tests.Router
         }
 
         [Test]
+        public void Guard_LaterGuardRejects_BlocksChain()
+        {
+            UI.Router.Open("home").GetAwaiter().GetResult();
+            UI.Router.AddGuard(_ => true);    // 先放行
+            UI.Router.AddGuard(_ => false);   // 后拒绝 → 整链被拦
+            Assert.Throws<NavigationRejectedException>(
+                () => UI.Router.Open("shop").GetAwaiter().GetResult());
+            CollectionAssert.AreEqual(new[] { "home" }, UI.Router.Chain);
+        }
+
+        [Test]
+        public void AddGuard_Null_Throws() =>
+            Assert.Throws<System.ArgumentNullException>(() => UI.Router.AddGuard(null));
+
+        [Test]
         public void RemoveGuard_RestoresNavigation()
         {
             System.Func<string, bool> g = _ => false;

--- a/Tests/EditMode/Router/RouterGuardTests.cs.meta
+++ b/Tests/EditMode/Router/RouterGuardTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 86a816fec1094604498f971a5ebc7561

--- a/Tests/EditMode/Tutorial.meta
+++ b/Tests/EditMode/Tutorial.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 46f22346046c8194cba0a7789c555cf8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Tutorial/SpotlightMaskTests.cs
+++ b/Tests/EditMode/Tutorial/SpotlightMaskTests.cs
@@ -1,0 +1,67 @@
+using NUnit.Framework;
+using PromptUGUI.Application.Tutorial;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Tests.Tutorial
+{
+    public class SpotlightMaskTests
+    {
+        private GameObject _canvasGo;
+        private SpotlightMask _mask;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _canvasGo = new GameObject("canvas", typeof(Canvas));
+            var go = new GameObject("mask", typeof(RectTransform));
+            go.transform.SetParent(_canvasGo.transform, false);
+            var rt = (RectTransform)go.transform;
+            rt.sizeDelta = new Vector2(800, 600);   // 本地坐标系:中心原点,±400/±300
+            _mask = go.AddComponent<SpotlightMask>();
+        }
+
+        [TearDown] public void TearDown() => Object.DestroyImmediate(_canvasGo);
+
+        [Test]
+        public void NoHole_BlocksEverywhere()
+        {
+            _mask.SetHole(null);
+            Assert.IsTrue(_mask.HitTestForTests(Vector2.zero));
+            Assert.IsTrue(_mask.HitTestForTests(new Vector2(390, 290)));
+        }
+
+        [Test]
+        public void Hole_PassesInside_BlocksOutside()
+        {
+            _mask.SetHole(new Rect(-50, -25, 100, 50));   // 中心 100x50 的洞
+            Assert.IsFalse(_mask.HitTestForTests(Vector2.zero));            // 洞内 → 穿透
+            Assert.IsFalse(_mask.HitTestForTests(new Vector2(49, 24)));     // 洞内边缘
+            Assert.IsTrue(_mask.HitTestForTests(new Vector2(51, 0)));       // 洞外
+            Assert.IsTrue(_mask.HitTestForTests(new Vector2(0, 26)));
+        }
+
+        [Test]
+        public void Mesh_NoHole_SingleQuad_4Verts()
+        {
+            _mask.SetHole(null);
+            Assert.AreEqual(4, _mask.PopulateMeshVertexCountForTests());
+        }
+
+        [Test]
+        public void Mesh_WithHole_FourBands_16Verts()
+        {
+            _mask.SetHole(new Rect(-50, -25, 100, 50));
+            Assert.AreEqual(16, _mask.PopulateMeshVertexCountForTests());
+        }
+
+        [Test]
+        public void Hole_ClampedToRect_DegenerateBandsSkipped()
+        {
+            // 洞超出整个 rect → 等效无遮挡区,但不得产出反向 quad
+            _mask.SetHole(new Rect(-1000, -1000, 2000, 2000));
+            Assert.AreEqual(0, _mask.PopulateMeshVertexCountForTests());
+            Assert.IsFalse(_mask.HitTestForTests(Vector2.zero));
+        }
+    }
+}

--- a/Tests/EditMode/Tutorial/SpotlightMaskTests.cs
+++ b/Tests/EditMode/Tutorial/SpotlightMaskTests.cs
@@ -63,5 +63,13 @@ namespace PromptUGUI.Tests.Tutorial
             Assert.AreEqual(0, _mask.PopulateMeshVertexCountForTests());
             Assert.IsFalse(_mask.HitTestForTests(Vector2.zero));
         }
+
+        [Test]
+        public void Hole_OverRightEdge_DropsRightBand_12Verts()
+        {
+            // 洞越过右缘 (xMax=450 > rect 400):右带退化被丢,留上/下/左三带
+            _mask.SetHole(new Rect(350, -25, 100, 50));
+            Assert.AreEqual(12, _mask.PopulateMeshVertexCountForTests());
+        }
     }
 }

--- a/Tests/EditMode/Tutorial/SpotlightMaskTests.cs.meta
+++ b/Tests/EditMode/Tutorial/SpotlightMaskTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f5095dae8635f6b49a657cd2dff8ad4e

--- a/Tests/EditMode/Tutorial/TutorialOverlaySmokeTests.cs
+++ b/Tests/EditMode/Tutorial/TutorialOverlaySmokeTests.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using PromptUGUI.Controls;
+
+namespace PromptUGUI.Tests.Tutorial
+{
+    public class TutorialOverlaySmokeTests
+    {
+        private const string Src = "PromptUGUI/Tutorial/TutorialOverlay.ui";
+
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Overlay_Loads_AndKeyIdsResolve()
+        {
+            ModalDocCache.EnsureLoaded(Src).GetAwaiter().GetResult();
+            var (screen, key) = UI.OpenModalScreen(Src);
+            try
+            {
+                Assert.IsNotNull(screen.Get<Frame>("mask"), "mask");
+                Assert.IsNotNull(screen.Get<Frame>("bubbleRoot"), "bubbleRoot");
+                Assert.IsNotNull(screen.Get<Image>("bubble"), "bubble");
+                Assert.IsNotNull(screen.Get<Text>("bubbleText"), "bubbleText");
+                Assert.IsNotNull(screen.Get<Image>("finger"), "finger");
+            }
+            finally { UI.CloseModalScreen(key); }
+        }
+    }
+}

--- a/Tests/EditMode/Tutorial/TutorialOverlaySmokeTests.cs.meta
+++ b/Tests/EditMode/Tutorial/TutorialOverlaySmokeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bb7b8c3bcbc93e247b82e13585182b7b

--- a/Tests/EditMode/Tutorial/TutorialPlacementTests.cs
+++ b/Tests/EditMode/Tutorial/TutorialPlacementTests.cs
@@ -41,6 +41,27 @@ namespace PromptUGUI.Tests.Tutorial
         }
 
         [Test]
+        public void Auto_TargetNearLeftEdge_PlacesRight()
+        {
+            // 竖屏 overlay,目标贴左缘 → Right 剩余空间最大(验证 room 的横轴分支)
+            var portrait = new Rect(-540, -960, 1080, 1920);
+            var target = new Rect(-520, -30, 60, 60);
+            var r = TutorialPlacement.Choose(portrait, target, Bubble, Gap, Side.Auto);
+            Assert.AreEqual(Side.Right, r.Side);
+            Assert.Greater(r.BubblePos.x, target.xMax);
+        }
+
+        [Test]
+        public void Build_BubblePos_ExactSpacing()
+        {
+            // 锁定间距公式:Top 气泡中心 y = target.yMax + gap + 半气泡;x 对齐目标中心
+            var target = new Rect(-50, -30, 100, 60);   // yMax = 30
+            var r = TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Top);
+            Assert.AreEqual(30f + Gap + Bubble.y / 2f, r.BubblePos.y, 1e-3f);
+            Assert.AreEqual(target.center.x, r.BubblePos.x, 1e-3f);
+        }
+
+        [Test]
         public void ExplicitPlace_Respected()
         {
             var target = new Rect(-50, -30, 100, 60);

--- a/Tests/EditMode/Tutorial/TutorialPlacementTests.cs
+++ b/Tests/EditMode/Tutorial/TutorialPlacementTests.cs
@@ -1,0 +1,72 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Tutorial;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Tutorial
+{
+    public class TutorialPlacementTests
+    {
+        private static readonly Rect Overlay = new(-960, -540, 1920, 1080);
+        private static readonly Vector2 Bubble = new(300, 100);
+        private const float Gap = 60f;   // 手指 + 间距占用
+
+        [Test]
+        public void Auto_TargetNearBottom_PlacesTop()
+        {
+            var target = new Rect(-50, -520, 100, 60);   // 贴近下边缘
+            var r = TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Auto);
+            Assert.AreEqual(Side.Top, r.Side);
+            Assert.Greater(r.BubblePos.y, target.yMax);
+        }
+
+        [Test]
+        public void Auto_TargetNearTop_PlacesBottom()
+        {
+            var target = new Rect(-50, 460, 100, 60);
+            var r = TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Auto);
+            Assert.AreEqual(Side.Bottom, r.Side);
+            Assert.Less(r.BubblePos.y, target.yMin);
+        }
+
+        [Test]
+        public void Auto_TargetNearRightEdge_NeverOverflows()
+        {
+            var target = new Rect(900, -30, 50, 60);   // 贴右缘,Right 放不下
+            var r = TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Auto);
+            Assert.AreNotEqual(Side.Right, r.Side);
+            // 气泡完全在 overlay 内
+            Assert.GreaterOrEqual(r.BubblePos.x - Bubble.x / 2, Overlay.xMin);
+            Assert.LessOrEqual(r.BubblePos.x + Bubble.x / 2, Overlay.xMax);
+        }
+
+        [Test]
+        public void ExplicitPlace_Respected()
+        {
+            var target = new Rect(-50, -30, 100, 60);
+            var r = TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Left);
+            Assert.AreEqual(Side.Left, r.Side);
+            Assert.Less(r.BubblePos.x, target.xMin);
+        }
+
+        [Test]
+        public void FingerAngle_PointsAtTarget()
+        {
+            var target = new Rect(-50, -30, 100, 60);
+            // 手指默认素材朝上;气泡在上方 → 手指在气泡与目标之间、旋转 180° 朝下指目标
+            Assert.AreEqual(180f, TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Top).FingerAngle);
+            Assert.AreEqual(0f, TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Bottom).FingerAngle);
+            Assert.AreEqual(90f, TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Right).FingerAngle);
+            Assert.AreEqual(-90f, TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Left).FingerAngle);
+        }
+
+        [Test]
+        public void FingerPos_BetweenBubbleAndTarget()
+        {
+            var target = new Rect(-50, -30, 100, 60);
+            var r = TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Top);
+            Assert.Greater(r.FingerPos.y, target.yMax);
+            Assert.Less(r.FingerPos.y, r.BubblePos.y - Bubble.y / 2);
+        }
+    }
+}

--- a/Tests/EditMode/Tutorial/TutorialPlacementTests.cs.meta
+++ b/Tests/EditMode/Tutorial/TutorialPlacementTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c320dcf7188602449b42362ef383d26a

--- a/Tests/EditMode/Tutorial/TutorialRunTests.cs
+++ b/Tests/EditMode/Tutorial/TutorialRunTests.cs
@@ -1,0 +1,168 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using PromptUGUI.Application.Tutorial;
+
+namespace PromptUGUI.Tests.Tutorial
+{
+    public class TutorialRunTests
+    {
+        private Dictionary<string, int> _store;
+
+        private static string Xml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'>
+  <Btn id='b' size='100x40'>x</Btn>
+</Screen></PromptUGUI>";
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            // MessageBox.XmlSrc 是可变静态字段;ModalTestFixture / RouterNavigateTests 等
+            // 会把它改到 "test/Box1" 之类且永不还原(ResetForTests 不复位它)。这里钉回内置
+            // 路径,让 EscDuringBlockStep_DoesNotCloseModal 不依赖跨 suite 的执行顺序。
+            MessageBox.XmlSrc = "PromptUGUI/Modals/MessageBox.ui";
+            _store = new Dictionary<string, int>();
+            UI.Tutorial.UseProgressStore(
+                id => _store.TryGetValue(id, out var v) ? v : 0,
+                (id, n) => _store[id] = n);
+            var files = new Dictionary<string, string> { ["home"] = Xml("home") };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+        }
+
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        // 驱动一个 Block+TapAnywhere(null target)步骤到完成
+        private static void ClickThrough()
+        {
+            UI.Tutorial.TickForTests(0.016f);
+            UI.Tutorial.ViewForTests.Mask
+                .GetComponent<TutorialClickRelay>().FireForTests();
+            UI.Tutorial.TickForTests(0.016f);
+        }
+
+        [Test]
+        public void Run_SavesProgressPerStep_AndSentinelOnFinish()
+        {
+            var run = UI.Tutorial.Run("t1", async t =>
+            {
+                await t.Step(null, text: "a");
+                await t.Step(null, text: "b");
+            });
+            Assert.IsTrue(UI.Tutorial.IsActive);
+            ClickThrough();
+            Assert.AreEqual(1, _store["t1"]);
+            ClickThrough();
+            run.GetAwaiter().GetResult();
+            Assert.AreEqual(int.MaxValue, _store["t1"]);
+            Assert.IsFalse(UI.Tutorial.IsActive);
+            Assert.IsNull(UI.Tutorial.ViewForTests);
+        }
+
+        [Test]
+        public void Run_Resume_FastForwardsCompletedSteps()
+        {
+            _store["t1"] = 1;
+            int shown = 0;
+            var run = UI.Tutorial.Run("t1", async t =>
+            {
+                await t.Step(null, text: "a"); shown++;
+                Assert.AreEqual(1, shown);
+                await t.Step(null, text: "b"); shown++;
+            });
+            ClickThrough();
+            run.GetAwaiter().GetResult();
+            Assert.AreEqual(2, shown);
+        }
+
+        [Test]
+        public void Run_Sentinel_WholeRunInstant_NoOverlay()
+        {
+            _store["t1"] = int.MaxValue;
+            UI.Tutorial.Run("t1", async t =>
+            {
+                await t.Step(null, text: "a");
+                await t.Step(null, text: "b");
+            }).GetAwaiter().GetResult();
+            Assert.IsNull(UI.Tutorial.ViewForTests, "全程 fast-forward 不应创建 overlay");
+        }
+
+        [Test]
+        public void Run_BlocksRouterNavigation_AndReleasesAfter()
+        {
+            var run = UI.Tutorial.Run("t1", async t => await t.Step(null, text: "a"));
+            Assert.Throws<NavigationRejectedException>(
+                () => UI.Router.Open("home").GetAwaiter().GetResult());
+            ClickThrough();
+            run.GetAwaiter().GetResult();
+            UI.Router.Open("home").GetAwaiter().GetResult();
+            Assert.AreEqual("home", UI.Router.Current);
+        }
+
+        [Test]
+        public void Flow_Navigate_BypassesGuard()
+        {
+            var run = UI.Tutorial.Run("t1", async t =>
+            {
+                await t.Navigate("home");
+                await t.Step(null, text: "a");
+            });
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.AreEqual("home", UI.Router.Current);
+            ClickThrough();
+            run.GetAwaiter().GetResult();
+        }
+
+        [Test]
+        public void Run_BodyThrows_GuardRemoved_OverlayDestroyed()
+        {
+            var run = UI.Tutorial.Run("t1",
+                t => throw new System.InvalidOperationException("boom"));
+            Assert.Throws<System.InvalidOperationException>(() => run.GetAwaiter().GetResult());
+            Assert.IsFalse(UI.Tutorial.IsActive);
+            Assert.IsNull(UI.Tutorial.ViewForTests);
+            UI.Router.Open("home").GetAwaiter().GetResult();
+            Assert.AreEqual("home", UI.Router.Current);
+        }
+
+        [Test]
+        public void Run_Reentry_Throws()
+        {
+            var run = UI.Tutorial.Run("t1", async t => await t.Step(null, text: "a"));
+            Assert.Throws<System.InvalidOperationException>(
+                () => UI.Tutorial.Run("t2", async t => await t.Step(null, text: "a")).GetAwaiter().GetResult());
+            ClickThrough();
+            run.GetAwaiter().GetResult();
+        }
+
+        [Test]
+        public void Run_NoStore_AlwaysFromScratch()
+        {
+            UI.ResetForTests();
+            UI.SourceResolver = src => AwaitableHelpers.Completed<string>(null);
+            var run = UI.Tutorial.Run("t1", async t => await t.Step(null, text: "a"));
+            Assert.IsTrue(UI.Tutorial.IsActive);
+            ClickThrough();
+            run.GetAwaiter().GetResult();
+        }
+
+        [Test]
+        public void EscDuringBlockStep_DoesNotCloseModal()
+        {
+            var run = UI.Tutorial.Run("t1", async t => await t.Step(null, text: "a"));
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsTrue(UI.Tutorial.IsBlockingInput);
+            _ = MessageBox.Open("hi");   // ad-hoc 模态(不 await)
+            var listener = UI.Modal.TopScreen.RootGameObject.GetComponent<ModalEscapeListener>();
+            Assert.IsNotNull(listener);
+            listener.FireForTests();
+            Assert.IsTrue(UI.Modal.IsAnyOpen, "Block 引导期间 ESC 不得关掉模态");
+            UI.Tutorial.ViewForTests.Mask.GetComponent<TutorialClickRelay>().FireForTests();
+            run.GetAwaiter().GetResult();
+        }
+    }
+}

--- a/Tests/EditMode/Tutorial/TutorialRunTests.cs
+++ b/Tests/EditMode/Tutorial/TutorialRunTests.cs
@@ -151,6 +151,23 @@ namespace PromptUGUI.Tests.Tutorial
         }
 
         [Test]
+        public void UnloadAll_MidRun_ClearsActive_AndReleasesGuard()
+        {
+            var run = UI.Tutorial.Run("t1", async t => await t.Step(null, text: "a"));
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsTrue(UI.Tutorial.IsActive);
+
+            UI.UnloadAll();   // 生产 teardown 路径(区别于 ResetForTests)
+
+            Assert.IsFalse(UI.Tutorial.IsActive, "UnloadAll 应清掉进行中的引导");
+            Assert.IsNull(UI.Tutorial.ViewForTests);
+            // _rejectAll guard 应已注销 → 导航不再被拒(home 路由 + resolver 在 UnloadAll 后仍在)
+            UI.Router.Open("home").GetAwaiter().GetResult();
+            Assert.AreEqual("home", UI.Router.Current);
+            _ = run;   // 挂起的 Run 被 teardown 抹掉,不 await
+        }
+
+        [Test]
         public void EscDuringBlockStep_DoesNotCloseModal()
         {
             var run = UI.Tutorial.Run("t1", async t => await t.Step(null, text: "a"));

--- a/Tests/EditMode/Tutorial/TutorialRunTests.cs.meta
+++ b/Tests/EditMode/Tutorial/TutorialRunTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 06fcb347b38e4472884572ab1b918e7f

--- a/Tests/EditMode/Tutorial/TutorialStepTests.cs
+++ b/Tests/EditMode/Tutorial/TutorialStepTests.cs
@@ -1,0 +1,175 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Tutorial;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Tutorial
+{
+    public class TutorialStepTests
+    {
+        private const string MainXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='main'>
+  <Btn id='shopBtn' size='200x80'>Shop</Btn>
+</Screen></PromptUGUI>";
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            UI.SourceResolver = src => AwaitableHelpers.Completed(src == "main" ? MainXml : null);
+        }
+
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static TutorialFlow BeginFlow() => UI.Tutorial.BeginSessionForTests();
+
+        [Test]
+        public void Step_TargetNotResolvable_StaysPending_NoHole()
+        {
+            var flow = BeginFlow();
+            var step = flow.Step("main/shopBtn", text: "hi");
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsFalse(step.GetAwaiter().IsCompleted);
+            Assert.IsNull(UI.Tutorial.ViewForTests.Mask.HoleForTests);
+        }
+
+        [Test]
+        public void Step_TargetAppears_HoleOpens_AndTapTargetAdvances()
+        {
+            var flow = BeginFlow();
+            var step = flow.Step("main/shopBtn", text: "hi");
+            UI.Tutorial.TickForTests(0.016f);
+
+            UI.LoadDocumentAsync("main").GetAwaiter().GetResult();
+            UI.Open("main");
+            UI.Tutorial.TickForTests(0.016f);
+
+            Assert.IsNotNull(UI.Tutorial.ViewForTests.Mask.HoleForTests);
+            var relay = UI.Get("main").Get<PromptUGUI.Controls.Btn>("shopBtn")
+                .GameObject.GetComponent<TutorialClickRelay>();
+            Assert.IsNotNull(relay, "TapTarget 应在目标 GO 挂 relay");
+            relay.FireForTests();
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsTrue(step.GetAwaiter().IsCompleted);
+        }
+
+        [Test]
+        public void Step_Timeout_Throws()
+        {
+            var flow = BeginFlow();
+            var step = flow.Step("main/missing", timeout: 1f);
+            UI.Tutorial.TickForTests(0.6f);
+            Assert.IsFalse(step.GetAwaiter().IsCompleted);
+            UI.Tutorial.TickForTests(0.6f);
+            var ex = Assert.Throws<System.TimeoutException>(() => step.GetAwaiter().GetResult());
+            StringAssert.Contains("main/missing", ex.Message);
+        }
+
+        [Test]
+        public void Step_TargetDestroyed_ReturnsToWaiting_HoleCloses()
+        {
+            var flow = BeginFlow();
+            UI.LoadDocumentAsync("main").GetAwaiter().GetResult();
+            UI.Open("main");
+            var step = flow.Step("main/shopBtn");
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsNotNull(UI.Tutorial.ViewForTests.Mask.HoleForTests);
+
+            UI.Close("main");
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsFalse(step.GetAwaiter().IsCompleted);
+            Assert.IsNull(UI.Tutorial.ViewForTests.Mask.HoleForTests);
+        }
+
+        [Test]
+        public void Step_NullTarget_TapAnywhere_MaskClickAdvances()
+        {
+            var flow = BeginFlow();
+            var step = flow.Step(null, text: "干得好");
+            UI.Tutorial.TickForTests(0.016f);
+            var relay = UI.Tutorial.ViewForTests.Mask.GetComponent<TutorialClickRelay>();
+            Assert.IsNotNull(relay);
+            relay.FireForTests();
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsTrue(step.GetAwaiter().IsCompleted);
+        }
+
+        [Test]
+        public void Step_AdvanceWhen_PredicatePolledPerTick()
+        {
+            bool flag = false;
+            var flow = BeginFlow();
+            var step = flow.Step(null, advance: Advance.When(() => flag));
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsFalse(step.GetAwaiter().IsCompleted);
+            flag = true;
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsTrue(step.GetAwaiter().IsCompleted);
+        }
+
+        [Test]
+        public void Step_AdvanceUntil_CompletesWithCondition()
+        {
+            var acs = new AwaitableCompletionSource();
+            var flow = BeginFlow();
+            var step = flow.Step(null, advance: Advance.Until(() => acs.Awaitable));
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsFalse(step.GetAwaiter().IsCompleted);
+            acs.SetResult();
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsTrue(step.GetAwaiter().IsCompleted);
+        }
+
+        [Test]
+        public void Step_TapAnywhere_HintMode_Throws()
+        {
+            var flow = BeginFlow();
+            Assert.Throws<System.ArgumentException>(() =>
+                flow.Step(null, mode: TutorialMode.Hint, advance: Advance.TapAnywhere));
+        }
+
+        [Test]
+        public void Step_TapTarget_NullTarget_Throws()
+        {
+            var flow = BeginFlow();
+            Assert.Throws<System.ArgumentException>(() =>
+                flow.Step(null, advance: Advance.TapTarget));
+        }
+
+        [Test]
+        public void HintMode_MaskDisabled_NotRaycastTarget()
+        {
+            var flow = BeginFlow();
+            UI.LoadDocumentAsync("main").GetAwaiter().GetResult();
+            UI.Open("main");
+            flow.Step("main/shopBtn", mode: TutorialMode.Hint);
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsFalse(UI.Tutorial.ViewForTests.Mask.enabled);
+            Assert.IsFalse(UI.Tutorial.ViewForTests.Mask.raycastTarget);
+            Assert.IsFalse(UI.Tutorial.IsBlockingInput);
+        }
+
+        [Test]
+        public void BlockMode_IsBlockingInput_True_DuringStep_FalseAfter()
+        {
+            var flow = BeginFlow();
+            var step = flow.Step(null, text: "x");
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsTrue(UI.Tutorial.IsBlockingInput);
+            UI.Tutorial.ViewForTests.Mask.GetComponent<TutorialClickRelay>().FireForTests();
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsTrue(step.GetAwaiter().IsCompleted);
+            Assert.IsFalse(UI.Tutorial.IsBlockingInput);
+        }
+
+        [Test]
+        public void Step_Text_AppliedToBubble_NullText_BubbleHidden()
+        {
+            var flow = BeginFlow();
+            flow.Step(null, text: "点这里");
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsTrue(UI.Tutorial.ViewForTests.BubbleRootActiveForTests);
+            Assert.AreEqual("点这里", UI.Tutorial.ViewForTests.BubbleTextForTests);
+        }
+    }
+}

--- a/Tests/EditMode/Tutorial/TutorialStepTests.cs.meta
+++ b/Tests/EditMode/Tutorial/TutorialStepTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dbcbc96ea21ff564ca812bc79f15a71e

--- a/Tests/PlayMode/Tutorial.meta
+++ b/Tests/PlayMode/Tutorial.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 138d6d21936994d4895c4b9c7c792e55
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/Tutorial/TutorialPlayTests.cs
+++ b/Tests/PlayMode/Tutorial/TutorialPlayTests.cs
@@ -40,8 +40,12 @@ namespace PromptUGUI.Tests.PlayMode.Tutorial
             Vector2 inside = RectTransformUtility.WorldToScreenPoint(null, target.RectTransform.position);
             Assert.IsFalse(view.Mask.IsRaycastLocationValid(inside, null),
                 "洞内:filter 应返回 false(穿透到真实控件)");
-            // 洞外点 = 屏幕角落(远离居中目标的洞)
-            Vector2 outside = new Vector2(2f, 2f);
+            // 洞外点:由实时洞矩形右缘 + 余量(mask 本地坐标)反推屏幕坐标,
+            // 与分辨率无关(不依赖固定屏幕角落),保证恒在洞外。
+            var hole = view.Mask.HoleForTests.Value;
+            Vector3 outsideWorld = view.Mask.rectTransform.TransformPoint(
+                new Vector3(hole.xMax + 50f, hole.center.y, 0f));
+            Vector2 outside = RectTransformUtility.WorldToScreenPoint(null, outsideWorld);
             Assert.IsTrue(view.Mask.IsRaycastLocationValid(outside, null),
                 "洞外:filter 应返回 true(拦截)");
 

--- a/Tests/PlayMode/Tutorial/TutorialPlayTests.cs
+++ b/Tests/PlayMode/Tutorial/TutorialPlayTests.cs
@@ -1,0 +1,92 @@
+using System.Collections;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Tutorial;
+using PromptUGUI.Controls;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.PlayMode.Tutorial
+{
+    public class TutorialPlayTests
+    {
+        private const string MainXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='main'>
+  <Btn id='target' anchor='center' size='200x80'>GO</Btn>
+</Screen></PromptUGUI>";
+
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static EventSystem EnsureES() =>
+            EventSystem.current ?? new GameObject("ES", typeof(EventSystem)).GetComponent<EventSystem>();
+
+        // 真实 LateUpdate 驱动:Block 步骤的挖洞 raycast filter 在洞内穿透、洞外拦截。
+        [UnityTest]
+        public IEnumerator BlockStep_MaskFilter_BlocksOutsideHole_PassesInside()
+        {
+            UI.LoadDocument("main", MainXml);
+            UI.Open("main");
+            var run = UI.Tutorial.Run("t", async t => await t.Step("main/target", text: "go"));
+            yield return null; yield return null;   // 让 LateUpdate 解析目标 + 开洞
+
+            var view = UI.Tutorial.ViewForTests;
+            Assert.IsNotNull(view, "overlay view should exist");
+            Assert.IsTrue(view.Mask.HoleForTests.HasValue, "hole should be open after target resolves");
+
+            var target = UI.Get("main").Get<Btn>("target");
+            // 洞内点 = 目标中心屏幕坐标(overlay 模式相机为 null)
+            Vector2 inside = RectTransformUtility.WorldToScreenPoint(null, target.RectTransform.position);
+            Assert.IsFalse(view.Mask.IsRaycastLocationValid(inside, null),
+                "洞内:filter 应返回 false(穿透到真实控件)");
+            // 洞外点 = 屏幕角落(远离居中目标的洞)
+            Vector2 outside = new Vector2(2f, 2f);
+            Assert.IsTrue(view.Mask.IsRaycastLocationValid(outside, null),
+                "洞外:filter 应返回 true(拦截)");
+
+            // 收尾:点击目标推进结束
+            ExecuteEvents.Execute(target.GameObject, new PointerEventData(EnsureES()),
+                ExecuteEvents.pointerClickHandler);
+            yield return null;
+            run.GetAwaiter().GetResult();
+        }
+
+        // TapTarget:对目标 GO 派发真实 click → relay → 步骤推进 → Run 结束。
+        [UnityTest]
+        public IEnumerator TapTarget_ClickAdvances_StepCompletes()
+        {
+            UI.LoadDocument("main", MainXml);
+            UI.Open("main");
+            var run = UI.Tutorial.Run("t", async t => await t.Step("main/target", text: "go"));
+            yield return null; yield return null;
+
+            Assert.IsTrue(UI.Tutorial.IsActive, "引导应在进行中");
+            var target = UI.Get("main").Get<Btn>("target");
+            Assert.IsNotNull(target.GameObject.GetComponent<TutorialClickRelay>(),
+                "TapTarget 应在目标 GO 挂 relay");
+
+            ExecuteEvents.Execute(target.GameObject, new PointerEventData(EnsureES()),
+                ExecuteEvents.pointerClickHandler);
+            yield return null;
+            Assert.IsFalse(UI.Tutorial.IsActive, "点击目标应推进并结束单步引导");
+            run.GetAwaiter().GetResult();
+        }
+
+        // When:不手动 tick,纯靠 LateUpdate 逐帧轮询谓词;翻真后自动推进。
+        [UnityTest]
+        public IEnumerator AdvanceWhen_PredicateFlips_AdvancesNextFrame()
+        {
+            bool flag = false;
+            var run = UI.Tutorial.Run("t",
+                async t => await t.Step(null, text: "x", advance: Advance.When(() => flag)));
+            yield return null; yield return null;
+            Assert.IsTrue(UI.Tutorial.IsActive, "谓词未满足时引导应继续");
+
+            flag = true;
+            yield return null; yield return null;   // LateUpdate 轮询到 true
+            Assert.IsFalse(UI.Tutorial.IsActive, "谓词翻真后应自动推进并结束");
+            run.GetAwaiter().GetResult();
+        }
+    }
+}

--- a/Tests/PlayMode/Tutorial/TutorialPlayTests.cs.meta
+++ b/Tests/PlayMode/Tutorial/TutorialPlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2f6aa40b9b126f541ae5a7ff3a18be56

--- a/docs~/superpowers/plans/2026-06-12-tutorial-system.md
+++ b/docs~/superpowers/plans/2026-06-12-tutorial-system.md
@@ -1,0 +1,1584 @@
+# UI.Tutorial 新手引导系统 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 实现 spec [`2026-06-12-tutorial-system-design.md`](../specs/2026-06-12-tutorial-system-design.md):`UI.Tutorial.Run` C# await 引导序列 + SpotlightMask 挖洞遮罩 + 手指/气泡 + 三层输入拦截(指针/ESC/Router guard)+ 断点续。
+
+**Architecture:** overlay 走 Toast 同款骨架(`ModalDocCache.EnsureLoaded` + `UI.OpenModalScreen`,内置 XML 可整张换肤);每步是 tick 驱动状态机(WaitTarget→Active→Done),`TutorialOverlayView.LateUpdate` 驱动、EditMode 测试用 `UI.Tutorial.TickForTests(dt)` 手动驱动;Router 新增前置 guard 链(独立交付件)。
+
+**Tech Stack:** Unity 6 uGUI、`Awaitable`/`AwaitableCompletionSource`(禁 Task)、NUnit EditMode/PlayMode、Unity MCP 跑测试、`dotnet format` lint。
+
+**全局约定(每个 task 都适用):**
+
+- 改完源码先 `mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)`,再 `mcp__UnityMCP__read_console(action="get", types=["error"])` 确认无编译错误,然后跑测试。
+- `run_tests` 是异步:拿 `job_id` 后轮询 `mcp__UnityMCP__get_test_job(job_id=...)`。按类过滤用 `group_names=["类名"]`。
+- 每个 task 收尾跑 lint:`cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx`(首次需 `dotnet restore PromptUGUI.Lint.slnx`);有 diff 就 `dotnet format whitespace/style/analyzers` 修掉。**禁止 `dotnet format analyzers --severity info`**(CLAUDE.md 列了会炸的规则)。
+- 提交都在 `feat/tutorial-system` 分支;新文件记得让 Unity refresh 生成 `.meta` 后一起 `git add`。
+- EditMode 测试类碰 `UI` 的,`[SetUp]`/`[TearDown]` 都要 `UI.ResetForTests()`;fake resolver 模式抄 `Tests/EditMode/Router/RouterReconcileTests.cs`。
+
+---
+
+## File Structure(全部新建/修改一览)
+
+| 文件 | 动作 | 职责 |
+|---|---|---|
+| `Runtime/Application/Router/NavigationRejectedException.cs` | 新建 | guard 拒绝异常(`RouteException` 是 sealed,独立继承 `Exception`) |
+| `Runtime/Application/UI.Router.cs` | 修改 | `AddGuard`/`RemoveGuard`/`BypassGuardsOnce`(internal)/guard 链存储 |
+| `Runtime/Application/UI.Router.Reconcile.cs` | 修改 | `Open()` 顶部 `CheckGuards`;`ResetForTestsInternal` 清 guard;routed-modal ESC 加 tutorial gate |
+| `Runtime/Application/UI.Modal.cs` | 修改 | `OnEscapePressed` 顶部加 tutorial gate |
+| `Runtime/Application/UI.cs` | 修改 | `TryResolvePath` 拆出返回 `IControl` 的 internal 重载;`ResetForTests` 调 `Tutorial.ResetForTestsInternal()` |
+| `Runtime/Application/Tutorial/SpotlightMask.cs` | 新建 | 挖洞 Graphic + `ICanvasRaycastFilter` |
+| `Runtime/Application/Tutorial/TutorialPlacement.cs` | 新建 | 气泡/手指四向避让纯几何 |
+| `Runtime/Application/Tutorial/TutorialClickRelay.cs` | 新建 | `IPointerClickHandler` 转发组件(TapTarget/TapAnywhere 共用) |
+| `Runtime/Application/Tutorial/TutorialOverlayView.cs` | 新建 | overlay 视图 + tick 状态机(定位/跟随/推进) |
+| `Runtime/Application/Tutorial/TutorialFlow.cs` | 新建 | `Step`/`Navigate`/`Advance`/`TutorialMode`/`Side` |
+| `Runtime/Application/UI.Tutorial.cs` | 新建 | `Run`/`UseProgressStore`/`IsActive`/`IsBlockingInput`/`MaskColor`/`TickForTests` |
+| `Runtime/Resources/PromptUGUI/Tutorial/TutorialOverlay.ui.xml` | 新建 | 可换肤视觉(mask 占位 Frame、气泡、手指) |
+| `Runtime/Resources/PromptUGUI/Tutorial/finger.pxl` | 新建 | 默认手指 sprite(authoring-promptugui-pxl skill 作画) |
+| `Tests/EditMode/Router/RouterGuardTests.cs` | 新建 | Task 1 |
+| `Tests/EditMode/Tutorial/SpotlightMaskTests.cs` | 新建 | Task 2 |
+| `Tests/EditMode/Tutorial/TutorialPlacementTests.cs` | 新建 | Task 3 |
+| `Tests/EditMode/Tutorial/TutorialStepTests.cs` | 新建 | Task 5(定位/超时/推进/视觉) |
+| `Tests/EditMode/Tutorial/TutorialRunTests.cs` | 新建 | Task 6(生命周期/持久化/guard) |
+| `Tests/PlayMode/Tutorial/TutorialPlayTests.cs` | 新建 | Task 7(真实 EventSystem 穿透) |
+| `.claude/skills/scripting-promptugui-csharp/SKILL.md` | 修改 | Task 8 |
+
+类型一致性基准(后续 task 全按这套签名,不得改名):
+
+```csharp
+namespace PromptUGUI.Application
+{
+    public enum TutorialMode { Block, Hint }
+    public enum Side { Auto, Top, Bottom, Left, Right }   // 若与既有类型撞名,改名 TutorialSide 并全计划同步
+
+    public readonly struct Advance
+    {
+        internal enum Kind { Default = 0, TapTarget, TapAnywhere, When, Until }
+        internal readonly Kind K;
+        internal readonly Func<bool> Predicate;
+        internal readonly Func<Awaitable> Condition;
+        public static Advance TapTarget { get; }
+        public static Advance TapAnywhere { get; }
+        public static Advance When(Func<bool> predicate);
+        public static Advance Until(Func<Awaitable> condition);
+    }
+
+    public sealed class TutorialFlow
+    {
+        public Awaitable Step(string target, string text = null,
+            TutorialMode mode = TutorialMode.Block, Advance advance = default,
+            Side place = Side.Auto, float padding = 8f, float timeout = -1f);
+        public Awaitable Navigate(string name, RouteQuery query = null);
+    }
+
+    public static partial class UI
+    {
+        public static class Tutorial
+        {
+            public static void UseProgressStore(Func<string, int> load, Action<string, int> save);
+            public static Awaitable Run(string id, Func<TutorialFlow, Awaitable> body);
+            public static bool IsActive { get; }
+            public static string XmlSrc { get; set; }      // = "PromptUGUI/Tutorial/TutorialOverlay.ui"
+            public static int SortingOrder { get; set; }   // = 3000(> Toast 2000 > Modal 1000)
+            public static string MaskColor { get; set; }   // = "#000000B0"
+            internal static bool IsBlockingInput { get; }  // Active 且当前步 mode==Block
+            internal static void TickForTests(float dt);
+            internal static void ResetForTestsInternal();
+        }
+    }
+}
+```
+
+---
+
+### Task 1: Router 导航 guard(独立交付件)
+
+**Files:**
+- Create: `Runtime/Application/Router/NavigationRejectedException.cs`
+- Modify: `Runtime/Application/UI.Router.cs`(guard 存储 + 公共 API)
+- Modify: `Runtime/Application/UI.Router.Reconcile.cs`(`Open` 检查 + `ResetForTestsInternal` 清理)
+- Test: `Tests/EditMode/Router/RouterGuardTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+```csharp
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+
+namespace PromptUGUI.Tests.Router
+{
+    public class RouterGuardTests
+    {
+        private static string Xml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'>
+  <Image id='bg' anchor='stretch'/>
+</Screen></PromptUGUI>";
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            var files = new Dictionary<string, string>
+            { ["home"] = Xml("home"), ["shop"] = Xml("shop") };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+            UI.Router.Map("shop", "shop", parent: "home");
+        }
+
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Guard_ReturnsFalse_OpenThrows_ChainUnchanged_ChangedNotFired()
+        {
+            UI.Router.Open("home").GetAwaiter().GetResult();
+            int changed = 0;
+            UI.Router.Changed += () => changed++;
+            UI.Router.AddGuard(_ => false);
+
+            Assert.Throws<NavigationRejectedException>(
+                () => UI.Router.Open("shop").GetAwaiter().GetResult());
+            CollectionAssert.AreEqual(new[] { "home" }, UI.Router.Chain);
+            Assert.AreEqual(0, changed);
+        }
+
+        [Test]
+        public void Guard_ReceivesTargetName()
+        {
+            string seen = null;
+            UI.Router.AddGuard(n => { seen = n; return true; });
+            UI.Router.Open("shop").GetAwaiter().GetResult();
+            Assert.AreEqual("shop", seen);
+        }
+
+        [Test]
+        public void Guard_AllTrue_NavigationProceeds()
+        {
+            UI.Router.AddGuard(_ => true);
+            UI.Router.AddGuard(_ => true);
+            UI.Router.Open("shop").GetAwaiter().GetResult();
+            Assert.AreEqual("shop", UI.Router.Current);
+        }
+
+        [Test]
+        public void RemoveGuard_RestoresNavigation()
+        {
+            System.Func<string, bool> g = _ => false;
+            UI.Router.AddGuard(g);
+            UI.Router.RemoveGuard(g);
+            UI.Router.Open("shop").GetAwaiter().GetResult();
+            Assert.AreEqual("shop", UI.Router.Current);
+        }
+
+        [Test]
+        public void Guard_AlsoBlocks_NavigateUrl()
+        {
+            UI.Router.AddGuard(_ => false);
+            Assert.Throws<NavigationRejectedException>(
+                () => UI.Router.Navigate("shop").GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public void BypassGuardsOnce_AllowsExactlyOneNavigation()
+        {
+            UI.Router.AddGuard(_ => false);
+            UI.Router.BypassGuardsOnce();
+            UI.Router.Open("shop").GetAwaiter().GetResult();   // 放行一次
+            Assert.AreEqual("shop", UI.Router.Current);
+            Assert.Throws<NavigationRejectedException>(
+                () => UI.Router.Open("home").GetAwaiter().GetResult());   // 标记已复位
+        }
+
+        [Test]
+        public void ResetForTests_ClearsGuardsAndBypass()
+        {
+            UI.Router.AddGuard(_ => false);
+            UI.Router.BypassGuardsOnce();
+            UI.ResetForTests();
+            SetUp();   // 重建路由表
+            UI.Router.Open("shop").GetAwaiter().GetResult();   // 不再被拦
+            Assert.AreEqual("shop", UI.Router.Current);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: refresh + 跑测试确认失败**
+
+`refresh_unity` 后 `read_console` 应报 CS0246(`NavigationRejectedException`/`AddGuard` 不存在)——编译失败即红。
+
+- [ ] **Step 3: 实现**
+
+`Runtime/Application/Router/NavigationRejectedException.cs`:
+
+```csharp
+using System;
+
+namespace PromptUGUI.Application
+{
+    /// <summary>导航被 UI.Router.AddGuard 注册的 guard 拒绝。</summary>
+    public sealed class NavigationRejectedException : Exception
+    {
+        public string RouteName { get; }
+        public NavigationRejectedException(string routeName)
+            : base($"navigation to '{routeName}' rejected by guard")
+            => RouteName = routeName;
+    }
+}
+```
+
+`UI.Router.cs`(partial 内追加):
+
+```csharp
+private static readonly List<Func<string, bool>> _guards = new();
+private static bool _bypassGuardsOnce;
+
+/// <summary>导航前置守卫:任一返回 false → Open/Navigate/Back 抛 NavigationRejectedException。</summary>
+public static void AddGuard(Func<string, bool> guard)
+{
+    if (guard == null) throw new ArgumentNullException(nameof(guard));
+    _guards.Add(guard);
+}
+
+public static void RemoveGuard(Func<string, bool> guard) => _guards.Remove(guard);
+
+/// <summary>下一次 Open 跳过整条 guard 链并复位(Tutorial 内部导航用)。</summary>
+internal static void BypassGuardsOnce() => _bypassGuardsOnce = true;
+
+private static void CheckGuards(string name)
+{
+    if (_bypassGuardsOnce) { _bypassGuardsOnce = false; return; }
+    foreach (var g in _guards)
+        if (!g(name)) throw new NavigationRejectedException(name);
+}
+```
+
+`UI.Router.Reconcile.cs` 改两处:`Open` 首行加 `CheckGuards(name);`(在创建 tcs 之前,同步抛);`ResetForTestsInternal` 里加 `_guards.Clear(); _bypassGuardsOnce = false;`。
+
+- [ ] **Step 4: refresh + 跑测试确认通过**
+
+`run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["RouterGuardTests"])` → 全 PASS。再跑整个 Router 目录相关组(`RouterReconcileTests` 等)确认无回归。
+
+- [ ] **Step 5: lint + commit**
+
+```bash
+git add Runtime/Application/Router/NavigationRejectedException.cs* Runtime/Application/UI.Router.cs Runtime/Application/UI.Router.Reconcile.cs Tests/EditMode/Router/RouterGuardTests.cs*
+git commit -m "feat(router): AddGuard/RemoveGuard 导航前置拒绝钩子 + NavigationRejectedException"
+```
+
+---
+
+### Task 2: SpotlightMask 挖洞遮罩
+
+**Files:**
+- Create: `Runtime/Application/Tutorial/SpotlightMask.cs`
+- Test: `Tests/EditMode/Tutorial/SpotlightMaskTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application.Tutorial;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Tests.Tutorial
+{
+    public class SpotlightMaskTests
+    {
+        private GameObject _canvasGo;
+        private SpotlightMask _mask;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _canvasGo = new GameObject("canvas", typeof(Canvas));
+            var go = new GameObject("mask", typeof(RectTransform));
+            go.transform.SetParent(_canvasGo.transform, false);
+            var rt = (RectTransform)go.transform;
+            rt.sizeDelta = new Vector2(800, 600);   // 本地坐标系:中心原点,±400/±300
+            _mask = go.AddComponent<SpotlightMask>();
+        }
+
+        [TearDown] public void TearDown() => Object.DestroyImmediate(_canvasGo);
+
+        [Test]
+        public void NoHole_BlocksEverywhere()
+        {
+            _mask.SetHole(null);
+            Assert.IsTrue(_mask.HitTestForTests(Vector2.zero));
+            Assert.IsTrue(_mask.HitTestForTests(new Vector2(390, 290)));
+        }
+
+        [Test]
+        public void Hole_PassesInside_BlocksOutside()
+        {
+            _mask.SetHole(new Rect(-50, -25, 100, 50));   // 中心 100x50 的洞
+            Assert.IsFalse(_mask.HitTestForTests(Vector2.zero));            // 洞内 → 穿透
+            Assert.IsFalse(_mask.HitTestForTests(new Vector2(49, 24)));     // 洞内边缘
+            Assert.IsTrue(_mask.HitTestForTests(new Vector2(51, 0)));       // 洞外
+            Assert.IsTrue(_mask.HitTestForTests(new Vector2(0, 26)));
+        }
+
+        [Test]
+        public void Mesh_NoHole_SingleQuad_4Verts()
+        {
+            _mask.SetHole(null);
+            Assert.AreEqual(4, _mask.PopulateMeshVertexCountForTests());
+        }
+
+        [Test]
+        public void Mesh_WithHole_FourBands_16Verts()
+        {
+            _mask.SetHole(new Rect(-50, -25, 100, 50));
+            Assert.AreEqual(16, _mask.PopulateMeshVertexCountForTests());
+        }
+
+        [Test]
+        public void Hole_ClampedToRect_DegenerateBandsSkipped()
+        {
+            // 洞超出整个 rect → 等效无遮挡区,但不得产出反向 quad
+            _mask.SetHole(new Rect(-1000, -1000, 2000, 2000));
+            Assert.AreEqual(0, _mask.PopulateMeshVertexCountForTests());
+            Assert.IsFalse(_mask.HitTestForTests(Vector2.zero));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: refresh,确认编译错误(类不存在)= 红**
+
+- [ ] **Step 3: 实现**
+
+```csharp
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Application.Tutorial
+{
+    /// <summary>
+    /// 引导挖洞遮罩(spec §5.2):洞外四块环形带渲染遮罩色并拦截 raycast,
+    /// 洞内不渲染、IsRaycastLocationValid 返回 false → 点击穿透到下层真实控件。
+    /// 不用 shader/stencil,WebGL 安全。
+    /// </summary>
+    internal sealed class SpotlightMask : MaskableGraphic, ICanvasRaycastFilter
+    {
+        private Rect? _hole;   // 本地坐标(pivot 居中)
+
+        /// <summary>null = 无洞(整屏遮罩,纯说明页/等待目标期)。</summary>
+        public void SetHole(Rect? holeInLocalSpace)
+        {
+            _hole = holeInLocalSpace;
+            SetVerticesDirty();
+        }
+
+        public bool IsRaycastLocationValid(Vector2 screenPoint, Camera eventCamera)
+        {
+            if (!RectTransformUtility.ScreenPointToLocalPointInRectangle(
+                    rectTransform, screenPoint, eventCamera, out var local))
+                return false;
+            return HitTest(local);
+        }
+
+        private bool HitTest(Vector2 local) => !(_hole.HasValue && _hole.Value.Contains(local));
+
+        protected override void OnPopulateMesh(VertexHelper vh)
+        {
+            vh.Clear();
+            var r = GetPixelAdjustedRect();
+            if (_hole == null) { AddQuad(vh, r.xMin, r.yMin, r.xMax, r.yMax); return; }
+
+            // 洞夹紧到自身 rect,四块环形带:上、下、左、右(左右带只到洞的上下沿)
+            var h = _hole.Value;
+            float hx0 = Mathf.Max(h.xMin, r.xMin), hx1 = Mathf.Min(h.xMax, r.xMax);
+            float hy0 = Mathf.Max(h.yMin, r.yMin), hy1 = Mathf.Min(h.yMax, r.yMax);
+            if (hx1 <= hx0 || hy1 <= hy0) { AddQuad(vh, r.xMin, r.yMin, r.xMax, r.yMax); return; }
+
+            AddQuad(vh, r.xMin, hy1, r.xMax, r.yMax);   // 上
+            AddQuad(vh, r.xMin, r.yMin, r.xMax, hy0);   // 下
+            AddQuad(vh, r.xMin, hy0, hx0, hy1);         // 左
+            AddQuad(vh, hx1, hy0, r.xMax, hy1);         // 右
+        }
+
+        private void AddQuad(VertexHelper vh, float x0, float y0, float x1, float y1)
+        {
+            if (x1 <= x0 || y1 <= y0) return;   // 退化带跳过
+            int i = vh.currentVertCount;
+            var c = color;
+            vh.AddVert(new Vector3(x0, y0), c, Vector2.zero);
+            vh.AddVert(new Vector3(x0, y1), c, Vector2.zero);
+            vh.AddVert(new Vector3(x1, y1), c, Vector2.zero);
+            vh.AddVert(new Vector3(x1, y0), c, Vector2.zero);
+            vh.AddTriangle(i, i + 1, i + 2);
+            vh.AddTriangle(i + 2, i + 3, i);
+        }
+
+        // —— 测试钩子 —— //
+        internal bool HitTestForTests(Vector2 local) => HitTest(local);
+
+        internal int PopulateMeshVertexCountForTests()
+        {
+            using var vh = new VertexHelper();
+            OnPopulateMesh(vh);
+            return vh.currentVertCount;
+        }
+    }
+}
+```
+
+注意 `Hole_ClampedToRect` 测试:洞吞掉整个 rect 时四带全退化 → 0 顶点(上面 `hx1<=hx0` 分支只处理"洞与 rect 不相交"回整屏;相交但全覆盖时走四带各自退化)。核对实现与两条测试语义一致后再跑。
+
+- [ ] **Step 4: refresh + `group_names=["SpotlightMaskTests"]` 全 PASS**
+
+- [ ] **Step 5: lint + commit**
+
+```bash
+git add Runtime/Application/Tutorial/ Tests/EditMode/Tutorial/
+git commit -m "feat(tutorial): SpotlightMask 挖洞遮罩 — 四带 mesh + ICanvasRaycastFilter 穿透"
+```
+
+---
+
+### Task 3: TutorialPlacement 气泡/手指避让几何
+
+**Files:**
+- Create: `Runtime/Application/Tutorial/TutorialPlacement.cs`
+- Test: `Tests/EditMode/Tutorial/TutorialPlacementTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Tutorial;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Tutorial
+{
+    public class TutorialPlacementTests
+    {
+        private static readonly Rect Overlay = new(-960, -540, 1920, 1080);
+        private static readonly Vector2 Bubble = new(300, 100);
+        private const float Gap = 60f;   // 手指 + 间距占用
+
+        [Test]
+        public void Auto_TargetNearBottom_PlacesTop()
+        {
+            var target = new Rect(-50, -520, 100, 60);   // 贴近下边缘
+            var r = TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Auto);
+            Assert.AreEqual(Side.Top, r.Side);
+            Assert.Greater(r.BubblePos.y, target.yMax);
+        }
+
+        [Test]
+        public void Auto_TargetNearTop_PlacesBottom()
+        {
+            var target = new Rect(-50, 460, 100, 60);
+            var r = TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Auto);
+            Assert.AreEqual(Side.Bottom, r.Side);
+            Assert.Less(r.BubblePos.y, target.yMin);
+        }
+
+        [Test]
+        public void Auto_TargetNearRightEdge_NeverOverflows()
+        {
+            var target = new Rect(900, -30, 50, 60);   // 贴右缘,Right 放不下
+            var r = TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Auto);
+            Assert.AreNotEqual(Side.Right, r.Side);
+            // 气泡完全在 overlay 内
+            Assert.GreaterOrEqual(r.BubblePos.x - Bubble.x / 2, Overlay.xMin);
+            Assert.LessOrEqual(r.BubblePos.x + Bubble.x / 2, Overlay.xMax);
+        }
+
+        [Test]
+        public void ExplicitPlace_Respected()
+        {
+            var target = new Rect(-50, -30, 100, 60);
+            var r = TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Left);
+            Assert.AreEqual(Side.Left, r.Side);
+            Assert.Less(r.BubblePos.x, target.xMin);
+        }
+
+        [Test]
+        public void FingerAngle_PointsAtTarget()
+        {
+            var target = new Rect(-50, -30, 100, 60);
+            // 手指默认素材朝上;气泡在上方 → 手指在气泡与目标之间、旋转 180° 朝下指目标
+            Assert.AreEqual(180f, TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Top).FingerAngle);
+            Assert.AreEqual(0f, TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Bottom).FingerAngle);
+            Assert.AreEqual(90f, TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Right).FingerAngle);
+            Assert.AreEqual(-90f, TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Left).FingerAngle);
+        }
+
+        [Test]
+        public void FingerPos_BetweenBubbleAndTarget()
+        {
+            var target = new Rect(-50, -30, 100, 60);
+            var r = TutorialPlacement.Choose(Overlay, target, Bubble, Gap, Side.Top);
+            Assert.Greater(r.FingerPos.y, target.yMax);
+            Assert.Less(r.FingerPos.y, r.BubblePos.y - Bubble.y / 2);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: refresh → 编译错误 = 红**
+
+- [ ] **Step 3: 实现**
+
+```csharp
+using UnityEngine;
+
+namespace PromptUGUI.Application.Tutorial
+{
+    /// <summary>
+    /// 气泡+手指四向避让(spec §5.3),全部在 overlay 本地坐标(中心原点)。
+    /// 纯函数,EditMode 可测。gap = 手指长度 + 间距,气泡中心 = 目标边缘 + gap + 半气泡。
+    /// </summary>
+    internal static class TutorialPlacement
+    {
+        internal readonly struct Result
+        {
+            public readonly Side Side;
+            public readonly Vector2 BubblePos;   // 气泡中心
+            public readonly Vector2 FingerPos;   // 手指中心(气泡与目标之间的 gap 中点)
+            public readonly float FingerAngle;   // Z 旋转;素材默认朝上(0°=指上)
+            public Result(Side s, Vector2 b, Vector2 f, float a)
+            { Side = s; BubblePos = b; FingerPos = f; FingerAngle = a; }
+        }
+
+        internal static Result Choose(Rect overlay, Rect target, Vector2 bubbleSize,
+            float gap, Side place)
+        {
+            if (place != Side.Auto) return Build(place, target, bubbleSize, gap, overlay);
+
+            Side best = Side.Top;
+            float bestScore = float.MinValue;
+            foreach (var s in new[] { Side.Top, Side.Bottom, Side.Left, Side.Right })
+            {
+                var r = Build(s, target, bubbleSize, gap, overlay);
+                var bubble = new Rect(r.BubblePos - bubbleSize / 2f, bubbleSize);
+                float overflow = Overflow(bubble, overlay);
+                // 零溢出里选剩余空间最大;有溢出则溢出最小
+                float room = s switch
+                {
+                    Side.Top => overlay.yMax - target.yMax,
+                    Side.Bottom => target.yMin - overlay.yMin,
+                    Side.Left => target.xMin - overlay.xMin,
+                    _ => overlay.xMax - target.xMax,
+                };
+                float score = overflow > 0f ? -1000f - overflow : room;
+                if (score > bestScore) { bestScore = score; best = s; }
+            }
+            return Build(best, target, bubbleSize, gap, overlay);
+        }
+
+        private static Result Build(Side s, Rect t, Vector2 b, float gap, Rect overlay)
+        {
+            Vector2 c = t.center, bubble, finger;
+            float angle;
+            switch (s)
+            {
+                case Side.Top:
+                    bubble = new Vector2(c.x, t.yMax + gap + b.y / 2f);
+                    finger = new Vector2(c.x, t.yMax + gap / 2f);
+                    angle = 180f; break;
+                case Side.Bottom:
+                    bubble = new Vector2(c.x, t.yMin - gap - b.y / 2f);
+                    finger = new Vector2(c.x, t.yMin - gap / 2f);
+                    angle = 0f; break;
+                case Side.Left:
+                    bubble = new Vector2(t.xMin - gap - b.x / 2f, c.y);
+                    finger = new Vector2(t.xMin - gap / 2f, c.y);
+                    angle = -90f; break;
+                default:   // Right
+                    bubble = new Vector2(t.xMax + gap + b.x / 2f, c.y);
+                    finger = new Vector2(t.xMax + gap / 2f, c.y);
+                    angle = 90f; break;
+            }
+            // 沿副轴夹紧让气泡不出屏(主轴出屏由 Auto 评分排除)
+            bubble.x = Mathf.Clamp(bubble.x, overlay.xMin + b.x / 2f, overlay.xMax - b.x / 2f);
+            bubble.y = Mathf.Clamp(bubble.y, overlay.yMin + b.y / 2f, overlay.yMax - b.y / 2f);
+            return new Result(s, bubble, finger, angle);
+        }
+
+        private static float Overflow(Rect r, Rect bounds) =>
+            Mathf.Max(0f, bounds.xMin - r.xMin) + Mathf.Max(0f, r.xMax - bounds.xMax)
+            + Mathf.Max(0f, bounds.yMin - r.yMin) + Mathf.Max(0f, r.yMax - bounds.yMax);
+    }
+}
+```
+
+手指角度约定:素材画成"指尖朝上";`Top`(气泡在上)→ 手指要朝下指目标 → 180°。与 Task 3 测试和 Task 5 视图代码一致,不得改。
+
+- [ ] **Step 4: refresh + `group_names=["TutorialPlacementTests"]` 全 PASS**
+- [ ] **Step 5: lint + commit**(`feat(tutorial): 气泡/手指四向避让纯几何`)
+
+---
+
+### Task 4: overlay XML + finger.pxl + TutorialClickRelay
+
+无独立测试(资产 + 5 行组件),由 Task 5 的测试覆盖。
+
+**Files:**
+- Create: `Runtime/Resources/PromptUGUI/Tutorial/TutorialOverlay.ui.xml`
+- Create: `Runtime/Resources/PromptUGUI/Tutorial/finger.pxl`
+- Create: `Runtime/Application/Tutorial/TutorialClickRelay.cs`
+
+- [ ] **Step 1: 写 overlay XML**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<PromptUGUI version="1">
+  <Screen name="PromptUGUI/Tutorial/TutorialOverlay.ui" reference="1920x1080" reference.portrait="1080x1920">
+    <!-- mask:纯容器占位,SpotlightMask 组件由 C# 挂载(遮罩色走 UI.Tutorial.MaskColor) -->
+    <Frame id="mask" anchor="stretch"/>
+    <!-- bubbleRoot:气泡+手指,位置由 C# 每帧摆放 -->
+    <Frame id="bubbleRoot" size="0x0">
+      <Image id="bubble" sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round" color="#222222EE" size="300x100">
+        <Text id="bubbleText" anchor="stretch" margin="16" fontSize="22" align="center"/>
+      </Image>
+      <Image id="finger" size="48x48"/>
+    </Frame>
+  </Screen>
+</PromptUGUI>
+```
+
+写完跑 XML lint:`dotnet run --project .lint/UIXmlLint -- Runtime/Resources/PromptUGUI/Tutorial/TutorialOverlay.ui.xml` → exit 0。
+(`finger` 的 sprite 属性在 Step 2 画完 .pxl 后回填;9-slice sprite 名以 `Runtime/Resources/PromptUGUI/Modals/MessageBox.ui.xml` 实际引用为准,先抄过来核对。)
+
+- [ ] **Step 2: 画 finger.pxl**
+
+调用 `authoring-promptugui-pxl` skill,要求:16x16、透明底、指尖朝上的手指/箭头形,文件 `Runtime/Resources/PromptUGUI/Tutorial/finger.pxl`;按该 skill 文档的引用方式回填 XML 的 `finger` sprite 属性。refresh 后用 `read_console` 确认 importer 无报错。
+
+- [ ] **Step 3: TutorialClickRelay**
+
+```csharp
+using System;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace PromptUGUI.Application.Tutorial
+{
+    /// <summary>
+    /// 临时挂到目标 GO(TapTarget)或 mask GO(TapAnywhere)的点击转发器,步骤结束移除。
+    /// 与 GO 上既有 Button 等 IPointerClickHandler 并存(uGUI 对命中 GO 上所有 handler 逐个执行)。
+    /// </summary>
+    internal sealed class TutorialClickRelay : MonoBehaviour, IPointerClickHandler
+    {
+        internal Action OnClicked;
+        public void OnPointerClick(PointerEventData _) => OnClicked?.Invoke();
+        internal void FireForTests() => OnClicked?.Invoke();
+    }
+}
+```
+
+- [ ] **Step 4: refresh、console 无 error;lint;commit**(`feat(tutorial): overlay XML 骨架 + finger.pxl + 点击转发器`)
+
+---
+
+### Task 5: TutorialOverlayView + TutorialFlow.Step(tick 状态机核心)
+
+最大的一个 task:Step 的 等待目标→显示→推进 全链路。`UI.Tutorial` 静态壳一并建立(`Run` 留到 Task 6,本 task 先提供 internal 的 `BeginSessionForTests`/`TickForTests` 钩子让 Step 可独测)。
+
+**Files:**
+- Create: `Runtime/Application/Tutorial/TutorialOverlayView.cs`
+- Create: `Runtime/Application/Tutorial/TutorialFlow.cs`
+- Create: `Runtime/Application/UI.Tutorial.cs`
+- Modify: `Runtime/Application/UI.cs`(`TryResolvePath` 拆 internal 重载,返回 `IControl`)
+- Test: `Tests/EditMode/Tutorial/TutorialStepTests.cs`
+
+- [ ] **Step 1: 先做 `UI.cs` 小重构(无行为变化)**
+
+把现有 `TryResolvePath(string, out RectTransform)` 的查找体抽成新 internal 重载,原方法转调:
+
+```csharp
+/// <summary>同 TryResolvePath,但回传 IControl(path==screen 名时 control=null、rect=root)。</summary>
+internal static bool TryResolvePath(string path, out IControl control, out UnityEngine.RectTransform rect)
+{
+    control = null; rect = null;
+    if (string.IsNullOrEmpty(path)) return false;
+    string bestKey = null;
+    foreach (var key in _open.Keys)
+    {
+        bool match = path == key || path.StartsWith(key + "/", System.StringComparison.Ordinal);
+        if (match && (bestKey == null || key.Length > bestKey.Length)) bestKey = key;
+    }
+    if (bestKey == null) return false;
+    var screen = _open[bestKey];
+    if (path.Length == bestKey.Length)
+    {
+        rect = screen.RootGameObject.GetComponent<UnityEngine.RectTransform>();
+        return rect != null;
+    }
+    string idPath = path.Substring(bestKey.Length + 1);
+    try
+    {
+        control = screen.Get(idPath);
+        rect = control?.RectTransform;
+        return rect != null;
+    }
+    catch (System.Collections.Generic.KeyNotFoundException) { return false; }
+}
+
+internal static bool TryResolvePath(string path, out UnityEngine.RectTransform rect)
+    => TryResolvePath(path, out _, out rect);
+```
+
+refresh + 跑既有 `PathResolveTests`、`ToastOverlayTests` 确认无回归,单独 commit:`refactor: TryResolvePath 拆出返回 IControl 的 internal 重载`。
+
+- [ ] **Step 2: 写失败测试**
+
+```csharp
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Tutorial;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Tutorial
+{
+    public class TutorialStepTests
+    {
+        private const string MainXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='main'>
+  <Btn id='shopBtn' size='200x80'>Shop</Btn>
+</Screen></PromptUGUI>";
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            UI.SourceResolver = src => AwaitableHelpers.Completed(src == "main" ? MainXml : null);
+        }
+
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static TutorialFlow BeginFlow() => UI.Tutorial.BeginSessionForTests();
+
+        // —— 等待目标出现 —— //
+        [Test]
+        public void Step_TargetNotResolvable_StaysPending_NoHole()
+        {
+            var flow = BeginFlow();
+            var step = flow.Step("main/shopBtn", text: "hi");
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsFalse(step.GetAwaiter().IsCompleted);
+            Assert.IsNull(UI.Tutorial.ViewForTests.Mask.HoleForTests);   // 等待期整屏遮罩
+        }
+
+        [Test]
+        public void Step_TargetAppears_HoleOpens_AndTapTargetAdvances()
+        {
+            var flow = BeginFlow();
+            var step = flow.Step("main/shopBtn", text: "hi");
+            UI.Tutorial.TickForTests(0.016f);
+
+            UI.LoadDocumentAsync("main").GetAwaiter().GetResult();
+            UI.Open("main");
+            UI.Tutorial.TickForTests(0.016f);
+
+            Assert.IsNotNull(UI.Tutorial.ViewForTests.Mask.HoleForTests);
+            var relay = UI.Get("main").Get<PromptUGUI.Controls.Btn>("shopBtn")
+                .GameObject.GetComponent<TutorialClickRelay>();
+            Assert.IsNotNull(relay, "TapTarget 应在目标 GO 挂 relay");
+            relay.FireForTests();
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsTrue(step.GetAwaiter().IsCompleted);
+            Assert.IsNull(relay.OnClicked, "步骤结束 relay 应被拆除");   // 或断言组件已销毁
+        }
+
+        [Test]
+        public void Step_Timeout_Throws()
+        {
+            var flow = BeginFlow();
+            var step = flow.Step("main/missing", timeout: 1f);
+            UI.Tutorial.TickForTests(0.6f);
+            Assert.IsFalse(step.GetAwaiter().IsCompleted);
+            UI.Tutorial.TickForTests(0.6f);   // 累计 1.2s > 1s
+            var ex = Assert.Throws<System.TimeoutException>(() => step.GetAwaiter().GetResult());
+            StringAssert.Contains("main/missing", ex.Message);
+        }
+
+        [Test]
+        public void Step_TargetDestroyed_ReturnsToWaiting_HoleCloses()
+        {
+            var flow = BeginFlow();
+            UI.LoadDocumentAsync("main").GetAwaiter().GetResult();
+            UI.Open("main");
+            var step = flow.Step("main/shopBtn");
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsNotNull(UI.Tutorial.ViewForTests.Mask.HoleForTests);
+
+            UI.Close("main");
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsFalse(step.GetAwaiter().IsCompleted);
+            Assert.IsNull(UI.Tutorial.ViewForTests.Mask.HoleForTests);
+        }
+
+        // —— 推进方式 —— //
+        [Test]
+        public void Step_NullTarget_TapAnywhere_MaskClickAdvances()
+        {
+            var flow = BeginFlow();
+            var step = flow.Step(null, text: "干得好");
+            UI.Tutorial.TickForTests(0.016f);
+            var relay = UI.Tutorial.ViewForTests.Mask.GetComponent<TutorialClickRelay>();
+            Assert.IsNotNull(relay);
+            relay.FireForTests();
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsTrue(step.GetAwaiter().IsCompleted);
+        }
+
+        [Test]
+        public void Step_AdvanceWhen_PredicatePolledPerTick()
+        {
+            bool flag = false;
+            var flow = BeginFlow();
+            var step = flow.Step(null, advance: Advance.When(() => flag));
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsFalse(step.GetAwaiter().IsCompleted);
+            flag = true;
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsTrue(step.GetAwaiter().IsCompleted);
+        }
+
+        [Test]
+        public void Step_AdvanceUntil_CompletesWithCondition()
+        {
+            var acs = new AwaitableCompletionSource();
+            var flow = BeginFlow();
+            var step = flow.Step(null, advance: Advance.Until(() => acs.Awaitable));
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsFalse(step.GetAwaiter().IsCompleted);
+            acs.SetResult();
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsTrue(step.GetAwaiter().IsCompleted);
+        }
+
+        // —— 参数校验 —— //
+        [Test]
+        public void Step_TapAnywhere_HintMode_Throws()
+        {
+            var flow = BeginFlow();
+            Assert.Throws<System.ArgumentException>(() =>
+                flow.Step(null, mode: TutorialMode.Hint, advance: Advance.TapAnywhere));
+        }
+
+        [Test]
+        public void Step_TapTarget_NullTarget_Throws()
+        {
+            var flow = BeginFlow();
+            Assert.Throws<System.ArgumentException>(() =>
+                flow.Step(null, advance: Advance.TapTarget));
+        }
+
+        // —— Block / Hint 视觉差异 —— //
+        [Test]
+        public void HintMode_MaskDisabled_NotRaycastTarget()
+        {
+            var flow = BeginFlow();
+            UI.LoadDocumentAsync("main").GetAwaiter().GetResult();
+            UI.Open("main");
+            flow.Step("main/shopBtn", mode: TutorialMode.Hint);
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsFalse(UI.Tutorial.ViewForTests.Mask.enabled);
+            Assert.IsFalse(UI.Tutorial.ViewForTests.Mask.raycastTarget);
+            Assert.IsFalse(UI.Tutorial.IsBlockingInput);
+        }
+
+        [Test]
+        public void BlockMode_IsBlockingInput_True_DuringStep_FalseAfter()
+        {
+            var flow = BeginFlow();
+            var step = flow.Step(null, text: "x");
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsTrue(UI.Tutorial.IsBlockingInput);
+            UI.Tutorial.ViewForTests.Mask.GetComponent<TutorialClickRelay>().FireForTests();
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsTrue(step.GetAwaiter().IsCompleted);
+            Assert.IsFalse(UI.Tutorial.IsBlockingInput);
+        }
+
+        // —— 文案与气泡 —— //
+        [Test]
+        public void Step_Text_AppliedToBubble_NullText_BubbleHidden()
+        {
+            var flow = BeginFlow();
+            flow.Step(null, text: "点这里");
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.IsTrue(UI.Tutorial.ViewForTests.BubbleRootActiveForTests);
+            Assert.AreEqual("点这里", UI.Tutorial.ViewForTests.BubbleTextForTests);
+        }
+    }
+}
+```
+
+- [ ] **Step 3: refresh → 编译错误 = 红**
+
+- [ ] **Step 4: 实现**
+
+`Runtime/Application/Tutorial/TutorialFlow.cs`(enums + Advance + flow;`Step` 做参数校验/fast-forward/编号,实际执行交给 view):
+
+```csharp
+using System;
+using UnityEngine;
+
+namespace PromptUGUI.Application
+{
+    public enum TutorialMode { Block, Hint }
+    public enum Side { Auto, Top, Bottom, Left, Right }
+
+    public readonly struct Advance
+    {
+        internal enum Kind { Default = 0, TapTargetK, TapAnywhereK, WhenK, UntilK }
+        internal readonly Kind K;
+        internal readonly Func<bool> Predicate;
+        internal readonly Func<Awaitable> Condition;
+        private Advance(Kind k, Func<bool> p, Func<Awaitable> c) { K = k; Predicate = p; Condition = c; }
+        public static Advance TapTarget => new(Kind.TapTargetK, null, null);
+        public static Advance TapAnywhere => new(Kind.TapAnywhereK, null, null);
+        public static Advance When(Func<bool> predicate) =>
+            new(Kind.WhenK, predicate ?? throw new ArgumentNullException(nameof(predicate)), null);
+        public static Advance Until(Func<Awaitable> condition) =>
+            new(Kind.UntilK, null, condition ?? throw new ArgumentNullException(nameof(condition)));
+    }
+
+    /// <summary>一次 UI.Tutorial.Run 的会话句柄;Step 顺序编号,支撑断点续。</summary>
+    public sealed class TutorialFlow
+    {
+        private readonly string _id;
+        private readonly int _resume;
+        private readonly Action<string, int> _save;
+        private int _stepIndex;
+        internal Tutorial.TutorialOverlayView View;   // 懒创建(Task 5 由 BeginSessionForTests 注入)
+
+        internal TutorialFlow(string id, int resume, Action<string, int> save)
+        { _id = id; _resume = resume; _save = save; }
+
+        public Awaitable Step(string target, string text = null,
+            TutorialMode mode = TutorialMode.Block, Advance advance = default,
+            Side place = Side.Auto, float padding = 8f, float timeout = -1f)
+        {
+            var kind = advance.K == Advance.Kind.Default
+                ? (target != null ? Advance.Kind.TapTargetK : Advance.Kind.TapAnywhereK)
+                : advance.K;
+            if (kind == Advance.Kind.TapTargetK && target == null)
+                throw new ArgumentException("Advance.TapTarget requires a target path");
+            if (kind == Advance.Kind.TapAnywhereK && mode == TutorialMode.Hint)
+                throw new ArgumentException("Advance.TapAnywhere requires TutorialMode.Block");
+
+            int index = _stepIndex++;
+            if (index < _resume) return AwaitableHelpers.Completed();   // fast-forward:无视觉无等待
+
+            return RunStep(index, new StepConfig
+            {
+                Target = target, Text = text, Mode = mode, AdvanceKind = kind,
+                Predicate = advance.Predicate, Condition = advance.Condition,
+                Place = place, Padding = padding, Timeout = timeout,
+            });
+        }
+
+        private async Awaitable RunStep(int index, StepConfig cfg)
+        {
+            var view = await UI.Tutorial.EnsureOverlay(this);
+            var acs = new AwaitableCompletionSource();
+            view.BeginStep(cfg, acs);
+            try { await acs.Awaitable; }
+            finally { view.EndStep(); }
+            _save?.Invoke(_id, index + 1);
+        }
+
+        public Awaitable Navigate(string name, RouteQuery query = null)
+        {
+            UI.Router.BypassGuardsOnce();
+            return UI.Router.Open(name, query);
+        }
+    }
+
+    internal struct StepConfig
+    {
+        public string Target, Text;
+        public TutorialMode Mode;
+        public Advance.Kind AdvanceKind;
+        public Func<bool> Predicate;
+        public Func<Awaitable> Condition;
+        public Side Place;
+        public float Padding, Timeout;
+    }
+}
+```
+
+`Runtime/Application/Tutorial/TutorialOverlayView.cs`(状态机;只列结构与关键逻辑,执行者按此实现):
+
+```csharp
+using System;
+using PromptUGUI.Controls;
+using UnityEngine;
+
+namespace PromptUGUI.Application.Tutorial
+{
+    /// <summary>
+    /// overlay 视图 + 每步状态机:WaitTarget(整屏遮罩,逐 tick 解析路径,累计超时)
+    /// → Active(开洞、摆气泡手指、装推进监听、逐 tick 跟随/检活/轮询 When)
+    /// → 完成(acs.SetResult)或超时(acs.SetException(TimeoutException))。
+    /// LateUpdate 调 Tick(Time.unscaledDeltaTime);EditMode 测试经 UI.Tutorial.TickForTests 手动驱动。
+    /// </summary>
+    internal sealed class TutorialOverlayView : MonoBehaviour
+    {
+        internal SpotlightMask Mask;          // mask Frame GO 上 AddComponent
+        private RectTransform _overlayRect;   // overlay 根
+        private RectTransform _bubbleRoot;    // bubbleRoot Frame
+        private IControl _bubble; private Text _bubbleText; private RectTransform _finger;
+
+        private StepConfig _cfg;
+        private AwaitableCompletionSource _acs;
+        private bool _stepActive;             // 有进行中的步骤
+        private bool _targetLive;             // Active 相
+        private float _waited;
+        private IControl _targetCtl; private RectTransform _targetRect;
+        private TutorialClickRelay _relay;    // TapTarget 在目标 GO / TapAnywhere 在 mask GO
+        private bool _untilStarted;
+
+        internal void Init(Screen screen) { /* Get mask/bubbleRoot/bubble/bubbleText/finger 各 id,
+            mask GO AddComponent<SpotlightMask>,色 = UI.Tutorial.MaskColor(用 Controls.Image.Color
+            同款解析链,grep 其 setter 找解析入口),bubbleRoot 初始 SetActive(false) */ }
+
+        internal void BeginStep(StepConfig cfg, AwaitableCompletionSource acs)
+        {
+            _cfg = cfg; _acs = acs; _stepActive = true; _targetLive = false;
+            _waited = 0f; _untilStarted = false;
+            bool block = cfg.Mode == TutorialMode.Block;
+            Mask.enabled = block; Mask.raycastTarget = block;
+            Mask.SetHole(null);
+            ApplyBubbleText(cfg.Text);          // null → bubbleRoot inactive
+            if (cfg.Target == null) EnterActive(null, null);   // 纯说明页直接 Active
+        }
+
+        internal void EndStep()
+        {
+            RemoveRelay(); _stepActive = false; _targetLive = false;
+            Mask.SetHole(null); HideBubble();
+        }
+
+        internal void Tick(float dt)
+        {
+            if (!_stepActive) return;
+            if (!_targetLive && _cfg.Target != null)
+            {
+                if (UI.TryResolvePath(_cfg.Target, out var ctl, out var rect))
+                    EnterActive(ctl, rect);
+                else
+                {
+                    _waited += dt;
+                    if (_cfg.Timeout >= 0f && _waited > _cfg.Timeout)
+                    { Fail(new TimeoutException($"tutorial step target '{_cfg.Target}' not found")); return; }
+                }
+            }
+            if (_targetLive)
+            {
+                if (_cfg.Target != null && (_targetRect == null))   // Unity 假 null:目标被销毁
+                { LeaveActive(); return; }
+                if (_cfg.Target != null) UpdateVisuals();           // 逐帧跟随(洞 + 气泡 + 手指)
+                if (_cfg.AdvanceKind == Advance.Kind.WhenK && _cfg.Predicate()) Complete();
+            }
+        }
+
+        private void EnterActive(IControl ctl, RectTransform rect)
+        {
+            _targetCtl = ctl; _targetRect = rect; _targetLive = true; _waited = 0f;
+            if (_cfg.AdvanceKind == Advance.Kind.TapTargetK)
+                _relay = AttachRelay(rect.gameObject);
+            else if (_cfg.AdvanceKind == Advance.Kind.TapAnywhereK)
+                _relay = AttachRelay(Mask.gameObject);
+            if (_cfg.AdvanceKind == Advance.Kind.UntilK && !_untilStarted)
+            { _untilStarted = true; _ = AwaitCondition(); }
+            if (_cfg.Target != null) UpdateVisuals();
+            else CenterBubble();
+        }
+
+        private void LeaveActive()   // 目标销毁 → 回等待态
+        { RemoveRelay(); _targetLive = false; Mask.SetHole(null); }
+
+        private void UpdateVisuals()
+        {
+            var local = WorldRectToLocal(_targetRect, _overlayRect);
+            var hole = new Rect(local.xMin - _cfg.Padding, local.yMin - _cfg.Padding,
+                local.width + 2 * _cfg.Padding, local.height + 2 * _cfg.Padding);
+            if (_cfg.Mode == TutorialMode.Block) Mask.SetHole(hole);
+            var bubbleSize = ((RectTransform)_bubble.RectTransform).rect.size;
+            var r = TutorialPlacement.Choose(_overlayRect.rect, local, bubbleSize,
+                gap: 60f, _cfg.Place);
+            /* bubbleRoot anchoredPosition = r.BubblePos(注意 bubbleRoot 锚点居中);
+               finger.anchoredPosition = r.FingerPos - r.BubblePos(finger 是 bubbleRoot 子节点,转相对坐标);
+               finger.localEulerAngles = (0,0,r.FingerAngle) */
+        }
+
+        private async Awaitable AwaitCondition()
+        { try { await _cfg.Condition(); Complete(); } catch (Exception ex) { Fail(ex); } }
+
+        private TutorialClickRelay AttachRelay(GameObject go)
+        {
+            var r = go.AddComponent<TutorialClickRelay>();
+            r.OnClicked = Complete;
+            return r;
+        }
+
+        private void RemoveRelay()
+        {
+            if (_relay == null) return;
+            _relay.OnClicked = null;
+            if (UnityEngine.Application.isPlaying) Destroy(_relay); else DestroyImmediate(_relay);
+            _relay = null;
+        }
+
+        private void Complete() { if (_stepActive) { _stepActive = false; _acs.TrySetResult(); } }
+        private void Fail(Exception ex) { if (_stepActive) { _stepActive = false; _acs.TrySetException(ex); } }
+
+        private void LateUpdate() => Tick(Time.unscaledDeltaTime);
+
+        internal static Rect WorldRectToLocal(RectTransform target, RectTransform overlayRect)
+        {
+            var corners = new Vector3[4];
+            target.GetWorldCorners(corners);
+            var srcCanvas = target.GetComponentInParent<Canvas>();
+            Camera srcCam = srcCanvas != null ? srcCanvas.worldCamera : null;
+            var dstCanvas = overlayRect.GetComponentInParent<Canvas>();
+            Camera dstCam = dstCanvas != null ? dstCanvas.worldCamera : null;
+            Vector2 min = new(float.MaxValue, float.MaxValue), max = new(float.MinValue, float.MinValue);
+            for (int i = 0; i < 4; i++)
+            {
+                Vector2 sp = RectTransformUtility.WorldToScreenPoint(srcCam, corners[i]);
+                RectTransformUtility.ScreenPointToLocalPointInRectangle(overlayRect, sp, dstCam, out var lp);
+                min = Vector2.Min(min, lp); max = Vector2.Max(max, lp);
+            }
+            return Rect.MinMaxRect(min.x, min.y, max.x, max.y);
+        }
+
+        internal bool IsBlockingStep => _stepActive && _cfg.Mode == TutorialMode.Block;
+        // 测试钩子:HoleForTests(SpotlightMask 加 internal Rect? HoleForTests => _hole)、
+        // BubbleRootActiveForTests、BubbleTextForTests
+    }
+}
+```
+
+`Runtime/Application/UI.Tutorial.cs`(本 task 版本:不含 Run,只含静态配置 + overlay 创建 + 测试钩子):
+
+```csharp
+using System;
+using PromptUGUI.Application.Modals;
+using PromptUGUI.Application.Tutorial;
+using UnityEngine;
+
+namespace PromptUGUI.Application
+{
+    public static partial class UI
+    {
+        public static class Tutorial
+        {
+            public static string XmlSrc { get; set; } = "PromptUGUI/Tutorial/TutorialOverlay.ui";
+            public static int SortingOrder { get; set; } = 3000;   // > Toast(2000) > Modal(1000)
+            public static string MaskColor { get; set; } = "#000000B0";
+
+            private static Func<string, int> _load;
+            private static Action<string, int> _save;
+            public static void UseProgressStore(Func<string, int> load, Action<string, int> save)
+            { _load = load; _save = save; }
+
+            internal static TutorialFlow Active;            // Task 6 的 Run 设置;测试经 BeginSessionForTests
+            private static TutorialOverlayView _view;
+            private static string _overlayKey;
+
+            public static bool IsActive => Active != null;
+            internal static bool IsBlockingInput => _view != null && _view.IsBlockingStep;
+
+            internal static async Awaitable<TutorialOverlayView> EnsureOverlay(TutorialFlow flow)
+            {
+                if (_view != null) return _view;
+                await ModalDocCache.EnsureLoaded(XmlSrc);
+                var (screen, key) = UI.OpenModalScreen(XmlSrc);
+                _overlayKey = key;
+                var canvas = screen.RootGameObject.GetComponent<Canvas>();
+                canvas.overrideSorting = true;
+                canvas.sortingOrder = SortingOrder;
+                _view = screen.RootGameObject.AddComponent<TutorialOverlayView>();
+                _view.Init(screen);
+                return _view;
+            }
+
+            internal static void DestroyOverlay()
+            {
+                if (_overlayKey != null) UI.CloseModalScreen(_overlayKey);
+                _overlayKey = null; _view = null;
+            }
+
+            internal static void ResetForTestsInternal()
+            { Active = null; _view = null; _overlayKey = null; _load = null; _save = null; }
+
+            // —— 测试钩子 —— //
+            internal static TutorialFlow BeginSessionForTests()
+            { var f = new TutorialFlow("test", 0, null); Active = f; return f; }
+            internal static void TickForTests(float dt) => _view?.Tick(dt);
+            internal static TutorialOverlayView ViewForTests => _view;
+        }
+    }
+}
+```
+
+`UI.cs` 的 `ResetForTests()` 里(`Router.ResetForTestsInternal();` 旁)加 `Tutorial.ResetForTestsInternal();`。
+
+实现注意:
+
+- `RunStep` 里 `EnsureOverlay` 是首个 await;EditMode 测试中 `ModalDocCache.EnsureLoaded` 对 Resources 内置 XML 同步完成(Toast 测试同款前提),故 `flow.Step(...)` 返回后 view 已就绪、可立即 `TickForTests`。若 `ModalSourceLoader.LoadAsync` 对 Resources 路径有真实异步点,照 `ToastOverlayTests` 的等待方式处理。
+- `Step_TargetNotResolvable_StaysPending_NoHole` 等测试在 `BeginFlow` 后第一次 Tick 前就要有 view → `BeginSessionForTests` 不创建 overlay,首个 `Step` 创建;测试第一行 `flow.Step(...)` 后 view 即存在。
+- `TimeoutException` 走 `Fail` → `acs.TrySetException`;测试用 `step.GetAwaiter().GetResult()` 解包。
+
+- [ ] **Step 5: refresh + `group_names=["TutorialStepTests"]` 全 PASS;再全量 EditMode 防回归**
+
+- [ ] **Step 6: lint + commit**(`feat(tutorial): TutorialFlow.Step + overlay 视图 tick 状态机(定位/跟随/四式推进)`)
+
+---
+
+### Task 6: UI.Tutorial.Run 生命周期 + 持久化 + guard + ESC gate
+
+**Files:**
+- Modify: `Runtime/Application/UI.Tutorial.cs`(加 `Run`)
+- Modify: `Runtime/Application/UI.Modal.cs`(`OnEscapePressed` 顶部 gate)
+- Modify: `Runtime/Application/UI.Router.Reconcile.cs`(routed-modal ESC lambda gate)
+- Test: `Tests/EditMode/Tutorial/TutorialRunTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+```csharp
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+
+namespace PromptUGUI.Tests.Tutorial
+{
+    public class TutorialRunTests
+    {
+        private Dictionary<string, int> _store;
+
+        private static string Xml(string name) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='{name}'>
+  <Btn id='b' size='100x40'>x</Btn>
+</Screen></PromptUGUI>";
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            _store = new Dictionary<string, int>();
+            UI.Tutorial.UseProgressStore(
+                id => _store.TryGetValue(id, out var v) ? v : 0,
+                (id, n) => _store[id] = n);
+            var files = new Dictionary<string, string> { ["home"] = Xml("home") };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            UI.Router.Map("home", "home");
+        }
+
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        // 驱动一个 Block+TapAnywhere 步骤到完成
+        private static void ClickThrough()
+        {
+            UI.Tutorial.TickForTests(0.016f);
+            UI.Tutorial.ViewForTests.Mask
+                .GetComponent<PromptUGUI.Application.Tutorial.TutorialClickRelay>().FireForTests();
+            UI.Tutorial.TickForTests(0.016f);
+        }
+
+        [Test]
+        public void Run_SavesProgressPerStep_AndSentinelOnFinish()
+        {
+            var run = UI.Tutorial.Run("t1", async t =>
+            {
+                await t.Step(null, text: "a");
+                await t.Step(null, text: "b");
+            });
+            Assert.IsTrue(UI.Tutorial.IsActive);
+            ClickThrough();
+            Assert.AreEqual(1, _store["t1"]);
+            ClickThrough();
+            run.GetAwaiter().GetResult();
+            Assert.AreEqual(int.MaxValue, _store["t1"]);
+            Assert.IsFalse(UI.Tutorial.IsActive);
+            Assert.IsNull(UI.Tutorial.ViewForTests);   // overlay 已销毁
+        }
+
+        [Test]
+        public void Run_Resume_FastForwardsCompletedSteps()
+        {
+            _store["t1"] = 1;   // 第 0 步已完成
+            int shown = 0;
+            var run = UI.Tutorial.Run("t1", async t =>
+            {
+                await t.Step(null, text: "a"); shown++;   // fast-forward:同步完成
+                Assert.AreEqual(1, shown);                 // 不等点击就到这
+                await t.Step(null, text: "b"); shown++;
+            });
+            ClickThrough();                                // 只需推进第 1 步
+            run.GetAwaiter().GetResult();
+            Assert.AreEqual(2, shown);
+        }
+
+        [Test]
+        public void Run_Sentinel_WholeRunInstant_NoOverlay()
+        {
+            _store["t1"] = int.MaxValue;
+            UI.Tutorial.Run("t1", async t =>
+            {
+                await t.Step(null, text: "a");
+                await t.Step(null, text: "b");
+            }).GetAwaiter().GetResult();   // 无需任何 Tick
+            Assert.IsNull(UI.Tutorial.ViewForTests, "全程 fast-forward 不应创建 overlay");
+        }
+
+        [Test]
+        public void Run_BlocksRouterNavigation_AndReleasesAfter()
+        {
+            var run = UI.Tutorial.Run("t1", async t => await t.Step(null, text: "a"));
+            Assert.Throws<NavigationRejectedException>(
+                () => UI.Router.Open("home").GetAwaiter().GetResult());
+            ClickThrough();
+            run.GetAwaiter().GetResult();
+            UI.Router.Open("home").GetAwaiter().GetResult();   // 引导结束放行
+            Assert.AreEqual("home", UI.Router.Current);
+        }
+
+        [Test]
+        public void Flow_Navigate_BypassesGuard()
+        {
+            var run = UI.Tutorial.Run("t1", async t =>
+            {
+                await t.Navigate("home");
+                await t.Step(null, text: "a");
+            });
+            UI.Tutorial.TickForTests(0.016f);
+            Assert.AreEqual("home", UI.Router.Current);   // 内部导航放行
+            ClickThrough();
+            run.GetAwaiter().GetResult();
+        }
+
+        [Test]
+        public void Run_BodyThrows_GuardRemoved_OverlayDestroyed()
+        {
+            var run = UI.Tutorial.Run("t1",
+                t => throw new System.InvalidOperationException("boom"));
+            Assert.Throws<System.InvalidOperationException>(() => run.GetAwaiter().GetResult());
+            Assert.IsFalse(UI.Tutorial.IsActive);
+            Assert.IsNull(UI.Tutorial.ViewForTests);
+            UI.Router.Open("home").GetAwaiter().GetResult();   // guard 已注销
+        }
+
+        [Test]
+        public void Run_Reentry_Throws()
+        {
+            var run = UI.Tutorial.Run("t1", async t => await t.Step(null, text: "a"));
+            Assert.Throws<System.InvalidOperationException>(
+                () => UI.Tutorial.Run("t2", async t => await t.Step(null)).GetAwaiter().GetResult());
+            ClickThrough();
+            run.GetAwaiter().GetResult();
+        }
+
+        [Test]
+        public void Run_NoStore_AlwaysFromScratch()
+        {
+            UI.ResetForTests();   // 清掉 store
+            UI.SourceResolver = src => AwaitableHelpers.Completed<string>(null);
+            var run = UI.Tutorial.Run("t1", async t => await t.Step(null, text: "a"));
+            Assert.IsTrue(UI.Tutorial.IsActive);   // load 缺省 0,正常显示
+            ClickThrough();
+            run.GetAwaiter().GetResult();          // save 缺省 no-op,不抛
+        }
+    }
+}
+```
+
+- [ ] **Step 2: refresh → 红**(`Run` 不存在)
+
+- [ ] **Step 3: 实现**
+
+`UI.Tutorial.cs` 加:
+
+```csharp
+private static readonly Func<string, bool> _rejectAll = _ => false;
+
+public static async Awaitable Run(string id, Func<TutorialFlow, Awaitable> body)
+{
+    if (id == null) throw new ArgumentNullException(nameof(id));
+    if (body == null) throw new ArgumentNullException(nameof(body));
+    if (Active != null)
+        throw new InvalidOperationException("UI.Tutorial.Run: a tutorial is already running");
+
+    int resume = _load?.Invoke(id) ?? 0;
+    var flow = new TutorialFlow(id, resume, _save);
+    Active = flow;
+    Router.AddGuard(_rejectAll);
+    try
+    {
+        await body(flow);
+        _save?.Invoke(id, int.MaxValue);
+    }
+    finally
+    {
+        Router.RemoveGuard(_rejectAll);
+        DestroyOverlay();
+        Active = null;
+    }
+}
+```
+
+(`BeginSessionForTests` 同步改用 `new TutorialFlow("test", 0, null)` 已是如此;`TutorialFlow` 构造已带 `_save`,Task 5 的签名不变。)
+
+ESC gate 两处:
+
+- `UI.Modal.cs` 找到 `OnEscapePressed`(ESC 关 ad-hoc 模态的入口),方法体首行加:
+
+```csharp
+if (Tutorial.IsBlockingInput) return;   // Block 引导期间吞 ESC(spec §3)
+```
+
+- `UI.Router.Reconcile.cs` 的 routed-modal `esc.OnEscape` lambda(`if (IsTop(captured) && !UI.Modal.IsAnyOpen) _ = Back();`)改为:
+
+```csharp
+if (UI.Tutorial.IsBlockingInput) return;
+if (IsTop(captured) && !UI.Modal.IsAnyOpen) _ = Back();
+```
+
+ESC gate 的测试加进 `TutorialRunTests`(此处补一条):
+
+```csharp
+[Test]
+public void EscDuringBlockStep_DoesNotCloseModal()
+{
+    var run = UI.Tutorial.Run("t1", async t => await t.Step(null, text: "a"));
+    UI.Tutorial.TickForTests(0.016f);
+    var msg = MessageBox.Open("hi");   // 引导下层有个 ad-hoc 模态(不 await)
+    UI.Modal.FireEscapeForTests();      // 若无此钩子,找 UI.Modal 既有测试的 ESC 触发方式(ModalEscapeListener.FireForTests)
+    Assert.IsTrue(UI.Modal.IsAnyOpen, "Block 引导期间 ESC 不得关掉模态");
+    ClickThrough();
+    run.GetAwaiter().GetResult();
+}
+```
+
+(`MessageBox.Open` 的可用性与 ESC 触发钩子以 `Tests/EditMode/Modals/` 既有测试写法为准,照抄其 SetUp;若 MessageBox 需先加载内置 XML,同样照抄。)
+
+- [ ] **Step 4: refresh + `group_names=["TutorialRunTests"]` 全 PASS;全量 EditMode + EditorOnly 防回归**
+
+- [ ] **Step 5: lint + commit**(`feat(tutorial): UI.Tutorial.Run 会话生命周期 — 断点续/导航锁/ESC gate`)
+
+---
+
+### Task 7: PlayMode 测试(真实 EventSystem 穿透与推进)
+
+**Files:**
+- Create: `Tests/PlayMode/Tutorial/TutorialPlayTests.cs`
+
+- [ ] **Step 1: 写测试**(参考 `Tests/PlayMode/` 既有测试的 SetUp/相机/EventSystem 模板,尤其 `CarouselPlayTests` 同款骨架)
+
+```csharp
+using System.Collections;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.PlayMode
+{
+    public class TutorialPlayTests
+    {
+        private const string MainXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='main'>
+  <Btn id='target' anchor='center' size='200x80'>GO</Btn>
+  <Btn id='other' anchor='top-left' size='200x80' margin='20'>NO</Btn>
+</Screen></PromptUGUI>";
+
+        // SetUp:UI.ResetForTests + resolver + EventSystem(无则建)照既有 PlayMode 测试模板
+
+        [UnityTest]
+        public IEnumerator BlockStep_RaycastBlockedOutsideHole_PassesInside()
+        {
+            // 1) 开 main 屏,起 Run + Step("main/target")
+            // 2) 等两帧让 LateUpdate 开洞
+            // 3) 用 EventSystem.RaycastAll 打"other"按钮中心的屏幕坐标 → 首个命中应是 SpotlightMask
+            // 4) 打"target"中心 → 首个命中应是 target 的可点击 Graphic(穿透)
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator TapTarget_ClickAdvances_StepCompletes()
+        {
+            // ExecuteEvents.Execute<IPointerClickHandler>(targetGo, pointerData, pointerClickHandler)
+            // 模拟真实点击路径;等一帧,断言 step awaitable 完成、save 被调
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator AdvanceWhen_PredicateFlips_AdvancesNextFrame()
+        {
+            // 不调 TickForTests,纯靠 LateUpdate 驱动:翻 flag 后 yield 两帧,断言完成
+            yield return null;
+        }
+    }
+}
+```
+
+三条用例的注释即实现要求,补全为真实代码(屏幕坐标取 `RectTransformUtility.WorldToScreenPoint(null, rt.position)`,Overlay canvas camera 为 null)。
+
+- [ ] **Step 2: `run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], group_names=["TutorialPlayTests"])` 全 PASS;全量 PlayMode 防回归**
+
+- [ ] **Step 3: lint + commit**(`test(tutorial): PlayMode 穿透/推进用例`)
+
+---
+
+### Task 8: SKILL 更新 + 收尾
+
+**Files:**
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md`
+
+- [ ] **Step 1: SKILL 更新(英文)**
+
+新增两节:
+
+1. **Tutorial(`UI.Tutorial`)**:`UseProgressStore(load, save)` 委托语义(默认每次从头);`Run(id, body)` 包裹会话 + 重入抛 `InvalidOperationException`;`Step` 全参数(target 路径 = Toast 同款 `"screenName/idPath"`、`TutorialMode.Block/Hint`、`Advance.TapTarget/TapAnywhere/When/Until` 与默认推断、`Side` 避让、`padding`、`timeout`);断点续 fast-forward 语义与 `int.MaxValue` 哨兵;`t.Navigate` 才能在引导中导航(直接 `UI.Router.Open` 会被拒);换肤(`UI.Tutorial.XmlSrc` 整张覆盖、`MaskColor`、`SortingOrder`);完整 Run 示例(抄 spec §2 用例)。
+2. **Router guards**:`UI.Router.AddGuard/RemoveGuard` + `NavigationRejectedException`,独立示例(未保存修改拦 `Back`)。
+
+- [ ] **Step 2: 终验**
+
+按顺序全跑:
+
+```
+refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+read_console(types=["error"]) → 0 error
+run_tests EditMode PromptUGUI.Tests.EditMode → 全绿
+run_tests EditMode PromptUGUI.Tests.EditorOnly → 全绿
+run_tests PlayMode PromptUGUI.Tests.PlayMode → 全绿
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx → exit 0
+dotnet run --project .lint/UIXmlLint -- Runtime/Resources/ → exit 0
+```
+
+- [ ] **Step 3: commit + push + PR**
+
+```bash
+git add .claude/skills/scripting-promptugui-csharp/SKILL.md
+git commit -m "docs(skill): UI.Tutorial 引导 API + Router guard 条目"
+git push -u origin feat/tutorial-system
+gh pr create --title "feat: UI.Tutorial 新手引导系统 — 路径定位/挖洞遮罩/全屏拦截/断点续" --body "..."
+```
+
+PR body 列:spec 链接、三层拦截机制、新公共 API 面、测试数、视觉 QA 待用户(手指/气泡/遮罩观感)。
+
+---
+
+## Self-Review 记录
+
+- **Spec 覆盖**:§2 API(Task 5/6)、§3 三层拦截(Task 1 guard、Task 2 挖洞、Task 6 ESC gate)、§4 guard(Task 1)、§5 视觉(Task 2/3/4/5)、§6 生命周期(Task 6)、§7 边界表(分散在 Task 5/6 测试)、§8 测试(Task 1-7)、§10 SKILL(Task 8)。spec §3 "overlay 挂 ModalEscapeListener 吞 ESC"在计划中改为 Modal 侧 gate(`IsBlockingInput` 检查)——因为各 ModalEscapeListener 独立监听全局输入,引导侧"吞"无法阻止 Modal 侧实例触发;机制变更,行为与 spec 一致,实施时在 spec §3 加一行勘误注记。
+- **类型一致性**:`Advance.Kind` 成员带 `K` 后缀避免与静态属性 `TapTarget` 撞名;`TutorialFlow` 构造 `(id, resume, save)` 三参在 Task 5/6 一致;`StepConfig`/`BeginStep`/`EndStep`/`Tick`/`IsBlockingStep` 名称全计划统一。
+- **已知留白(执行时按指引现场核对,非 TBD)**:MaskColor 的色值解析入口(grep `Controls.Image.Color` setter)、9-slice sprite 名(抄 MessageBox.ui.xml)、MessageBox EditMode 测试模板(抄 Tests/EditMode/Modals/)、PlayMode 模板(抄 CarouselPlayTests)、finger.pxl(authoring-promptugui-pxl skill)。

--- a/docs~/superpowers/specs/2026-06-12-tutorial-system-design.md
+++ b/docs~/superpowers/specs/2026-06-12-tutorial-system-design.md
@@ -130,14 +130,17 @@ public static partial class UI
 <?xml version="1.0" encoding="utf-8"?>
 <PromptUGUI version="1">
   <Screen name="PromptUGUI/Tutorial/TutorialOverlay.ui" reference="1920x1080" reference.portrait="1080x1920">
-    <!-- SpotlightMask 由 C# 在 mask 节点上挂载;XML 只占位提供颜色等可换肤项 -->
+    <!-- mask: 纯 RectTransform 容器(Frame 无 Graphic);C# 在其 GameObject 挂 SpotlightMask + 应用 MaskColor -->
     <Frame id="mask" anchor="stretch"/>
-    <Frame id="bubbleRoot" size="0x0">
-      <Image id="bubble" sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round" color="#222222EE">
-        <Text id="bubbleText" anchor="stretch" margin="16" fontSize="22" align="center"/>
+    <!-- bubbleRoot: 气泡+手指容器,锚点居中(对齐 TutorialPlacement 中心原点坐标系);C# 每帧摆位 -->
+    <Frame id="bubbleRoot" anchor="center" size="0x0">
+      <Image id="bubble" anchor="center" size="300x100"
+             sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round" color="#222222EE">
+        <Text id="bubbleText" anchor="stretch" margin="16" fontSize="22" align="center" color="white"/>
       </Image>
       <!-- finger: 复用内置 caret(本身朝下);视图按 FingerAngle+180 旋转使其指向目标 -->
-      <Image id="finger" sprite="PromptUGUI/Defaults/pugui.png#pugui_caret" size="48x48"/>
+      <Image id="finger" anchor="center" size="48x48"
+             sprite="PromptUGUI/Defaults/pugui.png#pugui_caret"/>
     </Frame>
   </Screen>
 </PromptUGUI>

--- a/docs~/superpowers/specs/2026-06-12-tutorial-system-design.md
+++ b/docs~/superpowers/specs/2026-06-12-tutorial-system-design.md
@@ -1,0 +1,226 @@
+# UI.Tutorial 新手引导系统:路径定位 + 挖洞遮罩 + 全屏输入拦截
+
+**日期**:2026-06-12
+**状态**:设计阶段(已 review 通过,待实施计划)
+**作用域**:新增 `UI.Tutorial` 门面(C# await 步骤序列)、`SpotlightMask` 挖洞遮罩、`TutorialOverlay.ui.xml` 可换肤视觉层、`UI.Router.AddGuard` 导航前置拒绝钩子。不新增作者可写的 XML 元素/属性。
+**关联**:定位复用 Toast 的 `"screenName/idPath"` 最长前缀匹配(`UI.TryResolvePath`,见 [`UI.Toast`] 体系);坐标转换复用 `ToastPosition.TryResolveLocalPoint` 三段式;置顶与输入拦截复用 Modal 的 `overrideSorting + sortingOrder` 手法。公开 C# API 新增 → `scripting-promptugui-csharp` 必须更新(见 §10);`authoring-promptugui-xml` 不动(overlay XML 是内部资产)。
+
+---
+
+## 1. 背景与目标
+
+新手引导是手游标配,但每个项目都要重新手搓"遮罩 + 手指 + 拦输入 + 等控件出现"这套脏活。PromptUGUI 已具备三块关键地基:
+
+1. **全局控件路径**:`UI.TryResolvePath("screenName/idPath")`(UI.cs)对开屏列表做最长前缀匹配,再经 `Screen.Get` 的 ScopedIds 递归定位——Toast 的 `At(controlPath)` 已在用;
+2. **跨 Canvas 坐标转换**:`ToastPosition.TryResolveLocalPoint` 的 世界坐标 → 屏幕坐标 → overlay 本地坐标 三段式;
+3. **置顶输入拦截**:Modal 的 overlay Canvas `overrideSorting + sortingOrder` + 全屏 raycast Image。
+
+缺口只有两处:**挖洞穿透**(只许点目标)与 **deeplink/导航拒绝钩子**(Router 目前只有 `onEnter` 后置钩子)。
+
+v1 目标(用户确认):核心(挖洞遮罩+目标穿透、手指+气泡、全屏拦截+Router guard、等待目标出现、resize/移动跟随) + 进度持久化委托 + 弱引导档位(Hint) + 气泡自动避让。**非目标**见 §9。
+
+## 2. C# API
+
+`Runtime/Application/UI.Tutorial.cs` + `Runtime/Application/Tutorial/TutorialFlow.cs`:
+
+```csharp
+public static partial class UI
+{
+    public static class Tutorial
+    {
+        // 持久化委托(同 SourceResolver 哲学:存哪是调用方的事;不注册 = 每次从头)
+        public static void UseProgressStore(Func<string, int> load, Action<string, int> save);
+
+        // 一段引导 = 一次 Run;id 用于持久化断点;body 内一步一 await
+        public static Awaitable Run(string id, Func<TutorialFlow, Awaitable> body);
+
+        public static bool IsActive { get; }
+    }
+}
+
+public sealed class TutorialFlow
+{
+    public Awaitable Step(
+        string target,                        // "screenName/idPath";null = 纯说明页(无洞、无手指指向)
+        string text = null,                   // 气泡文案,走现有 i18n;null = 不显示气泡
+        TutorialMode mode = TutorialMode.Block,   // Block 强引导 / Hint 弱引导
+        Advance advance = default,            // 默认:target!=null → TapTarget;target==null → TapAnywhere
+        Side place = Side.Auto,               // 气泡+手指方位:Auto 避让 / Top / Bottom / Left / Right
+        float padding = 8f,                   // 挖洞相对目标 rect 的外扩(设计单位)
+        float timeout = -1f);                 // 等目标出现的上限秒数;-1 = 无限
+
+    // 脚本内发起导航(带 bypass 标记,guard 放行)
+    public Awaitable Navigate(string name, RouteQuery query = null);
+}
+
+public enum TutorialMode { Block, Hint }
+public enum Side { Auto, Top, Bottom, Left, Right }
+
+public readonly struct Advance
+{
+    public static Advance TapTarget { get; }                    // 点击目标控件本体
+    public static Advance TapAnywhere { get; }                  // 点任意处
+    public static Advance When(Func<bool> predicate);           // 逐帧轮询谓词
+    public static Advance Until(Func<Awaitable> condition);     // await 外部条件
+}
+```
+
+用法示例:
+
+```csharp
+UI.Tutorial.UseProgressStore(id => PlayerPrefs.GetInt("tut_" + id, 0),
+                             (id, n) => PlayerPrefs.SetInt("tut_" + id, n));
+
+await UI.Tutorial.Run("first-purchase", async t =>
+{
+    await t.Step("main/shopBtn", text: "点这里进商店");
+    await t.Step("shop/items/0/buyBtn", text: "买下它");
+    await t.Step(null, text: "做得好！", advance: Advance.TapAnywhere);
+    await t.Step("main/bagBtn", text: "去背包看看", mode: TutorialMode.Hint,
+                 advance: Advance.When(() => bagOpened));
+});
+```
+
+设计要点:
+
+- **`Run(id, body)` 包裹式会话**:setup(创建 overlay、注册 guard、置 `IsActive`)与 teardown(销毁 overlay、注销 guard)在 try/finally 中,body 抛异常也保证清理。重入保护:`Run` 嵌套/并发调用直接抛 `InvalidOperationException`(引导天然全局独占)。
+- **断点续(fast-forward)**:`Run` 开始时 `load(id)` 取得已完成步数 `n`;`TutorialFlow` 内部维护步序号,序号 < n 的 `Step` **瞬时完成、不显示任何视觉**;每步真实完成后 `save(id, 序号+1)`。整段跑完后 `save(id, int.MaxValue)` 哨兵,下次 `Run` 直接整段瞬过。把游戏状态推进到断点对应场景是脚本自己的事——fast-forward 的 `Step` 不等待目标出现、不校验路径,脚本应在步骤间用 `t.Navigate` 等幂等操作铺路(深链 reconcile 保证"已在目标页时 Navigate 是 no-op")。
+- **`Advance.When` 轮询**:每帧检查(overlay view 的 Update),谓词为真即推进。不用 R3 依赖,保持 Runtime 零三方。
+- **取消**:v1 不提供 `CancellationToken`(无跳过按钮,引导只能走完或进程退出;退出后靠持久化续)。
+
+## 3. 输入拦截(Block 模式)
+
+三层封锁,`Run` 激活、Block 步骤期间生效:
+
+1. **指针**:overlay Canvas `overrideSorting = true`,`sortingOrder = TutorialSortingOrderBase`(常量,取值高于 `UI.Modal.SortingOrderBase + 合理栈深`,如 Modal 基数 + 1000)。全屏 `SpotlightMask` 是 raycast target,吃掉一切指针事件——除洞内。
+2. **挖洞穿透**:`SpotlightMask : MaskableGraphic, ICanvasRaycastFilter`,`IsRaycastLocationValid` 在洞矩形(目标 rect + padding,overlay 本地坐标)内返回 **false** → raycast 穿透到下层真实控件。`Advance.TapTarget` 因此不需要任何 hack:直接订阅目标控件自身的点击(`Btn.OnClick`;非 Btn 目标退化为在目标 GameObject 上临时挂 `IPointerClickHandler` 监听组件,步骤结束移除)。
+3. **导航/deeplink**:新增 `UI.Router.AddGuard` / `RemoveGuard`(§4)。引导注册"全拒"guard;`t.Navigate` 内部置 bypass 标记后调 `UI.Router.Open`,guard 检查标记放行。
+4. **ESC/手柄**:overlay 根挂 `ModalEscapeListener` 同款双轨监听(New Input System / Legacy),Block 步骤期间吞掉 escape 不做任何事(防止 ESC 关掉引导底下的 Modal)。
+
+Hint 模式:`SpotlightMask.enabled = false` + `raycastTarget = false`,ESC 监听不吞,guard 仍注册(整段 `Run` 期间导航锁定保持一致——弱引导步骤玩家可以无视提示,但不能 deeplink 跳走打断脚本时序)。
+
+**纯说明页(`target == null`)+ TapAnywhere**:无洞,整屏 mask 可点,点击即推进。
+
+## 4. `UI.Router.AddGuard`(独立交付件)
+
+```csharp
+public static partial class UI
+{
+    public static partial class Router
+    {
+        // 返回 false → 本次 Open/Navigate 立即失败(不改栈、不触发 Changed)
+        public static void AddGuard(Func<string /*name*/, bool> guard);
+        public static void RemoveGuard(Func<string, bool> guard);
+    }
+}
+```
+
+- `Open(name, query)` 与 `Navigate(url)`(解析后)在 reconcile **之前**逐个调用 guard,任一返回 false → 抛 `NavigationRejectedException`(不静默:调用方能区分"被拦"与"成功",与 reconcile 失败回滚的既有错误语义一致)。
+- guard 列表为静态 List,`ResetForTests` 清空。
+- 引导的 bypass:`TutorialFlow.Navigate` 在调用前设置内部静态标志(`Router.BypassGuardsOnce` internal),guard 链检查前若标志置位则跳过整链并复位。单线程主循环,无并发问题。
+- 独立价值:调用方可用它做"有未保存修改时拦截返回"等场景,写入 C# SKILL。
+
+## 5. 视觉层
+
+### 5.1 TutorialOverlay.ui.xml(内置、可换肤)
+
+`Runtime/Resources/PromptUGUI/Tutorial/TutorialOverlay.ui.xml`,克隆 Toast/LoadingOverlay 的骨架与加载机制(`TutorialOverlayView.XmlSrc` 静态属性可整张替换):
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<PromptUGUI version="1">
+  <Screen name="PromptUGUI/Tutorial/TutorialOverlay.ui" reference="1920x1080" reference.portrait="1080x1920">
+    <!-- SpotlightMask 由 C# 在 mask 节点上挂载;XML 只占位提供颜色等可换肤项 -->
+    <Frame id="mask" anchor="stretch"/>
+    <Frame id="bubbleRoot" size="0x0">
+      <Image id="bubble" sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round" color="#222222EE">
+        <Text id="bubbleText" anchor="stretch" margin="16" fontSize="22" align="center"/>
+      </Image>
+      <Image id="finger" sprite="PromptUGUI/Tutorial/finger.pxl" size="48x48"/>
+    </Frame>
+  </Screen>
+</PromptUGUI>
+```
+
+- 遮罩颜色、气泡皮肤、手指 sprite 都在 XML 里,用户照 Modal 的老办法整张覆盖换肤。
+- 手指默认资产用 `.pxl` 画(自家管线狗粮);四方位通过旋转/翻转同一张 sprite。
+- `SpotlightMask` 组件不是 XML 控件(无作者可写面),由 `TutorialOverlayView` 在 `mask` 节点的 GameObject 上 AddComponent 并接管渲染;遮罩色取 XML 里 mask 节点的 color 属性约定(读 `Frame` 背景色,缺省 `#000000B0`)。
+
+### 5.2 SpotlightMask
+
+`Runtime/Application/Tutorial/SpotlightMask.cs`:
+
+- `MaskableGraphic` 子类,`OnPopulateMesh` 生成洞外四块 quad(上/下/左/右环形带);洞矩形为空(纯说明页/无目标)时退化为整屏单 quad。不用 shader/stencil,WebGL 安全。
+- `ICanvasRaycastFilter.IsRaycastLocationValid`:洞内 → false(穿透),洞外 → true(拦截)。
+- 公开 `SetHole(Rect? holeInLocalSpace)`,变更时 `SetVerticesDirty()`。
+- v1 洞为矩形(含 padding),不做圆角/圆形——遮罩半透明,边角形状感知度低。
+
+### 5.3 定位、跟随与避让
+
+`Runtime/Application/Tutorial/TutorialTargetLocator.cs` + `TutorialOverlayView.cs`:
+
+- **等待目标出现**:`Step` 进入时逐帧尝试 `UI.TryResolvePath(target)`,成功且 `GameObject != null` 才开始显示;超过 `timeout` 抛 `TimeoutException`(-1 无限等)。覆盖异步开屏、BindItems 列表项晚到等场景。
+- **逐帧跟随**:`TutorialOverlayView.LateUpdate` 每帧重算目标 rect → overlay 本地坐标(ToastPosition 三段式:`TransformPoint` 世界坐标 → `WorldToScreenPoint` → `ScreenPointToLocalPointInRectangle`,取 rect 四角而非中心点),更新洞与气泡/手指。resize、ReSolve、Variant 切换、目标自身动画全自动跟上,无需订阅事件。
+- **失效重等**:目标 GameObject 中途被销毁(BindItems 重建等)→ 退回"等待目标出现"状态重新解析路径;期间洞收起(整屏遮罩),气泡保留。
+- **气泡避让(`Side.Auto`)**:在 Top/Bottom/Left/Right 四向中,计算气泡放在该侧后与 overlay 边界的溢出量,选溢出为零且剩余空间最大的一侧;全部溢出则取溢出最小者。手指贴在气泡与目标之间,按方位旋转(Top→手指朝下,依此类推)。`place` 显式指定则跳过计算。
+- **纯说明页**:无洞;气泡屏幕居中,手指隐藏。
+
+## 6. 生命周期与时序
+
+```
+UI.Tutorial.Run(id, body)
+  ├─ 重入检查 → load(id) 得 fastForwardCount
+  ├─ 创建 overlay Screen(LoadDocument 内置 XML)、AddComponent SpotlightMask、注册 Router guard
+  ├─ await body(flow)
+  │    └─ flow.Step(...) × N:
+  │         序号 < fastForwardCount → 立即返回
+  │         否则: await 目标可解析(timeout) → 显示洞/气泡/手指
+  │                → await advance 条件 → 隐藏视觉 → save(id, 序号+1)
+  ├─ save(id, int.MaxValue)
+  └─ finally: 注销 guard、销毁 overlay Screen
+```
+
+- overlay Screen 不进 `_open` 字典(同 Toast/LoadingOverlay 惯例),不参与路径解析、不被 Router reconcile 触碰。
+- `Screen.Close()` 的 EditMode `DestroyImmediate` 分支照常生效,EditMode 测试可同步驱动。
+
+## 7. 边界与防御
+
+| 场景 | 行为 |
+|---|---|
+| `Run` 嵌套/并发 | 抛 `InvalidOperationException` |
+| 目标路径永不出现且 `timeout=-1` | 永久等待(脚本作者责任);建议测试/开发期传有限 timeout |
+| 目标中途销毁 | 退回等待态重新解析(§5.3) |
+| 步骤期间横竖屏切换 | LateUpdate 逐帧跟随,洞/气泡自动重排;Variant ReSolve 不影响 overlay(独立 Screen) |
+| 引导期间代码直接调 `UI.Router.Open`(非 `t.Navigate`) | guard 拒绝,抛 `NavigationRejectedException` |
+| Block 步骤压在已开 Modal 之上 | sortingOrder 更高,Modal 不可点;ESC 被引导吞掉,Modal 不会被误关 |
+| 未注册 ProgressStore | load 恒 0、save no-op,每次从头 |
+| TapTarget 但目标非 Btn | 临时挂 `IPointerClickHandler` 监听组件,步骤结束移除 |
+
+## 8. 测试
+
+EditMode(`UI.ResetForTests` + fake resolver 模式,仿 `DocumentLoaderTests`):
+
+1. **Guard**:AddGuard 返回 false → `Open` 抛 `NavigationRejectedException` 且栈不变、`Changed` 不触发;RemoveGuard 后恢复;bypass 标记放行一次并复位。
+2. **fast-forward**:store 返回 n → 前 n 个 Step 瞬时完成不创建视觉;每步完成 save 序号;整段完成 save 哨兵。
+3. **Locator**:路径不可解析时挂起;注入 Screen 后解析成功;timeout 抛 `TimeoutException`;目标销毁后退回等待态。
+4. **避让几何**:给定目标 rect 与 overlay 尺寸,四向选择正确;`place` 覆盖生效;纯说明页居中。
+5. **SpotlightMask**:`SetHole` 后 `IsRaycastLocationValid` 洞内 false / 洞外 true;洞为 null 整屏 true;mesh 顶点数符合四象限/单 quad 预期。
+6. **Run 生命周期**:body 抛异常 → guard 已注销、overlay 已销毁;重入抛异常。
+
+PlayMode(仿 `CarouselPlayTests`):
+
+7. 真实 EventSystem 下,Block 步骤点击洞外控件无响应、点击洞内目标 Btn 触发 OnClick 且步骤推进;
+8. `Advance.When` 谓词翻真后下一帧推进。
+
+## 9. 非目标(v1)
+
+- 跳过按钮 / `CancellationToken` 中途取消(用户明确不选;持久化已覆盖"杀进程续"诉求)。
+- XML 数据驱动的 `.tutorial.xml` 步骤描述(将来可作为薄层叠加在 `TutorialFlow` 之上)。
+- 圆形/圆角洞、洞边缘描边动画、手指点击动效(换肤层将来可加)。
+- 文案气泡富文本(纯 `<Text>`;要图文混排等 `<Markdown>` 集成另议)。
+- 多段引导编排/依赖图(脚本层面自己 if/else)。
+
+## 10. SKILL 更新
+
+- `scripting-promptugui-csharp/SKILL.md`:新增「Tutorial 新手引导」一节(`UseProgressStore` / `Run` / `Step` 签名、`Advance` 四式、Block/Hint、`t.Navigate` 与 guard 的关系、断点续语义),以及 `UI.Router.AddGuard/RemoveGuard` 条目(独立用途示例:未保存拦返回)。
+- `authoring-promptugui-xml`:不动(overlay XML 非作者可写面,无新元素/属性)。

--- a/docs~/superpowers/specs/2026-06-12-tutorial-system-design.md
+++ b/docs~/superpowers/specs/2026-06-12-tutorial-system-design.md
@@ -162,7 +162,8 @@ public static partial class UI
 - **等待目标出现**:`Step` 进入时逐帧尝试 `UI.TryResolvePath(target)`,成功且 `GameObject != null` 才开始显示;超过 `timeout` 抛 `TimeoutException`(-1 无限等)。覆盖异步开屏、BindItems 列表项晚到等场景。
 - **逐帧跟随**:`TutorialOverlayView.LateUpdate` 每帧重算目标 rect → overlay 本地坐标(ToastPosition 三段式:`TransformPoint` 世界坐标 → `WorldToScreenPoint` → `ScreenPointToLocalPointInRectangle`,取 rect 四角而非中心点),更新洞与气泡/手指。resize、ReSolve、Variant 切换、目标自身动画全自动跟上,无需订阅事件。
 - **失效重等**:目标 GameObject 中途被销毁(BindItems 重建等)→ 退回"等待目标出现"状态重新解析路径;期间洞收起(整屏遮罩),气泡保留。
-- **气泡避让(`Side.Auto`)**:在 Top/Bottom/Left/Right 四向中,计算气泡放在该侧后与 overlay 边界的溢出量,选溢出为零且剩余空间最大的一侧;全部溢出则取溢出最小者。手指贴在气泡与目标之间,按方位旋转(Top→手指朝下,依此类推)。`place` 显式指定则跳过计算。
+- **气泡避让(`Side.Auto`)**:在 Top/Bottom/Left/Right 四向中,选目标与 overlay 边界之间剩余空间最大的一侧。手指贴在气泡与目标之间,按方位旋转(Top→手指朝下,依此类推)。`place` 显式指定则跳过计算。
+  - 实现勘误(2026-06-12):气泡中心在每侧均做双轴夹紧,保证恒不越过全屏 overlay,因此"溢出量"对任意现实输入恒为 0 —— 选边判据退化为单一的"剩余空间最大",不再需要原设想的"溢出为零优先 / 全溢出取最小"二级评分(那条分支在夹紧前提下永不可达,已从代码移除)。
 - **纯说明页**:无洞;气泡屏幕居中,手指隐藏。
 
 ## 6. 生命周期与时序

--- a/docs~/superpowers/specs/2026-06-12-tutorial-system-design.md
+++ b/docs~/superpowers/specs/2026-06-12-tutorial-system-design.md
@@ -95,7 +95,7 @@ await UI.Tutorial.Run("first-purchase", async t =>
 1. **指针**:overlay Canvas `overrideSorting = true`,`sortingOrder = TutorialSortingOrderBase`(常量,取值高于 `UI.Modal.SortingOrderBase + 合理栈深`,如 Modal 基数 + 1000)。全屏 `SpotlightMask` 是 raycast target,吃掉一切指针事件——除洞内。
 2. **挖洞穿透**:`SpotlightMask : MaskableGraphic, ICanvasRaycastFilter`,`IsRaycastLocationValid` 在洞矩形(目标 rect + padding,overlay 本地坐标)内返回 **false** → raycast 穿透到下层真实控件。`Advance.TapTarget` 因此不需要任何 hack:直接订阅目标控件自身的点击(`Btn.OnClick`;非 Btn 目标退化为在目标 GameObject 上临时挂 `IPointerClickHandler` 监听组件,步骤结束移除)。
 3. **导航/deeplink**:新增 `UI.Router.AddGuard` / `RemoveGuard`(§4)。引导注册"全拒"guard;`t.Navigate` 内部置 bypass 标记后调 `UI.Router.Open`,guard 检查标记放行。
-4. **ESC/手柄**:overlay 根挂 `ModalEscapeListener` 同款双轨监听(New Input System / Legacy),Block 步骤期间吞掉 escape 不做任何事(防止 ESC 关掉引导底下的 Modal)。
+4. **ESC/手柄**:不在 overlay 上自挂监听(各 `ModalEscapeListener` 是独立全局监听,引导侧"吞"拦不住底层 Modal 实例触发)。改为在 ESC 的两个落点加门:`UI.Modal.OnEscapePressed` 与 `UI.Router.Reconcile` 的 routed-modal ESC lambda 首行都判 `if (UI.Tutorial.IsBlockingInput) return;` —— Block 步骤期间 ESC 不关下层 Modal。引导本身无 ESC 监听(只能走完步骤推进)。
 
 Hint 模式:`SpotlightMask.enabled = false` + `raycastTarget = false`,ESC 监听不吞,guard 仍注册(整段 `Run` 期间导航锁定保持一致——弱引导步骤玩家可以无视提示,但不能 deeplink 跳走打断脚本时序)。
 

--- a/docs~/superpowers/specs/2026-06-12-tutorial-system-design.md
+++ b/docs~/superpowers/specs/2026-06-12-tutorial-system-design.md
@@ -136,14 +136,15 @@ public static partial class UI
       <Image id="bubble" sprite="PromptUGUI/Defaults/pugui.png#pugui_9slice_round" color="#222222EE">
         <Text id="bubbleText" anchor="stretch" margin="16" fontSize="22" align="center"/>
       </Image>
-      <Image id="finger" sprite="PromptUGUI/Tutorial/finger.pxl" size="48x48"/>
+      <!-- finger: 复用内置 caret(本身朝下);视图按 FingerAngle+180 旋转使其指向目标 -->
+      <Image id="finger" sprite="PromptUGUI/Defaults/pugui.png#pugui_caret" size="48x48"/>
     </Frame>
   </Screen>
 </PromptUGUI>
 ```
 
 - 遮罩颜色、气泡皮肤、手指 sprite 都在 XML 里,用户照 Modal 的老办法整张覆盖换肤。
-- 手指默认资产用 `.pxl` 画(自家管线狗粮);四方位通过旋转/翻转同一张 sprite。
+- 手指默认资产复用内置 caret 子精灵 `PromptUGUI/Defaults/pugui.png#pugui_caret`(本身朝下的下拉箭头);`.pxl` 需宿主工程 SpriteSet + Sync Atlases 工具,无法零配置作为内置资产从包 Resources 运行时加载,故不用。四方位通过旋转同一张 sprite 实现,换肤仍是"整张覆盖 overlay XML"。
 - `SpotlightMask` 组件不是 XML 控件(无作者可写面),由 `TutorialOverlayView` 在 `mask` 节点的 GameObject 上 AddComponent 并接管渲染;遮罩色取 XML 里 mask 节点的 color 属性约定(读 `Frame` 背景色,缺省 `#000000B0`)。
 
 ### 5.2 SpotlightMask


### PR DESCRIPTION
## 概要

新增 `UI.Tutorial` 新手引导(coach-mark / onboarding)系统:C# `await` 步骤序列驱动,逐步聚光任意控件(半透明全屏遮罩 + 挖洞)、显示气泡 + 手指、拦截全部其它输入(指针 + ESC + deeplink 导航),直到该步满足。控件定位复用 Toast 的 `"screenName/idPath"` 路径。附带独立交付件 `UI.Router.AddGuard/RemoveGuard` 导航前置拒绝钩子。

详见设计 spec:`docs~/superpowers/specs/2026-06-12-tutorial-system-design.md`。

## 用法

```csharp
UI.Tutorial.UseProgressStore(
    load: id => PlayerPrefs.GetInt("tut_" + id, 0),
    save: (id, n) => PlayerPrefs.SetInt("tut_" + id, n));

await UI.Tutorial.Run("first-purchase", async t =>
{
    await t.Step("main/shopBtn", text: "点这里进商店");
    await t.Step("shop/items/0/buyBtn", text: "买下它");
    await t.Step(null, text: "做得好！", advance: Advance.TapAnywhere);
    await t.Step("main/bagBtn", text: "去背包看看", mode: TutorialMode.Hint,
                 advance: Advance.When(() => bagOpened));
});
```

## 三层输入拦截

- **指针**:`SpotlightMask : MaskableGraphic, ICanvasRaycastFilter` —— 四带 mesh 渲染遮罩、洞内 `IsRaycastLocationValid=false` 让点击穿透到真实控件(无 shader/stencil,WebGL 安全)。
- **导航/deeplink**:`Run` 期间注册 reject-all `UI.Router` guard;脚本内 `t.Navigate(...)` 带 bypass 放行。
- **ESC**:在 `UI.Modal.OnEscapePressed` 与 Router routed-modal ESC 落点判 `IsBlockingInput`(不在 overlay 自挂监听 —— 各 listener 独立全局,引导侧吞不住底层 Modal)。

## 关键设计点

- **断点续**:`Run` 读 `load(id)` fast-forward 已完成步骤(无视觉),每步存 `index+1`,整段完成存 `int.MaxValue` 哨兵。
- **定位 + 跟随**:逐帧 `LateUpdate` 把目标 rect 转 overlay 坐标重算洞/气泡/手指;目标晚到则等待(可超时),中途销毁则退回等待态。
- **气泡四向避让**:`TutorialPlacement` 纯几何选剩余空间最大一侧;手指复用内置 `pugui.png#pugui_caret`(`.pxl` 需宿主 SpriteSet 工具,不能零配置作内置资产)。
- **换肤**:`UI.Tutorial.XmlSrc` 可整张替换 overlay,`MaskColor` / `SortingOrder`(默认 3000,高于 Modal/Toast)可调。

## 新增公开 API

`UI.Tutorial.{Run, UseProgressStore, IsActive, XmlSrc, SortingOrder, MaskColor}`、`TutorialFlow.{Step, Navigate}`、`Advance.{TapTarget, TapAnywhere, When, Until}`、枚举 `TutorialMode`/`Side`、`UI.Router.{AddGuard, RemoveGuard}`、`NavigationRejectedException`。`scripting-promptugui-csharp` SKILL 已更新(新增 Tutorial + Navigation guards 两节)。

## 测试

- EditMode **1641/1641** 绿(含 Router guard、SpotlightMask、TutorialPlacement、Step 状态机、Run 生命周期、UnloadAll 中途 teardown)。
- PlayMode **136/136** 绿(含 3 个 Tutorial 真实 EventSystem 穿透/推进用例)。
- lint(`dotnet format`)+ UIXmlLint clean(新文件)。
- ⚠️ EditorOnly 套件有 `SpriteAtlasSyncerTests` 失败,但**与本 PR 无关**:是宿主工程 sprite 库 `Box-Primary-Frame` 裸名冲突(`Sliced/Box-Primary-Frame` vs `Sliced/Box-Primary/Box-Primary-Frame`)—— 本 PR diff 不含任何 atlas/sprite/资产文件,`Box-Primary` 也不在本包内。

## 待办

- [ ] 视觉 QA(用户):手指/气泡/遮罩观感、四向避让、横竖屏跟随。

🤖 Generated with [Claude Code](https://claude.com/claude-code)