### PR TITLE
feat: `.pxl tiled: true` → 运行时自动 Image.Type.Tiled (pxl-tiled-hint)

### DIFF
--- a/.claude/skills/authoring-promptugui-pxl/SKILL.md
+++ b/.claude/skills/authoring-promptugui-pxl/SKILL.md
@@ -74,6 +74,7 @@ A line whose **first non-whitespace character is `#`** is a comment, anywhere in
 ### Per-section directives
 
 - `border: L,B,R,T` — optional 9-slice border, four non-negative ints in **Unity sprite-border order: left, bottom, right, top**. Must appear **before** `grid:`. Constraints: `L+R ≤ width`, `B+T ≤ height`. Omit for a non-sliced sprite.
+- `tiled: true` — optional render hint (default false). Every consumer (`<Image>`, `<Btn>`, `<Tab>`, default skins, Carousel cards) automatically renders this sprite with `Image.Type.Tiled` — corners stay fixed while edge strips and the center **repeat** instead of stretching. Use it for edges with a directional pattern that must not distort: vines, moss, wood grain, chains. Works with or without `border:` (borderless ⇒ the whole sprite tiles, e.g. a seamless grass fill). An explicit `type=` in the XML still overrides the hint. Must appear before `grid:`; like `border:`, a repeated declaration is last-wins.
 - `grid:` — the pixel rows follow, one line per row, one character per pixel, **top-down**. Rules:
   - Every row must have **exactly the same width** as the first row (the #1 authoring error — count characters).
   - Every non-`.` character must already be declared in `chars:`.
@@ -109,6 +110,7 @@ You are drawing, not just encoding. Apply these when composing a grid:
 - **1px outline** around the shape, usually the darkest palette color. It's what makes a small sprite read against any background.
 - **Limited ramp**: 2–4 shades per material (highlight / base / shadow). More shades at this size = mud.
 - **9-slice design**: the **corners carry all the detail** (rounded corners, rivets, notches). The **edge strips between the borders must tile** — keep each edge uniform along its axis (a horizontal edge strip should have identical columns; a vertical strip identical rows). The **center must tile or be flat** — a flat fill is safest and lets the button stretch to any size.
+- **Tiled edges** (`tiled: true`): design each edge strip as a seamless **repeating unit** — the pattern must loop cleanly across the strip's own length, and BOTH ends of the strip must return to the plain outline + base fill so the corners and the next repeat join invisibly. A strip that's busy at one end and empty at the other will show a visible seam every tile.
 - **Button states**: pressed = swap the highlight and shadow edges (bevel inverts) and/or darken the face; optionally shift the content 1px down. Hover = lighter face. Keep the outline identical across states so the silhouette doesn't jump.
 - **Centered glyphs want odd dimensions** (e.g. 9×9, 13×13) so there's a true center pixel.
 - **Design at the smallest size that reads**; let PPU / PromptUGUI scaling handle display size. A crisp 12×12 scaled up beats a fuzzy 48×48.

--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -121,7 +121,7 @@ uGUI Image，从 `Resources` 加载 sprite；可选 `RectMask2D`（`mask="rect"`
 |---|---|---|---|
 | `sprite` | sprite key | — | |
 | `color` | hex / CSS named / theme token | — | runtime theme token 优先于字面量；见 **Color Tokens** |
-| `type` | `simple` / `sliced` / `tiled` / `filled` / `contain` / `cover` | 自动 | 省略→sprite 有非零 border 取 `sliced`、否则 `simple`。`contain` / `cover` 是相对**父 rect** 的等比适配（`AspectRatioFitter`）：`contain` 内嵌留边、`cover` 填满溢出；尺寸设在**父级**，`cover` 时父级加 `mask="rect"` 裁切。适配模式下 Image 自身 `anchor` / `size` / `width` / `height` / `margin` 被接管失效（`PUI-IMAGE-FIT-GEOMETRY`）；不可 variant 覆盖（`PUI-IMAGE-FIT-VARIANT`）；勿直接作 `<VStack>` / `<HStack>` / `<Grid>` 子节点，套 `<Frame>` |
+| `type` | `simple` / `sliced` / `tiled` / `filled` / `contain` / `cover` | 自动 | 省略→sprite 有非零 border 取 `sliced`、否则 `simple`。`.pxl` 中声明 `tiled: true` 的 sprite 在每个 consumer 上自动渲染为 `tiled`，无需写 `type=`；显式写 `type=` 仍可覆盖。`contain` / `cover` 是相对**父 rect** 的等比适配（`AspectRatioFitter`）：`contain` 内嵌留边、`cover` 填满溢出；尺寸设在**父级**，`cover` 时父级加 `mask="rect"` 裁切。适配模式下 Image 自身 `anchor` / `size` / `width` / `height` / `margin` 被接管失效（`PUI-IMAGE-FIT-GEOMETRY`）；不可 variant 覆盖（`PUI-IMAGE-FIT-VARIANT`）；勿直接作 `<VStack>` / `<HStack>` / `<Grid>` 子节点，套 `<Frame>` |
 | `mask` | `rect` / `self` | — | |
 | `showMask` | bool | `true` | 仅 `mask="self"` |
 | `maskPadding` | `T,R,B,L` | — | 仅 `mask="rect"` |

--- a/Editor/Pxl/PxlImporter.cs
+++ b/Editor/Pxl/PxlImporter.cs
@@ -66,6 +66,7 @@ namespace PromptUGUI.Editor
 
             var basename = Path.GetFileNameWithoutExtension(ctx.assetPath);
             Texture2D main = null;
+            List<Sprite> tiledSprites = null;
             foreach (var section in doc.Sections)
             {
                 var name = section.Name ?? basename;
@@ -77,7 +78,15 @@ namespace PromptUGUI.Editor
                 sprite.name = name;
                 ctx.AddObjectToAsset($"tex:{name}", tex);
                 ctx.AddObjectToAsset($"sprite:{name}", sprite);
+                if (section.Tiled) (tiledSprites ??= new List<Sprite>()).Add(sprite);
                 if (main == null) main = tex;
+            }
+            if (tiledSprites != null)
+            {
+                var hints = ScriptableObject.CreateInstance<PromptUGUI.Application.PxlSpriteHints>();
+                hints.name = "__pxl_hints";
+                hints.SetTiledSpritesInternal(tiledSprites);
+                ctx.AddObjectToAsset("__pxl_hints", hints);
             }
             ctx.SetMainObject(main);
         }

--- a/Editor/Pxl/PxlImporterEditor.cs
+++ b/Editor/Pxl/PxlImporterEditor.cs
@@ -86,9 +86,9 @@ namespace PromptUGUI.Editor
                 EditorGUIUtility.PingObject(AssetDatabase.LoadAssetAtPath<Object>(_palettePath));
 
             EditorGUILayout.LabelField("Sections", EditorStyles.boldLabel);
-            var sprites = AssetDatabase.LoadAllAssetsAtPath(AssetPath)
-                .OfType<Sprite>().ToDictionary(s => s.name, s => s);
-            var hints = AssetDatabase.LoadAllAssetsAtPath(AssetPath)
+            var subAssets = AssetDatabase.LoadAllAssetsAtPath(AssetPath);
+            var sprites = subAssets.OfType<Sprite>().ToDictionary(s => s.name, s => s);
+            var hints = subAssets
                 .OfType<PromptUGUI.Application.PxlSpriteHints>().FirstOrDefault();
             var tiledNames = hints != null
                 ? new System.Collections.Generic.HashSet<string>(

--- a/Editor/Pxl/PxlImporterEditor.cs
+++ b/Editor/Pxl/PxlImporterEditor.cs
@@ -88,18 +88,25 @@ namespace PromptUGUI.Editor
             EditorGUILayout.LabelField("Sections", EditorStyles.boldLabel);
             var sprites = AssetDatabase.LoadAllAssetsAtPath(AssetPath)
                 .OfType<Sprite>().ToDictionary(s => s.name, s => s);
+            var hints = AssetDatabase.LoadAllAssetsAtPath(AssetPath)
+                .OfType<PromptUGUI.Application.PxlSpriteHints>().FirstOrDefault();
+            var tiledNames = hints != null
+                ? new System.Collections.Generic.HashSet<string>(
+                    hints.TiledSprites.Select(sp => sp.name))
+                : null;
             foreach (var s in _doc.Sections)
             {
                 var name = s.Name ?? BaseName;
                 var border = s.Border == Vector4.zero
                     ? "—"
                     : $"{s.Border.x},{s.Border.y},{s.Border.z},{s.Border.w}";
+                var tiledSuffix = tiledNames != null && tiledNames.Contains(name) ? "  tiled" : "";
                 using (new EditorGUILayout.HorizontalScope())
                 {
                     var rect = GUILayoutUtility.GetRect(32, 32, GUILayout.Width(32));
                     if (sprites.TryGetValue(name, out var sp) && sp.texture != null)
                         GUI.DrawTexture(rect, sp.texture, ScaleMode.ScaleToFit);
-                    EditorGUILayout.LabelField($"[{name}]  {s.Width}×{s.Height}  border: {border}");
+                    EditorGUILayout.LabelField($"[{name}]  {s.Width}×{s.Height}  border: {border}{tiledSuffix}");
                 }
             }
         }

--- a/Editor/Pxl/PxlParser.cs
+++ b/Editor/Pxl/PxlParser.cs
@@ -31,6 +31,7 @@ namespace PromptUGUI.Editor
     {
         public string Name;                  // null = 隐式单节
         public Vector4 Border;               // L,B,R,T（Unity Sprite border 序）
+        public bool Tiled;                   // tiled: true — 运行时按 Image.Type.Tiled 渲染的提示
         public int Width, Height;
         public readonly List<string> Rows = new(); // top-down，已 trim
 
@@ -145,6 +146,22 @@ namespace PromptUGUI.Editor
                     if (section.Rows.Count > 0)
                         throw new PxlParseException(lineNo, "border must come before grid");
                     section.Border = ParseBorder(line.Substring("border:".Length).Trim(), lineNo);
+                    continue;
+                }
+                if (line.StartsWith("tiled:", StringComparison.Ordinal))
+                {
+                    section = EnsureSection(doc, section, ref sawImplicitContent);
+                    if (section.Rows.Count > 0)
+                        throw new PxlParseException(lineNo, "tiled must come before grid");
+                    var tv = line.Substring("tiled:".Length).Trim();
+                    // 重复声明 last-wins，同 border:
+                    section.Tiled = tv switch
+                    {
+                        "true" => true,
+                        "false" => false,
+                        _ => throw new PxlParseException(lineNo,
+                            $"invalid tiled value '{tv}' (expected true|false)"),
+                    };
                     continue;
                 }
                 if (line == "grid:")

--- a/Editor/Pxl/PxlParser.cs
+++ b/Editor/Pxl/PxlParser.cs
@@ -150,11 +150,11 @@ namespace PromptUGUI.Editor
                 }
                 if (line.StartsWith("tiled:", StringComparison.Ordinal))
                 {
+                    // grid: 之前可反复声明，last-wins，同 border:。
                     section = EnsureSection(doc, section, ref sawImplicitContent);
                     if (section.Rows.Count > 0)
                         throw new PxlParseException(lineNo, "tiled must come before grid");
                     var tv = line.Substring("tiled:".Length).Trim();
-                    // 重复声明 last-wins，同 border:
                     section.Tiled = tv switch
                     {
                         "true" => true,

--- a/Editor/SpriteAtlasSyncer.cs
+++ b/Editor/SpriteAtlasSyncer.cs
@@ -844,11 +844,12 @@ namespace PromptUGUI.Editor
                     // Persist the (key → Sprite) projection SpriteResolverHelpers reads at
                     // runtime: every key in `lookup` (pathKey + unique bare alias) that
                     // resolves to a picked sprite gets one entry on the SpriteSet.
-                    var iconSetEntries = new List<(string key, Sprite sprite)>();
+                    var iconSetEntries = new List<(string key, Sprite sprite, bool tiled)>();
                     foreach (var kv in lookup)
                     {
                         if (!picked.Contains(kv.Value)) continue;
-                        iconSetEntries.Add((kv.Key, kv.Value));
+                        // TODO(pxl-tiled-hint Task 7): real tiled flag
+                        iconSetEntries.Add((kv.Key, kv.Value, false));
                     }
                     set.SetEntriesInternal(iconSetEntries);
 

--- a/Editor/SpriteAtlasSyncer.cs
+++ b/Editor/SpriteAtlasSyncer.cs
@@ -366,7 +366,8 @@ namespace PromptUGUI.Editor
         /// <param name="progressLabel">When non-null, drives a cancelable progress bar
         /// and throws <see cref="OperationCanceledException"/> if the user cancels.</param>
         public static List<(string pathKey, Sprite sprite)> EnumerateSpriteSources(
-            string folderAssetPath, string progressLabel = null)
+            string folderAssetPath, string progressLabel = null,
+            HashSet<Sprite> tiledOut = null)
         {
             var result = new List<(string, Sprite)>();
             if (string.IsNullOrEmpty(folderAssetPath)) return result;
@@ -399,10 +400,13 @@ namespace PromptUGUI.Editor
                     var relPxl = assetPath.Substring(folderPrefix.Length);
                     var pxlKey = relPxl.Substring(0, relPxl.Length - Path.GetExtension(relPxl).Length);
                     var pxlBase = Path.GetFileNameWithoutExtension(assetPath);
-                    foreach (var s in AssetDatabase.LoadAllAssetsAtPath(assetPath).OfType<Sprite>())
-                    {
+                    var objs = AssetDatabase.LoadAllAssetsAtPath(assetPath);
+                    foreach (var s in objs.OfType<Sprite>())
                         result.Add((s.name == pxlBase ? pxlKey : $"{pxlKey}/{s.name}", s));
-                    }
+                    if (tiledOut != null)
+                        foreach (var h in objs.OfType<PromptUGUI.Application.PxlSpriteHints>())
+                            foreach (var ts in h.TiledSprites)
+                                if (ts != null) tiledOut.Add(ts);
                     continue;
                 }
 #if PROMPTUGUI_HAS_ASEPRITE
@@ -802,7 +806,8 @@ namespace PromptUGUI.Editor
                         continue;
                     }
                     var label = $"Set {i + 1}/{setList.Count} '{set.SetName}'";
-                    var entries = EnumerateSpriteSources(folder, label);
+                    var tiledSprites = new HashSet<Sprite>();
+                    var entries = EnumerateSpriteSources(folder, label, tiledSprites);
                     var lookup = BuildLookup(entries, out var bareCandidates);
 
                     var needed = new HashSet<string>();
@@ -848,8 +853,7 @@ namespace PromptUGUI.Editor
                     foreach (var kv in lookup)
                     {
                         if (!picked.Contains(kv.Value)) continue;
-                        // TODO(pxl-tiled-hint Task 7): real tiled flag
-                        iconSetEntries.Add((kv.Key, kv.Value, false));
+                        iconSetEntries.Add((kv.Key, kv.Value, tiledSprites.Contains(kv.Value)));
                     }
                     set.SetEntriesInternal(iconSetEntries);
 

--- a/Runtime/Application/Internal/SpriteRenderHints.cs
+++ b/Runtime/Application/Internal/SpriteRenderHints.cs
@@ -1,29 +1,23 @@
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace PromptUGUI.Application.Internal
 {
-    /// <summary>sprite → 渲染提示(目前仅 tiled)的运行时登记表。按引用存，
-    /// 重导入后旧引用失效无害。填充口：UI.ResolveSprite 的 Resources
-    /// 分支、SpriteResolverHelpers.BuildLookup、ProceduralBuilders.GetDefaultSprite。</summary>
+    /// <summary>sprite → 渲染提示(目前仅 tiled)的运行时登记表。按 <see cref="EntityId"/>
+    /// (值类型 id)存，不持有 Sprite 引用 —— 登记表不会把资产钉在内存里，
+    /// Resources.UnloadUnusedAssets 仍可回收；重导入后旧 id 失配无害。
+    /// 填充口：UI.ResolveSprite 的 Resources 分支、SpriteResolverHelpers.BuildLookup、
+    /// ProceduralBuilders.GetDefaultSprite。</summary>
     internal static class SpriteRenderHints
     {
-        // Unity Object overrides == / GetHashCode; use CLR identity to avoid
-        // UnityEngine fake-null surprises and the obsolete GetInstanceID().
-        private sealed class IdentityComparer : IEqualityComparer<Sprite>
-        {
-            internal static readonly IdentityComparer Instance = new IdentityComparer();
-            public bool Equals(Sprite x, Sprite y) => ReferenceEquals(x, y);
-            public int GetHashCode(Sprite s) => RuntimeHelpers.GetHashCode(s);
-        }
-
-        private static readonly HashSet<Sprite> _tiledSprites =
-            new HashSet<Sprite>(IdentityComparer.Instance);
+        // 存 EntityId 而非 Sprite 引用：HashSet<Sprite> 会强引用、把 tiled 资产永久钉住
+        // (Clear() 仅测试调用)。EntityId 是 IEquatable 值类型，无 Unity Object 的 fake-null /
+        // GetHashCode 覆盖问题；GetInstanceID() 在 Unity 6 已废弃 → 用 GetEntityId()。
+        private static readonly HashSet<EntityId> _tiledIds = new();
 
         public static void Register(Sprite s)
         {
-            if (s != null) _tiledSprites.Add(s);
+            if (s != null) _tiledIds.Add(s.GetEntityId());
         }
 
         public static void Register(PxlSpriteHints hints)
@@ -34,8 +28,8 @@ namespace PromptUGUI.Application.Internal
         }
 
         public static bool IsTiled(Sprite s) =>
-            s != null && _tiledSprites.Contains(s);
+            s != null && _tiledIds.Contains(s.GetEntityId());
 
-        public static void Clear() => _tiledSprites.Clear();
+        public static void Clear() => _tiledIds.Clear();
     }
 }

--- a/Runtime/Application/Internal/SpriteRenderHints.cs
+++ b/Runtime/Application/Internal/SpriteRenderHints.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+
+namespace PromptUGUI.Application.Internal
+{
+    /// <summary>sprite → 渲染提示(目前仅 tiled)的运行时登记表。按引用存，
+    /// 重导入后旧引用失效无害。填充口：UI.ResolveSprite 的 Resources
+    /// 分支、SpriteResolverHelpers.BuildLookup、ProceduralBuilders.GetDefaultSprite。</summary>
+    internal static class SpriteRenderHints
+    {
+        // Unity Object overrides == / GetHashCode; use CLR identity to avoid
+        // UnityEngine fake-null surprises and the obsolete GetInstanceID().
+        private sealed class IdentityComparer : IEqualityComparer<Sprite>
+        {
+            internal static readonly IdentityComparer Instance = new IdentityComparer();
+            public bool Equals(Sprite x, Sprite y) => ReferenceEquals(x, y);
+            public int GetHashCode(Sprite s) => RuntimeHelpers.GetHashCode(s);
+        }
+
+        private static readonly HashSet<Sprite> _tiledSprites =
+            new HashSet<Sprite>(IdentityComparer.Instance);
+
+        public static void Register(Sprite s)
+        {
+            if (s != null) _tiledSprites.Add(s);
+        }
+
+        public static void Register(PxlSpriteHints hints)
+        {
+            if (hints == null) return;
+            for (var i = 0; i < hints.TiledSprites.Count; i++)
+                Register(hints.TiledSprites[i]);
+        }
+
+        public static bool IsTiled(Sprite s) =>
+            s != null && _tiledSprites.Contains(s);
+
+        public static void Clear() => _tiledSprites.Clear();
+    }
+}

--- a/Runtime/Application/Internal/SpriteRenderHints.cs.meta
+++ b/Runtime/Application/Internal/SpriteRenderHints.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c2ed89a631f070c47b8a3ed356b7686b

--- a/Runtime/Application/PxlSpriteHints.cs
+++ b/Runtime/Application/PxlSpriteHints.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PromptUGUI.Application
+{
+    /// <summary>.pxl 导入产物的渲染提示子资产：`tiled: true` 的 section 对应的
+    /// Sprite 引用清单。运行时由 SpriteRenderHints 各填充口登记；internal——
+    /// 作者不直接触碰(transparent default，C# SKILL 免更)。</summary>
+    internal sealed class PxlSpriteHints : ScriptableObject
+    {
+        [SerializeField] private List<Sprite> tiledSprites = new();
+        public IReadOnlyList<Sprite> TiledSprites => tiledSprites;
+#if UNITY_EDITOR
+        internal void SetTiledSpritesInternal(List<Sprite> sprites) => tiledSprites = sprites;
+#endif
+    }
+}

--- a/Runtime/Application/PxlSpriteHints.cs.meta
+++ b/Runtime/Application/PxlSpriteHints.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 62720d8d18e431644ad52e90fe0fff88

--- a/Runtime/Application/Screen.cs
+++ b/Runtime/Application/Screen.cs
@@ -35,6 +35,14 @@ namespace PromptUGUI.Application
         // (zero behavior change).
         private bool _hasFactorScale;
 
+        // Non-null only during Open()'s apply pass. Tab.bind queues its initial page-hide
+        // here (see DeferDuringOpen) so a bound page is not deactivated before its own
+        // auto-sized descendants finish measuring: a <Btn>/<Toggle>/<Dropdown> label is a
+        // TMP created via AddComponent in the apply pass, and a TMP added to an already
+        // inactive GameObject never runs Awake/OnEnable, so its preferredWidth measures
+        // garbage that freezes into the LayoutElement. Drained right after ApplyScales.
+        private List<Action> _deferredOpenActions;
+
         internal Controls.Internal.ToggleGroupRegistry ToggleGroups { get; private set; }
 
         // BindItems / Markdown 等经 ScreenInstantiator.InstantiateNode 动态实例化的子树。
@@ -147,7 +155,10 @@ namespace PromptUGUI.Application
             // (incl. Add blocks above) is built. See the SetActive(false) note above.
             root.SetActive(true);
             // Attributes applied last, on the now-Awake/active components, in the same
-            // DFS post-order the recursion would have used inline.
+            // DFS post-order the recursion would have used inline. Open the deferral window
+            // first: any bound-page hide a TabBar triggers mid-pass is queued, not run, so
+            // every control measures its content while still active.
+            _deferredOpenActions = new List<Action>();
             foreach (var node in result.ApplyOrder)
                 ControlAttributeApplier.Apply(node, _nodeMap[node],
                                               _registry.Resolve(node.Tag), Variants);
@@ -155,9 +166,24 @@ namespace PromptUGUI.Application
             // (so it doesn't fight ApplyCommon writes).
             RecomputeFactorScale();
             ApplyScales();
+            // Measuring is done (apply pass + ApplyScales). Run the deferred initial hides
+            // now, then close the window so all later (runtime) toggles hide immediately.
+            var deferredHides = _deferredOpenActions;
+            _deferredOpenActions = null;
+            foreach (var hide in deferredHides) hide();
             _variantSub = Variants.Changed.Subscribe(_ => ReSolve());
             _themeHandler = _ => ReSolve();
             UI.Theme.Changed += _themeHandler;
+        }
+
+        // Run <paramref name="action"/> after Open()'s measuring pass, or immediately if no
+        // Open is in progress (runtime toggles / ReSolve). Used by Tab.bind to postpone the
+        // initial deactivation of an unselected page so its auto-sized descendants measure
+        // while active. See the _deferredOpenActions field note.
+        internal void DeferDuringOpen(Action action)
+        {
+            if (_deferredOpenActions != null) _deferredOpenActions.Add(action);
+            else action();
         }
 
         private void ApplyCanvasScaler(UnityEngine.UI.CanvasScaler scaler)

--- a/Runtime/Application/SpriteResolverHelpers.cs
+++ b/Runtime/Application/SpriteResolverHelpers.cs
@@ -36,10 +36,11 @@ namespace PromptUGUI.Application
 
         private static Dictionary<string, Sprite> BuildLookup(IEnumerable<SpriteSet> sets)
         {
-            // Reads SpriteSet.Entries (filled by the Editor sync tool) instead of
+            // Reads SpriteSet.EntriesWithMeta (filled by the Editor sync tool) instead of
             // iterating the SpriteAtlas directly. The atlas's per-sprite .name can
             // collide when two PNGs in different subfolders share a basename;
-            // Entries carry the canonical pathKey + bare alias the syncer chose.
+            // entries carry the canonical pathKey + bare alias the syncer chose, plus
+            // the tiled hint to register into SpriteRenderHints.
             var map = new Dictionary<string, Sprite>(StringComparer.Ordinal);
             var seenSet = new HashSet<string>(StringComparer.Ordinal);
             UI.LoadedSpriteSetNames.Clear();

--- a/Runtime/Application/SpriteResolverHelpers.cs
+++ b/Runtime/Application/SpriteResolverHelpers.cs
@@ -56,9 +56,10 @@ namespace PromptUGUI.Application
                         $"Duplicate SpriteSet name '{set.SetName}'");
                 UI.LoadedSpriteSetNames.Add(set.SetName);
 
-                foreach (var (key, sprite) in set.Entries)
+                foreach (var (key, sprite, tiled) in set.EntriesWithMeta)
                 {
                     if (sprite == null) continue;
+                    if (tiled) Internal.SpriteRenderHints.Register(sprite);
                     map[$"{set.SetName}:{key}"] = sprite;
                 }
             }

--- a/Runtime/Application/SpriteSet.cs
+++ b/Runtime/Application/SpriteSet.cs
@@ -33,6 +33,7 @@ namespace PromptUGUI.Application
         {
             public string key;
             public Sprite sprite;
+            public bool tiled;   // pxl `tiled: true` 提示，Sync Atlases 烙入(List 序列化向后兼容，旧资产读出 false)
         }
         [SerializeField] private List<Entry> entries = new();
 
@@ -48,11 +49,11 @@ namespace PromptUGUI.Application
             EditorUtility.SetDirty(this);
         }
 
-        internal void SetEntriesInternal(IList<(string key, Sprite sprite)> es)
+        internal void SetEntriesInternal(IList<(string key, Sprite sprite, bool tiled)> es)
         {
             entries.Clear();
             for (var i = 0; i < es.Count; i++)
-                entries.Add(new Entry { key = es[i].key, sprite = es[i].sprite });
+                entries.Add(new Entry { key = es[i].key, sprite = es[i].sprite, tiled = es[i].tiled });
             EditorUtility.SetDirty(this);
         }
 #endif
@@ -69,6 +70,16 @@ namespace PromptUGUI.Application
             get
             {
                 foreach (var e in entries) yield return (e.key, e.sprite);
+            }
+        }
+
+        /// <summary>带 tiled 元数据的完整条目枚举，供 BuildLookup 登记 SpriteRenderHints 用。
+        /// Runtime-visible（不在 #if UNITY_EDITOR 块内）。</summary>
+        internal IEnumerable<(string key, Sprite sprite, bool tiled)> EntriesWithMeta
+        {
+            get
+            {
+                foreach (var e in entries) yield return (e.key, e.sprite, e.tiled);
             }
         }
     }

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -97,7 +97,10 @@ namespace PromptUGUI.Application
 
             int hashIdx = value.IndexOf('#');
             if (hashIdx < 0)
+            {
+                RegisterPxlHints(value);
                 return UnityEngine.Resources.Load<UnityEngine.Sprite>(value);
+            }
 
             var path = value.Substring(0, hashIdx);
             var sliceName = value.Substring(hashIdx + 1);
@@ -109,6 +112,7 @@ namespace PromptUGUI.Application
             var dotIdx = path.LastIndexOf('.');
             if (dotIdx > slashIdx && dotIdx > 0)
                 path = path.Substring(0, dotIdx);
+            RegisterPxlHints(path);
             var all = UnityEngine.Resources.LoadAll<UnityEngine.Sprite>(path);
             if (all == null || all.Length == 0)
                 return null;
@@ -121,6 +125,14 @@ namespace PromptUGUI.Application
                 $"sprite '{value}': slice '{sliceName}' not found in '{path}'. " +
                 $"Available: {string.Join(", ", names)}");
             return null;
+        }
+
+        // .pxl 导入的 tiled 提示子资产与 Sprite 同 Resources 路径；LoadAll 有 Unity 资源缓存，重复调用廉价。
+        private static void RegisterPxlHints(string resourcesPath)
+        {
+            var hints = UnityEngine.Resources.LoadAll<PxlSpriteHints>(resourcesPath);
+            for (int i = 0; i < hints.Length; i++)
+                Internal.SpriteRenderHints.Register(hints[i]);
         }
 
         // Shared between UI.ResolveSprite and Icon.Name. Splits the `set:key` form

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -1016,6 +1016,7 @@ namespace PromptUGUI.Application
             Orientation.ResetForTestsInternal();
             Theme.ResetForTestsInternal();
             Markdown.ResetForTestsInternal();
+            Internal.SpriteRenderHints.Clear();
             TranslationStore.Instance.UnloadAll();
             Router.ResetForTestsInternal();
             Tutorial.ResetForTestsInternal();

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -1017,6 +1017,7 @@ namespace PromptUGUI.Application
             Theme.ResetForTestsInternal();
             Markdown.ResetForTestsInternal();
             Internal.SpriteRenderHints.Clear();
+            Controls.Internal.ProceduralBuilders.ResetDefaultSpriteCacheForTests();
             TranslationStore.Instance.UnloadAll();
             Router.ResetForTestsInternal();
             Tutorial.ResetForTestsInternal();

--- a/Runtime/Controls/Btn.cs
+++ b/Runtime/Controls/Btn.cs
@@ -243,7 +243,7 @@ namespace PromptUGUI.Controls
             _bg.overrideSprite = authored
                 ?? (state == InteractState.Pressed ? DefaultPressedSprite() : null);
             _bg.type = authored != null
-                ? (authored.border != Vector4.zero ? UnityImage.Type.Sliced : UnityImage.Type.Simple)
+                ? PromptUGUI.Controls.Internal.ProceduralBuilders.DeriveType(authored)
                 : _baseType;
         }
 

--- a/Runtime/Controls/Image.cs
+++ b/Runtime/Controls/Image.cs
@@ -144,10 +144,7 @@ namespace PromptUGUI.Controls
             // Sprite border is set in the Sprite Editor; non-zero on any edge means the
             // asset was authored for 9-slice rendering.
             if (_typeExplicit) return;
-            var s = _img.sprite;
-            _img.type = (s != null && s.border != Vector4.zero)
-                ? UnityImage.Type.Sliced
-                : UnityImage.Type.Simple;
+            _img.type = Internal.ProceduralBuilders.DeriveType(_img.sprite);
         }
 
         public override Vector2? GetNativeSize()

--- a/Runtime/Controls/Internal/CarouselView.cs
+++ b/Runtime/Controls/Internal/CarouselView.cs
@@ -251,7 +251,7 @@ namespace PromptUGUI.Controls.Internal
                 if (shown != null)
                 {
                     img.sprite = shown;
-                    img.type = shown.border != Vector4.zero ? UnityImage.Type.Sliced : UnityImage.Type.Simple;
+                    img.type = ProceduralBuilders.DeriveType(shown);
                 }
                 ImageTint.Apply(img, _dotTint);
 

--- a/Runtime/Controls/Internal/CarouselView.cs
+++ b/Runtime/Controls/Internal/CarouselView.cs
@@ -173,6 +173,9 @@ namespace PromptUGUI.Controls.Internal
                 // Carry the source 9-slice border so segments don't stretch: the left cap keeps the
                 // left border, the right cap keeps the right border, internal cut edges get 0 (the
                 // tileable part stretches), and top/bottom carry to every segment.
+                // Note: these are fresh Sprite.Create instances with new EntityIds, so they do NOT
+                // inherit the source sprite's tiled hint — tri-slice segments render Sliced (middle
+                // stretches) by design; the whole-sprite dot path (else branch) honors the tiled hint.
                 float left = s == 0 ? Mathf.Min(b.x, third) : 0f;
                 float right = s == 2 ? Mathf.Min(b.z, third) : 0f;
                 var border = new Vector4(left, b.y, right, b.w);

--- a/Runtime/Controls/Internal/ProceduralBuilders.cs
+++ b/Runtime/Controls/Internal/ProceduralBuilders.cs
@@ -37,9 +37,10 @@ namespace PromptUGUI.Controls.Internal
         private static Dictionary<string, Sprite> _defaultSprites;
         private static bool _defaultHintsRegistered;
 
-        /// <summary>pugui.pxl の tiled hint 自举：SpriteRenderHints に登記。
-        /// GetDefaultSprite 経由でも ResolveSprite 経由でも DeriveType が正しく動くよう、
-        /// 二箇所から呼び出される（_defaultHintsRegistered フラグで二重登記防止）。</summary>
+        /// <summary>pugui.pxl 的 tiled hint 自举：注册进 SpriteRenderHints。
+        /// 无论默认皮肤经 GetDefaultSprite 还是经 UI.ResolveSprite 解析，DeriveType 都能正确判定，
+        /// 故从这两处各调用一次（_defaultHintsRegistered 标志防重复注册）。
+        /// 仅覆盖库自带默认皮肤；用户 pxl 的 tiled 注册仍由 ResolveSprite/BuildLookup 路径负责。</summary>
         private static void EnsureDefaultHintsRegistered()
         {
             if (_defaultHintsRegistered) return;

--- a/Runtime/Controls/Internal/ProceduralBuilders.cs
+++ b/Runtime/Controls/Internal/ProceduralBuilders.cs
@@ -70,10 +70,9 @@ namespace PromptUGUI.Controls.Internal
         public static UnityImage.Type DeriveType(Sprite s)
         {
             EnsureDefaultHintsRegistered();
-            return s == null ? UnityImage.Type.Simple :
-                   PromptUGUI.Application.Internal.SpriteRenderHints.IsTiled(s) ? UnityImage.Type.Tiled :
-                   s.border != Vector4.zero ? UnityImage.Type.Sliced :
-                                                                                                 UnityImage.Type.Simple;
+            if (s == null) return UnityImage.Type.Simple;
+            if (PromptUGUI.Application.Internal.SpriteRenderHints.IsTiled(s)) return UnityImage.Type.Tiled;
+            return s.border != Vector4.zero ? UnityImage.Type.Sliced : UnityImage.Type.Simple;
         }
 
         /// <summary>给 Image 应用 9-slice 圆角 sprite 兜底；调用者后续 sprite= 仍可 override。

--- a/Runtime/Controls/Internal/ProceduralBuilders.cs
+++ b/Runtime/Controls/Internal/ProceduralBuilders.cs
@@ -35,6 +35,19 @@ namespace PromptUGUI.Controls.Internal
 
         private const string DefaultSpritesPath = "PromptUGUI/Defaults/pugui";
         private static Dictionary<string, Sprite> _defaultSprites;
+        private static bool _defaultHintsRegistered;
+
+        /// <summary>pugui.pxl の tiled hint 自举：SpriteRenderHints に登記。
+        /// GetDefaultSprite 経由でも ResolveSprite 経由でも DeriveType が正しく動くよう、
+        /// 二箇所から呼び出される（_defaultHintsRegistered フラグで二重登記防止）。</summary>
+        private static void EnsureDefaultHintsRegistered()
+        {
+            if (_defaultHintsRegistered) return;
+            _defaultHintsRegistered = true;
+            var hintAssets = Resources.LoadAll<PromptUGUI.Application.PxlSpriteHints>(DefaultSpritesPath);
+            for (var i = 0; i < hintAssets.Length; i++)
+                PromptUGUI.Application.Internal.SpriteRenderHints.Register(hintAssets[i]);
+        }
 
         public static Sprite GetDefaultSprite(string name)
         {
@@ -44,30 +57,46 @@ namespace PromptUGUI.Controls.Internal
                 var loaded = Resources.LoadAll<Sprite>(DefaultSpritesPath);
                 foreach (var s in loaded)
                     if (s != null) _defaultSprites[s.name] = s;
+                EnsureDefaultHintsRegistered();
             }
             return _defaultSprites.TryGetValue(name, out var sprite) ? sprite : null;
         }
 
+        /// <summary>唯一的 Image.Type 推导点(spec pxl-tiled-hint §6):
+        /// hint 标 tiled → Tiled；有 border → Sliced；否则 Simple。
+        /// 内部调用 EnsureDefaultHintsRegistered 以兼容未经 GetDefaultSprite 加载的 sprite
+        /// （如 Progress/ScrollList 经 UI.ResolveSprite 直接解析 pugui 资产的情形）。</summary>
+        public static UnityImage.Type DeriveType(Sprite s)
+        {
+            EnsureDefaultHintsRegistered();
+            return s == null ? UnityImage.Type.Simple :
+                   PromptUGUI.Application.Internal.SpriteRenderHints.IsTiled(s) ? UnityImage.Type.Tiled :
+                   s.border != Vector4.zero ? UnityImage.Type.Sliced :
+                                                                                                 UnityImage.Type.Simple;
+        }
+
         /// <summary>给 Image 应用 9-slice 圆角 sprite 兜底；调用者后续 sprite= 仍可 override。
         /// Tiled 而非 Sliced：钉木框边带有方向性纹理（青苔/木纹），平铺保形不拉糊；
-        /// 带 border 的 Tiled = 四角固定 + 边/中心平铺（几何重复，不依赖 wrap mode，进图集安全）。</summary>
+        /// 带 border 的 Tiled = 四角固定 + 边/中心平铺（几何重复，不依赖 wrap mode，进图集安全）。
+        /// Image.Type 由 DeriveType(sprite) 推导 —— 依赖 pugui.pxl tiled: true hint 登记。</summary>
         public static void ApplyDefaultSlicedSprite(UnityImage img)
         {
             if (img == null || img.sprite != null) return;
             var s = GetDefaultSprite(SpriteRoundedRect);
             if (s == null) return;
             img.sprite = s;
-            img.type = UnityImage.Type.Tiled;
+            img.type = DeriveType(s);
         }
 
-        /// <summary>凹形容器（输入框/滑轨/列表底）的 9-slice 兜底；规则同 ApplyDefaultSlicedSprite。</summary>
+        /// <summary>凹形容器（输入框/滑轨/列表底）的 9-slice 兜底；Image.Type 由 DeriveType 推导
+        /// (inset 无 tiled hint → 有 border → Sliced)。</summary>
         public static void ApplyDefaultInsetSprite(UnityImage img)
         {
             if (img == null || img.sprite != null) return;
             var s = GetDefaultSprite(SpriteInset);
             if (s == null) return;
             img.sprite = s;
-            img.type = UnityImage.Type.Sliced;
+            img.type = DeriveType(s);
         }
 
         /// <summary>给 Image 应用 simple sprite 兜底（caret / checkmark 等无边界形状）。</summary>
@@ -81,13 +110,12 @@ namespace PromptUGUI.Controls.Internal
             img.preserveAspect = preserveAspect;
         }
 
-        /// <summary>sprite 有 border → Sliced，否则 Simple；null sprite 不动（镜像原 Progress 私有版规则）。</summary>
+        /// <summary>null sprite 不动；否则 type = DeriveType(sprite)
+        /// (hint tiled → Tiled, border → Sliced, else Simple)。</summary>
         public static void AutoSlice(UnityImage img)
         {
             if (img == null || img.sprite == null) return;
-            img.type = img.sprite.border != Vector4.zero
-                ? UnityImage.Type.Sliced
-                : UnityImage.Type.Simple;
+            img.type = DeriveType(img.sprite);
         }
 
         /// <summary>
@@ -128,7 +156,11 @@ namespace PromptUGUI.Controls.Internal
             mask.showMaskGraphic = false;
         }
 
-        internal static void ResetDefaultSpriteCacheForTests() => _defaultSprites = null;
+        internal static void ResetDefaultSpriteCacheForTests()
+        {
+            _defaultSprites = null;
+            _defaultHintsRegistered = false;
+        }
 
         public static RectTransform AddChild(RectTransform parent, string name)
         {

--- a/Runtime/Controls/Progress.cs
+++ b/Runtime/Controls/Progress.cs
@@ -192,11 +192,9 @@ namespace PromptUGUI.Controls
             }
             else // scale (default)
             {
-                // Reset away from Filled, then pick Simple/Sliced per sprite border.
+                // Reset away from Filled, then pick type via DeriveType (hint tiled → Tiled, border → Sliced, else Simple).
                 _fill.fillAmount = 1f;
-                _fill.type = (_fill.sprite != null && _fill.sprite.border != Vector4.zero)
-                    ? UnityImage.Type.Sliced
-                    : UnityImage.Type.Simple;
+                _fill.type = Controls.Internal.ProceduralBuilders.DeriveType(_fill.sprite);
                 (rt.anchorMin, rt.anchorMax) = _direction switch
                 {
                     "horizontal" => (Vector2.zero, new Vector2(_value, 1f)),

--- a/Runtime/Controls/Tab.cs
+++ b/Runtime/Controls/Tab.cs
@@ -98,7 +98,22 @@ namespace PromptUGUI.Controls
                 _bindResolved = true;
                 _bindId = null;     // prevent re-warn
             }
-            if (_boundFrame != null) _boundFrame.GameObject.SetActive(isOn);
+            if (_boundFrame == null) return;
+            // Hiding a bound page during Screen.Open's apply pass would deactivate it before
+            // its own auto-sized descendants (e.g. a <Btn> label TMP added via AddComponent)
+            // are applied; a TMP created on an inactive GameObject never runs Awake/OnEnable
+            // and mis-measures its preferredWidth. Defer the initial hide until Open finishes
+            // measuring. Shows stay immediate (keeping the page active to measure), as do all
+            // runtime toggles / ReSolve (the deferral window is only open during Open). The
+            // deferred action re-reads IsOn at drain time rather than hard-coding SetActive
+            // (false): the auto-select reconcile can queue a hide for a tab that is then
+            // selected (so its page must end up shown) — syncing to the final IsOn is correct
+            // for both, and idempotent with the immediate show above.
+            var frame = _boundFrame;
+            if (!isOn && UI.OwnerScreenOf(this) is PromptUGUI.Application.Screen owner)
+                owner.DeferDuringOpen(() => { if (frame != null) frame.GameObject.SetActive(IsOn); });
+            else
+                frame.GameObject.SetActive(isOn);
         }
 
         internal void ForceSyncBindFrame(bool isOn) => ApplyBindFrame(isOn);

--- a/Runtime/Controls/Tab.cs
+++ b/Runtime/Controls/Tab.cs
@@ -243,7 +243,7 @@ namespace PromptUGUI.Controls
             // Authored selectedSprite carries its own type; otherwise fall back to the base type
             // (default skin = Tiled — blanket "border -> Sliced" would un-tile the textured edges).
             _bg.type = showSelected
-                ? (_selectedSprite.border != Vector4.zero ? UnityImage.Type.Sliced : UnityImage.Type.Simple)
+                ? ProceduralBuilders.DeriveType(_selectedSprite)
                 : _baseType;
         }
 
@@ -270,7 +270,7 @@ namespace PromptUGUI.Controls
         {
             if (sprite == null) return;
             _bg.sprite = sprite;
-            _bg.type = sprite.border != Vector4.zero ? UnityImage.Type.Sliced : UnityImage.Type.Simple;
+            _bg.type = ProceduralBuilders.DeriveType(sprite);
             _baseType = _bg.type;
         }
 

--- a/Runtime/Resources/PromptUGUI/Defaults/pugui.pxl
+++ b/Runtime/Resources/PromptUGUI/Defaults/pugui.pxl
@@ -20,6 +20,7 @@ chars:
 # 条带两端必须收回纯轮廓+底色，保证与四角及下一周期无缝衔接。
 [pugui_9slice_round]
 border: 5,5,5,5
+tiled: true
 grid:
   ..KKKKKGGKKKKGGGKKKKKK..
   .KwwwwwggwWWwgggwwwwwwK.
@@ -48,6 +49,7 @@ grid:
 
 [pugui_9slice_pressed]
 border: 5,5,5,5
+tiled: true
 grid:
   ..KKKKKGGKKKKGGGKKKKKK..
   .KWWWWWggWKKWgggWWWWWWK.

--- a/Samples~/CommonControls/CommonControls.unity
+++ b/Samples~/CommonControls/CommonControls.unity
@@ -412,6 +412,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fd717e9221e73d847981eaa94384b1eb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PromptUGUI.Samples.CommonControls.CommonControlsRunner
+  spriteSets:
+  - {fileID: 11400000, guid: e6e6943674de6484a94ca62b946b431d, type: 2}
 --- !u!4 &1579209940
 Transform:
   m_ObjectHideFlags: 0

--- a/Samples~/CommonControls/CommonControls.unity.meta
+++ b/Samples~/CommonControls/CommonControls.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: efd9dad496ff6bb41a7e1e1200e3947d
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/CommonControls/CommonControlsRunner.cs.meta
+++ b/Samples~/CommonControls/CommonControlsRunner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fd717e9221e73d847981eaa94384b1eb

--- a/Samples~/CommonControls/Resources.meta
+++ b/Samples~/CommonControls/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 231c52bd0770d0040be98ff9cf2a07df
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/CommonControls/Resources/UI.meta
+++ b/Samples~/CommonControls/Resources/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 829c44c2cc631874f90462cbe555cc38
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/CommonControls/Resources/UI/CommonControls.ui.xml
+++ b/Samples~/CommonControls/Resources/UI/CommonControls.ui.xml
@@ -12,7 +12,7 @@
   <!-- Carousel 卡片模板（bg tint / 标题由 C# BindItems 填） -->
   <Template name="DemoCard">
     <Frame>
-      <Image id="bg" anchor="stretch" sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round" type="tiled"/>
+      <Image id="bg" anchor="stretch" sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round"/>
       <Text id="title" anchor="center" fontSize="22" raycastTarget="false"/>
     </Frame>
   </Template>
@@ -25,7 +25,7 @@
 
       <!-- 顶部固定：木牌标题 + 常驻新手引导按钮（Btn 不写 color，吃默认皮肤） -->
       <HStack anchor="top-stretch" height="44" padding="8" spacing="8">
-        <Image sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round" type="tiled" color="#E8B86B" width="220" height="30">
+        <Image sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round" color="#E8B86B" width="220" height="30">
           <Text anchor="center" fontSize="18" raycastTarget="false">Common Controls Demo</Text>
         </Image>
         <Frame width="0"/>
@@ -46,7 +46,7 @@
 
       <!-- ① 表单输入（原 Settings 内容保留） -->
       <Frame id="pageForm" anchor="stretch" margin="84,8,8,8">
-        <Image anchor="stretch" sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round" type="tiled" raycastTarget="false"/>
+        <Image anchor="stretch" sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round" raycastTarget="false"/>
         <VStack anchor="stretch" spacing="12" padding="8">
           <InputField id="username" placeholder="Username" width="240" height="30"/>
           <Toggle id="muteAudio">静音</Toggle>
@@ -57,7 +57,7 @@
 
       <!-- ② 展示反馈 -->
       <Frame id="pageDisplay" anchor="stretch" margin="84,8,8,8">
-        <Image anchor="stretch" sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round" type="tiled" raycastTarget="false"/>
+        <Image anchor="stretch" sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round" raycastTarget="false"/>
         <VStack anchor="stretch" spacing="10" padding="8">
           <Progress id="progress" height="16" value="0.3" bgColor="#E8CFA0" fillColor="#58A63C"/>
           <HStack height="28" spacing="8">
@@ -84,7 +84,7 @@
 
       <!-- ③ 列表轮播 -->
       <Frame id="pageList" anchor="stretch" margin="84,8,8,8">
-        <Image anchor="stretch" sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round" type="tiled" raycastTarget="false"/>
+        <Image anchor="stretch" sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round" raycastTarget="false"/>
         <VStack anchor="stretch" spacing="10" padding="8">
           <!-- farm: SpriteSet 12 作物橱窗 -->
           <Grid columns="6" cellSize="32x32" spacing="4" height="72">
@@ -103,7 +103,7 @@
 
       <!-- ④ 模态提示 -->
       <Frame id="pageModal" anchor="stretch" margin="84,8,8,8">
-        <Image anchor="stretch" sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round" type="tiled" raycastTarget="false"/>
+        <Image anchor="stretch" sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round" raycastTarget="false"/>
         <VStack anchor="stretch" spacing="10" padding="8">
           <Btn id="msgBoxBtn"   height="30" fontSize="15">MessageBox</Btn>
           <Btn id="inputBoxBtn" height="30" fontSize="15">InputBox</Btn>

--- a/Samples~/CommonControls/Resources/UI/CommonControls.ui.xml.meta
+++ b/Samples~/CommonControls/Resources/UI/CommonControls.ui.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 72668593d9a9e6646b60aba48946656c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/CommonControls/Sprites.meta
+++ b/Samples~/CommonControls/Sprites.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4b4d43123d96a2841b98cda357141123
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/CommonControls/Sprites/crops.pxl.meta
+++ b/Samples~/CommonControls/Sprites/crops.pxl.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 9600f3f2a96e1434791a9ccaacf4dbec
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 52005a060a4e54a40b77f1ca5c4deaa4, type: 3}

--- a/Samples~/CommonControls/farm.asset
+++ b/Samples~/CommonControls/farm.asset
@@ -1,0 +1,92 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d34ab5c6513e65b4497659dd376d6ea7, type: 3}
+  m_Name: farm
+  m_EditorClassIdentifier: PromptUGUI.Runtime::PromptUGUI.Application.SpriteSet
+  setName: farm
+  atlas: {fileID: 4343727234628468602, guid: cb2f357ebb7051747b3cd0b1823ce649, type: 2}
+  alwaysInclude: []
+  generateTmpSpriteAsset: 0
+  entries:
+  - key: crops/strawberry
+    sprite: {fileID: 6051404646482987322, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: crops/wheat
+    sprite: {fileID: -8827232178786053898, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: crops/watermelon
+    sprite: {fileID: -2121056816349745006, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: crops/sunflower
+    sprite: {fileID: -4956282018316935132, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: crops/grape
+    sprite: {fileID: 108566834224758175, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: crops/turnip
+    sprite: {fileID: 6061771559911817710, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: crops/pumpkin
+    sprite: {fileID: 5448784098124822628, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: crops/tomato
+    sprite: {fileID: 5481853894613533732, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: crops/carrot
+    sprite: {fileID: -9133205770265997170, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: crops/corn
+    sprite: {fileID: -1667197454111312221, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: crops/eggplant
+    sprite: {fileID: -6368116060139219187, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: crops/apple
+    sprite: {fileID: -327891350732577185, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: strawberry
+    sprite: {fileID: 6051404646482987322, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: wheat
+    sprite: {fileID: -8827232178786053898, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: watermelon
+    sprite: {fileID: -2121056816349745006, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: sunflower
+    sprite: {fileID: -4956282018316935132, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: grape
+    sprite: {fileID: 108566834224758175, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: turnip
+    sprite: {fileID: 6061771559911817710, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: pumpkin
+    sprite: {fileID: 5448784098124822628, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: tomato
+    sprite: {fileID: 5481853894613533732, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: carrot
+    sprite: {fileID: -9133205770265997170, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: corn
+    sprite: {fileID: -1667197454111312221, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: eggplant
+    sprite: {fileID: -6368116060139219187, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  - key: apple
+    sprite: {fileID: -327891350732577185, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    tiled: 0
+  sourceFolder: {fileID: 102900000, guid: 4b4d43123d96a2841b98cda357141123, type: 3}

--- a/Samples~/CommonControls/farm.asset.meta
+++ b/Samples~/CommonControls/farm.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e6e6943674de6484a94ca62b946b431d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/CommonControls/farm.spriteatlas
+++ b/Samples~/CommonControls/farm.spriteatlas
@@ -1,0 +1,68 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!687078895 &4343727234628468602
+SpriteAtlas:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: farm
+  m_EditorData:
+    serializedVersion: 2
+    textureSettings:
+      serializedVersion: 2
+      anisoLevel: 1
+      compressionQuality: 50
+      maxTextureSize: 2048
+      textureCompression: 0
+      filterMode: 0
+      generateMipMaps: 0
+      readable: 0
+      crunchedCompression: 0
+      sRGB: 1
+    platformSettings: []
+    packingSettings:
+      serializedVersion: 2
+      padding: 4
+      blockOffset: 1
+      allowAlphaSplitting: 0
+      enableRotation: 1
+      enableTightPacking: 1
+      enableAlphaDilation: 0
+    secondaryTextureSettings: {}
+    variantMultiplier: 1
+    packables:
+    - {fileID: 6051404646482987322, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    - {fileID: -9133205770265997170, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    - {fileID: 5481853894613533732, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    - {fileID: -8827232178786053898, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    - {fileID: -327891350732577185, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    - {fileID: -1667197454111312221, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    - {fileID: 5448784098124822628, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    - {fileID: -6368116060139219187, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    - {fileID: -4956282018316935132, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    - {fileID: 108566834224758175, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    - {fileID: -2121056816349745006, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    - {fileID: 6061771559911817710, guid: 9600f3f2a96e1434791a9ccaacf4dbec, type: 3}
+    bindAsDefault: 1
+    isAtlasV2: 0
+    cachedData: {fileID: 0}
+    packedSpriteRenderDataKeys:
+    - 9600f3f2a96e1434791a9ccaacf4dbec: -8827232178786053898
+    - 9600f3f2a96e1434791a9ccaacf4dbec: -2121056816349745006
+    - 9600f3f2a96e1434791a9ccaacf4dbec: 6061771559911817710
+    - 9600f3f2a96e1434791a9ccaacf4dbec: 5448784098124822628
+    - 9600f3f2a96e1434791a9ccaacf4dbec: -4956282018316935132
+    - 9600f3f2a96e1434791a9ccaacf4dbec: 6051404646482987322
+    - 9600f3f2a96e1434791a9ccaacf4dbec: 5481853894613533732
+    - 9600f3f2a96e1434791a9ccaacf4dbec: 108566834224758175
+    - 9600f3f2a96e1434791a9ccaacf4dbec: -327891350732577185
+    - 9600f3f2a96e1434791a9ccaacf4dbec: -6368116060139219187
+    - 9600f3f2a96e1434791a9ccaacf4dbec: -1667197454111312221
+    - 9600f3f2a96e1434791a9ccaacf4dbec: -9133205770265997170
+  m_MasterAtlas: {fileID: 0}
+  m_RenderDataMap: {}
+  m_Tag: farm
+  m_IsVariant: 0
+  m_Guid: cb2f357ebb7051747b3cd0b1823ce649

--- a/Samples~/CommonControls/farm.spriteatlas.meta
+++ b/Samples~/CommonControls/farm.spriteatlas.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cb2f357ebb7051747b3cd0b1823ce649
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 4343727234628468602
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Application/SpriteRenderHintsTests.cs
+++ b/Tests/EditMode/Application/SpriteRenderHintsTests.cs
@@ -1,0 +1,42 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Internal;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Application
+{
+    public class SpriteRenderHintsTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static Sprite MakeSprite() =>
+            Sprite.Create(new Texture2D(4, 4), new Rect(0, 0, 4, 4), new Vector2(0.5f, 0.5f));
+
+        [Test]
+        public void Register_then_IsTiled_true_idempotent()
+        {
+            var s = MakeSprite();
+            Assert.IsFalse(SpriteRenderHints.IsTiled(s));
+            SpriteRenderHints.Register(s);
+            SpriteRenderHints.Register(s); // 幂等
+            Assert.IsTrue(SpriteRenderHints.IsTiled(s));
+        }
+
+        [Test]
+        public void Null_safe()
+        {
+            SpriteRenderHints.Register((Sprite)null);
+            Assert.IsFalse(SpriteRenderHints.IsTiled(null));
+        }
+
+        [Test]
+        public void ResetForTests_clears()
+        {
+            var s = MakeSprite();
+            SpriteRenderHints.Register(s);
+            UI.ResetForTests();
+            Assert.IsFalse(SpriteRenderHints.IsTiled(s));
+        }
+    }
+}

--- a/Tests/EditMode/Application/SpriteRenderHintsTests.cs.meta
+++ b/Tests/EditMode/Application/SpriteRenderHintsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3f84882beb193b142b83e4719b162767

--- a/Tests/EditMode/Application/SpriteSetTiledEntryTests.cs
+++ b/Tests/EditMode/Application/SpriteSetTiledEntryTests.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Application
+{
+    public class SpriteSetTiledEntryTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void BuildLookup_registers_tiled_entries()
+        {
+            var tiled = Sprite.Create(new Texture2D(4, 4), new Rect(0, 0, 4, 4), new Vector2(0.5f, 0.5f));
+            var plain = Sprite.Create(new Texture2D(4, 4), new Rect(0, 0, 4, 4), new Vector2(0.5f, 0.5f));
+
+            var set = ScriptableObject.CreateInstance<SpriteSet>();
+            var so = new UnityEditor.SerializedObject(set);
+            so.FindProperty("setName").stringValue = "t";
+            so.ApplyModifiedPropertiesWithoutUndo();
+            set.SetEntriesInternal(new List<(string, Sprite, bool)>
+            {
+                ("vine", tiled, true),
+                ("leaf", plain, false),
+            });
+
+            SpriteResolverHelpers.UseSpriteSetResolver(new[] { set });
+
+            Assert.AreSame(tiled, UI.ResolveSprite("t:vine"));
+            Assert.IsTrue(PromptUGUI.Application.Internal.SpriteRenderHints.IsTiled(tiled));
+            Assert.IsFalse(PromptUGUI.Application.Internal.SpriteRenderHints.IsTiled(plain));
+        }
+    }
+}

--- a/Tests/EditMode/Application/SpriteSetTiledEntryTests.cs.meta
+++ b/Tests/EditMode/Application/SpriteSetTiledEntryTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 86713c5ebf164804fad60d4d512c5851

--- a/Tests/EditMode/Controls/BtnContentSizingTests.cs
+++ b/Tests/EditMode/Controls/BtnContentSizingTests.cs
@@ -124,6 +124,44 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
+        public void Btn_on_hidden_tab_page_measures_same_as_active_page()
+        {
+            // Regression: a TabBar deactivates its non-selected bound pages from
+            // TabBar.OnAfterApply — which runs DURING the apply pass, before those pages'
+            // own Btn descendants are applied (TabBar precedes the pages in document order).
+            // A Btn's auto label is created via AddComponent<TMP> in EnsureLabel; on a
+            // GameObject that is already inactive, TMP's Awake/OnEnable never runs, so
+            // GetNativeSize measures a garbage (~1/10) preferredWidth that gets frozen into
+            // LayoutElement.preferredWidth → the page, once shown, has an undersized button
+            // whose text overflows. The same Btn on the SELECTED page measures correctly;
+            // the hidden-page Btn must match it.
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='tabs' anchor='top-stretch' height='32'>
+    <Tab id='tabA' width='84' text='A' isOn='true' bind='pageA'/>
+    <Tab id='tabB' width='84' text='B' bind='pageB'/>
+  </TabBar>
+  <Frame id='pageA' anchor='stretch' margin='32,0,0,0'>
+    <VStack anchor='stretch'><Btn id='activeBtn'>MessageBox</Btn></VStack>
+  </Frame>
+  <Frame id='pageB' anchor='stretch' margin='32,0,0,0'>
+    <VStack anchor='stretch'><Btn id='hiddenBtn'>MessageBox</Btn></VStack>
+  </Frame>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+
+            var activeLE = screen.Get<Btn>("activeBtn").GameObject.GetComponent<LayoutElement>();
+            var hiddenLE = screen.Get<Btn>("hiddenBtn").GameObject.GetComponent<LayoutElement>();
+            Assert.IsNotNull(activeLE);
+            Assert.IsNotNull(hiddenLE);
+            Assert.Greater(activeLE.preferredWidth, 32f,
+                "sanity: active-page Btn measures label+padding, well above the 32 padding floor");
+            Assert.AreEqual(activeLE.preferredWidth, hiddenLE.preferredWidth, 0.5f,
+                "a Btn on an initially-hidden tab page must measure the same width as the same Btn on the active page");
+        }
+
+        [Test]
         public void Btn_in_HStack_variant_text_change_updates_preferred()
         {
             // BCS-D9: ApplyCommon 在 Variant 切换时重跑 → GetNativeSize 重算 → LE.preferred 跟随

--- a/Tests/EditMode/Controls/BtnStateTests.cs
+++ b/Tests/EditMode/Controls/BtnStateTests.cs
@@ -373,6 +373,26 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.AreEqual(UnityImage.Type.Sliced, bg.type, "bordered pressedSprite renders 9-sliced");
         }
 
+        // Sibling of the above: when the bordered pressedSprite is hint-registered (.pxl tiled:true),
+        // the authored-override branch of ApplyStateSprite derives Tiled (hint beats border).
+        [Test]
+        public void PressedSprite_TiledHint_RendersTiled()
+        {
+            var tex = new Texture2D(16, 16);
+            var bordered = Sprite.Create(tex, new Rect(0, 0, 16, 16), new Vector2(0.5f, 0.5f), 100f, 0,
+                SpriteMeshType.FullRect, new Vector4(4, 4, 4, 4));
+            PromptUGUI.Application.Internal.SpriteRenderHints.Register(bordered);
+            UI.SpriteResolver = _ => bordered;
+
+            var btn = BuildBtn("sprite='' pressedSprite='ui:pressed'");
+            var bg = btn.GameObject.GetComponent<UnityImage>();
+            var puiBtn = btn.GameObject.GetComponent<PuiButton>();
+
+            puiBtn.SimulateState(Pressed);
+            Assert.AreEqual(bordered, bg.overrideSprite);
+            Assert.AreEqual(UnityImage.Type.Tiled, bg.type, "hint-registered pressedSprite renders Tiled");
+        }
+
         [Test]
         public void PressedSprite_DisablesDefaultColorTint()
         {

--- a/Tests/EditMode/Controls/DefaultSkinTests.cs
+++ b/Tests/EditMode/Controls/DefaultSkinTests.cs
@@ -120,7 +120,8 @@ namespace PromptUGUI.Tests.EditMode.Controls
                 ProceduralBuilders.ApplyDefaultInsetSprite(img);
                 Assert.IsNotNull(img.sprite, "default inset sprite must resolve");
                 Assert.AreEqual("pugui_9slice_inset", img.sprite.name);
-                Assert.AreEqual(UnityEngine.UI.Image.Type.Sliced, img.type);
+                Assert.AreEqual(UnityEngine.UI.Image.Type.Sliced, img.type,
+                    "inset 无 tiled hint → DeriveType 落到 border → Sliced");
             }
             finally { Object.DestroyImmediate(go); }
         }

--- a/Tests/EditMode/Controls/DefaultSkinTests.cs
+++ b/Tests/EditMode/Controls/DefaultSkinTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using PromptUGUI.Application;
+using PromptUGUI.Application.Internal;
 using PromptUGUI.Controls.Internal;
 using UnityEngine;
 
@@ -122,6 +123,27 @@ namespace PromptUGUI.Tests.EditMode.Controls
                 Assert.AreEqual(UnityEngine.UI.Image.Type.Sliced, img.type);
             }
             finally { Object.DestroyImmediate(go); }
+        }
+
+        [Test]
+        public void DeriveType_four_branches()
+        {
+            Assert.AreEqual(UnityEngine.UI.Image.Type.Simple, ProceduralBuilders.DeriveType(null));
+
+            var plain = Sprite.Create(new Texture2D(4, 4), new Rect(0, 0, 4, 4), new Vector2(0.5f, 0.5f));
+            Assert.AreEqual(UnityEngine.UI.Image.Type.Simple, ProceduralBuilders.DeriveType(plain));
+
+            var bordered = Sprite.Create(new Texture2D(8, 8), new Rect(0, 0, 8, 8), new Vector2(0.5f, 0.5f),
+                100f, 0, SpriteMeshType.FullRect, new Vector4(2, 2, 2, 2));
+            Assert.AreEqual(UnityEngine.UI.Image.Type.Sliced, ProceduralBuilders.DeriveType(bordered));
+
+            SpriteRenderHints.Register(bordered);
+            Assert.AreEqual(UnityEngine.UI.Image.Type.Tiled, ProceduralBuilders.DeriveType(bordered),
+                "hint 优先于 border 推导");
+
+            SpriteRenderHints.Register(plain);
+            Assert.AreEqual(UnityEngine.UI.Image.Type.Tiled, ProceduralBuilders.DeriveType(plain),
+                "无 border 也可平铺(整图无缝纹理)");
         }
     }
 }

--- a/Tests/EditMode/Controls/ImageFitTests.cs
+++ b/Tests/EditMode/Controls/ImageFitTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using PromptUGUI.Application;
+using PromptUGUI.Application.Internal;
 using UnityEngine;
 using UnityEngine.UI;
 using PromptUGUIImage = PromptUGUI.Controls.Image;
@@ -123,6 +124,43 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var arf = img.GameObject.GetComponent<AspectRatioFitter>();
             var expected = unityImg.sprite.rect.width / unityImg.sprite.rect.height;
             Assert.AreEqual(expected, arf.aspectRatio, 0.001f);
+        }
+
+        [Test]
+        public void Image_autopick_tiled_for_hinted_sprite()
+        {
+            // Use a plain (no-border) sprite registered as tiled — DeriveType returns Tiled for registered sprites
+            // regardless of border (see DefaultSkinTests.DeriveType_four_branches).
+            var sp = UnityEngine.Sprite.Create(Texture2D.whiteTexture, new Rect(0, 0, 1, 1), Vector2.zero);
+            SpriteRenderHints.Register(sp);
+            UI.SpriteResolver = _ => sp;
+
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Image id='i' sprite='ui:x'/>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var img = UI.Open("S").Get<PromptUGUIImage>("i");
+            Assert.AreEqual(Image.Type.Tiled, img.GameObject.GetComponent<Image>().type,
+                "hint-registered sprite must auto-pick Tiled");
+        }
+
+        [Test]
+        public void Image_explicit_type_overrides_hint()
+        {
+            // Even a tiled-hinted sprite must not override an explicit type= attribute.
+            var sp = UnityEngine.Sprite.Create(Texture2D.whiteTexture, new Rect(0, 0, 1, 1), Vector2.zero);
+            SpriteRenderHints.Register(sp);
+            UI.SpriteResolver = _ => sp;
+
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Image id='i' sprite='ui:x' type='sliced'/>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var img = UI.Open("S").Get<PromptUGUIImage>("i");
+            Assert.AreEqual(Image.Type.Sliced, img.GameObject.GetComponent<Image>().type,
+                "explicit type= must override the tiled hint");
         }
     }
 }

--- a/Tests/EditMode/Controls/ProgressTests.cs
+++ b/Tests/EditMode/Controls/ProgressTests.cs
@@ -236,7 +236,7 @@ namespace PromptUGUI.Tests.EditMode.Controls
         {
             var p = Open("<Progress id='p' value='0.5' fill='PromptUGUI/Defaults/pugui#pugui_9slice_round'/>");
             var fill = p.GameObject.transform.Find("MaskWrapper/Fill").GetComponent<UnityImage>();
-            Assert.AreEqual(UnityImage.Type.Sliced, fill.type);
+            Assert.AreEqual(UnityImage.Type.Tiled, fill.type, "pugui_9slice_round 有 tiled hint → Tiled");
         }
 
         [Test]
@@ -264,7 +264,7 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.IsTrue(bg.gameObject.activeSelf, "Bg activated by bg=");
             var img = bg.GetComponent<UnityImage>();
             Assert.IsNotNull(img.sprite);
-            Assert.AreEqual(UnityImage.Type.Sliced, img.type, "9-slice sprite auto-Sliced");
+            Assert.AreEqual(UnityImage.Type.Tiled, img.type, "pugui_9slice_round 有 tiled hint → Tiled");
         }
 
         [Test]
@@ -294,7 +294,7 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.IsTrue(frame.gameObject.activeSelf);
             var img = frame.GetComponent<UnityImage>();
             Assert.IsNotNull(img.sprite);
-            Assert.AreEqual(UnityImage.Type.Sliced, img.type, "9-slice sprite auto-Sliced");
+            Assert.AreEqual(UnityImage.Type.Tiled, img.type, "pugui_9slice_round 有 tiled hint → Tiled");
             Assert.IsFalse(img.raycastTarget, "Frame must not eat input (PB-D16)");
         }
 

--- a/Tests/EditMode/Controls/ScrollListTests.cs
+++ b/Tests/EditMode/Controls/ScrollListTests.cs
@@ -51,7 +51,7 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var img = vp.GetComponent<UnityEngine.UI.Image>();
             Assert.AreEqual("pugui_9slice_round", img.sprite.name);
             Assert.AreEqual(1f, img.color.a, "alpha=1 critical (4af322b)");
-            Assert.AreEqual(UnityEngine.UI.Image.Type.Sliced, img.type, "AutoSlice: border 非零 → Sliced");
+            Assert.AreEqual(UnityEngine.UI.Image.Type.Tiled, img.type, "pugui_9slice_round 有 tiled hint → Tiled");
             Assert.IsNull(vp.GetComponent<UnityEngine.UI.RectMask2D>());
         }
 
@@ -253,7 +253,7 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var img = frame.GetComponent<UnityEngine.UI.Image>();
             Assert.IsFalse(img.raycastTarget);
             Assert.AreEqual("pugui_9slice_round", img.sprite.name);
-            Assert.AreEqual(UnityEngine.UI.Image.Type.Sliced, img.type);
+            Assert.AreEqual(UnityEngine.UI.Image.Type.Tiled, img.type, "pugui_9slice_round 有 tiled hint → Tiled");
             var rt = (UnityEngine.RectTransform)frame;
             Assert.AreEqual(UnityEngine.Vector2.zero, rt.anchorMin);
             Assert.AreEqual(UnityEngine.Vector2.one, rt.anchorMax);

--- a/Tests/EditMode/Controls/TabTests.cs
+++ b/Tests/EditMode/Controls/TabTests.cs
@@ -348,6 +348,26 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.AreEqual(UnityImage.Type.Simple, bg.type, "reverts to Simple for the empty normal sprite");
         }
 
+        // Sibling of the above: a hint-registered (.pxl tiled:true) selectedSprite renders Tiled while
+        // selected — ApplySelectedSprite derives via DeriveType, so the hint beats the border.
+        [Test]
+        public void Tab_SelectedSprite_TiledHint_RendersTiled()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
+            var tex = new Texture2D(16, 16);
+            var bordered = Sprite.Create(tex, new Rect(0, 0, 16, 16), new Vector2(0.5f, 0.5f), 100f, 0,
+                SpriteMeshType.FullRect, new Vector4(4, 4, 4, 4));
+            PromptUGUI.Application.Internal.SpriteRenderHints.Register(bordered);
+            UI.SpriteResolver = key => key == "ui:tab_sel" ? bordered : null;
+            var t = OpenTab("<Tab id='t' sprite='' selectedSprite='ui:tab_sel'/>");
+            var bg = t.GameObject.GetComponent<UnityImage>();
+
+            t.IsOn = true;
+            Assert.AreSame(bordered, bg.overrideSprite);
+            Assert.AreEqual(UnityImage.Type.Tiled, bg.type, "hint-registered selectedSprite renders Tiled");
+        }
+
         // Default-skin tab (no sprite=, no selectedSprite=): the built-in wood frame renders Tiled
         // (moss/grain edges tile, ApplyDefaultSlicedSprite). Selecting/deselecting must NOT flip it
         // to Sliced — ApplySelectedSprite re-derives the type and has to fall back to the base type,

--- a/Tests/EditMode/Editor/Pxl/PxlImporterTests.cs
+++ b/Tests/EditMode/Editor/Pxl/PxlImporterTests.cs
@@ -177,5 +177,26 @@ namespace PromptUGUI.Tests.Editor
             Assert.IsNull(AssetDatabase.LoadAllAssetsAtPath(path)
                 .OfType<PxlSpriteHints>().SingleOrDefault());
         }
+
+        [Test]
+        public void ResolveSprite_resources_path_registers_tiled_hint()
+        {
+            UI.ResetForTests();
+            try
+            {
+                if (!AssetDatabase.IsValidFolder($"{TmpDir}/Resources"))
+                    AssetDatabase.CreateFolder(TmpDir, "Resources");
+                var abs = Path.Combine(UnityEngine.Application.dataPath, "__test_pxl__/Resources", "rt.pxl");
+                File.WriteAllText(abs,
+                    "chars:\n  K: #000000\n\n[a]\nborder: 1,1,1,1\ntiled: true\ngrid:\n  KKK\n  KKK\n  KKK\n");
+                AssetDatabase.ImportAsset($"{TmpDir}/Resources/rt.pxl",
+                    ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+
+                var sprite = UI.ResolveSprite("rt#a");
+                Assert.IsNotNull(sprite);
+                Assert.IsTrue(PromptUGUI.Application.Internal.SpriteRenderHints.IsTiled(sprite));
+            }
+            finally { UI.ResetForTests(); }
+        }
     }
 }

--- a/Tests/EditMode/Editor/Pxl/PxlImporterTests.cs
+++ b/Tests/EditMode/Editor/Pxl/PxlImporterTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using PromptUGUI.Application;
 using PromptUGUI.Editor;
 using UnityEditor;
 using UnityEngine;
@@ -153,6 +154,28 @@ namespace PromptUGUI.Tests.Editor
             AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
             Assert.IsNotNull(AssetDatabase.LoadAssetAtPath<Texture2D>(path),
                 "adding the missing .gpl must re-trigger the broken .pxl import");
+        }
+
+        [Test]
+        public void Import_tiled_section_creates_hints_subasset()
+        {
+            var path = Write("hint.pxl",
+                "chars:\n  K: #000000\n\n[a]\ntiled: true\ngrid:\n  KK\n  KK\n\n[b]\ngrid:\n  KK\n  KK\n");
+            var hints = AssetDatabase.LoadAllAssetsAtPath(path)
+                .OfType<PxlSpriteHints>().SingleOrDefault();
+            Assert.IsNotNull(hints, "tiled section -> hints sub-asset");
+            var sprites = AssetDatabase.LoadAllAssetsAtPath(path).OfType<Sprite>().ToList();
+            var a = sprites.Single(s => s.name == "a");
+            CollectionAssert.AreEquivalent(new[] { a }, hints.TiledSprites,
+                "only the tiled section's sprite is referenced");
+        }
+
+        [Test]
+        public void Import_no_tiled_sections_no_hints_subasset()
+        {
+            var path = Write("plain.pxl", "chars:\n  K: #000000\n\ngrid:\n  KK\n  KK\n");
+            Assert.IsNull(AssetDatabase.LoadAllAssetsAtPath(path)
+                .OfType<PxlSpriteHints>().SingleOrDefault());
         }
     }
 }

--- a/Tests/EditMode/Editor/Pxl/PxlParserTests.cs
+++ b/Tests/EditMode/Editor/Pxl/PxlParserTests.cs
@@ -162,8 +162,11 @@ namespace PromptUGUI.Tests.Editor
         [Test]
         public void Parse_tiled_after_grid_throws()
         {
-            Assert.Throws<PxlParseException>(() =>
-                PxlParser.Parse("chars:\n  K: #000000\n\n[a]\ngrid:\n  KK\n  KK\ntiled: true\n"));
+            // Blank line ends the grid; a later tiled: on the same section must hit the
+            // "tiled must come before grid" guard (Rows already populated).
+            var ex = Assert.Throws<PxlParseException>(() =>
+                PxlParser.Parse("chars:\n  K: #000000\n\n[a]\ngrid:\n  KK\n  KK\n\ntiled: true\n"));
+            StringAssert.Contains("tiled must come before grid", ex.Message);
         }
 
         [Test]

--- a/Tests/EditMode/Editor/Pxl/PxlParserTests.cs
+++ b/Tests/EditMode/Editor/Pxl/PxlParserTests.cs
@@ -151,6 +151,13 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
+        public void Parse_tiled_false_explicit_accepted()
+        {
+            var doc = PxlParser.Parse("chars:\n  K: #000000\n\n[a]\ntiled: false\ngrid:\n  KK\n  KK\n");
+            Assert.IsFalse(doc.Sections[0].Tiled);
+        }
+
+        [Test]
         public void Parse_tiled_invalid_value_reports_line()
         {
             var ex = Assert.Throws<PxlParseException>(() =>

--- a/Tests/EditMode/Editor/Pxl/PxlParserTests.cs
+++ b/Tests/EditMode/Editor/Pxl/PxlParserTests.cs
@@ -135,5 +135,42 @@ namespace PromptUGUI.Tests.Editor
                 "chars:\n  K: #000000\ngrid:\n  K\n\nborder: 0,0,0,0\n"));
             StringAssert.Contains("border must come before grid", ex.Message);
         }
+
+        [Test]
+        public void Parse_tiled_true_sets_section_flag()
+        {
+            var doc = PxlParser.Parse("chars:\n  K: #000000\n\n[a]\nborder: 1,1,1,1\ntiled: true\ngrid:\n  KKK\n  KKK\n  KKK\n");
+            Assert.IsTrue(doc.Sections[0].Tiled);
+        }
+
+        [Test]
+        public void Parse_tiled_defaults_false()
+        {
+            var doc = PxlParser.Parse("chars:\n  K: #000000\n\n[a]\ngrid:\n  KK\n  KK\n");
+            Assert.IsFalse(doc.Sections[0].Tiled);
+        }
+
+        [Test]
+        public void Parse_tiled_invalid_value_reports_line()
+        {
+            var ex = Assert.Throws<PxlParseException>(() =>
+                PxlParser.Parse("chars:\n  K: #000000\n\n[a]\ntiled: yes\ngrid:\n  KK\n  KK\n"));
+            StringAssert.Contains("invalid tiled value 'yes'", ex.Message);
+            StringAssert.Contains("line 5", ex.Message);
+        }
+
+        [Test]
+        public void Parse_tiled_after_grid_throws()
+        {
+            Assert.Throws<PxlParseException>(() =>
+                PxlParser.Parse("chars:\n  K: #000000\n\n[a]\ngrid:\n  KK\n  KK\ntiled: true\n"));
+        }
+
+        [Test]
+        public void Parse_tiled_implicit_section_supported()
+        {
+            var doc = PxlParser.Parse("chars:\n  K: #000000\n\ntiled: true\ngrid:\n  KK\n  KK\n");
+            Assert.IsTrue(doc.Sections[0].Tiled);
+        }
     }
 }

--- a/Tests/EditMode/Editor/Pxl/PxlSyncerTests.cs
+++ b/Tests/EditMode/Editor/Pxl/PxlSyncerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
@@ -94,6 +95,20 @@ namespace PromptUGUI.Tests.Editor
             ImportAll();
             Assert.AreEqual(0, SpriteAtlasSyncer.ResetTextureImportSettings(TestRoot),
                 ".pxl has no TextureImporter; reset must skip it");
+        }
+
+        [Test]
+        public void EnumerateSpriteSources_collects_tiled_sprites()
+        {
+            WritePxl("vineframe.pxl",
+                "chars:\n  K: #000000\n\n[vine]\nborder: 1,1,1,1\ntiled: true\ngrid:\n  KKK\n  KKK\n  KKK\n\n[flat]\ngrid:\n  KK\n  KK\n");
+            ImportAll();
+            var tiled = new HashSet<Sprite>();
+            var entries = SpriteAtlasSyncer.EnumerateSpriteSources(TestRoot, null, tiled);
+            var vine = entries.Single(e => e.pathKey == "vineframe/vine").sprite;
+            var flat = entries.Single(e => e.pathKey == "vineframe/flat").sprite;
+            Assert.IsTrue(tiled.Contains(vine));
+            Assert.IsFalse(tiled.Contains(flat));
         }
 
         [Test]

--- a/Tests/PlayMode/Controls/IconRuntimeTests.cs
+++ b/Tests/PlayMode/Controls/IconRuntimeTests.cs
@@ -153,8 +153,8 @@ namespace PromptUGUI.Tests.PlayMode
             var loaded = AssetDatabase.LoadAssetAtPath<SpriteSet>(setPath);
             // Bypass the editor sync tool: populate entries directly so the runtime
             // resolver (which reads SpriteSet.Entries) can resolve these by-name.
-            var entries = new List<(string key, Sprite sprite)>();
-            for (var i = 0; i < iconNames.Length; i++) entries.Add((iconNames[i], sprites[i]));
+            var entries = new List<(string key, Sprite sprite, bool tiled)>();
+            for (var i = 0; i < iconNames.Length; i++) entries.Add((iconNames[i], sprites[i], false));
             loaded.SetEntriesInternal(entries);
             return (loaded, atlas);
         }

--- a/Tests/PlayMode/Controls/IconRuntimeTests.cs
+++ b/Tests/PlayMode/Controls/IconRuntimeTests.cs
@@ -152,7 +152,7 @@ namespace PromptUGUI.Tests.PlayMode
             _toCleanup.Add(setPath);
             var loaded = AssetDatabase.LoadAssetAtPath<SpriteSet>(setPath);
             // Bypass the editor sync tool: populate entries directly so the runtime
-            // resolver (which reads SpriteSet.Entries) can resolve these by-name.
+            // resolver (which reads SpriteSet.EntriesWithMeta) can resolve these by-name.
             var entries = new List<(string key, Sprite sprite, bool tiled)>();
             for (var i = 0; i < iconNames.Length; i++) entries.Add((iconNames[i], sprites[i], false));
             loaded.SetEntriesInternal(entries);

--- a/Tests/PlayMode/Controls/ImageTests.cs
+++ b/Tests/PlayMode/Controls/ImageTests.cs
@@ -46,9 +46,12 @@ namespace PromptUGUI.Tests.Controls
         [UnityTest]
         public IEnumerator Type_auto_detects_Sliced_when_sprite_has_border()
         {
+            // Uses the inset skin: bordered but NOT tiled-hinted, so DeriveType picks Sliced.
+            // (pugui_9slice_round carries `tiled: true` now → it would auto-pick Tiled, which is
+            // covered separately in ImageFitTests.Image_autopick_tiled_for_hinted_sprite.)
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'><Screen name='S'>
-  <Image id='bg' anchor='stretch' sprite='PromptUGUI/Defaults/pugui.png#pugui_9slice_round'/>
+  <Image id='bg' anchor='stretch' sprite='PromptUGUI/Defaults/pugui.png#pugui_9slice_inset'/>
 </Screen></PromptUGUI>";
             UI.LoadDocument("test", xml);
             var screen = UI.Open("S");

--- a/docs~/superpowers/plans/2026-06-12-pxl-tiled-hint.md
+++ b/docs~/superpowers/plans/2026-06-12-pxl-tiled-hint.md
@@ -1,0 +1,871 @@
+# pxl-tiled-hint 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `.pxl` section 声明 `tiled: true` 后,该 sprite 在所有解析通道、所有控件上自动以 `Image.Type.Tiled` 渲染(显式 `type=` 仍优先)。
+
+**Architecture:** parser 加指令 → importer 产 `PxlSpriteHints` 子资产(直接 Sprite 引用) → 运行时 `SpriteRenderHints` 登记表(instanceID HashSet,三个填充口:ResolveSprite Resources 分支 / SpriteSet entry / 内置皮肤自举) → 消费端统一 `ProceduralBuilders.DeriveType`。最后回收 farm-pixel-skin 轮的硬编码与 sample 的显式 `type="tiled"`。
+
+**Tech Stack:** Unity 6 uGUI / ScriptedImporter / NUnit(UnityMCP 跑测试)。Spec: `docs~/superpowers/specs/2026-06-12-pxl-tiled-hint-design.md`。
+
+**通用约定(每个 Task 适用):**
+- 分支 `feat/pxl-tiled-hint`。提交前 `git branch --show-current` 确认不在 main。
+- 测试一律走 UnityMCP:改完源码先 `refresh_unity(compile="request", mode="force", scope="all")`,`read_console(types=["error"])` 确认零编译错,再 `run_tests`(EditMode 用 `assembly_names=["PromptUGUI.Tests.EditMode"]`,EditorOnly 用 `["PromptUGUI.Tests.EditorOnly"]`;按 `group_names=["类名"]` 过滤)。`run_tests` 返回 job_id,用 `get_test_job(job_id, wait_timeout=60, include_failed_tests=true)` 取结果。
+- C# 改动跑 `cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx`。
+
+---
+
+### Task 1: parser — `tiled:` 指令
+
+**Files:**
+- Modify: `Editor/Pxl/PxlParser.cs`(`PxlSection` 加字段;`Parse` 加分支,插在 `border:` 分支之后、`grid:` 分支之前)
+- Test: `Tests/EditMode/Editor/Pxl/PxlParserTests.cs`
+
+- [ ] **Step 1: 写失败测试**(追加到 `PxlParserTests` 类尾部;该文件已有同风格用例,如 `Parse_border_exceeding_size_throws`)
+
+```csharp
+[Test]
+public void Parse_tiled_true_sets_section_flag()
+{
+    var doc = PxlParser.Parse("chars:\n  K: #000000\n\n[a]\nborder: 1,1,1,1\ntiled: true\ngrid:\n  KKK\n  KKK\n  KKK\n");
+    Assert.IsTrue(doc.Sections[0].Tiled);
+}
+
+[Test]
+public void Parse_tiled_defaults_false()
+{
+    var doc = PxlParser.Parse("chars:\n  K: #000000\n\n[a]\ngrid:\n  KK\n  KK\n");
+    Assert.IsFalse(doc.Sections[0].Tiled);
+}
+
+[Test]
+public void Parse_tiled_invalid_value_reports_line()
+{
+    var ex = Assert.Throws<PxlParseException>(() =>
+        PxlParser.Parse("chars:\n  K: #000000\n\n[a]\ntiled: yes\ngrid:\n  KK\n  KK\n"));
+    StringAssert.Contains("invalid tiled value 'yes'", ex.Message);
+    StringAssert.Contains("line 5", ex.Message);
+}
+
+[Test]
+public void Parse_tiled_after_grid_throws()
+{
+    var ex = Assert.Throws<PxlParseException>(() =>
+        PxlParser.Parse("chars:\n  K: #000000\n\n[a]\ngrid:\n  KK\n  KK\ntiled: true\n"));
+    // grid 块内的非段头行按像素行校验失败(行宽/未知字符),或掉出 grid 后按
+    // "tiled must come before grid" 报——两者都接受,断言只看异常类型。
+}
+
+[Test]
+public void Parse_tiled_implicit_section_supported()
+{
+    var doc = PxlParser.Parse("chars:\n  K: #000000\n\ntiled: true\ngrid:\n  KK\n  KK\n");
+    Assert.IsTrue(doc.Sections[0].Tiled);
+}
+```
+
+注意 `Parse_tiled_after_grid_throws` 里 `tiled: true` 行出现在 grid 行之后**且无空行**——它会被当 grid 行校验(行宽不符报错),异常类型即可。`PxlParseException` 的 message 前缀格式以现有测试为准(先看 `Parse_unknown_grid_char_reports_line` 的断言写法,保持一致)。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+refresh + `run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"], group_names=["PxlParserTests"])`。
+预期:`Tiled` 字段不存在 → **编译错误**(read_console 可见 CS1061)。这一步的"红"是编译失败。
+
+- [ ] **Step 3: 实现**
+
+`PxlSection` 加字段(`Border` 之后):
+
+```csharp
+public bool Tiled;                   // tiled: true — 运行时按 Image.Type.Tiled 渲染的提示
+```
+
+`Parse` 里 `border:` 分支(`if (line.StartsWith("border:", ...))` 块)之后插入:
+
+```csharp
+if (line.StartsWith("tiled:", StringComparison.Ordinal))
+{
+    section = EnsureSection(doc, section, ref sawImplicitContent);
+    if (section.Rows.Count > 0)
+        throw new PxlParseException(lineNo, "tiled must come before grid");
+    var tv = line.Substring("tiled:".Length).Trim();
+    // 重复声明 last-wins,同 border:
+    section.Tiled = tv switch
+    {
+        "true" => true,
+        "false" => false,
+        _ => throw new PxlParseException(lineNo,
+            $"invalid tiled value '{tv}' (expected true|false)"),
+    };
+    continue;
+}
+```
+
+- [ ] **Step 4: 跑测试确认通过**(同 Step 2 命令,预期全 PASS;顺带跑全量 EditorOnly 防回归)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Editor/Pxl/PxlParser.cs Tests/EditMode/Editor/Pxl/PxlParserTests.cs
+git commit -m "feat(pxl): parser 支持 per-section tiled: 指令"
+```
+
+---
+
+### Task 2: `PxlSpriteHints` 子资产 + importer 产出 + Inspector 显示
+
+**Files:**
+- Create: `Runtime/Application/PxlSpriteHints.cs`
+- Modify: `Editor/Pxl/PxlImporter.cs:67-83`(section 循环)
+- Modify: `Editor/Pxl/PxlImporterEditor.cs`(只读面板的 section 行)
+- Test: `Tests/EditMode/Editor/Pxl/PxlImporterTests.cs`
+
+- [ ] **Step 1: 写失败测试**(追加到 `PxlImporterTests`;沿用该文件的 `Write(fileName, content)` 辅助)
+
+```csharp
+[Test]
+public void Import_tiled_section_creates_hints_subasset()
+{
+    var path = Write("hint.pxl",
+        "chars:\n  K: #000000\n\n[a]\ntiled: true\ngrid:\n  KK\n  KK\n\n[b]\ngrid:\n  KK\n  KK\n");
+    var hints = AssetDatabase.LoadAllAssetsAtPath(path)
+        .OfType<PromptUGUI.Application.PxlSpriteHints>().SingleOrDefault();
+    Assert.IsNotNull(hints, "tiled section -> hints sub-asset");
+    var sprites = AssetDatabase.LoadAllAssetsAtPath(path).OfType<Sprite>().ToList();
+    var a = sprites.Single(s => s.name == "a");
+    CollectionAssert.AreEquivalent(new[] { a }, hints.TiledSprites,
+        "only the tiled section's sprite is referenced");
+}
+
+[Test]
+public void Import_no_tiled_sections_no_hints_subasset()
+{
+    var path = Write("plain.pxl", "chars:\n  K: #000000\n\ngrid:\n  KK\n  KK\n");
+    Assert.IsNull(AssetDatabase.LoadAllAssetsAtPath(path)
+        .OfType<PromptUGUI.Application.PxlSpriteHints>().SingleOrDefault());
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**(`group_names=["PxlImporterTests"]`,预期编译错:类型不存在)
+
+- [ ] **Step 3: 实现**
+
+新文件 `Runtime/Application/PxlSpriteHints.cs`:
+
+```csharp
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PromptUGUI.Application
+{
+    /// <summary>.pxl 导入产物的渲染提示子资产:`tiled: true` 的 section 对应的
+    /// Sprite 引用清单。运行时由 SpriteRenderHints 各填充口登记;internal——
+    /// 作者不直接触碰(transparent default,C# SKILL 免更)。</summary>
+    internal sealed class PxlSpriteHints : ScriptableObject
+    {
+        [SerializeField] private List<Sprite> tiledSprites = new();
+        public IReadOnlyList<Sprite> TiledSprites => tiledSprites;
+#if UNITY_EDITOR
+        internal void SetTiledSpritesInternal(List<Sprite> sprites) => tiledSprites = sprites;
+#endif
+    }
+}
+```
+
+`PxlImporter.OnImportAsset` 的 section 循环改为收集 tiled sprite,循环后产出子资产(替换现有 67-83 行循环体):
+
+```csharp
+var basename = Path.GetFileNameWithoutExtension(ctx.assetPath);
+Texture2D main = null;
+List<Sprite> tiledSprites = null;
+foreach (var section in doc.Sections)
+{
+    var name = section.Name ?? basename;
+    var tex = BuildTexture(section, colors, name);
+    var sprite = Sprite.Create(tex,
+        new Rect(0, 0, section.Width, section.Height),
+        new Vector2(0.5f, 0.5f), doc.Ppu, 0,
+        SpriteMeshType.FullRect, section.Border);
+    sprite.name = name;
+    ctx.AddObjectToAsset($"tex:{name}", tex);
+    ctx.AddObjectToAsset($"sprite:{name}", sprite);
+    if (section.Tiled) (tiledSprites ??= new List<Sprite>()).Add(sprite);
+    if (main == null) main = tex;
+}
+if (tiledSprites != null)
+{
+    var hints = ScriptableObject.CreateInstance<PromptUGUI.Application.PxlSpriteHints>();
+    hints.name = "__pxl_hints";
+    hints.SetTiledSpritesInternal(tiledSprites);
+    ctx.AddObjectToAsset("__pxl_hints", hints);
+}
+ctx.SetMainObject(main);
+```
+
+`PxlImporterEditor` 只读面板:在列出 section 尺寸/border 的那行(先读该文件找到拼接处)追加 tiled 标记——找到形如 `"{name}  {w}x{h}  border L,B,R,T"` 的展示字符串,当该 section 的 sprite 在 hints.TiledSprites 中时 append `"  tiled"`。Editor 侧可 `AssetDatabase.LoadAllAssetsAtPath(assetPath).OfType<PxlSpriteHints>()` 获取。纯展示,不写测试。
+
+- [ ] **Step 4: 跑测试确认通过**(`PxlImporterTests` 全绿 + 全量 EditorOnly 防回归)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Application/PxlSpriteHints.cs Runtime/Application/PxlSpriteHints.cs.meta \
+        Editor/Pxl/PxlImporter.cs Editor/Pxl/PxlImporterEditor.cs \
+        Tests/EditMode/Editor/Pxl/PxlImporterTests.cs
+git commit -m "feat(pxl): tiled section -> PxlSpriteHints 子资产 + Inspector 标记"
+```
+
+(新 .cs 在 Unity refresh 后会生成 .meta,**必须一并提交**。)
+
+---
+
+### Task 3: 运行时登记表 `SpriteRenderHints`
+
+**Files:**
+- Create: `Runtime/Application/Internal/SpriteRenderHints.cs`
+- Modify: `Runtime/Application/UI.cs`(`ResetForTests` 主体,grep `public static void ResetForTests` 定位)
+- Test: 新建 `Tests/EditMode/Application/SpriteRenderHintsTests.cs`(若无 `Tests/EditMode/Application/` 目录则放 `Tests/EditMode/` 根,随邻居)
+
+- [ ] **Step 1: 写失败测试**
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Internal;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Application
+{
+    public class SpriteRenderHintsTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static Sprite MakeSprite() =>
+            Sprite.Create(new Texture2D(4, 4), new Rect(0, 0, 4, 4), new Vector2(0.5f, 0.5f));
+
+        [Test]
+        public void Register_then_IsTiled_true_idempotent()
+        {
+            var s = MakeSprite();
+            Assert.IsFalse(SpriteRenderHints.IsTiled(s));
+            SpriteRenderHints.Register(s);
+            SpriteRenderHints.Register(s); // 幂等
+            Assert.IsTrue(SpriteRenderHints.IsTiled(s));
+        }
+
+        [Test]
+        public void Null_safe()
+        {
+            SpriteRenderHints.Register(null);
+            Assert.IsFalse(SpriteRenderHints.IsTiled(null));
+        }
+
+        [Test]
+        public void ResetForTests_clears()
+        {
+            var s = MakeSprite();
+            SpriteRenderHints.Register(s);
+            UI.ResetForTests();
+            Assert.IsFalse(SpriteRenderHints.IsTiled(s));
+        }
+    }
+}
+```
+
+(namespace `PromptUGUI.Application.Internal` 如与既有 Internal 目录文件的 namespace 惯例不符——先看 `Runtime/Application/Internal/` 里任一文件的 namespace,跟随它,测试 using 同步调整。)
+
+- [ ] **Step 2: 跑测试确认失败**(`group_names=["SpriteRenderHintsTests"]`,预期编译错)
+
+- [ ] **Step 3: 实现**
+
+```csharp
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PromptUGUI.Application.Internal   // 跟随 Internal 目录既有 namespace
+{
+    /// <summary>sprite → 渲染提示(目前仅 tiled)的运行时登记表。按 instanceID 存,
+    /// 不 pin 资产;重导入后旧 ID 残留无害。填充口:UI.ResolveSprite 的 Resources
+    /// 分支、SpriteResolverHelpers.BuildLookup、ProceduralBuilders.GetDefaultSprite。</summary>
+    internal static class SpriteRenderHints
+    {
+        private static readonly HashSet<int> _tiledIds = new();
+
+        public static void Register(Sprite s)
+        {
+            if (s != null) _tiledIds.Add(s.GetInstanceID());
+        }
+
+        public static void Register(PxlSpriteHints hints)
+        {
+            if (hints == null) return;
+            for (var i = 0; i < hints.TiledSprites.Count; i++)
+                Register(hints.TiledSprites[i]);
+        }
+
+        public static bool IsTiled(Sprite s) =>
+            s != null && _tiledIds.Contains(s.GetInstanceID());
+
+        public static void Clear() => _tiledIds.Clear();
+    }
+}
+```
+
+`UI.ResetForTests` 主体内(与其它 `ResetForTestsInternal` 调用并列)加:
+
+```csharp
+Internal.SpriteRenderHints.Clear();
+```
+
+(`PxlSpriteHints` 在 `PromptUGUI.Application`、registry 在 `...Internal`,跨 namespace 引用按需补 using。)
+
+- [ ] **Step 4: 跑测试确认通过**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Application/Internal/SpriteRenderHints.cs Runtime/Application/Internal/SpriteRenderHints.cs.meta \
+        Runtime/Application/UI.cs Tests/EditMode/Application/SpriteRenderHintsTests.cs Tests/EditMode/Application/SpriteRenderHintsTests.cs.meta
+git commit -m "feat(runtime): SpriteRenderHints tiled 登记表 + ResetForTests 接线"
+```
+
+---
+
+### Task 4: `DeriveType` 统一推导 + `ProceduralBuilders` 自身改写
+
+**Files:**
+- Modify: `Runtime/Controls/Internal/ProceduralBuilders.cs`(`AutoSlice` / `ApplyDefaultSlicedSprite` / `ApplyDefaultInsetSprite` / `GetDefaultSprite`)
+- Test: `Tests/EditMode/Controls/DefaultSkinTests.cs`
+
+- [ ] **Step 1: 写失败测试**(追加到 `DefaultSkinTests`)
+
+```csharp
+[Test]
+public void DeriveType_four_branches()
+{
+    Assert.AreEqual(UnityEngine.UI.Image.Type.Simple, ProceduralBuilders.DeriveType(null));
+
+    var plain = Sprite.Create(new Texture2D(4, 4), new Rect(0, 0, 4, 4), new Vector2(0.5f, 0.5f));
+    Assert.AreEqual(UnityEngine.UI.Image.Type.Simple, ProceduralBuilders.DeriveType(plain));
+
+    var bordered = Sprite.Create(new Texture2D(8, 8), new Rect(0, 0, 8, 8), new Vector2(0.5f, 0.5f),
+        100f, 0, SpriteMeshType.FullRect, new Vector4(2, 2, 2, 2));
+    Assert.AreEqual(UnityEngine.UI.Image.Type.Sliced, ProceduralBuilders.DeriveType(bordered));
+
+    PromptUGUI.Application.Internal.SpriteRenderHints.Register(bordered);
+    Assert.AreEqual(UnityEngine.UI.Image.Type.Tiled, ProceduralBuilders.DeriveType(bordered),
+        "hint 优先于 border 推导");
+
+    PromptUGUI.Application.Internal.SpriteRenderHints.Register(plain);
+    Assert.AreEqual(UnityEngine.UI.Image.Type.Tiled, ProceduralBuilders.DeriveType(plain),
+        "无 border 也可平铺(整图无缝纹理)");
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**(`group_names=["DefaultSkinTests"]`,预期编译错:DeriveType 不存在)
+
+- [ ] **Step 3: 实现**(`ProceduralBuilders` 内)
+
+```csharp
+/// <summary>唯一的 Image.Type 推导点(spec pxl-tiled-hint §6):
+/// hint 标 tiled → Tiled;有 border → Sliced;否则 Simple。</summary>
+public static UnityImage.Type DeriveType(Sprite s) =>
+    s == null                                                  ? UnityImage.Type.Simple :
+    PromptUGUI.Application.Internal.SpriteRenderHints.IsTiled(s) ? UnityImage.Type.Tiled :
+    s.border != Vector4.zero                                   ? UnityImage.Type.Sliced :
+                                                                 UnityImage.Type.Simple;
+```
+
+三处改写:
+
+```csharp
+// AutoSlice:null sprite 不动的契约保留
+public static void AutoSlice(UnityImage img)
+{
+    if (img == null || img.sprite == null) return;
+    img.type = DeriveType(img.sprite);
+}
+
+// ApplyDefaultSlicedSprite:删掉硬编码 Tiled(若只做这一步,默认皮肤暂回 Sliced、
+// 两个既有 Tiled 断言会红——所以本 Task 的 Step 4 立即给 pugui.pxl 标 tiled 恢复)
+img.sprite = s;
+img.type = DeriveType(s);
+
+// ApplyDefaultInsetSprite 同样:
+img.sprite = s;
+img.type = DeriveType(s);
+```
+
+`GetDefaultSprite` 的首次加载块(`_defaultSprites == null` 分支内,LoadAll<Sprite> 之后)加自举登记:
+
+```csharp
+var hintAssets = Resources.LoadAll<PromptUGUI.Application.PxlSpriteHints>(DefaultSpritesPath);
+for (var i = 0; i < hintAssets.Length; i++)
+    PromptUGUI.Application.Internal.SpriteRenderHints.Register(hintAssets[i]);
+```
+
+**注意排序陷阱**:`UI.ResetForTests` 会 `SpriteRenderHints.Clear()` 但 `_defaultSprites` 缓存也会被 `ResetDefaultSpriteCacheForTests` 置空(确认该方法已挂在 ResetForTests;若没挂,本 Task 把它挂上)——两者同生命周期,下次 GetDefaultSprite 重新登记。
+
+- [ ] **Step 4: 处理预期内的暂时红**
+
+`pugui.pxl` 还没标 `tiled: true`(Task 8),所以本 Task 后
+`ApplyDefaultSlicedSprite_SetsRoundTiled` 与 `Tab_DefaultSkin_StaysTiled_AcrossSelection`
+会红(默认皮肤暂回 Sliced)。**不要改这两个测试**——直接在本 Task 顺手给
+`Runtime/Resources/PromptUGUI/Defaults/pugui.pxl` 的 `[pugui_9slice_round]` 与
+`[pugui_9slice_pressed]` 两节 `border: 5,5,5,5` 行后各加一行:
+
+```
+tiled: true
+```
+
+(Task 8 的其余清理仍留在 Task 8。)refresh 后跑全量 EditMode,预期全绿。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Internal/ProceduralBuilders.cs \
+        Runtime/Resources/PromptUGUI/Defaults/pugui.pxl \
+        Tests/EditMode/Controls/DefaultSkinTests.cs
+git commit -m "feat(runtime): ProceduralBuilders.DeriveType 统一推导 + 默认皮肤经 hints 走 Tiled"
+```
+
+---
+
+### Task 5: `UI.ResolveSprite` Resources 分支登记
+
+**Files:**
+- Modify: `Runtime/Application/UI.cs:98-124`(ResolveSprite 的裸路径与 `#` 分支)
+- Test: `Tests/EditMode/Editor/Pxl/PxlImporterTests.cs`(需要真实导入的 .pxl + Resources 路径,放 EditorOnly)
+
+- [ ] **Step 1: 写失败测试**(追加到 `PxlImporterTests`;注意要用 **Resources** 子目录)
+
+```csharp
+[Test]
+public void ResolveSprite_resources_path_registers_tiled_hint()
+{
+    UI.ResetForTests();
+    try
+    {
+        if (!AssetDatabase.IsValidFolder($"{TmpDir}/Resources"))
+            AssetDatabase.CreateFolder(TmpDir, "Resources");
+        var abs = Path.Combine(UnityEngine.Application.dataPath, "__test_pxl__/Resources", "rt.pxl");
+        File.WriteAllText(abs,
+            "chars:\n  K: #000000\n\n[a]\nborder: 1,1,1,1\ntiled: true\ngrid:\n  KKK\n  KKK\n  KKK\n");
+        AssetDatabase.ImportAsset($"{TmpDir}/Resources/rt.pxl",
+            ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+
+        var sprite = UI.ResolveSprite("rt#a");
+        Assert.IsNotNull(sprite);
+        Assert.IsTrue(PromptUGUI.Application.Internal.SpriteRenderHints.IsTiled(sprite));
+    }
+    finally { UI.ResetForTests(); }
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**(`group_names=["PxlImporterTests"]`,预期 `IsTiled` 为 false → FAIL)
+
+- [ ] **Step 3: 实现**(`UI.ResolveSprite`)
+
+裸路径分支(原 `return Resources.Load<Sprite>(value);`)改:
+
+```csharp
+if (hashIdx < 0)
+{
+    RegisterPxlHints(value);
+    return UnityEngine.Resources.Load<UnityEngine.Sprite>(value);
+}
+```
+
+`#` 分支在 `var all = Resources.LoadAll<Sprite>(path);` 之前(或之后,效果相同)加:
+
+```csharp
+RegisterPxlHints(path);
+```
+
+同类(`UI`)内加私有方法:
+
+```csharp
+// .pxl 导入的 tiled 提示子资产与 Sprite 同路径;LoadAll 有 Unity 资源缓存,重复调用廉价。
+private static void RegisterPxlHints(string resourcesPath)
+{
+    var hints = UnityEngine.Resources.LoadAll<PxlSpriteHints>(resourcesPath);
+    for (int i = 0; i < hints.Length; i++)
+        Internal.SpriteRenderHints.Register(hints[i]);
+}
+```
+
+- [ ] **Step 4: 跑测试确认通过**(PxlImporterTests 全绿 + 全量 EditMode 防回归)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Application/UI.cs Tests/EditMode/Editor/Pxl/PxlImporterTests.cs
+git commit -m "feat(runtime): ResolveSprite Resources 分支登记 pxl tiled 提示"
+```
+
+---
+
+### Task 6: `SpriteSet.Entry.tiled` + `BuildLookup` 登记
+
+**Files:**
+- Modify: `Runtime/Application/SpriteSet.cs`(Entry 结构、SetEntriesInternal、新 internal 访问器)
+- Modify: `Runtime/Application/SpriteResolverHelpers.cs`(BuildLookup)
+- Modify: `Tests/PlayMode/Controls/IconRuntimeTests.cs:158`(SetEntriesInternal 签名随动)
+- Test: 新建 `Tests/EditMode/Application/SpriteSetTiledEntryTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+```csharp
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Application
+{
+    public class SpriteSetTiledEntryTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void BuildLookup_registers_tiled_entries()
+        {
+            var tiled = Sprite.Create(new Texture2D(4, 4), new Rect(0, 0, 4, 4), new Vector2(0.5f, 0.5f));
+            var plain = Sprite.Create(new Texture2D(4, 4), new Rect(0, 0, 4, 4), new Vector2(0.5f, 0.5f));
+
+            var set = ScriptableObject.CreateInstance<SpriteSet>();
+            var so = new UnityEditor.SerializedObject(set);
+            so.FindProperty("setName").stringValue = "t";
+            so.ApplyModifiedPropertiesWithoutUndo();
+            set.SetEntriesInternal(new List<(string, Sprite, bool)>
+            {
+                ("vine", tiled, true),
+                ("leaf", plain, false),
+            });
+
+            SpriteResolverHelpers.UseSpriteSetResolver(new[] { set });
+
+            Assert.AreSame(tiled, UI.ResolveSprite("t:vine"));
+            Assert.IsTrue(PromptUGUI.Application.Internal.SpriteRenderHints.IsTiled(tiled));
+            Assert.IsFalse(PromptUGUI.Application.Internal.SpriteRenderHints.IsTiled(plain));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**(预期编译错:SetEntriesInternal 还是二元组签名)
+
+- [ ] **Step 3: 实现**
+
+`SpriteSet.Entry` 加字段:
+
+```csharp
+[Serializable]
+internal struct Entry
+{
+    public string key;
+    public Sprite sprite;
+    public bool tiled;   // pxl `tiled: true` 提示,Sync Atlases 烙入(List 序列化向后兼容,旧资产读出 false)
+}
+```
+
+`SetEntriesInternal` 签名改三元组(唯一编辑器调用方在 Task 7 随动;PlayMode 测试本 Task 随动):
+
+```csharp
+internal void SetEntriesInternal(IList<(string key, Sprite sprite, bool tiled)> es)
+{
+    entries.Clear();
+    for (var i = 0; i < es.Count; i++)
+        entries.Add(new Entry { key = es[i].key, sprite = es[i].sprite, tiled = es[i].tiled });
+    EditorUtility.SetDirty(this);
+}
+```
+
+公共 `Entries` 二元组 getter **保持原样**(公共面零变化);加 internal 访问器:
+
+```csharp
+internal IEnumerable<(string key, Sprite sprite, bool tiled)> EntriesWithMeta
+{
+    get
+    {
+        foreach (var e in entries) yield return (e.key, e.sprite, e.tiled);
+    }
+}
+```
+
+`BuildLookup` 末段循环改用 `EntriesWithMeta` 并登记:
+
+```csharp
+foreach (var (key, sprite, tiled) in set.EntriesWithMeta)
+{
+    if (sprite == null) continue;
+    if (tiled) PromptUGUI.Application.Internal.SpriteRenderHints.Register(sprite);
+    map[$"{set.SetName}:{key}"] = sprite;
+}
+```
+
+`Tests/PlayMode/Controls/IconRuntimeTests.cs:158` 的 `SetEntriesInternal(entries)`:把 entries 的元素改成三元组(原值 + `false`)——先读该处上下文,把列表构造改为 `(key, sprite, false)` 形。
+
+- [ ] **Step 4: 跑测试确认通过**(新类 + 全量 EditMode;PlayMode 跑 `group_names=["IconRuntimeTests"]`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Application/SpriteSet.cs Runtime/Application/SpriteResolverHelpers.cs \
+        Tests/EditMode/Application/SpriteSetTiledEntryTests.cs Tests/EditMode/Application/SpriteSetTiledEntryTests.cs.meta \
+        Tests/PlayMode/Controls/IconRuntimeTests.cs
+git commit -m "feat(runtime): SpriteSet entry 携带 tiled 标记,BuildLookup 时登记"
+```
+
+(此刻 `Editor/SpriteAtlasSyncer.cs:853` 的调用点会编译错——**本 Task 内先把它最小修复**为 `iconSetEntries` 三元组 + `false` 占位,Task 7 再填真值。最小修复:`iconSetEntries` 类型改 `List<(string key, Sprite sprite, bool tiled)>`,Add 处补 `, false`。)
+
+---
+
+### Task 7: Syncer 烙入 tiled
+
+**Files:**
+- Modify: `Editor/SpriteAtlasSyncer.cs:368`(EnumerateSpriteSources 加可选 out 集合)、`:805-853`(调用点 + entry 组装)
+- Test: `Tests/EditMode/Editor/Pxl/PxlSyncerTests.cs`
+
+- [ ] **Step 1: 写失败测试**(追加到 `PxlSyncerTests`,沿用其 TestRoot 建 .pxl 的辅助;先读该文件 SetUp 确认根目录与写文件方式)
+
+```csharp
+[Test]
+public void EnumerateSpriteSources_collects_tiled_sprites()
+{
+    // 在 TestRoot 写一个含 tiled 节的 .pxl(沿用本文件既有的写文件辅助)
+    WritePxl("vineframe.pxl",
+        "chars:\n  K: #000000\n\n[vine]\nborder: 1,1,1,1\ntiled: true\ngrid:\n  KKK\n  KKK\n  KKK\n\n[flat]\ngrid:\n  KK\n  KK\n");
+    var tiled = new HashSet<Sprite>();
+    var entries = SpriteAtlasSyncer.EnumerateSpriteSources(TestRoot, null, tiled);
+    var vine = entries.Single(e => e.pathKey == "vineframe/vine").sprite;
+    var flat = entries.Single(e => e.pathKey == "vineframe/flat").sprite;
+    Assert.IsTrue(tiled.Contains(vine));
+    Assert.IsFalse(tiled.Contains(flat));
+}
+```
+
+(`WritePxl` 为该文件既有辅助名;若实际名不同,跟随现状。)
+
+- [ ] **Step 2: 跑测试确认失败**(预期编译错:三参重载不存在)
+
+- [ ] **Step 3: 实现**
+
+`EnumerateSpriteSources` 签名加可选参:
+
+```csharp
+public static List<(string pathKey, Sprite sprite)> EnumerateSpriteSources(
+    string folderAssetPath, string progressLabel = null,
+    HashSet<Sprite> tiledOut = null)
+```
+
+pxl 分支改为单次 LoadAll、双 OfType:
+
+```csharp
+if (AssetImporter.GetAtPath(assetPath) is PxlImporter)
+{
+    var relPxl = assetPath.Substring(folderPrefix.Length);
+    var pxlKey = relPxl.Substring(0, relPxl.Length - Path.GetExtension(relPxl).Length);
+    var pxlBase = Path.GetFileNameWithoutExtension(assetPath);
+    var objs = AssetDatabase.LoadAllAssetsAtPath(assetPath);
+    foreach (var s in objs.OfType<Sprite>())
+        result.Add((s.name == pxlBase ? pxlKey : $"{pxlKey}/{s.name}", s));
+    if (tiledOut != null)
+        foreach (var h in objs.OfType<PromptUGUI.Application.PxlSpriteHints>())
+            foreach (var ts in h.TiledSprites)
+                if (ts != null) tiledOut.Add(ts);
+    continue;
+}
+```
+
+调用点(`:805` 附近)与 entry 组装(`:846-853`,替换 Task 6 的 `false` 占位):
+
+```csharp
+var tiledSprites = new HashSet<Sprite>();
+var entries = EnumerateSpriteSources(folder, label, tiledSprites);
+...
+var iconSetEntries = new List<(string key, Sprite sprite, bool tiled)>();
+foreach (var kv in lookup)
+{
+    if (!picked.Contains(kv.Value)) continue;
+    iconSetEntries.Add((kv.Key, kv.Value, tiledSprites.Contains(kv.Value)));
+}
+set.SetEntriesInternal(iconSetEntries);
+```
+
+(裸名别名 entry 与路径 entry 引用同一 Sprite 对象 → `Contains` 同真,spec §5 的"含裸名别名条目"自动满足。)
+
+- [ ] **Step 4: 跑测试确认通过**(`PxlSyncerTests` + 全量 EditorOnly + `SpriteAtlasSyncerTests`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Editor/SpriteAtlasSyncer.cs Tests/EditMode/Editor/Pxl/PxlSyncerTests.cs
+git commit -m "feat(editor): Sync Atlases 把 pxl tiled 提示烙入 SpriteSet entry"
+```
+
+---
+
+### Task 8: 消费端改写 + 回收临时手段
+
+**Files:**
+- Modify: `Runtime/Controls/Image.cs:143-150`(auto-pick)
+- Modify: `Runtime/Controls/Btn.cs`(`ApplyStateSprite` 内 authored 三元推导)
+- Modify: `Runtime/Controls/Tab.cs`(`ApplySelectedSprite` / `ApplyBgSprite` 内三元推导)
+- Modify: `Runtime/Controls/Internal/CarouselView.cs:254`(dot sub-sprite)
+- Modify: `Samples~/CommonControls/Resources/UI/CommonControls.ui.xml`(删 6 处 `type="tiled"`)
+- Test: `Tests/EditMode/Controls/ImageControlTests.cs`(或 Image 测试实际所在文件,grep `auto-pick`/`_typeExplicit` 相关用例定位)
+
+- [ ] **Step 1: 写失败测试**(加到 Image 的测试类;先 grep `Type.Sliced` 找到 auto-pick 既有用例所在文件,追加)
+
+```csharp
+[Test]
+public void Image_autopick_tiled_for_hinted_sprite()
+{
+    var bordered = Sprite.Create(new Texture2D(8, 8), new Rect(0, 0, 8, 8), new Vector2(0.5f, 0.5f),
+        100f, 0, SpriteMeshType.FullRect, new Vector4(2, 2, 2, 2));
+    PromptUGUI.Application.Internal.SpriteRenderHints.Register(bordered);
+    UI.SpriteResolver = _ => bordered;
+    // 沿用该测试文件既有的"开屏 + 取 <Image sprite='ui:x'>"辅助
+    var img = OpenImage("<Image id='i' sprite='ui:x' width='64' height='64'/>");
+    Assert.AreEqual(UnityEngine.UI.Image.Type.Tiled,
+        img.GameObject.GetComponent<UnityEngine.UI.Image>().type);
+}
+
+[Test]
+public void Image_explicit_type_overrides_hint()
+{
+    var bordered = Sprite.Create(new Texture2D(8, 8), new Rect(0, 0, 8, 8), new Vector2(0.5f, 0.5f),
+        100f, 0, SpriteMeshType.FullRect, new Vector4(2, 2, 2, 2));
+    PromptUGUI.Application.Internal.SpriteRenderHints.Register(bordered);
+    UI.SpriteResolver = _ => bordered;
+    var img = OpenImage("<Image id='i' sprite='ui:x' type='sliced' width='64' height='64'/>");
+    Assert.AreEqual(UnityEngine.UI.Image.Type.Sliced,
+        img.GameObject.GetComponent<UnityEngine.UI.Image>().type);
+}
+```
+
+(`OpenImage` 代表该文件既有的开屏辅助;落地时跟随现有用例的写法。)
+
+- [ ] **Step 2: 跑测试确认失败**(hinted 用例 FAIL:auto-pick 仍是 Sliced)
+
+- [ ] **Step 3: 实现**
+
+`Image.cs` auto-pick(143-150 行)改:
+
+```csharp
+if (_typeExplicit) return;
+_img.type = PromptUGUI.Controls.Internal.ProceduralBuilders.DeriveType(_img.sprite);
+```
+
+`Btn.ApplyStateSprite` 的 authored 推导改:
+
+```csharp
+_bg.type = authored != null
+    ? PromptUGUI.Controls.Internal.ProceduralBuilders.DeriveType(authored)
+    : _baseType;
+```
+
+`Tab.ApplySelectedSprite`:
+
+```csharp
+_bg.type = showSelected
+    ? ProceduralBuilders.DeriveType(_selectedSprite)
+    : _baseType;
+```
+
+`Tab.ApplyBgSprite`:
+
+```csharp
+_bg.sprite = sprite;
+_bg.type = ProceduralBuilders.DeriveType(sprite);
+_baseType = _bg.type;
+```
+
+(Btn 的 `Sprite` setter 已走 `AutoSlice` → Task 4 改写后自动 DeriveType,无需再动。)
+
+`CarouselView.cs:254`:
+
+```csharp
+img.sprite = shown;
+img.type = ProceduralBuilders.DeriveType(shown);
+```
+
+`CommonControls.ui.xml`:
+
+```bash
+sed -i 's| type="tiled"||g' Samples~/CommonControls/Resources/UI/CommonControls.ui.xml
+dotnet run --project .lint/UIXmlLint -- Samples~/CommonControls/Resources/UI/CommonControls.ui.xml
+```
+
+(sample 走 `path#name` Resources 通道 → Task 5 的登记口 + 本 Task 的 auto-pick 自动 Tiled。)
+
+- [ ] **Step 4: 跑全量**(EditMode 全量 + PlayMode 全量;重点确认既有
+`ApplyDefaultSlicedSprite_SetsRoundTiled`、`Tab_DefaultSkin_StaysTiled_AcrossSelection`、
+`PressedSprite_With9SliceBorder_OnTransparentNormal_RendersSliced`、
+`Tab_SelectedSprite_With9SliceBorder_RendersSliced`、CarouselDots 的 Sliced 用例全部仍绿——
+未标记 sprite 行为零变化)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Image.cs Runtime/Controls/Btn.cs Runtime/Controls/Tab.cs \
+        Runtime/Controls/Internal/CarouselView.cs Samples~/CommonControls/Resources/UI/CommonControls.ui.xml \
+        Tests/EditMode/Controls/   # Image 测试实际文件
+git commit -m "feat(controls): Image/Btn/Tab/Carousel 统一 DeriveType,sample 去显式 tiled"
+```
+
+---
+
+### Task 9: SKILL 同步 + 终检
+
+**Files:**
+- Modify: `.claude/skills/authoring-promptugui-pxl/SKILL.md`
+- Modify: `.claude/skills/authoring-promptugui-xml/SKILL.md`
+
+- [ ] **Step 1: pxl SKILL**(英文)
+
+"Per-section directives" 段、`border:` 条目之后加:
+
+```markdown
+- `tiled: true` — optional render hint: every consumer (`<Image>`, `<Btn>`, `<Tab>`, default skins, Carousel cards) automatically renders this sprite with `Image.Type.Tiled` (corners fixed, edge strips and center REPEAT instead of stretch). Use for edges with directional patterns — vines, moss, wood grain, chains. Works with or without `border:` (borderless = the whole sprite tiles, e.g. seamless grass fill). An explicit `type=` in XML still wins. Must appear before `grid:`; repeated declaration last-wins like `border:`.
+```
+
+craft 段(9-slice design 条目内)补一句:
+
+```markdown
+For `tiled: true` frames, design each edge strip as a repeating unit: the pattern must loop seamlessly across the strip's own width/height AND both ends must return to the plain outline + base fill so corners and the next repeat join invisibly.
+```
+
+- [ ] **Step 2: XML SKILL**(英文)
+
+Image `type` 属性说明处(grep `tiled` 定位该行)补:
+
+```markdown
+Sprites authored in `.pxl` with `tiled: true` auto-render as Tiled on every control (no `type=` needed); writing `type=` explicitly still overrides the hint.
+```
+
+- [ ] **Step 3: lint + 全量终检**
+
+```bash
+cd .lint && dotnet restore PromptUGUI.Lint.slnx && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+
+UnityMCP:EditMode 全量 + EditorOnly 全量 + PlayMode 全量,read_console 零 error。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/authoring-promptugui-pxl/SKILL.md .claude/skills/authoring-promptugui-xml/SKILL.md
+git commit -m "docs(skill): pxl tiled: 指令 + XML 自动 Tiled 说明"
+```
+
+- [ ] **Step 5: 收尾** — 视觉 QA 留给用户(CommonControls 删掉显式 type 后外观应与删前一致);之后走 superpowers:finishing-a-development-branch(push + PR)。
+
+---
+
+## Spec 覆盖自查
+
+- §3 格式 → Task 1;§4 载体/Inspector → Task 2;§5 登记表三填充口 → Task 3(表)+ 5(Resources)+ 6(BuildLookup)+ 4(自举);§6 DeriveType 与改写清单 → Task 4 + 8;§7 回收 → Task 4(pugui 标记+硬编码还原)+ 8(sample/消费端);§8 边界 → Task 3 幂等/Clear 测试、§hints 丢失退化由 DeriveType 分支天然覆盖;§9 测试计划 → 各 Task Step 1;§10 SKILL → Task 9。
+- PNG 往返保留 `tiled:`(§3 末条):PxlPngSync 只重写 grid 行,无代码改动,**不加测试**(现行 `ppu:`/`border:` 同理无测试,YAGNI)。

--- a/docs~/superpowers/specs/2026-06-12-pxl-tiled-hint-design.md
+++ b/docs~/superpowers/specs/2026-06-12-pxl-tiled-hint-design.md
@@ -1,0 +1,171 @@
+# `.pxl` tiled 标记 → 运行时自动 Image.Type.Tiled（pxl-tiled-hint）设计
+
+日期：2026-06-12
+分支：基于 `feat/farm-pixel-skin` 的工作（依赖该分支未提交的"默认皮肤 Sliced→Tiled + Btn/Tab `_baseType`"改动）
+前置：`.pxl` 像素导入管线（Editor/Pxl）、Sync Atlases（SpriteAtlasSyncer）、SpriteSet 解析（SpriteResolverHelpers）
+
+## 1. 目标与动机
+
+带 border 的 sprite 在 uGUI 里有两种渲染：Sliced（边拉伸）和 Tiled（角固定 + 边/中心平铺）。
+青苔、藤蔓、木纹这类**有方向性图案的边框必须 Tiled**，否则拉糊。当前的痛点：
+
+1. 作者每个 `<Image sprite=...>` 都要手写 `type="tiled"`，忘写就默默变 Sliced（CommonControls
+   实际踩坑：6 处面板框漏写）。
+2. Tab / Btn 等控件根本没有 `type=` 属性，控件内部从 `border != 0 → Sliced` 盲推，默认皮肤
+   只能靠硬编码特判（feat/farm-pixel-skin 这轮在 Btn / Tab 各加了一套 `_baseType` 手工补丁）。
+3. "这张图设计成平铺"本质是**资产自身的属性**，应该声明在 `.pxl` 里、随 sprite 走，而不是
+   散落在每个引用点。
+
+本设计：`.pxl` section 加 `tiled: true` 指令；运行时凡解析到该 sprite（任何通道、任何控件）
+自动选 `Image.Type.Tiled`；显式 `type=` 仍最高优先。
+
+## 2. 非目标（YAGNI）
+
+- 不做 PNG sprite 的 tiled 标记（无 sidecar 文件格式；但 §5 的 `SpriteSet.Entry.tiled`
+  字段是格式无关的，未来若有 PNG sidecar 可直接喂入）。
+- 不做 per-edge 平铺控制（CSS `border-image` 式逐边 repeat/stretch）——uGUI Image 单
+  `type` 字段，做不到也不需要。
+- 不给 Tab / Btn / Toggle 等控件新增 `type=` XML 属性。
+- 不改 `<Icon>` / TMP 内联图文（始终 Simple / TMP 自管，平铺无意义）。
+
+## 3. `.pxl` 格式：per-section `tiled:` 指令
+
+```
+[vine-frame]
+border: 4,4,4,4
+tiled: true
+grid:
+  ...
+```
+
+- 位置：section 内、`grid:` 之前，与 `border:` 同级；两者顺序不限。
+- 取值：`true` / `false`（默认 false）。其他值 = 带行号的导入错误
+  （`invalid tiled value '...' (expected true|false)`）。
+- 重复声明 = 错误（同 `border:` 的重复规则）。
+- **允许无 border**：整图无缝纹理（草地、水面填充）也可平铺。PxlImporter 一律
+  `SpriteMeshType.FullRect`，borderless Tiled 走几何重复，合法。
+- 隐式单 section 文件同样支持（指令直接放 header 之后）。
+- PNG 往返（Export/Sync）：`tiled:` 是元数据，与 `border:`/`ppu:` 同等待遇——
+  Sync from PNG 只重写 grid 行，`tiled:` 原样保留，无需改 PxlPngSync。
+
+## 4. 载体：`PxlSpriteHints` 子资产
+
+运行时无法从 `Sprite` 引用反查任何自定义元数据，所以 hints 作为 `.pxl` 导入产物
+的一个子资产随资产库走：
+
+- 新 Runtime 类型 `PromptUGUI.Application.PxlSpriteHints : ScriptableObject`，
+  唯一字段 `[SerializeField] List<Sprite> tiledSprites`（**直接 Sprite 引用**，
+  不存名字——避免跨集撞名 / 改名失效）。类放 Runtime asmdef（运行时要
+  `Resources.LoadAll<PxlSpriteHints>` 反序列化），创建只在 Editor（importer）。
+- `PxlImporter`：文件中存在任何 `tiled: true` section 时，`ctx.AddObjectToAsset`
+  一个 hints 子资产（命名固定 `__pxl_hints`，不参与 sprite key 空间），引用对应
+  Sprite 子资产。全 false 则不生成（零成本路径）。
+- `PxlImporterEditor` 只读面板：有 tiled 标记的 section 在尺寸/border 行旁追加
+  "tiled" 字样。
+
+## 5. 运行时登记表：`SpriteRenderHints`
+
+`Runtime/Application/Internal/SpriteRenderHints.cs`，internal static：
+
+```csharp
+internal static class SpriteRenderHints
+{
+    static readonly HashSet<int> _tiledIds = new();   // instanceID，不 pin 资产
+    public static void Register(Sprite s);             // null 安全
+    public static bool IsTiled(Sprite s);              // null → false
+    public static void Clear();                        // UI.ResetForTests 调用
+}
+```
+
+三个填充口（覆盖全部解析通道）：
+
+1. **`UI.ResolveSprite` 的 Resources 分支**（裸路径 + `path#name` 两个子分支）：
+   在 `Resources.LoadAll<Sprite>(path)` 同处补一次
+   `Resources.LoadAll<PxlSpriteHints>(path)` 并逐个 Register。Resources.LoadAll
+   有 Unity 自身缓存，重复调用廉价。
+2. **SpriteSet 通道**（Resources 与 Addressables 共用 `BuildLookup`）：
+   `SpriteSet.Entry` 增加 `public bool tiled;`（List 序列化向后兼容，旧资产读出
+   false）。`BuildLookup` 构表时对 `tiled` 条目 Register。
+   Editor 侧 `SpriteAtlasSyncer`：扫 sourceFolder 时对每个 `.pxl` 加载其
+   `PxlSpriteHints` 子资产，含于其中的 Sprite 对应的 entry（含裸名别名条目）烙
+   `tiled = true`。Addressables 路线拿到的 Entry 引用同一批 `.pxl` 子资产 Sprite
+   原件（无克隆），同一张表天然生效。
+3. **内置皮肤自举**：`ProceduralBuilders.GetDefaultSprite` 首次
+   `Resources.LoadAll<Sprite>` 处，同步 LoadAll hints 并 Register
+   （`ResetDefaultSpriteCacheForTests` 同时让位给 `SpriteRenderHints.Clear`，
+   二者都挂在 `UI.ResetForTests`）。
+
+## 6. 消费端：统一 `DeriveType`
+
+`ProceduralBuilders` 新增唯一推导点：
+
+```csharp
+public static UnityImage.Type DeriveType(Sprite s) =>
+    s == null                       ? UnityImage.Type.Simple :
+    SpriteRenderHints.IsTiled(s)    ? UnityImage.Type.Tiled  :
+    s.border != Vector4.zero        ? UnityImage.Type.Sliced :
+                                      UnityImage.Type.Simple;
+```
+
+改写所有手写 border 推导处（行号为当前工作树）：
+
+| 调用点 | 现状 | 改后 |
+|---|---|---|
+| `ProceduralBuilders.AutoSlice` | border→Sliced/Simple | `img.type = DeriveType(img.sprite)`（null sprite 不动，维持原契约） |
+| `ProceduralBuilders.ApplyDefaultSlicedSprite` | 硬编码 Tiled（本分支临时手段） | `DeriveType(s)`（pugui round 标了 tiled → 结果不变） |
+| `ProceduralBuilders.ApplyDefaultInsetSprite` | 硬编码 Sliced | `DeriveType(s)`（inset 未标 → Sliced 不变） |
+| `Image` auto-pick（`Image.cs:143-150`，`!_typeExplicit`） | border→Sliced/Simple | `DeriveType`；显式 `type=` 优先级不变 |
+| `Btn.Sprite` setter / `ApplyStateSprite` | AutoSlice + authored override 手写 border 推导 | 均走 `DeriveType`；`_baseType` 机制保留，值来源统一 |
+| `Tab.ApplyBgSprite` / `ApplySelectedSprite` | 手写 border 推导 | 同上 |
+| `Progress` 轨/填充的 Simple/Sliced 选择（非 Filled 分支） | AutoSlice 镜像规则 | 已经走 `AutoSlice` 的自动受益；私有重复实现（若有）改 `DeriveType` |
+| `CarouselView.cs:254` 卡片 sub-sprite | 手写 border 推导 | `DeriveType` |
+
+不改：`Dropdown.cs:105`（item 行有意 Simple）、mask 路径（stencil 形状用,
+`AutoSlice` 改动对纯白 mask sprite 无视觉差，可随 AutoSlice 自然变化）、
+`Image type="contain|cover"`（强制 Simple）。
+
+## 7. 回收临时手段（同一交付物内）
+
+1. `pugui.pxl`：`pugui_9slice_round` / `pugui_9slice_pressed` 标 `tiled: true`。
+2. `ApplyDefaultSlicedSprite` 的硬编码 `Type.Tiled` 还原为 `DeriveType`（§6）。
+3. CommonControls.ui.xml：删除 6 处 `type="tiled"`（自动推导接管）。
+4. Btn / Tab 的 `_baseType` 赋值点全部改经 `DeriveType`，删除散落的三元 border 推导。
+5. 既有测试随契约微调：`ApplyDefaultSlicedSprite_SetsRoundTiled` /
+   `Tab_DefaultSkin_StaysTiled_AcrossSelection` 断言不变（结果仍 Tiled，来源变了）；
+   作者 sprite 的 Sliced 断言不变（未标记 sprite 行为零变化）。
+
+## 8. 错误与边界
+
+- `tiled: 1` / `tiled: yes` 等 → 导入错误（行号），sprite 不产出（同既有 pxl 错误模型）。
+- hints 子资产损坏/丢失（手删）→ 登记缺失，退化为 border 推导（Sliced）——渲染退化但不报错。
+- 同一 Sprite 经多通道重复 Register → HashSet 幂等。
+- 域重载/`ResetForTests` → `Clear()` 后由各通道在下次解析时重新登记（与
+  `_defaultSprites` 缓存同生命周期）。
+- 烫更新（pxl 重导入触发 SpriteResolverRebuilder）→ BuildLookup 重跑即重新登记；
+  instanceID 在重导入后可能变化，旧 ID 残留无害（不会撞上新 sprite）。
+
+## 9. 测试计划
+
+EditorOnly（`PromptUGUI.Tests.EditorOnly`）：
+- parser：`tiled: true/false` 解析、非法值/重复声明报错（带行号）、隐式 section 支持、
+  PNG Sync 往返保留 `tiled:` 行。
+- importer：标记 section → hints 子资产存在且引用正确 sprite；全 false → 无子资产。
+- syncer：sourceFolder 含标记 `.pxl` → SpriteSet entry（路径 key + 裸名别名）`tiled=true`。
+
+EditMode（`PromptUGUI.Tests.EditMode`）：
+- `SpriteRenderHints` 注册/查询/Clear/幂等。
+- `DeriveType` 四分支。
+- `ResolveSprite` Resources 分支登记（fake hints 资产放 Tests 用 Resources）。
+- `BuildLookup` 对 tiled entry 登记。
+- 消费端各一条：Image auto-pick、Btn authored sprite、Tab selectedSprite、Carousel 卡片
+  ——标记 sprite → Tiled，未标记带 border → Sliced（回归）。
+- 内置皮肤自举：默认 Btn bg `type == Tiled` 且来源是 hints（删除硬编码后仍绿）。
+
+## 10. SKILL 同步
+
+- `authoring-promptugui-pxl/SKILL.md`：per-section 指令清单加 `tiled:`；craft 段补
+  "平铺边设计准则"（边条带按周期设计、两端收回底色衔接四角）。
+- `authoring-promptugui-xml/SKILL.md`：Image `type` 段补一句"`.pxl` 标记 `tiled: true`
+  的 sprite 自动按 Tiled 渲染，显式 `type=` 可覆盖"。
+- C# SKILL：免更（`SpriteRenderHints` internal，`SpriteSet.Entry.tiled` 由工具填，
+  均为 transparent default）。

--- a/docs~/superpowers/specs/2026-06-12-pxl-tiled-hint-design.md
+++ b/docs~/superpowers/specs/2026-06-12-pxl-tiled-hint-design.md
@@ -41,7 +41,7 @@ grid:
 - 位置：section 内、`grid:` 之前，与 `border:` 同级；两者顺序不限。
 - 取值：`true` / `false`（默认 false）。其他值 = 带行号的导入错误
   （`invalid tiled value '...' (expected true|false)`）。
-- 重复声明 = 错误（同 `border:` 的重复规则）。
+- 重复声明 last-wins（同 `border:` 的既有规则：grid 前重复声明取最后一个）。
 - **允许无 border**：整图无缝纹理（草地、水面填充）也可平铺。PxlImporter 一律
   `SpriteMeshType.FullRect`，borderless Tiled 走几何重复，合法。
 - 隐式单 section 文件同样支持（指令直接放 header 之后）。


### PR DESCRIPTION
## Summary

`.pxl` 像素 sprite 现可在 section 上声明 `tiled: true`(peer of `border:`,在 `grid:` 之前)。该提示随导入的 sprite 流到运行时,**每个 consumer**(`<Image>` / `<Btn>` / `<Tab>` / 默认控件皮肤 / Carousel)自动以 `Image.Type.Tiled` 渲染——四角固定、边条与中心**平铺**而非拉伸。显式写 `type=` 仍可覆盖。用于藤蔓、青苔、木纹、链条这类有方向性、不能被拉变形的边框;可带 border 也可不带(无 border = 整图无缝平铺,如草地填充)。

farm 钉木框默认皮肤(`pugui_9slice_round` / `pressed`)与 CommonControls 样例因此免费获得平铺——样例里 6 处手写的 `type="tiled"` 已删除。

## 架构(单一推导链)

```
.pxl `tiled: true`
  → PxlImporter 产 PxlSpriteHints 子资产(记 tiled section 的 Sprite)
  → 运行时 SpriteRenderHints(HashSet<EntityId>,不 pin 资产)三个填充口:
      ① UI.ResolveSprite 的 Resources 分支   ② SpriteSet.Entry.tiled + BuildLookup(覆盖 Resources & Addressables)   ③ 默认皮肤自举
  → 消费端统一 ProceduralBuilders.DeriveType(sprite):
      IsTiled→Tiled  ·  有 border→Sliced  ·  否则 Simple   (显式 type= 优先)
```

- `SpriteRenderHints` 存 `EntityId` 值类型而非 Sprite 引用:`GetInstanceID()` 在 Unity 6 已废弃(用 `GetEntityId()`),且引用存储会把 tiled 资产永久 pin 在内存里。
- 公共 API 零破坏:`SpriteSet.Entry` 仅**追加** `bool tiled`(旧资产读出 false);`SpriteSet.Entries`(2-tuple)不变,新增内部 `EntriesWithMeta`;`PxlSpriteHints` / `SpriteRenderHints` 均 internal。
- PNG 往返(Export/Sync from PNG)天然保留 `tiled:`(只重写 grid 行)。

详见 `docs~/superpowers/specs/2026-06-12-pxl-tiled-hint-design.md` + plan。

## Test Plan

- [x] 全程 TDD(red→green),每 task 经 spec-compliance + code-quality 双评审 + 最终 opus 全特性评审。
- [x] EditMode + EditorOnly 全特性面绿:parser/importer/syncer、SpriteRenderHints、DeriveType 四分支、ResolveSprite & BuildLookup 登记、Image/Btn/Tab/Carousel/Progress/ScrollList/默认皮肤消费端(含新增 Btn/Tab authored-tiled→Tiled 用例补 spec §9)。
- [x] PlayMode ImageTests / CarouselPlayTests / IconRuntimeTests 绿;修复一处被遗漏的回归 `ImageTests.Type_auto_detects_Sliced_when_sprite_has_border`(round 现带 tiled hint → 改用 `pugui_9slice_inset` 保留"有边框→Sliced"覆盖)。
- [x] lint clean(`dotnet format --verify-no-changes`)+ UIXmlLint 样例 0 issue。
- [ ] ⚠️ 完整 PlayMode assembly 单轮 sweep 未跑成:本环境 PlayMode runner 多轮后退化(unfiltered run resolve 成 host `ssw_re_client`/0 测试),需重启 Unity 恢复。静态分析(全树 grep `Type.Sliced`/`Type.Tiled` 断言)确认无其它受影响用例,但建议合并前在干净 Unity 会话补一轮完整 PlayMode。
- [ ] 视觉 QA(藤蔓/青苔木纹框平铺观感)待人工。

🤖 Generated with [Claude Code](https://claude.com/claude-code)