### PR TITLE
feat: 渐变色支持（颜色值语法扩展）

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -856,7 +856,7 @@ Append a comma between two colour values to produce a **vertical two-stop gradie
 
 **Where gradients are NOT supported** (runtime error; static lint):
 - `*Modulate` attributes (`hoverModulate`, `pressedModulate`, `selectedModulate`, `disabledModulate`) — these are solid-only multipliers; a gradient value is rejected (lint `PUI-GRADIENT-MODULATE`)
-- Rich-text `<Animation char-color>` and inline `<c=>` segment colours
+- `<Animation char-color="from:to">` — the per-character animation colour; each side is a solid
 - `<InputField>` `textColor` / `placeholderColor` / `caretColor` / `selectionColor` — caret/selection are TMP `Color` fields with no vertices; editable text stays solid
 - `<Carousel>` `dotColor` / `dotSelectedColor` — the dots stay solid
 

--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -829,6 +829,41 @@ Append `/<0..1>` to any color **reference** to set its opacity. The suffix REPLA
 - Value is a `0..1` float. Out of range or malformed (`/1.5`, `/abc`, `/`, no color before `/`) → `ParseException` with node context.
 - Suffix is **reference-only**. Definition-side `<Color value="...">` does NOT take a suffix — bake alpha into the hex there (`value="#00000080"`) if you want a baked-alpha token.
 
+### Gradients
+
+Append a comma between two colour values to produce a **vertical two-stop gradient** (top colour, bottom colour). Gradients are a value-syntax extension — no new attributes.
+
+**Definition site** (`<Color value="...">` inside `<Theme>`): both segments must be plain literals (hex or CSS-named). No theme tokens, no `/alpha` suffix here — bake alpha into the hex if needed:
+
+```xml
+<Theme name="default">
+  <Color name="gold-grad" value="#ffe08a,#b8860b"/>
+</Theme>
+```
+
+**Reference site** (any colour attribute): each segment independently supports theme tokens, hex/named literals, and `/alpha`. You can mix:
+
+```xml
+<Text  color="gold-grad">Title</Text>         <!-- token → gradient -->
+<Icon  color="white,#aaa"/>                   <!-- two literals, inline -->
+<Image color="accent,accent-dark/0.5"/>       <!-- mix token + token/alpha -->
+<Btn   color="gold-grad/0.5"/>               <!-- /alpha on gradient token → BOTH stops' alpha replaced -->
+```
+
+**Where gradients work** — every attribute that paints a `Graphic`:
+- `color` on `<Image>` / `<Icon>` / `<RawImage>` / `<Btn>` / `<Tab>` / `<Toggle>` / `<Dropdown>` (+ `popupColor`) / `<Progress>` (`color`, `bgColor`, `frameColor`) / `<ScrollList>` (`color`, `frameColor`) / `<Slider>` (`bgColor`) / `<InputField>` (bg only, see below) / `<Text>`
+- Absolute state colours: `hoverColor` / `pressedColor` / `selectedColor` / `disabledColor`
+
+**Where gradients are NOT supported** (runtime error; static lint):
+- `*Modulate` attributes (`hoverModulate`, `pressedModulate`, `selectedModulate`, `disabledModulate`) — these are solid-only multipliers; a gradient value is rejected (lint `PUI-GRADIENT-MODULATE`)
+- Rich-text `<Animation char-color>` and inline `<c=>` segment colours
+- `<InputField>` `textColor` / `placeholderColor` / `caretColor` / `selectionColor` — caret/selection are TMP `Color` fields with no vertices; editable text stays solid
+- `<Carousel>` `dotColor` / `dotSelectedColor` — the dots stay solid
+
+**`<Text>` per-character gradient.** On `<Text>` the gradient is TMP-native and applied per-character — each glyph's vertices run top→bottom independently. This makes a solid "gold-foil" title effect without a single stretched gradient across the text block.
+
+**State-colour transition timing.** A state transition whose start or end colour is a gradient **snaps** immediately (no ~0.1s fade) — there is no colour-lerp for a vertex gradient. Solid ↔ solid transitions still fade as before.
+
 ### Error codes
 
 - `<Theme>: missing required attribute 'name'`
@@ -841,6 +876,11 @@ Append `/<0..1>` to any color **reference** to set its opacity. The suffix REPLA
 - (Runtime, when value can't resolve) `<Image id='X'> attribute color="Y": unknown color token "Y" (no entry in theme 'Z', not a valid hex/named literal)`
 - (Runtime, bad alpha suffix) `color "black/1.5": alpha 1.5 is out of range — must be 0..1`
 - (Lint) `PUI-COLOR-LITERAL-INVALID` — static check: `color="#..."` literal that doesn't parse, or a hex literal with an out-of-range / malformed `/alpha` suffix
+- `<Color name="X" value="A,B,C">: gradient supports exactly two colours (top,bottom)` — also fires for empty segments (e.g. `value="#fff,"`, `value=",#000"`)
+- (Lint, CLI) `PUI-COLOR-GRADIENT-MALFORMED` — malformed gradient shape on a `color` attribute (wrong segment count or empty segment)
+- (Lint, CLI) `PUI-GRADIENT-MODULATE` — a gradient value on a `*Modulate` attribute
+- (Runtime) `color "...": this attribute does not support gradient colors` — gradient on a solid-only attribute (`*Modulate`, caret/selection colours, etc.)
+- (Runtime) `color "...": token resolves to a gradient — gradients cannot nest inside a gradient` — one segment of a gradient reference resolves to another gradient token
 
 ## Tint blend modes
 

--- a/.claude/skills/authoring-promptugui-xml/reference/animations.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/animations.md
@@ -149,7 +149,7 @@ Text family default: looks for the unique `<Text>` in the subtree. Multiple `<Te
 
 ```xml
 <Animation count="0:1000" format="{0:N0}" duration="2s">
-  <Animation char-color="1,1,1,1:1,0.8,0.2,1" char-stagger="0.05s" delay="2s" duration="0.4s">
+  <Animation char-color="#ffffff:#ffcc33" char-stagger="0.05s" delay="2s" duration="0.4s">
     <Text id="score">0</Text>
   </Animation>
 </Animation>

--- a/.claude/skills/authoring-promptugui-xml/reference/states.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/states.md
@@ -6,9 +6,9 @@
 
 ## 1. State colour — two families
 
-**Absolute `*Color`** (`hoverColor` / `pressedColor` / `selectedColor` / `disabledColor`) sets the per-state colour of the control's base graphic (`targetGraphic` / bg) **only** — the same graphic that `color=` targets. It does **not** fan out to descendants. Normal has no `*Color` (use `color=`). Accepts the same value forms as `color` (hex / CSS named / theme token).
+**Absolute `*Color`** (`hoverColor` / `pressedColor` / `selectedColor` / `disabledColor`) sets the per-state colour of the control's base graphic (`targetGraphic` / bg) **only** — the same graphic that `color=` targets. It does **not** fan out to descendants. Normal has no `*Color` (use `color=`). Accepts the same value forms as `color` (hex / CSS named / theme token), **including gradients** (`hoverColor="#fff,#aaa"`). A state transition into or out of a gradient **snaps** (no ~0.1s fade); solid ↔ solid transitions still fade. See [Color Tokens → Gradients](../SKILL.md#gradients) for the full grammar.
 
-**Relative `*Modulate`** (`hoverModulate` / `pressedModulate` / `selectedModulate` / `disabledModulate`) is a **relative multiplier** (Godot `modulate` semantics: white = identity, the normal uGUI ColorTint model). It fans out to the bg **and every descendant Graphic** (label, icons, nested images), switching the control off uGUI's built-in ColorTint, and the tint **fades** over ~0.1s.
+**Relative `*Modulate`** (`hoverModulate` / `pressedModulate` / `selectedModulate` / `disabledModulate`) is a **relative multiplier** (Godot `modulate` semantics: white = identity, the normal uGUI ColorTint model). It fans out to the bg **and every descendant Graphic** (label, icons, nested images), switching the control off uGUI's built-in ColorTint, and the tint **fades** over ~0.1s. `*Modulate` is **solid-only** — a gradient value is a parse error (lint `PUI-GRADIENT-MODULATE`); use `*Color` when you need a per-state gradient.
 
 They compose: per state, `displayed = (absolute ?? color) × (modulate ?? white)`.
 

--- a/Runtime/Application/ColorSpec.cs
+++ b/Runtime/Application/ColorSpec.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+namespace PromptUGUI.Application
+{
+    /// <summary>
+    /// A resolved colour value: solid, or a two-stop vertical gradient (Top → Bottom).
+    /// Produced by <see cref="UI.Theme.ResolveSpec"/> (Task 3); applied by <c>ColorApplier</c>
+    /// (vertex-tint slot) or the TMP vertex-gradient path in <c>Text</c>.
+    /// Solid values keep <see cref="Bottom"/> == <see cref="Top"/> so consumers that
+    /// only need one colour can read Top unconditionally.
+    /// </summary>
+    internal readonly struct ColorSpec
+    {
+        public readonly Color Top;
+        public readonly Color Bottom;
+        public readonly bool IsGradient;
+
+        private ColorSpec(Color top, Color bottom, bool isGradient)
+        {
+            Top = top;
+            Bottom = bottom;
+            IsGradient = isGradient;
+        }
+
+        public static ColorSpec Solid(Color c) => new ColorSpec(c, c, false);
+        public static ColorSpec Gradient(Color top, Color bottom) => new ColorSpec(top, bottom, true);
+
+        /// <summary>Component-wise multiply both stops (modulate premultiply, spec §5).</summary>
+        public ColorSpec Multiply(Color m) => new ColorSpec(Top * m, Bottom * m, IsGradient);
+    }
+}

--- a/Runtime/Application/ColorSpec.cs
+++ b/Runtime/Application/ColorSpec.cs
@@ -4,7 +4,7 @@ namespace PromptUGUI.Application
 {
     /// <summary>
     /// A resolved colour value: solid, or a two-stop vertical gradient (Top → Bottom).
-    /// Produced by <see cref="UI.Theme.ResolveSpec"/> (Task 3); applied by <c>ColorApplier</c>
+    /// Produced by <c>UI.Theme.ResolveSpec</c> (arriving in a later task); applied by <c>ColorApplier</c>
     /// (vertex-tint slot) or the TMP vertex-gradient path in <c>Text</c>.
     /// Solid values keep <see cref="Bottom"/> == <see cref="Top"/> so consumers that
     /// only need one colour can read Top unconditionally.
@@ -25,7 +25,7 @@ namespace PromptUGUI.Application
         public static ColorSpec Solid(Color c) => new ColorSpec(c, c, false);
         public static ColorSpec Gradient(Color top, Color bottom) => new ColorSpec(top, bottom, true);
 
-        /// <summary>Component-wise multiply both stops (modulate premultiply, spec §5).</summary>
+        /// <summary>Component-wise multiply (modulate) a tint colour into both stops.</summary>
         public ColorSpec Multiply(Color m) => new ColorSpec(Top * m, Bottom * m, IsGradient);
     }
 }

--- a/Runtime/Application/ColorSpec.cs
+++ b/Runtime/Application/ColorSpec.cs
@@ -4,7 +4,7 @@ namespace PromptUGUI.Application
 {
     /// <summary>
     /// A resolved colour value: solid, or a two-stop vertical gradient (Top → Bottom).
-    /// Produced by <c>UI.Theme.ResolveSpec</c> (arriving in a later task); applied by <c>ColorApplier</c>
+    /// Produced by <c>UI.Theme.ResolveSpec</c>; applied by <c>ColorApplier</c>
     /// (vertex-tint slot) or the TMP vertex-gradient path in <c>Text</c>.
     /// Solid values keep <see cref="Bottom"/> == <see cref="Top"/> so consumers that
     /// only need one colour can read Top unconditionally.

--- a/Runtime/Application/ColorSpec.cs.meta
+++ b/Runtime/Application/ColorSpec.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 02cd5e3670a960e409c4773b4384c2af

--- a/Runtime/Application/ThemeStore.cs
+++ b/Runtime/Application/ThemeStore.cs
@@ -17,7 +17,7 @@ namespace PromptUGUI.Application
         {
             public string Name;
             public string BaseName;
-            public Dictionary<string, Color> Colors;
+            public Dictionary<string, ColorSpec> Colors;
             public string Src;
             public Entry ResolvedBase;
         }
@@ -27,7 +27,7 @@ namespace PromptUGUI.Application
         public IReadOnlyCollection<string> Available => _themes.Keys;
 
         public void Register(string name, string baseName,
-                             IReadOnlyDictionary<string, Color> colors, string src)
+                             IReadOnlyDictionary<string, ColorSpec> colors, string src)
         {
             if (_themes.TryGetValue(name, out var existing) && existing.Src != src)
                 throw new ParseException(
@@ -46,13 +46,13 @@ namespace PromptUGUI.Application
             {
                 Name = name,
                 BaseName = baseName,
-                Colors = new Dictionary<string, Color>(colors),
+                Colors = new Dictionary<string, ColorSpec>(colors),
                 Src = src,
             };
         }
 
         public void ReplaceFromSrc(string src,
-            IReadOnlyList<(string name, string baseName, IReadOnlyDictionary<string, Color> colors)> blocks)
+            IReadOnlyList<(string name, string baseName, IReadOnlyDictionary<string, ColorSpec> colors)> blocks)
         {
             // Hot reload: drop everything previously from src, then register new.
             var toRemove = new List<string>();
@@ -89,7 +89,7 @@ namespace PromptUGUI.Application
             }
         }
 
-        public Color? LookupChained(string themeName, string token)
+        public ColorSpec? LookupChained(string themeName, string token)
         {
             if (!_themes.TryGetValue(themeName, out var e)) return null;
             for (var cur = e; cur != null; cur = cur.ResolvedBase)

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -439,10 +439,17 @@ namespace PromptUGUI.Application
                 Changed?.Invoke(name);
             }
 
+            /// <summary>
+            /// Looks up a color token in the current theme.
+            /// For gradient tokens, returns the Top stop (the public surface always returns
+            /// a single <see cref="UnityEngine.Color"/>). Use <c>ThemeStore.Instance.LookupChained</c>
+            /// directly when a <see cref="ColorSpec"/> with both stops is needed.
+            /// </summary>
             public static UnityEngine.Color? Lookup(string token)
             {
                 if (Current == null) return null;
-                return ThemeStore.Instance.LookupChained(Current, token);
+                var spec = ThemeStore.Instance.LookupChained(Current, token);
+                return spec.HasValue ? spec.Value.Top : (UnityEngine.Color?)null;
             }
 
             public static UnityEngine.Color Resolve(string value)
@@ -466,7 +473,7 @@ namespace PromptUGUI.Application
                 if (Current != null)
                 {
                     var hit = ThemeStore.Instance.LookupChained(Current, value);
-                    if (hit.HasValue) return hit.Value;
+                    if (hit.HasValue) return hit.Value.Top;
                 }
                 if (UnityEngine.ColorUtility.TryParseHtmlString(value, out var c))
                     return c;
@@ -916,12 +923,21 @@ namespace PromptUGUI.Application
         {
             foreach (var (theme, themeSrc) in loaded.Themes)
             {
-                var colors = new System.Collections.Generic.Dictionary<string, UnityEngine.Color>(
+                var colors = new System.Collections.Generic.Dictionary<string, ColorSpec>(
                     theme.Colors.Count);
                 foreach (var ce in theme.Colors)
                 {
-                    UnityEngine.ColorUtility.TryParseHtmlString(ce.Value, out var c);
-                    colors[ce.Name] = c;
+                    Parser.ColorParser.TrySplitGradient(ce.Value, out var topRaw, out var bottomRaw, out _);
+                    UnityEngine.ColorUtility.TryParseHtmlString(topRaw, out var top);
+                    if (bottomRaw == null)
+                    {
+                        colors[ce.Name] = ColorSpec.Solid(top);
+                    }
+                    else
+                    {
+                        UnityEngine.ColorUtility.TryParseHtmlString(bottomRaw, out var bottom);
+                        colors[ce.Name] = ColorSpec.Gradient(top, bottom);
+                    }
                 }
                 ThemeStore.Instance.Register(theme.Name, theme.BaseName, colors, themeSrc);
             }
@@ -981,15 +997,24 @@ namespace PromptUGUI.Application
             var bySrc = new System.Collections.Generic.Dictionary<
                 string,
                 System.Collections.Generic.List<(string name, string baseName,
-                    System.Collections.Generic.IReadOnlyDictionary<string, UnityEngine.Color> colors)>>();
+                    System.Collections.Generic.IReadOnlyDictionary<string, ColorSpec> colors)>>();
             foreach (var (theme, themeSrc) in loaded.Themes)
             {
-                var colors = new System.Collections.Generic.Dictionary<string, UnityEngine.Color>(
+                var colors = new System.Collections.Generic.Dictionary<string, ColorSpec>(
                     theme.Colors.Count);
                 foreach (var ce in theme.Colors)
                 {
-                    UnityEngine.ColorUtility.TryParseHtmlString(ce.Value, out var c);
-                    colors[ce.Name] = c;
+                    Parser.ColorParser.TrySplitGradient(ce.Value, out var topRaw, out var bottomRaw, out _);
+                    UnityEngine.ColorUtility.TryParseHtmlString(topRaw, out var top);
+                    if (bottomRaw == null)
+                    {
+                        colors[ce.Name] = ColorSpec.Solid(top);
+                    }
+                    else
+                    {
+                        UnityEngine.ColorUtility.TryParseHtmlString(bottomRaw, out var bottom);
+                        colors[ce.Name] = ColorSpec.Gradient(top, bottom);
+                    }
                 }
                 if (!bySrc.TryGetValue(themeSrc, out var list))
                     bySrc[themeSrc] = list = new();

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -442,8 +442,9 @@ namespace PromptUGUI.Application
             /// <summary>
             /// Looks up a color token in the current theme.
             /// For gradient tokens, returns the Top stop (the public surface always returns
-            /// a single <see cref="UnityEngine.Color"/>). Use <c>ThemeStore.Instance.LookupChained</c>
-            /// directly when a <see cref="ColorSpec"/> with both stops is needed.
+            /// a single <see cref="UnityEngine.Color"/>). Internal callers that need a
+            /// <see cref="ColorSpec"/> with both stops should use
+            /// <c>UI.Theme.ResolveSpec</c> (arriving in a later task).
             /// </summary>
             public static UnityEngine.Color? Lookup(string token)
             {
@@ -913,6 +914,22 @@ namespace PromptUGUI.Application
         }
 
         /// <summary>
+        /// Parses a raw color string (hex, named, or "top,bottom" gradient) from a
+        /// <c>&lt;Color value="…"/&gt;</c> attribute into a <see cref="ColorSpec"/>.
+        /// Called from both <see cref="RegisterThemesAndAutoSet"/> and
+        /// <see cref="ReplaceThemesAndNotify"/> so the two theme-registration paths
+        /// share identical parsing logic and can't silently diverge.
+        /// </summary>
+        private static ColorSpec ParseThemeColor(string raw)
+        {
+            Parser.ColorParser.TrySplitGradient(raw, out var topRaw, out var bottomRaw, out _);
+            UnityEngine.ColorUtility.TryParseHtmlString(topRaw, out var top);
+            if (bottomRaw == null) return ColorSpec.Solid(top);
+            UnityEngine.ColorUtility.TryParseHtmlString(bottomRaw, out var bottom);
+            return ColorSpec.Gradient(top, bottom);
+        }
+
+        /// <summary>
         /// Shared helper: parse colors from <paramref name="loaded"/>.Themes,
         /// register each into <see cref="ThemeStore"/>, resolve base-chains, and
         /// auto-select when exactly one theme is available. Called from both
@@ -926,19 +943,7 @@ namespace PromptUGUI.Application
                 var colors = new System.Collections.Generic.Dictionary<string, ColorSpec>(
                     theme.Colors.Count);
                 foreach (var ce in theme.Colors)
-                {
-                    Parser.ColorParser.TrySplitGradient(ce.Value, out var topRaw, out var bottomRaw, out _);
-                    UnityEngine.ColorUtility.TryParseHtmlString(topRaw, out var top);
-                    if (bottomRaw == null)
-                    {
-                        colors[ce.Name] = ColorSpec.Solid(top);
-                    }
-                    else
-                    {
-                        UnityEngine.ColorUtility.TryParseHtmlString(bottomRaw, out var bottom);
-                        colors[ce.Name] = ColorSpec.Gradient(top, bottom);
-                    }
-                }
+                    colors[ce.Name] = ParseThemeColor(ce.Value);
                 ThemeStore.Instance.Register(theme.Name, theme.BaseName, colors, themeSrc);
             }
             ThemeStore.Instance.ResolveBases();
@@ -1003,19 +1008,7 @@ namespace PromptUGUI.Application
                 var colors = new System.Collections.Generic.Dictionary<string, ColorSpec>(
                     theme.Colors.Count);
                 foreach (var ce in theme.Colors)
-                {
-                    Parser.ColorParser.TrySplitGradient(ce.Value, out var topRaw, out var bottomRaw, out _);
-                    UnityEngine.ColorUtility.TryParseHtmlString(topRaw, out var top);
-                    if (bottomRaw == null)
-                    {
-                        colors[ce.Name] = ColorSpec.Solid(top);
-                    }
-                    else
-                    {
-                        UnityEngine.ColorUtility.TryParseHtmlString(bottomRaw, out var bottom);
-                        colors[ce.Name] = ColorSpec.Gradient(top, bottom);
-                    }
-                }
+                    colors[ce.Name] = ParseThemeColor(ce.Value);
                 if (!bySrc.TryGetValue(themeSrc, out var list))
                     bySrc[themeSrc] = list = new();
                 list.Add((theme.Name, theme.BaseName, colors));

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -453,31 +453,67 @@ namespace PromptUGUI.Application
                 return spec.HasValue ? spec.Value.Top : (UnityEngine.Color?)null;
             }
 
-            public static UnityEngine.Color Resolve(string value)
+            /// <summary>
+            /// Resolve a colour value that may be a two-stop vertical gradient ("top,bottom").
+            /// Each segment independently supports theme tokens, hex/named literals and the
+            /// /alpha suffix. A whole-value token may itself BE a gradient token; "/alpha" on
+            /// it replaces BOTH stops' alpha. A gradient token used as ONE segment of another
+            /// gradient is an error (no nested gradients).
+            /// </summary>
+            internal static ColorSpec ResolveSpec(string value)
             {
                 if (string.IsNullOrEmpty(value))
                     throw new System.Exception("empty color value");
 
-                // Reference-site alpha suffix: "black/0.5" → resolve "black", then set a = 0.5.
-                // The suffix REPLACES the resolved colour's own alpha (Color.a semantics),
-                // so a 50%-opaque token referenced as "scrim/1" comes out fully opaque.
+                if (!Parser.ColorParser.TrySplitGradient(value, out var topRaw, out var bottomRaw, out var gErr))
+                    throw new System.Exception(gErr);
+
+                if (bottomRaw == null)
+                    return ResolveSingle(topRaw, allowGradientToken: true);
+
+                var top = ResolveSingle(topRaw, allowGradientToken: false);
+                var bottom = ResolveSingle(bottomRaw, allowGradientToken: false);
+                return ColorSpec.Gradient(top.Top, bottom.Top);
+            }
+
+            /// <summary>One segment: token / literal + optional /alpha. Solid unless the whole
+            /// segment is a gradient token AND allowGradientToken.</summary>
+            private static ColorSpec ResolveSingle(string value, bool allowGradientToken)
+            {
                 if (!Parser.ColorParser.TrySplitAlpha(value, out var baseValue, out var alpha, out var err))
                     throw new System.Exception(err);
 
-                var resolved = ResolveBase(baseValue);
-                if (alpha.HasValue) resolved.a = alpha.Value;
-                return resolved;
+                var spec = ResolveBaseSpec(baseValue);
+                if (spec.IsGradient && !allowGradientToken)
+                    throw new System.Exception(
+                        $"color \"{value}\": token resolves to a gradient — gradients cannot nest inside a gradient");
+                if (alpha.HasValue)
+                {
+                    var t = spec.Top; t.a = alpha.Value;
+                    var b = spec.Bottom; b.a = alpha.Value;
+                    spec = spec.IsGradient ? ColorSpec.Gradient(t, b) : ColorSpec.Solid(t);
+                }
+                return spec;
             }
 
-            private static UnityEngine.Color ResolveBase(string value)
+            public static UnityEngine.Color Resolve(string value)
+            {
+                var spec = ResolveSpec(value);
+                if (spec.IsGradient)
+                    throw new System.Exception(
+                        $"color \"{value}\": this attribute does not support gradient colors");
+                return spec.Top;
+            }
+
+            private static ColorSpec ResolveBaseSpec(string value)
             {
                 if (Current != null)
                 {
                     var hit = ThemeStore.Instance.LookupChained(Current, value);
-                    if (hit.HasValue) return hit.Value.Top;
+                    if (hit.HasValue) return hit.Value;
                 }
                 if (UnityEngine.ColorUtility.TryParseHtmlString(value, out var c))
-                    return c;
+                    return ColorSpec.Solid(c);
                 // Soft-fail for the in-flight load case: Current was Set but its
                 // named theme isn't registered yet (e.g. Theme.Set("dark") fired
                 // before LoadCommonLibraryAsync completed, or the user pre-Set a
@@ -486,7 +522,7 @@ namespace PromptUGUI.Application
                 // pass calls RaiseChangedIfCurrent and fires Theme.Changed.
                 if (Current != null
                     && !System.Linq.Enumerable.Contains(ThemeStore.Instance.Available, Current))
-                    return UnityEngine.Color.white;
+                    return ColorSpec.Solid(UnityEngine.Color.white);
                 throw new System.Exception(
                     $"unknown color token \"{value}\" (no entry in theme " +
                     $"'{Current ?? "(none)"}', not a valid hex/named literal)");

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -444,7 +444,7 @@ namespace PromptUGUI.Application
             /// For gradient tokens, returns the Top stop (the public surface always returns
             /// a single <see cref="UnityEngine.Color"/>). Internal callers that need a
             /// <see cref="ColorSpec"/> with both stops should use
-            /// <c>UI.Theme.ResolveSpec</c> (arriving in a later task).
+            /// <c>UI.Theme.ResolveSpec</c>.
             /// </summary>
             public static UnityEngine.Color? Lookup(string token)
             {
@@ -476,8 +476,9 @@ namespace PromptUGUI.Application
                 return ColorSpec.Gradient(top.Top, bottom.Top);
             }
 
-            /// <summary>One segment: token / literal + optional /alpha. Solid unless the whole
-            /// segment is a gradient token AND allowGradientToken.</summary>
+            /// <summary>Resolve one segment: token / literal + optional /alpha. Returns a gradient only
+            /// when the resolved token is itself a gradient AND <paramref name="allowGradientToken"/> is
+            /// true; if it's a gradient token but nesting isn't allowed, throws.</summary>
             private static ColorSpec ResolveSingle(string value, bool allowGradientToken)
             {
                 if (!Parser.ColorParser.TrySplitAlpha(value, out var baseValue, out var alpha, out var err))
@@ -486,7 +487,7 @@ namespace PromptUGUI.Application
                 var spec = ResolveBaseSpec(baseValue);
                 if (spec.IsGradient && !allowGradientToken)
                     throw new System.Exception(
-                        $"color \"{value}\": token resolves to a gradient — gradients cannot nest inside a gradient");
+                        $"color segment \"{value}\": token resolves to a gradient — gradients cannot nest inside a gradient");
                 if (alpha.HasValue)
                 {
                     var t = spec.Top; t.a = alpha.Value;

--- a/Runtime/Controls/Btn.cs
+++ b/Runtime/Controls/Btn.cs
@@ -99,8 +99,8 @@ namespace PromptUGUI.Controls
         {
             base.OnAfterApply();
             _btn.interactable = Interactable;
-            var abs = StateColorSet.Resolve(_hoverColor, _pressedColor, null, _disabledColor);
-            var mod = StateColorSet.Resolve(_hoverModulate, _pressedModulate, null, _disabledModulate);
+            var abs = StateColorSet.ResolveAbsolutes(_hoverColor, _pressedColor, null, _disabledColor);
+            var mod = StateColorSet.ResolveModulates(_hoverModulate, _pressedModulate, null, _disabledModulate);
             StateTintInstaller.Install(GameObject, _btn, Children, abs, mod);
             // A pressed/disabled sprite is itself a state visual: drop uGUI's built-in ColorTint so the
             // swapped image isn't double-darkened. Set-only, matching the state-colour path

--- a/Runtime/Controls/Btn.cs
+++ b/Runtime/Controls/Btn.cs
@@ -164,7 +164,7 @@ namespace PromptUGUI.Controls
         [UIAttr(IsColor = true), Preserve]
         public string Color
         {
-            set => _bg.color = UI.Theme.Resolve(value);
+            set => Internal.ColorApplier.Apply(_bg, UI.Theme.ResolveSpec(value));
         }
 
         /// <summary>Absolute bg colour while Hover.</summary>

--- a/Runtime/Controls/Dropdown.cs
+++ b/Runtime/Controls/Dropdown.cs
@@ -190,7 +190,7 @@ namespace PromptUGUI.Controls
         [UIAttr(IsColor = true), Preserve]
         public string Color
         {
-            set => _bg.color = UI.Theme.Resolve(value);
+            set => Internal.ColorApplier.Apply(_bg, UI.Theme.ResolveSpec(value));
         }
 
         [UIAttr, Preserve]
@@ -218,7 +218,7 @@ namespace PromptUGUI.Controls
         [UIAttr(IsColor = true), Preserve]
         public string PopupColor
         {
-            set => _templateBg.color = UI.Theme.Resolve(value);
+            set => Internal.ColorApplier.Apply(_templateBg, UI.Theme.ResolveSpec(value));
         }
 
         [UIAttr(IsSprite = true), Preserve]

--- a/Runtime/Controls/Icon.cs
+++ b/Runtime/Controls/Icon.cs
@@ -45,7 +45,7 @@ namespace PromptUGUI.Controls
         [UIAttr(IsColor = true), Preserve]
         public string Color
         {
-            set => _img.color = UI.Theme.Resolve(value);
+            set => Internal.ColorApplier.Apply(_img, UI.Theme.ResolveSpec(value));
         }
 
         [UIAttr, Preserve]

--- a/Runtime/Controls/Image.cs
+++ b/Runtime/Controls/Image.cs
@@ -45,7 +45,7 @@ namespace PromptUGUI.Controls
         [UIAttr(IsColor = true), Preserve]
         public string Color
         {
-            set => _img.color = UI.Theme.Resolve(value);
+            set => Internal.ColorApplier.Apply(_img, UI.Theme.ResolveSpec(value));
         }
 
         [UIAttr, Preserve]

--- a/Runtime/Controls/InputField.cs
+++ b/Runtime/Controls/InputField.cs
@@ -229,7 +229,7 @@ namespace PromptUGUI.Controls
         [UIAttr(IsColor = true), Preserve]
         public string Color
         {
-            set => _bg.color = UI.Theme.Resolve(value);
+            set => Internal.ColorApplier.Apply(_bg, UI.Theme.ResolveSpec(value));
         }
 
         [UIAttr, Preserve]

--- a/Runtime/Controls/Internal/CarouselView.cs
+++ b/Runtime/Controls/Internal/CarouselView.cs
@@ -263,6 +263,8 @@ namespace PromptUGUI.Controls.Internal
                 btn.targetGraphic = img;
                 btn.onClick.AddListener(() => GoTo(captured, animated: true));
 
+                // Dots are solid-only per spec §5; wrap the already-solid selected base as a
+                // ColorSpec just to satisfy the shared installer's ColorSpec? signature.
                 ColorSpec? dotSelBase = _dotSelectedColor.HasValue
                     ? ColorSpec.Solid(_dotSelectedColor.Value)
                     : (ColorSpec?)null;

--- a/Runtime/Controls/Internal/CarouselView.cs
+++ b/Runtime/Controls/Internal/CarouselView.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using LitMotion;
+using PromptUGUI.Application;
 using PromptUGUI.IR;
 using PromptUGUI.Layout;
 using UnityEngine;
@@ -236,7 +237,7 @@ namespace PromptUGUI.Controls.Internal
             layout.childForceExpandWidth = false;
             layout.childForceExpandHeight = false;
 
-            var abs = StateColorSet.Resolve(_dotHoverColor, _dotPressedColor, null, null);
+            var abs = StateColorSet.ResolveAbsolutes(_dotHoverColor, _dotPressedColor, null, null);
             var emptyChildren = System.Array.Empty<IControl>();
             for (int i = 0; i < _cards.Count; i++)
             {
@@ -262,8 +263,11 @@ namespace PromptUGUI.Controls.Internal
                 btn.targetGraphic = img;
                 btn.onClick.AddListener(() => GoTo(captured, animated: true));
 
+                ColorSpec? dotSelBase = _dotSelectedColor.HasValue
+                    ? ColorSpec.Solid(_dotSelectedColor.Value)
+                    : (ColorSpec?)null;
                 var reactor = StateTintInstaller.Install(dotRt.gameObject, btn, emptyChildren,
-                    abs, default, _dotSelectedColor, selected: captured == _current);
+                    abs, default, dotSelBase, selected: captured == _current);
 
                 _dotImages.Add(img);
                 _dotReactors.Add(reactor);

--- a/Runtime/Controls/Internal/ColorApplier.cs
+++ b/Runtime/Controls/Internal/ColorApplier.cs
@@ -1,0 +1,43 @@
+using PromptUGUI.Application;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Controls.Internal
+{
+    /// <summary>
+    /// Single chokepoint for landing a resolved <see cref="ColorSpec"/> on a Graphic
+    /// (spec §4.1). Solid → <c>graphic.color</c> (and disables any GradientTint);
+    /// gradient → GradientTint vertex slot + <c>graphic.color = white</c> so the
+    /// Graphic.color slot stays free for state modulates. GradientTint is lazy-added
+    /// and toggled, never destroyed.
+    /// </summary>
+    internal static class ColorApplier
+    {
+        public static void Apply(Graphic g, ColorSpec spec)
+        {
+            if (spec.IsGradient)
+            {
+                var tint = g.GetComponent<GradientTint>() ?? g.gameObject.AddComponent<GradientTint>();
+                tint.Set(spec.Top, spec.Bottom);
+                tint.enabled = true;
+                g.color = Color.white;
+            }
+            else
+            {
+                var tint = g.GetComponent<GradientTint>();
+                if (tint != null) tint.enabled = false;
+                g.color = spec.Top;
+            }
+        }
+
+        /// <summary>Read back the currently-applied value — gradient if a GradientTint is
+        /// enabled, else the plain graphic colour. Used by StateTintReactor base capture.</summary>
+        public static ColorSpec Peek(Graphic g)
+        {
+            var tint = g.GetComponent<GradientTint>();
+            return tint != null && tint.enabled
+                ? ColorSpec.Gradient(tint.Top, tint.Bottom)
+                : ColorSpec.Solid(g.color);
+        }
+    }
+}

--- a/Runtime/Controls/Internal/ColorApplier.cs.meta
+++ b/Runtime/Controls/Internal/ColorApplier.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a0efad552ec741e5835c85a3e64a1c95

--- a/Runtime/Controls/Internal/GradientTint.cs
+++ b/Runtime/Controls/Internal/GradientTint.cs
@@ -1,0 +1,55 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Controls.Internal
+{
+    /// <summary>
+    /// Two-stop vertical gradient tint as a vertex-colour effect (spec §4.2). Multiplies
+    /// Lerp(Bottom, Top, normalizedY) into each vertex's existing colour, so the final
+    /// composite stays <c>texture × Graphic.color × gradient</c> — the Graphic.color slot
+    /// remains free for state modulates. Y is normalized across the actual mesh bounds
+    /// (Sliced/Tiled have &gt;4 verts; vertex order is not assumed). Lazy-added by
+    /// <c>ColorApplier</c> and toggled via <c>enabled</c>, never destroyed
+    /// (Variant/ReSolve round-trips, same convention as ApplyViewportMask).
+    /// </summary>
+    [RequireComponent(typeof(Graphic))]
+    internal sealed class GradientTint : BaseMeshEffect
+    {
+        private Color _top = Color.white;
+        private Color _bottom = Color.white;
+
+        public void Set(Color top, Color bottom)
+        {
+            if (_top == top && _bottom == bottom) return;
+            _top = top;
+            _bottom = bottom;
+            if (graphic != null) graphic.SetVerticesDirty();
+        }
+
+        public Color Top => _top;
+        public Color Bottom => _bottom;
+
+        public override void ModifyMesh(VertexHelper vh)
+        {
+            if (!IsActive() || vh.currentVertCount == 0) return;
+
+            var v = new UIVertex();
+            float minY = float.MaxValue, maxY = float.MinValue;
+            for (var i = 0; i < vh.currentVertCount; i++)
+            {
+                vh.PopulateUIVertex(ref v, i);
+                if (v.position.y < minY) minY = v.position.y;
+                if (v.position.y > maxY) maxY = v.position.y;
+            }
+
+            var h = maxY - minY;
+            for (var i = 0; i < vh.currentVertCount; i++)
+            {
+                vh.PopulateUIVertex(ref v, i);
+                var t = h > 0f ? (v.position.y - minY) / h : 1f;
+                v.color = (Color)v.color * Color.Lerp(_bottom, _top, t);
+                vh.SetUIVertex(v, i);
+            }
+        }
+    }
+}

--- a/Runtime/Controls/Internal/GradientTint.cs.meta
+++ b/Runtime/Controls/Internal/GradientTint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 66fb74a146a365047812e5d74d4b57f0

--- a/Runtime/Controls/Internal/StateColorSet.cs
+++ b/Runtime/Controls/Internal/StateColorSet.cs
@@ -4,20 +4,19 @@ using UnityEngine;
 namespace PromptUGUI.Controls.Internal
 {
     /// <summary>
-    /// Four optional colours keyed by <see cref="InteractState"/> (Hover / Pressed / Selected /
+    /// Four optional colour specs keyed by <see cref="InteractState"/> (Hover / Pressed / Selected /
     /// Disabled; Normal has no entry). Used twice by <see cref="StateTintReactor"/>: as per-state
-    /// ABSOLUTE base overrides (applied only to the control's <c>targetGraphic</c>) and as per-state
-    /// relative MULTIPLIERS (white = identity, fanned out to the whole subtree). A null entry means
-    /// "no override for that state".
+    /// ABSOLUTE base overrides (targetGraphic only — gradients allowed) and as per-state relative
+    /// MULTIPLIERS (white = identity, solid-only, fanned out to the whole subtree). null = no override.
     /// </summary>
     internal readonly struct StateColorSet
     {
-        public readonly Color? Hover;
-        public readonly Color? Pressed;
-        public readonly Color? Selected;
-        public readonly Color? Disabled;
+        public readonly ColorSpec? Hover;
+        public readonly ColorSpec? Pressed;
+        public readonly ColorSpec? Selected;
+        public readonly ColorSpec? Disabled;
 
-        public StateColorSet(Color? hover, Color? pressed, Color? selected, Color? disabled)
+        public StateColorSet(ColorSpec? hover, ColorSpec? pressed, ColorSpec? selected, ColorSpec? disabled)
         {
             Hover = hover;
             Pressed = pressed;
@@ -25,7 +24,7 @@ namespace PromptUGUI.Controls.Internal
             Disabled = disabled;
         }
 
-        public Color? For(InteractState state) => state switch
+        public ColorSpec? For(InteractState state) => state switch
         {
             InteractState.Hover => Hover,
             InteractState.Pressed => Pressed,
@@ -37,14 +36,20 @@ namespace PromptUGUI.Controls.Internal
         // "HasAny" (not "Any") so a use-site like `set.HasAny` never reads as a LINQ Enumerable.Any call.
         public bool HasAny => Hover.HasValue || Pressed.HasValue || Selected.HasValue || Disabled.HasValue;
 
-        /// <summary>Resolve four raw attribute strings (hex / CSS named / theme token; null / empty /
-        /// whitespace ⇒ no override) into resolved colours via <see cref="UI.Theme"/>.</summary>
-        public static StateColorSet Resolve(string hover, string pressed, string selected, string disabled)
-            => new(R(hover), R(pressed), R(selected), R(disabled));
+        /// <summary>Absolute per-state base overrides — gradients allowed (spec §5). null/empty/whitespace
+        /// ⇒ no override. Resolved via <see cref="UI.Theme.ResolveSpec"/>.</summary>
+        public static StateColorSet ResolveAbsolutes(string hover, string pressed, string selected, string disabled)
+            => new(RSpec(hover), RSpec(pressed), RSpec(selected), RSpec(disabled));
 
-        // IsNullOrWhiteSpace (not IsNullOrEmpty): a whitespace-only attribute value from XML is
-        // treated as "no override" rather than passed to Theme.Resolve, which would error.
-        private static Color? R(string v)
-            => string.IsNullOrWhiteSpace(v) ? (Color?)null : UI.Theme.Resolve(v);
+        /// <summary>Relative per-state multipliers — SOLID ONLY (spec §6). A gradient value throws via
+        /// <see cref="UI.Theme.Resolve"/> ("does not support gradient colors"). null/empty/whitespace ⇒ none.</summary>
+        public static StateColorSet ResolveModulates(string hover, string pressed, string selected, string disabled)
+            => new(RSolid(hover), RSolid(pressed), RSolid(selected), RSolid(disabled));
+
+        // IsNullOrWhiteSpace (not IsNullOrEmpty): a whitespace-only XML attr value is "no override".
+        private static ColorSpec? RSpec(string v)
+            => string.IsNullOrWhiteSpace(v) ? (ColorSpec?)null : UI.Theme.ResolveSpec(v);
+        private static ColorSpec? RSolid(string v)
+            => string.IsNullOrWhiteSpace(v) ? (ColorSpec?)null : ColorSpec.Solid(UI.Theme.Resolve(v));
     }
 }

--- a/Runtime/Controls/Internal/StateTintInstaller.cs
+++ b/Runtime/Controls/Internal/StateTintInstaller.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using PromptUGUI.Application;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -19,7 +20,7 @@ namespace PromptUGUI.Controls.Internal
             IReadOnlyList<IControl> children,
             StateColorSet absolutes,
             StateColorSet modulates,
-            Color? selectedBase = null,
+            ColorSpec? selectedBase = null,
             bool selected = false)
         {
             if (!absolutes.HasAny && !modulates.HasAny && !selectedBase.HasValue) return null;
@@ -45,7 +46,7 @@ namespace PromptUGUI.Controls.Internal
                 // Absolutes + selectedBase apply ONLY to the control's base graphic (targetGraphic) —
                 // fanning them out would paint label/icon the bg colour. Descendants get the multiplier only.
                 var abs = isTarget ? absolutes : default;
-                var selBase = isTarget ? selectedBase : null;
+                ColorSpec? selBase = isTarget ? selectedBase : null;
                 var reactor = InstallReactor(g, abs, modulates, fade, selBase, selected);
                 if (isTarget) targetReactor = reactor;
             }
@@ -73,7 +74,7 @@ namespace PromptUGUI.Controls.Internal
                 CollectBlocked(child as Control, blocked);
         }
 
-        private static StateTintReactor InstallReactor(Graphic graphic, StateColorSet absolutes, StateColorSet modulates, float fade, Color? selectedBase, bool selected)
+        private static StateTintReactor InstallReactor(Graphic graphic, StateColorSet absolutes, StateColorSet modulates, float fade, ColorSpec? selectedBase, bool selected)
         {
             if (graphic == null) return null;
             var reactor = graphic.GetComponent<StateTintReactor>()

--- a/Runtime/Controls/Internal/StateTintReactor.cs
+++ b/Runtime/Controls/Internal/StateTintReactor.cs
@@ -1,5 +1,6 @@
 using System;
 using LitMotion;
+using PromptUGUI.Application;
 using R3;
 using UnityEngine;
 using UnityEngine.UI;
@@ -34,8 +35,8 @@ namespace PromptUGUI.Controls.Internal
 
         private Graphic _graphic;
         private bool _baseCaptured;
-        private Color _baseColor = Color.white;
-        private Color? _selectedBase;       // base while the source is selected (Tab/Toggle isOn); null ⇒ none
+        private ColorSpec _baseColor = ColorSpec.Solid(Color.white);
+        private ColorSpec? _selectedBase;   // base while the source is selected (Tab/Toggle isOn); null ⇒ none
         private bool _selected;             // pushed by the owning control via SetSelected
 
         private StateColorSet _absolutes;   // per-state ABSOLUTE base override (targetGraphic only)
@@ -52,7 +53,7 @@ namespace PromptUGUI.Controls.Internal
             _graphic = GetComponent<Graphic>();
             if (_graphic != null && !_baseCaptured)
             {
-                _baseColor = _graphic.color;
+                _baseColor = ColorApplier.Peek(_graphic);
                 _baseCaptured = true;
             }
 
@@ -68,7 +69,7 @@ namespace PromptUGUI.Controls.Internal
         /// (Re)set the per-state absolute overrides + relative multipliers + fade. Safe to call
         /// repeatedly (Variant ReSolve): the base colour stays captured from the first init.
         /// </summary>
-        public void Configure(StateColorSet absolutes, StateColorSet modulates, float fade, Color? selectedBase = null, bool selected = false)
+        public void Configure(StateColorSet absolutes, StateColorSet modulates, float fade, ColorSpec? selectedBase = null, bool selected = false)
         {
             // Assign the colour sets BEFORE EnsureInit subscribes: the OnState subscription replays
             // the source's current state synchronously, so if the control is already in a non-Normal
@@ -106,9 +107,9 @@ namespace PromptUGUI.Controls.Internal
             if (_source != null) OnState(_source.Current);
         }
 
-        private Color MultiplierFor(InteractState state) => _modulates.For(state) ?? Color.white;
+        private Color MultiplierFor(InteractState state) => _modulates.For(state)?.Top ?? Color.white;
 
-        private Color BaseFor(InteractState state)
+        private ColorSpec BaseFor(InteractState state)
             => _absolutes.For(state)
                ?? ((_selected && _selectedBase.HasValue) ? _selectedBase.Value : _baseColor);
 
@@ -123,17 +124,22 @@ namespace PromptUGUI.Controls.Internal
         private void OnState(InteractState state)
         {
             if (_graphic == null) return;
-            var target = BaseFor(state) * MultiplierFor(state);
+            var target = BaseFor(state).Multiply(MultiplierFor(state));   // premultiply modulate into both stops
 
             if (_handle.IsActive()) _handle.TryCancel();
 
-            if (TestForceInstant || _fade <= 0f || CrossesTransparency(_graphic.color, target))
+            var current = ColorApplier.Peek(_graphic);
+            // Gradients snap: there's no Color-lerp for a vertex gradient. Solid↔solid (non-transparent)
+            // keeps the existing fade. Mirrors the CrossesTransparency snap precedent.
+            if (TestForceInstant || _fade <= 0f
+                || target.IsGradient || current.IsGradient
+                || CrossesTransparency(current.Top, target.Top))
             {
-                _graphic.color = target;
+                ColorApplier.Apply(_graphic, target);
                 return;
             }
 
-            _handle = LMotion.Create(_graphic.color, target, _fade)
+            _handle = LMotion.Create(_graphic.color, target.Top, _fade)
                 .Bind(_graphic, static (c, g) => g.color = c);
         }
 

--- a/Runtime/Controls/Internal/StateTintReactor.cs
+++ b/Runtime/Controls/Internal/StateTintReactor.cs
@@ -19,7 +19,9 @@ namespace PromptUGUI.Controls.Internal
     /// The base (authored) colour is captured ONCE on first init and never re-captured: a
     /// re-<see cref="Configure"/> (e.g. a Variant ReSolve) must not promote the currently-tinted
     /// colour into the new base. A state with no absolute and no modulate returns the graphic to
-    /// its base colour.
+    /// its base colour. Base/absolute/selected colours may be gradients (landed via
+    /// <see cref="ColorApplier"/>); a transition with a gradient endpoint snaps instead of fading
+    /// (no Color-lerp for a vertex gradient — see <c>OnState</c>). Modulates stay solid.
     /// </remarks>
     internal sealed class StateTintReactor : MonoBehaviour
     {

--- a/Runtime/Controls/Progress.cs
+++ b/Runtime/Controls/Progress.cs
@@ -87,7 +87,7 @@ namespace PromptUGUI.Controls
         [UIAttr(IsColor = true), Preserve]
         public string FillColor
         {
-            set => _fill.color = UI.Theme.Resolve(value);
+            set => Internal.ColorApplier.Apply(_fill, UI.Theme.ResolveSpec(value));
         }
 
         [UIAttr(IsSprite = true), Preserve]
@@ -108,7 +108,7 @@ namespace PromptUGUI.Controls
         {
             set
             {
-                _bg.color = UI.Theme.Resolve(value);
+                Internal.ColorApplier.Apply(_bg, UI.Theme.ResolveSpec(value));
                 _bg.gameObject.SetActive(true);
                 ReconcileMaskVisibility();
             }
@@ -131,7 +131,7 @@ namespace PromptUGUI.Controls
         {
             set
             {
-                _frame.color = UI.Theme.Resolve(value);
+                Internal.ColorApplier.Apply(_frame, UI.Theme.ResolveSpec(value));
                 _frame.gameObject.SetActive(true);
             }
         }

--- a/Runtime/Controls/RawImage.cs
+++ b/Runtime/Controls/RawImage.cs
@@ -45,7 +45,7 @@ namespace PromptUGUI.Controls
         [UIAttr(IsColor = true), Preserve]
         public string Color
         {
-            set => _raw.color = UI.Theme.Resolve(value);
+            set => Internal.ColorApplier.Apply(_raw, UI.Theme.ResolveSpec(value));
         }
 
         [UIAttr, Preserve]

--- a/Runtime/Controls/ScrollList.cs
+++ b/Runtime/Controls/ScrollList.cs
@@ -172,7 +172,7 @@ namespace PromptUGUI.Controls
         [UIAttr(IsColor = true), Preserve]
         public string Color
         {
-            set => _bg.color = UI.Theme.Resolve(value);
+            set => Internal.ColorApplier.Apply(_bg, UI.Theme.ResolveSpec(value));
         }
 
         [UIAttr, Preserve]
@@ -219,7 +219,7 @@ namespace PromptUGUI.Controls
         [UIAttr(IsColor = true), Preserve]
         public string FrameColor
         {
-            set => EnsureFrame().color = UI.Theme.Resolve(value);
+            set => Internal.ColorApplier.Apply(EnsureFrame(), UI.Theme.ResolveSpec(value));
         }
 
         internal override void OnAfterApply()

--- a/Runtime/Controls/Slider.cs
+++ b/Runtime/Controls/Slider.cs
@@ -114,7 +114,7 @@ namespace PromptUGUI.Controls
         [UIAttr(IsColor = true), Preserve]
         public string Color
         {
-            set => _bg.color = UI.Theme.Resolve(value);
+            set => Internal.ColorApplier.Apply(_bg, UI.Theme.ResolveSpec(value));
         }
 
         [UIAttr, Preserve]

--- a/Runtime/Controls/Tab.cs
+++ b/Runtime/Controls/Tab.cs
@@ -265,7 +265,7 @@ namespace PromptUGUI.Controls
         [UIAttr(IsColor = true), Preserve]
         public string Color
         {
-            set => _bg.color = UI.Theme.Resolve(value);
+            set => Internal.ColorApplier.Apply(_bg, UI.Theme.ResolveSpec(value));
         }
 
         /// <summary>

--- a/Runtime/Controls/Tab.cs
+++ b/Runtime/Controls/Tab.cs
@@ -334,11 +334,11 @@ namespace PromptUGUI.Controls
             _toggle.interactable = Interactable;
             // selectedColor is the selection-aware BASE (not a Selected-state absolute), so pass null
             // for the Selected absolute; selectedModulate stays the Selected multiplier.
-            var abs = StateColorSet.Resolve(_hoverColor, _pressedColor, null, _disabledColor);
-            var mod = StateColorSet.Resolve(_hoverModulate, _pressedModulate, _selectedModulate, _disabledModulate);
-            Color? selectedBase = string.IsNullOrWhiteSpace(_selectedColor)
-                ? (Color?)null
-                : UI.Theme.Resolve(_selectedColor);
+            var abs = StateColorSet.ResolveAbsolutes(_hoverColor, _pressedColor, null, _disabledColor);
+            var mod = StateColorSet.ResolveModulates(_hoverModulate, _pressedModulate, _selectedModulate, _disabledModulate);
+            ColorSpec? selectedBase = string.IsNullOrWhiteSpace(_selectedColor)
+                ? (ColorSpec?)null
+                : UI.Theme.ResolveSpec(_selectedColor);
             _bgReactor = StateTintInstaller.Install(GameObject, _toggle, Children, abs, mod, selectedBase, IsOn);
             if (_selectedSprite != null) _toggle.transition = Selectable.Transition.None;
             ApplySelectedSprite();

--- a/Runtime/Controls/Text.cs
+++ b/Runtime/Controls/Text.cs
@@ -86,7 +86,21 @@ namespace PromptUGUI.Controls
         [UIAttr(IsColor = true), Preserve]
         public string Color
         {
-            set => _tmp.color = UI.Theme.Resolve(value);
+            set
+            {
+                var spec = UI.Theme.ResolveSpec(value);
+                if (spec.IsGradient)
+                {
+                    _tmp.enableVertexGradient = true;
+                    _tmp.colorGradient = new VertexGradient(spec.Top, spec.Top, spec.Bottom, spec.Bottom);
+                    _tmp.color = UnityEngine.Color.white;
+                }
+                else
+                {
+                    _tmp.enableVertexGradient = false;
+                    _tmp.color = spec.Top;
+                }
+            }
         }
 
         [UIAttr, Preserve]

--- a/Runtime/Controls/Toggle.cs
+++ b/Runtime/Controls/Toggle.cs
@@ -198,11 +198,11 @@ namespace PromptUGUI.Controls
             _toggle.interactable = Interactable;
             // selectedColor is the selection-aware BASE (not a Selected-state absolute); selectedModulate
             // stays the Selected multiplier. Toggle keeps its Checkmark overlay unchanged.
-            var abs = StateColorSet.Resolve(_hoverColor, _pressedColor, null, _disabledColor);
-            var mod = StateColorSet.Resolve(_hoverModulate, _pressedModulate, _selectedModulate, _disabledModulate);
-            Color? selectedBase = string.IsNullOrWhiteSpace(_selectedColor)
-                ? (Color?)null
-                : UI.Theme.Resolve(_selectedColor);
+            var abs = StateColorSet.ResolveAbsolutes(_hoverColor, _pressedColor, null, _disabledColor);
+            var mod = StateColorSet.ResolveModulates(_hoverModulate, _pressedModulate, _selectedModulate, _disabledModulate);
+            ColorSpec? selectedBase = string.IsNullOrWhiteSpace(_selectedColor)
+                ? (ColorSpec?)null
+                : UI.Theme.ResolveSpec(_selectedColor);
             _bgReactor = StateTintInstaller.Install(GameObject, _toggle, Children, abs, mod, selectedBase, IsOn);
         }
 

--- a/Runtime/Controls/Toggle.cs
+++ b/Runtime/Controls/Toggle.cs
@@ -120,7 +120,7 @@ namespace PromptUGUI.Controls
         [UIAttr(IsColor = true), Preserve]
         public string Color
         {
-            set => _bg.color = UI.Theme.Resolve(value);
+            set => Internal.ColorApplier.Apply(_bg, UI.Theme.ResolveSpec(value));
         }
 
         [UIAttr, Preserve]

--- a/Runtime/Core/Lint/ColorLiteralRules.cs
+++ b/Runtime/Core/Lint/ColorLiteralRules.cs
@@ -5,23 +5,43 @@ using PromptUGUI.Parser;
 namespace PromptUGUI.Lint
 {
     /// <summary>
-    /// Static check on <c>color="..."</c> attribute values. Only flags hex literals
-    /// that fail to parse (values starting with '#'). Bare words are deliberately not
-    /// flagged — they may be tokens registered in a theme file not visible to this
-    /// lint pass.
+    /// Static check on <c>color="..."</c> attribute values. Checks gradient structure first
+    /// (more than two segments, or an empty segment → <c>PUI-COLOR-GRADIENT-MALFORMED</c>),
+    /// then validates each segment as a hex literal that must parse. Bare words (tokens) are
+    /// deliberately not flagged — they may be tokens registered in a theme file not visible
+    /// to this lint pass.
     ///
-    /// Consumed by both <c>IRWalker</c> (UIXmlLint CLI, build-time errors) and
-    /// <c>ScreenInstantiator</c> (runtime warnings). Single source of truth.
+    /// Consumed by <c>IRWalker</c> (UIXmlLint CLI, build-time errors). CLI-only; not
+    /// dispatched from <c>ScreenInstantiator</c> (the runtime already hard-throws on
+    /// malformed gradients at apply time).
     /// </summary>
     public static class ColorLiteralRules
     {
         public const string ColorLiteralCode = "PUI-COLOR-LITERAL-INVALID";
+        public const string GradientMalformedCode = "PUI-COLOR-GRADIENT-MALFORMED";
 
         public static IEnumerable<LintIssue> Check(ElementNode node)
         {
             if (!node.Attributes.TryGetValue("color", out var value)) yield break;
             if (string.IsNullOrEmpty(value)) yield break;
 
+            // Gradient shape first: >2 segments or an empty segment is structurally invalid
+            // regardless of whether segments are tokens or hex (tokens can't fix a bad shape).
+            if (!ColorParser.TrySplitGradient(value, out var top, out var bottom, out var gErr))
+            {
+                yield return new LintIssue(GradientMalformedCode, node.Tag, node.Id,
+                    $"<{node.Tag} id='{node.Id}'>: {gErr}");
+                yield break;
+            }
+
+            foreach (var issue in CheckSegment(top, node)) yield return issue;
+            if (bottom != null)
+                foreach (var issue in CheckSegment(bottom, node)) yield return issue;
+        }
+
+        // Existing single-colour validation, now applied per gradient segment.
+        private static IEnumerable<LintIssue> CheckSegment(string value, ElementNode node)
+        {
             // Reference-site /alpha suffix ("black/0.5"): strip it before the hex check.
             // A malformed suffix on a hex literal is flagged at build time; on a bare word
             // it's left to the runtime resolver (tokens aren't statically checked anyway).

--- a/Runtime/Core/Lint/GradientModulateRules.cs
+++ b/Runtime/Core/Lint/GradientModulateRules.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using PromptUGUI.IR;
+
+namespace PromptUGUI.Lint
+{
+    /// <summary>
+    /// Flags a gradient value (contains ',') on any <c>*Modulate</c> attribute. Modulate is a
+    /// per-state colour MULTIPLIER fanned out to the subtree; it is solid-only by design (spec §6),
+    /// and the runtime <see cref="PromptUGUI.Application.UI.Theme.Resolve"/> hard-throws on a
+    /// gradient there. This surfaces the same mistake statically. CLI-only (dispatched from
+    /// <c>IRWalker</c>), mirroring <see cref="ColorLiteralRules"/>.
+    /// </summary>
+    public static class GradientModulateRules
+    {
+        public const string GradientModulateCode = "PUI-GRADIENT-MODULATE";
+
+        public static IEnumerable<LintIssue> Check(ElementNode node)
+        {
+            foreach (var kv in node.Attributes)
+            {
+                if (!kv.Key.EndsWith("Modulate", System.StringComparison.Ordinal)) continue;
+                if (string.IsNullOrEmpty(kv.Value) || kv.Value.IndexOf(',') < 0) continue;
+                yield return new LintIssue(GradientModulateCode, node.Tag, node.Id,
+                    $"<{node.Tag} id='{node.Id}'>: '{kv.Key}' is a colour multiplier — " +
+                    "gradients are not supported on *Modulate (use a solid colour/token).");
+            }
+        }
+    }
+}

--- a/Runtime/Core/Lint/GradientModulateRules.cs.meta
+++ b/Runtime/Core/Lint/GradientModulateRules.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 309c436ff2a5f334698304e6fe5726a3

--- a/Runtime/Core/Lint/IRWalker.cs
+++ b/Runtime/Core/Lint/IRWalker.cs
@@ -84,6 +84,10 @@ namespace PromptUGUI.Lint
             foreach (var issue in ColorLiteralRules.Check(node))
                 yield return issue;
 
+            // Static reject: a gradient value on a *Modulate multiplier (solid-only, spec §6).
+            foreach (var issue in GradientModulateRules.Check(node))
+                yield return issue;
+
             // Ancestor-aware (like PUI-TAB-PARENT, but upward): a bare state-* trigger /
             // animation / show resolves to its nearest clickable (<Btn>/<Tab>/<Toggle>) ancestor
             // at runtime. With no such ancestor it hard-throws (TriggerSourceResolver.FindStateSource);

--- a/Runtime/Core/Parser/ColorParser.cs
+++ b/Runtime/Core/Parser/ColorParser.cs
@@ -86,6 +86,42 @@ namespace PromptUGUI.Parser
             return true;
         }
 
+        /// <summary>
+        /// Splits an optional two-stop gradient value on ','. <c>"#fff,#000"</c> → top <c>"#fff"</c>,
+        /// bottom <c>"#000"</c>; no comma → top = raw, bottom = null. Segments are trimmed (authors
+        /// write <c>"a, b"</c>). Each segment still carries its own token / <c>/alpha</c> form —
+        /// this method does NOT validate segment contents, only the split shape.
+        /// Returns false when there are &gt;2 segments or any segment is empty.
+        /// </summary>
+        public static bool TrySplitGradient(string raw, out string top, out string bottom, out string error)
+        {
+            top = raw;
+            bottom = null;
+            error = null;
+            if (string.IsNullOrEmpty(raw)) return true;   // empty handled by caller
+
+            var comma = raw.IndexOf(',');
+            if (comma < 0) return true;
+
+            if (raw.IndexOf(',', comma + 1) >= 0)
+            {
+                error = $"color \"{raw}\": gradient supports exactly two colours (top,bottom)";
+                return false;
+            }
+
+            var head = raw.Substring(0, comma).Trim();
+            var tail = raw.Substring(comma + 1).Trim();
+            if (head.Length == 0 || tail.Length == 0)
+            {
+                error = $"color \"{raw}\": gradient segment is empty — expected \"top,bottom\"";
+                return false;
+            }
+
+            top = head;
+            bottom = tail;
+            return true;
+        }
+
         private static bool IsHexDigit(char c)
         {
             return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');

--- a/Runtime/Core/Parser/UIDocumentParser.cs
+++ b/Runtime/Core/Parser/UIDocumentParser.cs
@@ -113,9 +113,13 @@ namespace PromptUGUI.Parser
                 if (!KebabRx.IsMatch(cn))
                     throw new ParseException(
                         $"<Color name=\"{cn}\">: token name must be kebab-case [a-z0-9-]");
-                if (!ColorParser.TryParseHtmlString(cv))
+                if (!ColorParser.TrySplitGradient(cv, out var gTop, out var gBottom, out var gErr))
+                    throw new ParseException($"<Color name=\"{cn}\" value=\"{cv}\">: {gErr}");
+                if (!ColorParser.TryParseHtmlString(gTop)
+                    || (gBottom != null && !ColorParser.TryParseHtmlString(gBottom)))
                     throw new ParseException(
-                        $"<Color name=\"{cn}\" value=\"{cv}\">: invalid color literal");
+                        $"<Color name=\"{cn}\" value=\"{cv}\">: invalid color literal" +
+                        (gBottom != null ? " (each gradient segment must be a hex/named literal — no tokens, no /alpha)" : ""));
                 if (!seen.Add(cn))
                     throw new ParseException(
                         $"<Theme name=\"{name}\"> declares '{cn}' twice");

--- a/Tests/EditMode/Application/ColorAlphaSuffixTests.cs
+++ b/Tests/EditMode/Application/ColorAlphaSuffixTests.cs
@@ -19,8 +19,12 @@ namespace PromptUGUI.Tests.Application
 
         private static void Seed(string name, string baseName, params (string k, string v)[] entries)
         {
-            var d = new Dictionary<string, Color>();
-            foreach (var (k, v) in entries) { ColorUtility.TryParseHtmlString(v, out var c); d[k] = c; }
+            var d = new Dictionary<string, ColorSpec>();
+            foreach (var (k, v) in entries)
+            {
+                ColorUtility.TryParseHtmlString(v, out var c);
+                d[k] = ColorSpec.Solid(c);
+            }
             ThemeStore.Instance.Register(name, baseName, d, src: "test");
             ThemeStore.Instance.ResolveBases();
         }

--- a/Tests/EditMode/Application/ThemeGradientTests.cs
+++ b/Tests/EditMode/Application/ThemeGradientTests.cs
@@ -41,6 +41,25 @@ namespace PromptUGUI.Tests.Application
         // ── load-path tests (via XML round-trip through UI infrastructure) ──
 
         [Test]
+        public void LoadDocumentAsync_RegistersGradient_EndToEnd()
+        {
+            // Round-trips through the real pipeline: SourceResolver → LoadDocumentAsync
+            // → RegisterThemesAndAutoSet → ParseThemeColor → ThemeStore.
+            var xml = Header +
+                "<Theme name='t'><Color name='grad' value='#ffffff,#000000'/></Theme>" +
+                "<Screen name='s'><Frame/></Screen>" +
+                Footer;
+            UI.SourceResolver = _ => AwaitableHelpers.Completed(xml);
+            UI.LoadDocumentAsync("main").GetAwaiter().GetResult();
+
+            var spec = ThemeStore.Instance.LookupChained("t", "grad");
+            Assert.IsTrue(spec.HasValue, "gradient token must be registered after LoadDocumentAsync");
+            Assert.IsTrue(spec.Value.IsGradient);
+            Assert.AreEqual(Color.white, spec.Value.Top);
+            Assert.AreEqual(Color.black, spec.Value.Bottom);
+        }
+
+        [Test]
         public void Load_GradientToken_IsGradient_Top_White_Bottom_Black()
         {
             var xml = Header +
@@ -142,6 +161,7 @@ namespace PromptUGUI.Tests.Application
         {
             var half = new Color(0.5f, 0.5f, 0.5f, 1f);
             var spec = ColorSpec.Gradient(Color.white, Color.white).Multiply(half);
+            Assert.IsTrue(spec.IsGradient, "Multiply must preserve IsGradient");
             Assert.AreEqual(half, spec.Top);
             Assert.AreEqual(half, spec.Bottom);
         }

--- a/Tests/EditMode/Application/ThemeGradientTests.cs
+++ b/Tests/EditMode/Application/ThemeGradientTests.cs
@@ -165,5 +165,97 @@ namespace PromptUGUI.Tests.Application
             Assert.AreEqual(half, spec.Top);
             Assert.AreEqual(half, spec.Bottom);
         }
+
+        // ── UI.Theme.ResolveSpec / Resolve tests ──────────────────────────────
+
+        [Test]
+        public void ResolveSpec_LiteralGradient_IsGradient_Top_White_Bottom_Black()
+        {
+            var spec = UI.Theme.ResolveSpec("#ffffff,#000000");
+            Assert.IsTrue(spec.IsGradient);
+            Assert.AreEqual(Color.white, spec.Top);
+            Assert.AreEqual(Color.black, spec.Bottom);
+        }
+
+        [Test]
+        public void ResolveSpec_GradientToken_IsGradient()
+        {
+            SeedGradient("t", null, "grad", "#ffffff", "#000000");
+            UI.Theme.Set("t");
+            var spec = UI.Theme.ResolveSpec("grad");
+            Assert.IsTrue(spec.IsGradient);
+        }
+
+        [Test]
+        public void ResolveSpec_GradientToken_WithAlpha_BothStopsAlpha()
+        {
+            SeedGradient("t", null, "grad", "#ffffff", "#000000");
+            UI.Theme.Set("t");
+            var spec = UI.Theme.ResolveSpec("grad/0.5");
+            Assert.IsTrue(spec.IsGradient);
+            Assert.AreEqual(0.5f, spec.Top.a, 0.001f);
+            Assert.AreEqual(0.5f, spec.Bottom.a, 0.001f);
+        }
+
+        [Test]
+        public void ResolveSpec_PerSegmentAlpha_OnlyAffectsThatStop()
+        {
+            // "#ffffff/0.5,#000000" → Top.a ≈ 0.5, Bottom.a ≈ 1
+            var spec = UI.Theme.ResolveSpec("#ffffff/0.5,#000000");
+            Assert.IsTrue(spec.IsGradient);
+            Assert.AreEqual(0.5f, spec.Top.a, 0.001f);
+            Assert.AreEqual(1.0f, spec.Bottom.a, 0.001f);
+        }
+
+        [Test]
+        public void ResolveSpec_NestedGradientToken_Throws_ContainsCannotNest()
+        {
+            SeedGradient("t", null, "grad", "#ffffff", "#000000");
+            UI.Theme.Set("t");
+            // "grad,#000000" — the first segment resolves to a gradient token; must error
+            var ex = Assert.Throws<System.Exception>(() => UI.Theme.ResolveSpec("grad,#000000"));
+            StringAssert.Contains("cannot nest", ex.Message);
+        }
+
+        [Test]
+        public void Resolve_LiteralGradient_Throws_ContainsDoesNotSupport()
+        {
+            var ex = Assert.Throws<System.Exception>(() => UI.Theme.Resolve("#ffffff,#000000"));
+            StringAssert.Contains("does not support gradient", ex.Message);
+        }
+
+        [Test]
+        public void Resolve_GradientToken_Throws_ContainsDoesNotSupport()
+        {
+            SeedGradient("t", null, "grad", "#ffffff", "#000000");
+            UI.Theme.Set("t");
+            var ex = Assert.Throws<System.Exception>(() => UI.Theme.Resolve("grad"));
+            StringAssert.Contains("does not support gradient", ex.Message);
+        }
+
+        [Test]
+        public void ResolveSpec_SolidLiteral_NotGradient_TopIsRed()
+        {
+            var spec = UI.Theme.ResolveSpec("#ff0000");
+            Assert.IsFalse(spec.IsGradient);
+            Assert.AreEqual(new Color32(0xff, 0x00, 0x00, 0xff), (Color32)spec.Top);
+        }
+
+        [Test]
+        public void Resolve_SolidLiteral_ReturnsRed_NoRegression()
+        {
+            var c = UI.Theme.Resolve("#ff0000");
+            Assert.AreEqual(new Color32(0xff, 0x00, 0x00, 0xff), (Color32)c);
+        }
+
+        [Test]
+        public void ResolveSpec_SoftFail_UnknownTheme_ReturnsSolidWhite()
+        {
+            // Set a theme name that has no registered theme → soft-fail path
+            UI.Theme.Set("nope");
+            var spec = UI.Theme.ResolveSpec("anytoken");
+            Assert.IsFalse(spec.IsGradient, "soft-fail must return Solid (not gradient)");
+            Assert.AreEqual(Color.white, spec.Top);
+        }
     }
 }

--- a/Tests/EditMode/Application/ThemeGradientTests.cs
+++ b/Tests/EditMode/Application/ThemeGradientTests.cs
@@ -1,0 +1,149 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Parser;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Application
+{
+    public class ThemeGradientTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private const string Header = "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>";
+        private const string Footer = "</PromptUGUI>";
+
+        private static void SeedSolid(string name, string baseName, params (string k, string v)[] entries)
+        {
+            var d = new Dictionary<string, ColorSpec>();
+            foreach (var (k, v) in entries)
+            {
+                ColorUtility.TryParseHtmlString(v, out var c);
+                d[k] = ColorSpec.Solid(c);
+            }
+            ThemeStore.Instance.Register(name, baseName, d, src: "test");
+            ThemeStore.Instance.ResolveBases();
+        }
+
+        private static void SeedGradient(string name, string baseName, string tokenName, string topHex, string bottomHex)
+        {
+            ColorUtility.TryParseHtmlString(topHex, out var top);
+            ColorUtility.TryParseHtmlString(bottomHex, out var bottom);
+            var d = new Dictionary<string, ColorSpec>
+            {
+                [tokenName] = ColorSpec.Gradient(top, bottom),
+            };
+            ThemeStore.Instance.Register(name, baseName, d, src: "test");
+            ThemeStore.Instance.ResolveBases();
+        }
+
+        // ── load-path tests (via XML round-trip through UI infrastructure) ──
+
+        [Test]
+        public void Load_GradientToken_IsGradient_Top_White_Bottom_Black()
+        {
+            var xml = Header +
+                "<Theme name='t'><Color name='grad' value='#ffffff,#000000'/></Theme>" +
+                Footer;
+            var doc = UIDocumentParser.Parse(xml);
+            Assert.AreEqual(1, doc.Themes.Count);
+            Assert.AreEqual("#ffffff,#000000", doc.Themes[0].Colors[0].Value);
+
+            // Seed via ThemeStore directly to mirror RegisterThemesAndAutoSet behavior
+            ColorParser.TrySplitGradient("#ffffff,#000000", out var topRaw, out var bottomRaw, out _);
+            ColorUtility.TryParseHtmlString(topRaw, out var topC);
+            ColorUtility.TryParseHtmlString(bottomRaw, out var bottomC);
+            var d = new Dictionary<string, ColorSpec>
+            {
+                ["grad"] = ColorSpec.Gradient(topC, bottomC),
+            };
+            ThemeStore.Instance.Register("t", null, d, "test");
+            ThemeStore.Instance.ResolveBases();
+
+            var spec = ThemeStore.Instance.LookupChained("t", "grad");
+            Assert.IsTrue(spec.HasValue);
+            Assert.IsTrue(spec.Value.IsGradient);
+            Assert.AreEqual(Color.white, spec.Value.Top);
+            Assert.AreEqual(Color.black, spec.Value.Bottom);
+        }
+
+        [Test]
+        public void GradientToken_Inherited_By_Derived_Theme()
+        {
+            // base has gradient token; derived overrides a different token
+            ColorUtility.TryParseHtmlString("#ffffff", out var white);
+            ColorUtility.TryParseHtmlString("#000000", out var black);
+            var baseColors = new Dictionary<string, ColorSpec>
+            {
+                ["grad"] = ColorSpec.Gradient(white, black),
+                ["bg"] = ColorSpec.Solid(white),
+            };
+            ThemeStore.Instance.Register("base", null, baseColors, "test");
+
+            ColorUtility.TryParseHtmlString("#ff0000", out var red);
+            var derivedColors = new Dictionary<string, ColorSpec>
+            {
+                ["bg"] = ColorSpec.Solid(red),
+            };
+            ThemeStore.Instance.Register("derived", "base", derivedColors, "test");
+            ThemeStore.Instance.ResolveBases();
+
+            var spec = ThemeStore.Instance.LookupChained("derived", "grad");
+            Assert.IsTrue(spec.HasValue, "gradient token should be inherited from base");
+            Assert.IsTrue(spec.Value.IsGradient);
+            Assert.AreEqual(Color.white, spec.Value.Top);
+            Assert.AreEqual(Color.black, spec.Value.Bottom);
+        }
+
+        [Test]
+        public void SolidToken_Still_Resolves_IsGradient_False()
+        {
+            SeedSolid("light", null, ("primary", "#ff8800"));
+
+            var spec = ThemeStore.Instance.LookupChained("light", "primary");
+            Assert.IsTrue(spec.HasValue);
+            Assert.IsFalse(spec.Value.IsGradient);
+            Assert.AreEqual(new Color32(0xff, 0x88, 0x00, 0xff), (Color32)spec.Value.Top);
+            Assert.AreEqual(new Color32(0xff, 0x88, 0x00, 0xff), (Color32)spec.Value.Bottom,
+                "solid: Bottom should equal Top");
+        }
+
+        [Test]
+        public void Lookup_Returns_Top_Stop_For_Gradient()
+        {
+            SeedGradient("t", null, "grad", "#ffffff", "#000000");
+            UI.Theme.Set("t");
+            var color = UI.Theme.Lookup("grad");
+            Assert.IsTrue(color.HasValue);
+            Assert.AreEqual(Color.white, color.Value, "public Lookup returns the Top stop");
+        }
+
+        [Test]
+        public void ColorSpec_Solid_Top_Equals_Bottom()
+        {
+            ColorUtility.TryParseHtmlString("#ff8800", out var orange);
+            var spec = ColorSpec.Solid(orange);
+            Assert.IsFalse(spec.IsGradient);
+            Assert.AreEqual(spec.Top, spec.Bottom);
+        }
+
+        [Test]
+        public void ColorSpec_Gradient_Preserves_Stops()
+        {
+            var spec = ColorSpec.Gradient(Color.white, Color.black);
+            Assert.IsTrue(spec.IsGradient);
+            Assert.AreEqual(Color.white, spec.Top);
+            Assert.AreEqual(Color.black, spec.Bottom);
+        }
+
+        [Test]
+        public void ColorSpec_Multiply_Scales_Both_Stops()
+        {
+            var half = new Color(0.5f, 0.5f, 0.5f, 1f);
+            var spec = ColorSpec.Gradient(Color.white, Color.white).Multiply(half);
+            Assert.AreEqual(half, spec.Top);
+            Assert.AreEqual(half, spec.Bottom);
+        }
+    }
+}

--- a/Tests/EditMode/Application/ThemeGradientTests.cs
+++ b/Tests/EditMode/Application/ThemeGradientTests.cs
@@ -218,6 +218,17 @@ namespace PromptUGUI.Tests.Application
         }
 
         [Test]
+        public void ResolveSpec_NestedGradientToken_WithAlpha_Throws_ContainsCannotNest()
+        {
+            SeedGradient("t", null, "grad", "#ffffff", "#000000");
+            UI.Theme.Set("t");
+            // "grad/0.5,#000000" — alpha-split happens before the IsGradient guard;
+            // the base "grad" still resolves to a gradient token and must error
+            var ex = Assert.Throws<System.Exception>(() => UI.Theme.ResolveSpec("grad/0.5,#000000"));
+            StringAssert.Contains("cannot nest", ex.Message);
+        }
+
+        [Test]
         public void Resolve_LiteralGradient_Throws_ContainsDoesNotSupport()
         {
             var ex = Assert.Throws<System.Exception>(() => UI.Theme.Resolve("#ffffff,#000000"));

--- a/Tests/EditMode/Application/ThemeGradientTests.cs.meta
+++ b/Tests/EditMode/Application/ThemeGradientTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dcf8007548155074384e79014199d40b

--- a/Tests/EditMode/Application/ThemeHotReloadTests.cs
+++ b/Tests/EditMode/Application/ThemeHotReloadTests.cs
@@ -24,21 +24,21 @@ namespace PromptUGUI.Tests.Application
         public void ReplaceFromSrc_Updates_Token_Value_And_Notifies()
         {
             // Seed: 'light' theme with primary=#ff8800 registered against src='themes/main'.
-            var v1 = new Dictionary<string, Color>();
-            ColorUtility.TryParseHtmlString("#ff8800", out var c1); v1["primary"] = c1;
+            var v1 = new Dictionary<string, ColorSpec>();
+            ColorUtility.TryParseHtmlString("#ff8800", out var c1); v1["primary"] = ColorSpec.Solid(c1);
             ThemeStore.Instance.Register("light", null, v1, "themes/main");
             ThemeStore.Instance.ResolveBases();
             UI.Theme.Set("light");
 
             // Simulate hot reload: same src, new value for primary.
-            var v2 = new Dictionary<string, Color>();
-            ColorUtility.TryParseHtmlString("#00ff00", out var c2); v2["primary"] = c2;
+            var v2 = new Dictionary<string, ColorSpec>();
+            ColorUtility.TryParseHtmlString("#00ff00", out var c2); v2["primary"] = ColorSpec.Solid(c2);
 
             string fired = null;
             UI.Theme.Changed += n => fired = n;
 
             ThemeStore.Instance.ReplaceFromSrc("themes/main",
-                new List<(string, string, IReadOnlyDictionary<string, Color>)>
+                new List<(string, string, IReadOnlyDictionary<string, ColorSpec>)>
                 {
                     ("light", null, v2)
                 });
@@ -53,8 +53,8 @@ namespace PromptUGUI.Tests.Application
         public void RaiseChangedIfCurrent_NonCurrent_Does_Not_Fire()
         {
             // Seed two themes; Current = 'light'.
-            var v = new Dictionary<string, Color>();
-            ColorUtility.TryParseHtmlString("#ff8800", out var c); v["primary"] = c;
+            var v = new Dictionary<string, ColorSpec>();
+            ColorUtility.TryParseHtmlString("#ff8800", out var c); v["primary"] = ColorSpec.Solid(c);
             ThemeStore.Instance.Register("light", null, v, "themes/main");
             ThemeStore.Instance.Register("dark", null, v, "themes/main");
             ThemeStore.Instance.ResolveBases();

--- a/Tests/EditMode/Application/ThemeStoreTests.cs
+++ b/Tests/EditMode/Application/ThemeStoreTests.cs
@@ -12,13 +12,13 @@ namespace PromptUGUI.Tests.Application
         [SetUp] public void SetUp() => ThemeStore.Instance.Clear();
         [TearDown] public void TearDown() => ThemeStore.Instance.Clear();
 
-        private static Dictionary<string, Color> Map(params (string k, string v)[] entries)
+        private static Dictionary<string, ColorSpec> Map(params (string k, string v)[] entries)
         {
-            var d = new Dictionary<string, Color>();
+            var d = new Dictionary<string, ColorSpec>();
             foreach (var (k, v) in entries)
             {
                 ColorUtility.TryParseHtmlString(v, out var c);
-                d[k] = c;
+                d[k] = ColorSpec.Solid(c);
             }
             return d;
         }
@@ -30,7 +30,7 @@ namespace PromptUGUI.Tests.Application
             ThemeStore.Instance.ResolveBases();
             var c = ThemeStore.Instance.LookupChained("light", "primary");
             Assert.IsTrue(c.HasValue);
-            Assert.AreEqual(new Color32(0xff, 0x88, 0x00, 0xff), (Color32)c.Value);
+            Assert.AreEqual(new Color32(0xff, 0x88, 0x00, 0xff), (Color32)c.Value.Top);
         }
 
         [Test]
@@ -44,7 +44,7 @@ namespace PromptUGUI.Tests.Application
             Assert.IsTrue(bg.HasValue);
             // primary in dark → returns dark's
             var p = ThemeStore.Instance.LookupChained("dark", "primary");
-            Assert.AreEqual(new Color32(0xcc, 0x66, 0x00, 0xff), (Color32)p.Value);
+            Assert.AreEqual(new Color32(0xcc, 0x66, 0x00, 0xff), (Color32)p.Value.Top);
         }
 
         [Test]
@@ -97,7 +97,7 @@ namespace PromptUGUI.Tests.Application
             ThemeStore.Instance.ResolveBases();
 
             var c = ThemeStore.Instance.LookupChained("light", "primary");
-            Assert.AreEqual(new Color32(0x00, 0xff, 0x00, 0xff), (Color32)c.Value);
+            Assert.AreEqual(new Color32(0x00, 0xff, 0x00, 0xff), (Color32)c.Value.Top);
         }
     }
 }

--- a/Tests/EditMode/Application/ThemeSwitchTests.cs
+++ b/Tests/EditMode/Application/ThemeSwitchTests.cs
@@ -14,12 +14,12 @@ namespace PromptUGUI.Tests.EditMode.Application
 
         private static void RegisterTwoThemes()
         {
-            var light = new Dictionary<string, Color>();
-            ColorUtility.TryParseHtmlString("#ff8800", out var lp); light["primary"] = lp;
+            var light = new Dictionary<string, ColorSpec>();
+            ColorUtility.TryParseHtmlString("#ff8800", out var lp); light["primary"] = ColorSpec.Solid(lp);
             ThemeStore.Instance.Register("light", null, light, "test");
 
-            var dark = new Dictionary<string, Color>();
-            ColorUtility.TryParseHtmlString("#cc6600", out var dp); dark["primary"] = dp;
+            var dark = new Dictionary<string, ColorSpec>();
+            ColorUtility.TryParseHtmlString("#cc6600", out var dp); dark["primary"] = ColorSpec.Solid(dp);
             ThemeStore.Instance.Register("dark", null, dark, "test");
             ThemeStore.Instance.ResolveBases();
         }

--- a/Tests/EditMode/Application/UIThemeTests.cs
+++ b/Tests/EditMode/Application/UIThemeTests.cs
@@ -14,8 +14,12 @@ namespace PromptUGUI.Tests.Application
 
         private static void Seed(string name, string baseName, params (string k, string v)[] entries)
         {
-            var d = new Dictionary<string, Color>();
-            foreach (var (k, v) in entries) { ColorUtility.TryParseHtmlString(v, out var c); d[k] = c; }
+            var d = new Dictionary<string, ColorSpec>();
+            foreach (var (k, v) in entries)
+            {
+                ColorUtility.TryParseHtmlString(v, out var c);
+                d[k] = ColorSpec.Solid(c);
+            }
             ThemeStore.Instance.Register(name, baseName, d, src: "test");
             ThemeStore.Instance.ResolveBases();
         }

--- a/Tests/EditMode/Controls/AnimationCharColorTokenTests.cs
+++ b/Tests/EditMode/Controls/AnimationCharColorTokenTests.cs
@@ -13,9 +13,9 @@ namespace PromptUGUI.Tests.EditMode.Controls
 
         private static void Seed(string token, string hex)
         {
-            var d = new Dictionary<string, Color>();
+            var d = new Dictionary<string, ColorSpec>();
             ColorUtility.TryParseHtmlString(hex, out var c);
-            d[token] = c;
+            d[token] = ColorSpec.Solid(c);
             ThemeStore.Instance.Register("t", null, d, "test");
             ThemeStore.Instance.ResolveBases();
             UI.Theme.Set("t");

--- a/Tests/EditMode/Controls/ColorApplierTests.cs
+++ b/Tests/EditMode/Controls/ColorApplierTests.cs
@@ -1,0 +1,110 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls.Internal;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class ColorApplierTests
+    {
+        private GameObject _go;
+        private Image _img;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _go = new GameObject("g", typeof(Image));
+            _img = _go.GetComponent<Image>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(_go);
+        }
+
+        [Test]
+        public void Solid_SetsGraphicColor_NoTint()
+        {
+            ColorApplier.Apply(_img, ColorSpec.Solid(Color.red));
+
+            Assert.AreEqual(Color.red, _img.color);
+            Assert.IsNull(_img.GetComponent<GradientTint>());
+        }
+
+        [Test]
+        public void Gradient_AddsEnabledTint_AndWhitensColor()
+        {
+            ColorApplier.Apply(_img, ColorSpec.Gradient(Color.red, Color.blue));
+
+            var tint = _img.GetComponent<GradientTint>();
+            Assert.IsNotNull(tint);
+            Assert.IsTrue(tint.enabled);
+            Assert.AreEqual(Color.red, tint.Top);
+            Assert.AreEqual(Color.blue, tint.Bottom);
+            Assert.AreEqual(Color.white, _img.color);
+        }
+
+        [Test]
+        public void GradientThenSolid_DisablesTint_NotDestroyed()
+        {
+            ColorApplier.Apply(_img, ColorSpec.Gradient(Color.red, Color.blue));
+            ColorApplier.Apply(_img, ColorSpec.Solid(Color.green));
+
+            var tint = _img.GetComponent<GradientTint>();
+            Assert.IsNotNull(tint);
+            Assert.IsFalse(tint.enabled);
+            Assert.AreEqual(Color.green, _img.color);
+        }
+
+        [Test]
+        public void SolidThenGradient_ReEnablesSameTint()
+        {
+            ColorApplier.Apply(_img, ColorSpec.Gradient(Color.red, Color.blue));
+            ColorApplier.Apply(_img, ColorSpec.Solid(Color.green));
+            ColorApplier.Apply(_img, ColorSpec.Gradient(Color.cyan, Color.yellow));
+
+            var tints = _img.GetComponents<GradientTint>();
+            Assert.AreEqual(1, tints.Length);
+            Assert.IsTrue(tints[0].enabled);
+            Assert.AreEqual(Color.cyan, tints[0].Top);
+            Assert.AreEqual(Color.yellow, tints[0].Bottom);
+        }
+
+        [Test]
+        public void Peek_Solid_ReturnsGraphicColor()
+        {
+            _img.color = Color.magenta;
+
+            var spec = ColorApplier.Peek(_img);
+
+            Assert.IsFalse(spec.IsGradient);
+            Assert.AreEqual(Color.magenta, spec.Top);
+        }
+
+        [Test]
+        public void Peek_Gradient_ReturnsStops()
+        {
+            ColorApplier.Apply(_img, ColorSpec.Gradient(Color.red, Color.blue));
+
+            var spec = ColorApplier.Peek(_img);
+
+            Assert.IsTrue(spec.IsGradient);
+            Assert.AreEqual(Color.red, spec.Top);
+            Assert.AreEqual(Color.blue, spec.Bottom);
+        }
+
+        [Test]
+        public void Peek_DisabledTint_ReadsSolid()
+        {
+            ColorApplier.Apply(_img, ColorSpec.Gradient(Color.red, Color.blue));
+            ColorApplier.Apply(_img, ColorSpec.Solid(Color.green));
+
+            var spec = ColorApplier.Peek(_img);
+
+            Assert.IsFalse(spec.IsGradient);
+            Assert.AreEqual(Color.green, spec.Top);
+        }
+    }
+}

--- a/Tests/EditMode/Controls/ColorApplierTests.cs.meta
+++ b/Tests/EditMode/Controls/ColorApplierTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c0ea2d27447b4a428ec5eb0f2f360865

--- a/Tests/EditMode/Controls/ColorTokenIntegrationTests.cs
+++ b/Tests/EditMode/Controls/ColorTokenIntegrationTests.cs
@@ -16,9 +16,9 @@ namespace PromptUGUI.Tests.EditMode.Controls
 
         private static void SeedLight(string primaryHex)
         {
-            var d = new System.Collections.Generic.Dictionary<string, Color>();
+            var d = new System.Collections.Generic.Dictionary<string, ColorSpec>();
             ColorUtility.TryParseHtmlString(primaryHex, out var c);
-            d["primary"] = c;
+            d["primary"] = ColorSpec.Solid(c);
             ThemeStore.Instance.Register("light", null, d, "test");
             ThemeStore.Instance.ResolveBases();
             UI.Theme.Set("light");

--- a/Tests/EditMode/Controls/GradientColorAttrTests.cs
+++ b/Tests/EditMode/Controls/GradientColorAttrTests.cs
@@ -148,5 +148,68 @@ namespace PromptUGUI.Tests.EditMode.Controls
                 Open("<Btn id='b' hoverModulate='#ffffff,#000000'>x</Btn>"));
             StringAssert.Contains("does not support gradient", ex.Message);
         }
+
+        // 8. Text gradient — enables TMP VertexGradient, top=white, bottom=black, color==white
+        [Test]
+        public void Text_Gradient_SetsTmpVertexGradient()
+        {
+            var s = Open("<Text id='t' color='#ffffff,#000000'>hello</Text>");
+            var tmp = s.Get<PromptUGUI.Controls.Text>("t").GameObject
+                       .GetComponentInChildren<TMPro.TMP_Text>();
+            Assert.IsNotNull(tmp, "TMP_Text component must be present");
+            Assert.IsTrue(tmp.enableVertexGradient, "enableVertexGradient must be true for gradient");
+            Assert.AreEqual(Color.white, tmp.colorGradient.topLeft, "topLeft must be white");
+            Assert.AreEqual(Color.white, tmp.colorGradient.topRight, "topRight must be white");
+            Assert.AreEqual(Color.black, tmp.colorGradient.bottomLeft, "bottomLeft must be black");
+            Assert.AreEqual(Color.black, tmp.colorGradient.bottomRight, "bottomRight must be black");
+            Assert.AreEqual(Color.white, tmp.color, "color must be white when gradient is active");
+        }
+
+        // 9. Text solid color — no VertexGradient, color==red
+        [Test]
+        public void Text_Solid_NoVertexGradient()
+        {
+            var s = Open("<Text id='t' color='#ff0000'>hi</Text>");
+            var tmp = s.Get<PromptUGUI.Controls.Text>("t").GameObject
+                       .GetComponentInChildren<TMPro.TMP_Text>();
+            Assert.IsNotNull(tmp, "TMP_Text component must be present");
+            Assert.IsFalse(tmp.enableVertexGradient, "enableVertexGradient must be false for solid color");
+            Assert.AreEqual(Color.red, tmp.color, "solid color must be applied directly");
+        }
+
+        // 10. Text Variant round-trip: gradient→solid reverts enableVertexGradient; solid→gradient restores it
+        [Test]
+        public void Text_Variant_GradientToSolid_RevertsVertexGradient()
+        {
+            var s = Open("<Text id='t' color='#ffffff,#000000' color.mobile='#ff0000'>x</Text>");
+            var tmp = s.Get<PromptUGUI.Controls.Text>("t").GameObject
+                       .GetComponentInChildren<TMPro.TMP_Text>();
+            Assert.IsNotNull(tmp, "TMP_Text component must be present");
+
+            // Baseline: gradient active
+            Assert.IsTrue(tmp.enableVertexGradient, "enableVertexGradient must be true at baseline");
+            Assert.AreEqual(Color.white, tmp.colorGradient.topLeft, "gradient top must be white at baseline");
+            Assert.AreEqual(Color.black, tmp.colorGradient.bottomRight, "gradient bottom must be black at baseline");
+
+            try
+            {
+                // Activate mobile variant → solid red, gradient disabled
+                UI.Variants.Set("mobile", true);
+
+                Assert.IsFalse(tmp.enableVertexGradient, "enableVertexGradient must be false after switching to solid variant");
+                Assert.AreEqual(Color.red, tmp.color, "solid variant color must be applied");
+
+                // Deactivate → gradient restored
+                UI.Variants.Set("mobile", false);
+
+                Assert.IsTrue(tmp.enableVertexGradient, "enableVertexGradient must be re-enabled after restoring gradient variant");
+                Assert.AreEqual(Color.white, tmp.colorGradient.topLeft, "gradient top must be white after restore");
+                Assert.AreEqual(Color.black, tmp.colorGradient.bottomRight, "gradient bottom must be black after restore");
+            }
+            finally
+            {
+                UI.Variants.Set("mobile", false);
+            }
+        }
     }
 }

--- a/Tests/EditMode/Controls/GradientColorAttrTests.cs
+++ b/Tests/EditMode/Controls/GradientColorAttrTests.cs
@@ -1,0 +1,152 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using PromptUGUI.Parser;
+using UnityEngine;
+using UnityImage = UnityEngine.UI.Image;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class GradientColorAttrTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static PromptUGUI.Application.Screen Open(string innerXml)
+        {
+            UI.LoadDocument("t",
+                $"<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>" +
+                $"<Screen name='S'>{innerXml}</Screen></PromptUGUI>");
+            return UI.Open("S");
+        }
+
+        // 1. Image gradient — enabled GradientTint, top=white, bottom=black, graphic.color==white
+        [Test]
+        public void Image_Gradient_Applies_GradientTint()
+        {
+            var s = Open("<Image id='im' color='#ffffff,#000000'/>");
+            var img = s.Get<Image>("im").GameObject.GetComponent<UnityImage>();
+            var tint = img.GetComponent<GradientTint>();
+            Assert.IsNotNull(tint, "GradientTint component must be present");
+            Assert.IsTrue(tint.enabled, "GradientTint must be enabled");
+            Assert.AreEqual(Color.white, tint.Top, "top stop must be white");
+            Assert.AreEqual(Color.black, tint.Bottom, "bottom stop must be black");
+            Assert.AreEqual(Color.white, img.color, "graphic.color must be white for gradient");
+        }
+
+        // 2. Image solid no-regression — no enabled GradientTint, graphic.color==red
+        [Test]
+        public void Image_Solid_NoGradientTint()
+        {
+            var s = Open("<Image id='im' color='#ff0000'/>");
+            var img = s.Get<Image>("im").GameObject.GetComponent<UnityImage>();
+            Assert.AreEqual(Color.red, img.color, "solid color must be applied directly");
+            var tint = img.GetComponent<GradientTint>();
+            // Either no GradientTint component at all, or it must be disabled.
+            Assert.IsTrue(tint == null || !tint.enabled,
+                "no enabled GradientTint for solid color");
+        }
+
+        // 3. Btn bg gradient (static, no state colors) — bg graphic has enabled GradientTint
+        [Test]
+        public void Btn_Color_Gradient_Applies_GradientTint()
+        {
+            var s = Open("<Btn id='b' color='#ffffff,#000000'>x</Btn>");
+            var bg = s.Get<Btn>("b").GameObject.GetComponent<UnityImage>();
+            var tint = bg.GetComponent<GradientTint>();
+            Assert.IsNotNull(tint, "GradientTint must be present on Btn bg");
+            Assert.IsTrue(tint.enabled, "GradientTint must be enabled");
+            Assert.AreEqual(Color.white, tint.Top);
+            Assert.AreEqual(Color.black, tint.Bottom);
+        }
+
+        // 4. Progress fill gradient — fill graphic has enabled GradientTint
+        [Test]
+        public void Progress_FillColor_Gradient_Applies_GradientTint()
+        {
+            var s = Open("<Progress id='p' fillColor='#ffffff,#000000'/>");
+            var fill = s.Get<Progress>("p").GameObject.transform
+                        .Find("MaskWrapper/Fill").GetComponent<UnityImage>();
+            var tint = fill.GetComponent<GradientTint>();
+            Assert.IsNotNull(tint, "GradientTint must be present on fill");
+            Assert.IsTrue(tint.enabled, "GradientTint must be enabled on fill");
+            Assert.AreEqual(Color.white, tint.Top);
+            Assert.AreEqual(Color.black, tint.Bottom);
+        }
+
+        // 5. ScrollList frameColor gradient — frame graphic has enabled GradientTint
+        [Test]
+        public void ScrollList_FrameColor_Gradient_Applies_GradientTint()
+        {
+            // ScrollList requires an itemTemplate; use the full document form so the
+            // <Template> lives at root level alongside <Screen>.
+            const string xml =
+                "<?xml version='1.0' encoding='utf-8'?>" +
+                "<PromptUGUI version='1'>" +
+                "<Template name='Slot'><Frame/></Template>" +
+                "<Screen name='S'>" +
+                "<ScrollList id='sl' itemTemplate='Slot' frameColor='#ffffff,#000000'/>" +
+                "</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            var sl = screen.Get<ScrollList>("sl");
+            var frame = sl.GameObject.transform.Find("Frame");
+            Assert.IsNotNull(frame, "Frame child must exist after frameColor is set");
+            var img = frame.GetComponent<UnityImage>();
+            Assert.IsNotNull(img);
+            var tint = img.GetComponent<GradientTint>();
+            Assert.IsNotNull(tint, "GradientTint must be present on ScrollList frame");
+            Assert.IsTrue(tint.enabled, "GradientTint must be enabled on frame");
+            Assert.AreEqual(Color.white, tint.Top);
+            Assert.AreEqual(Color.black, tint.Bottom);
+        }
+
+        // 6. Variant round-trip: solid↔gradient via ReSolve
+        [Test]
+        public void Variant_RoundTrip_SolidAndGradient()
+        {
+            // Base = gradient (#ffffff,#000000); mobile variant = solid (#ff0000).
+            var s = Open("<Image id='im' color='#ffffff,#000000' color.mobile='#ff0000'/>");
+            var img = s.Get<Image>("im").GameObject.GetComponent<UnityImage>();
+
+            // Baseline: gradient active
+            var tint = img.GetComponent<GradientTint>();
+            Assert.IsNotNull(tint, "GradientTint component must exist");
+            Assert.IsTrue(tint.enabled, "GradientTint must be enabled at baseline");
+            Assert.AreEqual(Color.white, tint.Top);
+            Assert.AreEqual(Color.black, tint.Bottom);
+
+            try
+            {
+                // Activate variant → solid red, tint disabled
+                UI.Variants.Set("mobile", true);
+
+                Assert.IsFalse(tint.enabled, "GradientTint must be disabled after switching to solid variant");
+                Assert.AreEqual(Color.red, img.color, "solid variant color must be applied");
+
+                // Deactivate → gradient restored
+                UI.Variants.Set("mobile", false);
+
+                Assert.IsTrue(tint.enabled, "GradientTint must be re-enabled after restoring gradient");
+                Assert.AreEqual(Color.white, tint.Top, "gradient top restored");
+                Assert.AreEqual(Color.black, tint.Bottom, "gradient bottom restored");
+            }
+            finally
+            {
+                UI.Variants.Set("mobile", false);
+            }
+        }
+
+        // 7. hoverModulate with gradient value throws (UI.Theme.Resolve still rejects gradients)
+        [Test]
+        public void HoverModulate_Gradient_Throws_On_Open()
+        {
+            // hoverModulate still routes through UI.Theme.Resolve which throws on gradients.
+            // ControlAttributeApplier wraps the System.Exception as a ParseException.
+            var ex = Assert.Throws<ParseException>(() =>
+                Open("<Btn id='b' hoverModulate='#ffffff,#000000'>x</Btn>"));
+            StringAssert.Contains("does not support gradient", ex.Message);
+        }
+    }
+}

--- a/Tests/EditMode/Controls/GradientColorAttrTests.cs.meta
+++ b/Tests/EditMode/Controls/GradientColorAttrTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 74534ef9efb79f04da51f59a50b0cbce

--- a/Tests/EditMode/Controls/GradientTintTests.cs
+++ b/Tests/EditMode/Controls/GradientTintTests.cs
@@ -116,6 +116,18 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
+        public void Set_SameValue_IsIdempotent()
+        {
+            // Driving graphic.SetVerticesDirty is hard to observe directly in EditMode;
+            // assert the value-level idempotency: Set then Set-same leaves Top/Bottom equal.
+            var fx = _go.AddComponent<GradientTint>();
+            fx.Set(Color.red, Color.blue);
+            fx.Set(Color.red, Color.blue);   // same values — early-return path
+            Assert.AreEqual(Color.red, fx.Top);
+            Assert.AreEqual(Color.blue, fx.Bottom);
+        }
+
+        [Test]
         public void MidVertex_HalfwayLerps()
         {
             var fx = _go.AddComponent<GradientTint>();

--- a/Tests/EditMode/Controls/GradientTintTests.cs
+++ b/Tests/EditMode/Controls/GradientTintTests.cs
@@ -1,0 +1,137 @@
+using NUnit.Framework;
+using PromptUGUI.Controls.Internal;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class GradientTintTests
+    {
+        private GameObject _go;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _go = new GameObject("GradientTintTest", typeof(Image));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(_go);
+        }
+
+        // Helper: compare two Color32 values within a byte tolerance.
+        private static void AssertColorApprox(Color32 expected, Color32 actual, int tol = 3)
+        {
+            Assert.That(Mathf.Abs(expected.r - actual.r), Is.LessThanOrEqualTo(tol), $"R: expected {expected.r}, got {actual.r}");
+            Assert.That(Mathf.Abs(expected.g - actual.g), Is.LessThanOrEqualTo(tol), $"G: expected {expected.g}, got {actual.g}");
+            Assert.That(Mathf.Abs(expected.b - actual.b), Is.LessThanOrEqualTo(tol), $"B: expected {expected.b}, got {actual.b}");
+        }
+
+        // Build a VertexHelper with 4 white verts forming a quad at y=0 (bottom two) and y=100 (top two).
+        private static VertexHelper BuildWhiteQuad()
+        {
+            var vh = new VertexHelper();
+            var white = new Color32(255, 255, 255, 255);
+            // Bottom-left, bottom-right
+            vh.AddVert(new Vector3(0, 0, 0), white, new Vector4(0, 0, 0, 0));
+            vh.AddVert(new Vector3(100, 0, 0), white, new Vector4(1, 0, 0, 0));
+            // Top-right, top-left
+            vh.AddVert(new Vector3(100, 100, 0), white, new Vector4(1, 1, 0, 0));
+            vh.AddVert(new Vector3(0, 100, 0), white, new Vector4(0, 1, 0, 0));
+            return vh;
+        }
+
+        [Test]
+        public void TopAndBottom_PaintedAtExtremes()
+        {
+            var fx = _go.AddComponent<GradientTint>();
+            // Set(top, bottom): top=red, bottom=blue
+            fx.Set(Color.red, Color.blue);
+
+            var vh = BuildWhiteQuad();
+            fx.ModifyMesh(vh);
+
+            // Verts 0 and 1 are at y=0 (bottom) → should be blue
+            var v0 = default(UIVertex);
+            var v1 = default(UIVertex);
+            var v2 = default(UIVertex);
+            var v3 = default(UIVertex);
+            vh.PopulateUIVertex(ref v0, 0);
+            vh.PopulateUIVertex(ref v1, 1);
+            vh.PopulateUIVertex(ref v2, 2);
+            vh.PopulateUIVertex(ref v3, 3);
+
+            AssertColorApprox(new Color32(0, 0, 255, 255), v0.color, 3);   // bottom-left ≈ blue
+            AssertColorApprox(new Color32(0, 0, 255, 255), v1.color, 3);   // bottom-right ≈ blue
+            AssertColorApprox(new Color32(255, 0, 0, 255), v2.color, 3);   // top-right ≈ red
+            AssertColorApprox(new Color32(255, 0, 0, 255), v3.color, 3);   // top-left ≈ red
+        }
+
+        [Test]
+        public void Multiplies_IntoExistingVertexColor()
+        {
+            var fx = _go.AddComponent<GradientTint>();
+            // Flat red gradient (both stops red) to prove multiply not replace
+            fx.Set(Color.red, Color.red);
+
+            var vh = new VertexHelper();
+            var grey = new Color32(128, 128, 128, 255);
+            // Build quad with grey verts at y=0 and y=100
+            vh.AddVert(new Vector3(0, 0, 0), grey, new Vector4(0, 0, 0, 0));
+            vh.AddVert(new Vector3(100, 0, 0), grey, new Vector4(1, 0, 0, 0));
+            vh.AddVert(new Vector3(100, 100, 0), grey, new Vector4(1, 1, 0, 0));
+            vh.AddVert(new Vector3(0, 100, 0), grey, new Vector4(0, 1, 0, 0));
+
+            fx.ModifyMesh(vh);
+
+            // grey × red = (128,0,0,255) — prove it's multiply not replace
+            for (var i = 0; i < 4; i++)
+            {
+                var v = default(UIVertex);
+                vh.PopulateUIVertex(ref v, i);
+                // R ≈ 128 (128/255 * 255 ≈ 128), G ≈ 0, B ≈ 0
+                AssertColorApprox(new Color32(128, 0, 0, 255), v.color, 3);
+            }
+        }
+
+        [Test]
+        public void Disabled_DoesNotModify()
+        {
+            var fx = _go.AddComponent<GradientTint>();
+            fx.Set(Color.red, Color.blue);
+            fx.enabled = false;
+
+            var vh = BuildWhiteQuad();
+            fx.ModifyMesh(vh);
+
+            // All verts should remain white
+            for (var i = 0; i < 4; i++)
+            {
+                var v = default(UIVertex);
+                vh.PopulateUIVertex(ref v, i);
+                AssertColorApprox(new Color32(255, 255, 255, 255), v.color, 3);
+            }
+        }
+
+        [Test]
+        public void MidVertex_HalfwayLerps()
+        {
+            var fx = _go.AddComponent<GradientTint>();
+            // Set(top=red, bottom=blue): at y=50 out of [0,100] → Lerp(blue,red,0.5) = (0.5,0,0.5)
+            fx.Set(Color.red, Color.blue);
+
+            var vh = BuildWhiteQuad();
+            // Add a 5th white vertex at y=50 (midpoint)
+            vh.AddVert(new Vector3(50, 50, 0), new Color32(255, 255, 255, 255), new Vector4(0.5f, 0.5f, 0, 0));
+
+            fx.ModifyMesh(vh);
+
+            var mid = default(UIVertex);
+            vh.PopulateUIVertex(ref mid, 4);
+            // Lerp(blue, red, 0.5) = (0.5, 0, 0.5) → Color32 ≈ (127, 0, 127)
+            AssertColorApprox(new Color32(127, 0, 127, 255), mid.color, 3);
+        }
+    }
+}

--- a/Tests/EditMode/Controls/GradientTintTests.cs.meta
+++ b/Tests/EditMode/Controls/GradientTintTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 87330fc3c22bd2b41929c712b4ae8609

--- a/Tests/EditMode/Controls/ProgressTests.cs
+++ b/Tests/EditMode/Controls/ProgressTests.cs
@@ -435,9 +435,9 @@ namespace PromptUGUI.Tests.EditMode.Controls
 
         private static void SeedLight(string primaryHex)
         {
-            var d = new Dictionary<string, Color>();
+            var d = new Dictionary<string, ColorSpec>();
             ColorUtility.TryParseHtmlString(primaryHex, out var c);
-            d["primary"] = c;
+            d["primary"] = ColorSpec.Solid(c);
             ThemeStore.Instance.Register("light", null, d, "test");
             ThemeStore.Instance.ResolveBases();
             UI.Theme.Set("light");

--- a/Tests/EditMode/Controls/SliderTests.cs
+++ b/Tests/EditMode/Controls/SliderTests.cs
@@ -159,9 +159,9 @@ namespace PromptUGUI.Tests.EditMode.Controls
 
         private static void SeedLight(string primaryHex)
         {
-            var d = new Dictionary<string, Color>();
+            var d = new Dictionary<string, ColorSpec>();
             ColorUtility.TryParseHtmlString(primaryHex, out var c);
-            d["primary"] = c;
+            d["primary"] = ColorSpec.Solid(c);
             ThemeStore.Instance.Register("light", null, d, "test");
             ThemeStore.Instance.ResolveBases();
             UI.Theme.Set("light");

--- a/Tests/EditMode/Controls/StateColorSetTests.cs
+++ b/Tests/EditMode/Controls/StateColorSetTests.cs
@@ -14,11 +14,13 @@ namespace PromptUGUI.Tests.EditMode.Controls
         [Test]
         public void For_MapsEachState_NormalIsNull()
         {
-            var set = new StateColorSet(Color.red, Color.green, Color.blue, Color.gray);
-            Assert.AreEqual(Color.red, set.For(InteractState.Hover));
-            Assert.AreEqual(Color.green, set.For(InteractState.Pressed));
-            Assert.AreEqual(Color.blue, set.For(InteractState.Selected));
-            Assert.AreEqual(Color.gray, set.For(InteractState.Disabled));
+            var set = new StateColorSet(
+                ColorSpec.Solid(Color.red), ColorSpec.Solid(Color.green),
+                ColorSpec.Solid(Color.blue), ColorSpec.Solid(Color.gray));
+            Assert.AreEqual(Color.red, set.For(InteractState.Hover).Value.Top);
+            Assert.AreEqual(Color.green, set.For(InteractState.Pressed).Value.Top);
+            Assert.AreEqual(Color.blue, set.For(InteractState.Selected).Value.Top);
+            Assert.AreEqual(Color.gray, set.For(InteractState.Disabled).Value.Top);
             Assert.IsNull(set.For(InteractState.Normal));
         }
 
@@ -26,18 +28,40 @@ namespace PromptUGUI.Tests.EditMode.Controls
         public void HasAny_TrueWhenAnyPresent_FalseWhenAllNull()
         {
             Assert.IsFalse(default(StateColorSet).HasAny);
-            Assert.IsTrue(new StateColorSet(null, Color.red, null, null).HasAny);
-            Assert.IsFalse(StateColorSet.Resolve("", null, " ", "").HasAny, "all-blank Resolve -> HasAny false");
+            Assert.IsTrue(new StateColorSet(null, ColorSpec.Solid(Color.red), null, null).HasAny);
+            Assert.IsFalse(StateColorSet.ResolveAbsolutes("", null, " ", "").HasAny, "all-blank Resolve -> HasAny false");
+            Assert.IsFalse(StateColorSet.ResolveModulates("", null, " ", "").HasAny, "all-blank modulates -> HasAny false");
         }
 
         [Test]
-        public void Resolve_EmptyOrNull_BecomesNull_LiteralBecomesColor()
+        public void ResolveAbsolutes_EmptyOrNull_BecomesNull_LiteralBecomesColor()
         {
-            var set = StateColorSet.Resolve("", null, "#ff0000", "  ");
+            var set = StateColorSet.ResolveAbsolutes("", null, "#ff0000", "  ");
             Assert.IsNull(set.For(InteractState.Hover), "empty string -> null");
             Assert.IsNull(set.For(InteractState.Pressed), "null -> null");
             Assert.IsNull(set.For(InteractState.Disabled), "whitespace -> null");
-            Assert.AreEqual(new Color(1f, 0f, 0f, 1f), set.For(InteractState.Selected));
+            var sel = set.For(InteractState.Selected).Value;
+            Assert.IsFalse(sel.IsGradient, "solid literal -> non-gradient spec");
+            Assert.AreEqual(new Color(1f, 0f, 0f, 1f), sel.Top);
+        }
+
+        [Test]
+        public void ResolveAbsolutes_GradientLiteral_BecomesGradientSpec()
+        {
+            var set = StateColorSet.ResolveAbsolutes("#ffffff,#000000", null, null, null);
+            var hover = set.For(InteractState.Hover).Value;
+            Assert.IsTrue(hover.IsGradient, "comma literal -> gradient spec");
+            Assert.AreEqual(Color.white, hover.Top);
+            Assert.AreEqual(Color.black, hover.Bottom);
+        }
+
+        [Test]
+        public void ResolveModulates_GradientLiteral_Throws()
+        {
+            // Modulates are solid-only: a gradient value routes through UI.Theme.Resolve, which throws.
+            Assert.Throws<System.Exception>(
+                () => StateColorSet.ResolveModulates("#ffffff,#000000", null, null, null),
+                "gradient modulate must throw");
         }
     }
 }

--- a/Tests/EditMode/Controls/StateGradientTests.cs
+++ b/Tests/EditMode/Controls/StateGradientTests.cs
@@ -1,0 +1,192 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using PromptUGUI.Parser;
+using UnityEngine;
+using UnityImage = UnityEngine.UI.Image;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    /// <summary>
+    /// Task 8 — gradient state colours. State ABSOLUTES (hover/pressed/selected/disabled Color)
+    /// may be gradients and land through <see cref="ColorApplier"/> (enabling/disabling the bg
+    /// <see cref="GradientTint"/>); *Modulate stays solid-only and a gradient value throws.
+    /// </summary>
+    public class StateGradientTests
+    {
+        // PuiButton SelectionState ordinals (mirror of the protected enum; PuiButton casts internally).
+        private const int Highlighted = 1; // -> Hover
+        private const int Pressed = 2;     // -> Pressed
+        private const int Normal = 0;
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            StateTintReactor.TestForceInstant = true;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UI.ResetForTests();
+            StateTintReactor.TestForceInstant = false;
+        }
+
+        private static PromptUGUI.Application.Screen Open(string innerXml)
+        {
+            UI.LoadDocument("t",
+                $"<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>" +
+                $"<Screen name='S'>{innerXml}</Screen></PromptUGUI>");
+            return UI.Open("S");
+        }
+
+        private static Btn BuildBtn(string attrs)
+        {
+            var s = Open($"<Btn id='b' {attrs}>x</Btn>");
+            return s.Get<Btn>("b");
+        }
+
+        private static Color Hex(string h)
+        {
+            ColorUtility.TryParseHtmlString(h, out var c);
+            return c;
+        }
+
+        private static void AssertColorApprox(Color actual, Color expected, float within, string msg)
+        {
+            Assert.That(actual.r, Is.EqualTo(expected.r).Within(within), msg + " (r)");
+            Assert.That(actual.g, Is.EqualTo(expected.g).Within(within), msg + " (g)");
+            Assert.That(actual.b, Is.EqualTo(expected.b).Within(within), msg + " (b)");
+        }
+
+        // 1. Gradient hoverColor over a solid base — enters Hover -> gradient tint; back to Normal -> base restored.
+        [Test]
+        public void GradientHoverColor_EnablesGradientTintOnHover_RestoresSolidBaseOnNormal()
+        {
+            var btn = BuildBtn("color='#888888' hoverColor='#ffffff,#000000'");
+            var bg = btn.GameObject.GetComponent<UnityImage>();
+            var pui = btn.GameObject.GetComponent<PuiButton>();
+            var tint = bg.GetComponent<GradientTint>();
+
+            // At rest (Normal): solid base, no enabled gradient.
+            Assert.IsTrue(tint == null || !tint.enabled, "no gradient at rest (solid base)");
+
+            pui.SimulateState(Highlighted); // -> Hover
+            tint = bg.GetComponent<GradientTint>();
+            Assert.IsNotNull(tint, "GradientTint added on hover");
+            Assert.IsTrue(tint.enabled, "GradientTint enabled on hover");
+            Assert.AreEqual(Color.white, tint.Top, "hover gradient top white");
+            Assert.AreEqual(Color.black, tint.Bottom, "hover gradient bottom black");
+
+            pui.SimulateState(Normal); // -> Normal
+            Assert.IsFalse(tint.enabled, "GradientTint disabled back at Normal");
+            AssertColorApprox(bg.color, Hex("#888888"), 0.01f, "solid base #888888 restored");
+        }
+
+        // 2. Gradient BASE + solid hoverColor — the Peek-base-capture test.
+        [Test]
+        public void GradientBase_SolidHoverColor_RoundTripsTintAcrossStates()
+        {
+            var btn = BuildBtn("color='#ffffff,#000000' hoverColor='#ff0000'");
+            var bg = btn.GameObject.GetComponent<UnityImage>();
+            var pui = btn.GameObject.GetComponent<PuiButton>();
+            var tint = bg.GetComponent<GradientTint>();
+
+            // At rest (Normal): the BASE gradient must be live (Peek captured it as the reactor base).
+            Assert.IsNotNull(tint, "base gradient tint present at rest");
+            Assert.IsTrue(tint.enabled, "base gradient enabled at rest");
+            Assert.AreEqual(Color.white, tint.Top, "base gradient top white");
+            Assert.AreEqual(Color.black, tint.Bottom, "base gradient bottom black");
+
+            pui.SimulateState(Highlighted); // -> Hover (solid red)
+            Assert.IsFalse(tint.enabled, "solid hover disables base gradient");
+            AssertColorApprox(bg.color, Color.red, 0.01f, "solid hover red applied");
+
+            pui.SimulateState(Normal); // -> Normal: base gradient restored
+            Assert.IsTrue(tint.enabled, "base gradient re-enabled at Normal");
+            Assert.AreEqual(Color.white, tint.Top, "base gradient top restored");
+            Assert.AreEqual(Color.black, tint.Bottom, "base gradient bottom restored");
+        }
+
+        // 3. Gradient base × solid pressedModulate — both stops are halved.
+        [Test]
+        public void GradientBase_SolidPressedModulate_MultipliesBothStops()
+        {
+            var btn = BuildBtn("color='#ffffff,#000000' pressedModulate='#808080'");
+            var bg = btn.GameObject.GetComponent<UnityImage>();
+            var pui = btn.GameObject.GetComponent<PuiButton>();
+            var tint = bg.GetComponent<GradientTint>();
+            Assert.IsNotNull(tint, "base gradient present");
+
+            pui.SimulateState(Pressed); // -> Pressed: gradient × 0.5
+            Assert.IsTrue(tint.enabled, "gradient stays enabled under solid modulate");
+            var half = 0x80 / 255f; // ~0.5019608
+            // white × 0.5 = (half,half,half); black × 0.5 = (0,0,0). ±3 bytes ≈ 0.012 tolerance.
+            AssertColorApprox(tint.Top, new Color(half, half, half, 1f), 3f / 255f, "top = white × grey");
+            AssertColorApprox(tint.Bottom, new Color(0f, 0f, 0f, 1f), 3f / 255f, "bottom = black × grey");
+        }
+
+        // 4. Gradient selectedColor on a Tab (selection base) — active tab shows the gradient at rest.
+        [Test]
+        public void GradientSelectedColor_OnActiveTab_ShowsGradientAtRest()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'><Tab id='a' isOn='true' selectedColor='#ffffff,#000000'/><Tab id='b'/></TabBar>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var s = UI.Open("S");
+            var a = s.Get<Tab>("bar/a");
+            var bg = a.GameObject.GetComponent<UnityImage>();
+
+            var tint = bg.GetComponent<GradientTint>();
+            Assert.IsNotNull(tint, "selected tab gradient present");
+            Assert.IsTrue(tint.enabled, "selected tab gradient enabled at rest");
+            Assert.AreEqual(Color.white, tint.Top, "selected gradient top white");
+            Assert.AreEqual(Color.black, tint.Bottom, "selected gradient bottom black");
+        }
+
+        // 5. A *Modulate with a gradient value throws (modulates are solid-only).
+        [Test]
+        public void GradientModulate_Throws_On_Open()
+        {
+            // hoverModulate routes through UI.Theme.Resolve, which rejects gradients;
+            // ControlAttributeApplier wraps the System.Exception as a ParseException.
+            var ex = Assert.Throws<ParseException>(
+                () => Open("<Btn id='b' hoverModulate='#ffffff,#000000'>x</Btn>"));
+            StringAssert.Contains("does not support gradient", ex.Message);
+        }
+
+        // 6. ReSolve (Variant toggle) must not lose an active gradient state.
+        [Test]
+        public void ReSolve_KeepsGradientHoverState()
+        {
+            var btn = BuildBtn("color='#888888' hoverColor='#ffffff,#000000'");
+            var bg = btn.GameObject.GetComponent<UnityImage>();
+            var pui = btn.GameObject.GetComponent<PuiButton>();
+
+            pui.SimulateState(Highlighted); // -> Hover (gradient enabled)
+            var tint = bg.GetComponent<GradientTint>();
+            Assert.IsNotNull(tint);
+            Assert.IsTrue(tint.enabled, "precondition: gradient hover enabled before ReSolve");
+
+            try
+            {
+                // Toggling any variant fires Variants.Changed -> Screen.ReSolve, which re-runs
+                // ControlAttributeApplier.Apply -> Btn.OnAfterApply -> reactor re-Configure (repaint).
+                UI.Variants.Set("mobile", true);
+
+                Assert.IsTrue(tint.enabled,
+                    "gradient hover state must survive ReSolve (re-Configure repaint)");
+                Assert.AreEqual(Color.white, tint.Top, "gradient top kept after ReSolve");
+                Assert.AreEqual(Color.black, tint.Bottom, "gradient bottom kept after ReSolve");
+            }
+            finally
+            {
+                UI.Variants.Set("mobile", false);
+            }
+        }
+    }
+}

--- a/Tests/EditMode/Controls/StateGradientTests.cs.meta
+++ b/Tests/EditMode/Controls/StateGradientTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: db00001220ed43adb25e54b46ae22a33

--- a/Tests/EditMode/Lint/GradientLintTests.cs
+++ b/Tests/EditMode/Lint/GradientLintTests.cs
@@ -1,0 +1,163 @@
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.Lint;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.EditMode.Lint
+{
+    /// <summary>
+    /// Tests for gradient-related lint rules:
+    ///   <see cref="ColorLiteralRules.GradientMalformedCode"/> (PUI-COLOR-GRADIENT-MALFORMED) and
+    ///   <see cref="GradientModulateRules.GradientModulateCode"/> (PUI-GRADIENT-MODULATE).
+    /// </summary>
+    public class GradientLintTests
+    {
+        // ── ColorLiteralRules: gradient shape validation ─────────────────────────
+
+        [Test]
+        public void ValidGradient_TwoSegments_NoIssue()
+        {
+            var n = new IR.ElementNode("Image") { Id = "test" };
+            n.Attributes["color"] = "#fff,#000";
+            var issues = ColorLiteralRules.Check(n).ToList();
+            Assert.IsEmpty(issues);
+        }
+
+        [Test]
+        public void InvalidGradient_ThreeSegments_MalformedIssue()
+        {
+            var n = new IR.ElementNode("Image") { Id = "bad" };
+            n.Attributes["color"] = "#fff,#000,#111";
+            var issues = ColorLiteralRules.Check(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ColorLiteralRules.GradientMalformedCode, issues[0].Code);
+        }
+
+        [Test]
+        public void InvalidGradient_EmptyBottomSegment_MalformedIssue()
+        {
+            var n = new IR.ElementNode("Image") { Id = "bad" };
+            n.Attributes["color"] = "#fff,";
+            var issues = ColorLiteralRules.Check(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ColorLiteralRules.GradientMalformedCode, issues[0].Code);
+        }
+
+        [Test]
+        public void ValidShape_BadHexBottomSegment_LiteralInvalidIssue()
+        {
+            // Structural shape is valid (2 segments), but bottom segment is bad hex.
+            var n = new IR.ElementNode("Image") { Id = "bad" };
+            n.Attributes["color"] = "#fff,#zzz";
+            var issues = ColorLiteralRules.Check(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(ColorLiteralRules.ColorLiteralCode, issues[0].Code);
+        }
+
+        [Test]
+        public void ValidShape_TokenTopSegment_NoIssue()
+        {
+            // Token segment is not statically checked; shape is valid.
+            var n = new IR.ElementNode("Image") { Id = "test" };
+            n.Attributes["color"] = "tok,#000";
+            var issues = ColorLiteralRules.Check(n).ToList();
+            Assert.IsEmpty(issues);
+        }
+
+        // ── GradientModulateRules ─────────────────────────────────────────────────
+
+        [Test]
+        public void HoverModulate_GradientValue_GradientModulateIssue()
+        {
+            var n = new IR.ElementNode("Btn") { Id = "b" };
+            n.Attributes["hoverModulate"] = "#fff,#000";
+            var issues = GradientModulateRules.Check(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(GradientModulateRules.GradientModulateCode, issues[0].Code);
+        }
+
+        [Test]
+        public void HoverColor_GradientValue_NoIssueFromGradientModulateRules()
+        {
+            // hoverColor is NOT a *Modulate attribute, so GradientModulateRules is silent.
+            var n = new IR.ElementNode("Btn") { Id = "b" };
+            n.Attributes["hoverColor"] = "#fff,#000";
+            var issues = GradientModulateRules.Check(n).ToList();
+            Assert.IsEmpty(issues);
+        }
+
+        [Test]
+        public void HoverColor_GradientValue_NoIssueFromColorLiteralRules()
+        {
+            // ColorLiteralRules only checks the 'color' attribute; hoverColor is not checked.
+            var n = new IR.ElementNode("Btn") { Id = "b" };
+            n.Attributes["hoverColor"] = "#fff,#000";
+            var issues = ColorLiteralRules.Check(n).ToList();
+            Assert.IsEmpty(issues);
+        }
+
+        [Test]
+        public void PressedModulate_SolidToken_NoIssue()
+        {
+            // No comma → not a gradient attempt.
+            var n = new IR.ElementNode("Btn") { Id = "b" };
+            n.Attributes["pressedModulate"] = "solidtoken";
+            var issues = GradientModulateRules.Check(n).ToList();
+            Assert.IsEmpty(issues);
+        }
+
+        [Test]
+        public void SelectedModulate_GradientValue_GradientModulateIssue()
+        {
+            var n = new IR.ElementNode("Tab") { Id = "t" };
+            n.Attributes["selectedModulate"] = "#aaa,#bbb";
+            var issues = GradientModulateRules.Check(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(GradientModulateRules.GradientModulateCode, issues[0].Code);
+        }
+
+        [Test]
+        public void DisabledModulate_GradientValue_GradientModulateIssue()
+        {
+            var n = new IR.ElementNode("Toggle") { Id = "tg" };
+            n.Attributes["disabledModulate"] = "#fff,#000";
+            var issues = GradientModulateRules.Check(n).ToList();
+            Assert.AreEqual(1, issues.Count);
+            Assert.AreEqual(GradientModulateRules.GradientModulateCode, issues[0].Code);
+        }
+
+        // ── IRWalker integration ──────────────────────────────────────────────────
+
+        [Test]
+        public void IRWalker_DispatchesGradientModulateRule()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <Btn id='b' hoverModulate='#fff,#000'/>
+  </Screen>
+</PromptUGUI>";
+            var doc = UIDocumentParser.Parse(xml);
+            var issues = IRWalker.Walk(doc).ToList();
+            Assert.IsTrue(issues.Any(i =>
+                i.Code == GradientModulateRules.GradientModulateCode && i.Id == "b"),
+                "IRWalker must surface PUI-GRADIENT-MODULATE for hoverModulate gradient");
+        }
+
+        [Test]
+        public void IRWalker_DispatchesGradientMalformedRule()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <Image id='img' color='#fff,#000,#111'/>
+  </Screen>
+</PromptUGUI>";
+            var doc = UIDocumentParser.Parse(xml);
+            var issues = IRWalker.Walk(doc).ToList();
+            Assert.IsTrue(issues.Any(i =>
+                i.Code == ColorLiteralRules.GradientMalformedCode && i.Id == "img"),
+                "IRWalker must surface PUI-COLOR-GRADIENT-MALFORMED for 3-segment gradient");
+        }
+    }
+}

--- a/Tests/EditMode/Lint/GradientLintTests.cs.meta
+++ b/Tests/EditMode/Lint/GradientLintTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 057be8335e0bb5343878f5a5197ff046

--- a/Tests/EditMode/Parser/ColorParserGradientTests.cs
+++ b/Tests/EditMode/Parser/ColorParserGradientTests.cs
@@ -1,0 +1,43 @@
+using NUnit.Framework;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.EditMode.Parser
+{
+    public class ColorParserGradientTests
+    {
+        [Test]
+        public void NoComma_ReturnsSingleSegment()
+        {
+            Assert.IsTrue(ColorParser.TrySplitGradient("black/0.5", out var top, out var bottom, out var err));
+            Assert.AreEqual("black/0.5", top);
+            Assert.IsNull(bottom);
+            Assert.IsNull(err);
+        }
+
+        [Test]
+        public void TwoSegments_SplitAndTrimmed()
+        {
+            Assert.IsTrue(ColorParser.TrySplitGradient("#ffe08a, #b8860b", out var top, out var bottom, out _));
+            Assert.AreEqual("#ffe08a", top);
+            Assert.AreEqual("#b8860b", bottom);
+        }
+
+        [TestCase("a,b,c")]
+        [TestCase("a,")]
+        [TestCase(",b")]
+        [TestCase(",")]
+        public void Malformed_Fails(string raw)
+        {
+            Assert.IsFalse(ColorParser.TrySplitGradient(raw, out _, out _, out var err));
+            StringAssert.Contains("gradient", err);
+        }
+
+        [Test]
+        public void Empty_IsSingleNullSegment_HandledByCaller()
+        {
+            Assert.IsTrue(ColorParser.TrySplitGradient("", out var top, out var bottom, out _));
+            Assert.AreEqual("", top);
+            Assert.IsNull(bottom);
+        }
+    }
+}

--- a/Tests/EditMode/Parser/ColorParserGradientTests.cs.meta
+++ b/Tests/EditMode/Parser/ColorParserGradientTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: af9230205f0754648806eb2b7a00fa8d

--- a/Tests/EditMode/Parser/ThemeParseTests.cs
+++ b/Tests/EditMode/Parser/ThemeParseTests.cs
@@ -108,5 +108,56 @@ namespace PromptUGUI.Tests.Parser
             Assert.DoesNotThrow(() => UIDocumentParser.Parse(
                 Header + "<Theme name='l'><Color name='primary' value='Red'/></Theme>" + Footer));
         }
+
+        // ── gradient definition-site parse errors ──
+
+        [Test]
+        public void Gradient_Valid_Two_Stop_Parses()
+        {
+            Assert.DoesNotThrow(() => UIDocumentParser.Parse(
+                Header + "<Theme name='l'><Color name='g' value='#ffffff,#000000'/></Theme>" + Footer));
+        }
+
+        [Test]
+        public void Gradient_Named_Colors_Both_Valid_Parses()
+        {
+            // "red,black" — both are Unity-supported named colors → valid gradient
+            Assert.DoesNotThrow(() => UIDocumentParser.Parse(
+                Header + "<Theme name='l'><Color name='g' value='red,black'/></Theme>" + Footer));
+        }
+
+        [Test]
+        public void Gradient_Three_Segments_Throws()
+        {
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(
+                Header + "<Theme name='l'><Color name='g' value='#fff,#000,#111'/></Theme>" + Footer));
+            StringAssert.Contains("gradient", ex.Message);
+        }
+
+        [Test]
+        public void Gradient_Trailing_Comma_Throws()
+        {
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(
+                Header + "<Theme name='l'><Color name='g' value='#fff,'/></Theme>" + Footer));
+            StringAssert.Contains("gradient", ex.Message);
+        }
+
+        [Test]
+        public void Gradient_Invalid_Top_Segment_Throws()
+        {
+            // "sometoken" is not a hex/named literal → invalid color literal
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(
+                Header + "<Theme name='l'><Color name='g' value='sometoken,black'/></Theme>" + Footer));
+            StringAssert.Contains("invalid color literal", ex.Message);
+        }
+
+        [Test]
+        public void Gradient_Alpha_Suffix_In_Segment_Throws()
+        {
+            // /alpha not allowed at definition site; #fff/0.5 fails TryParseHtmlString
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(
+                Header + "<Theme name='l'><Color name='g' value='#fff/0.5,#000'/></Theme>" + Footer));
+            StringAssert.Contains("invalid color literal", ex.Message);
+        }
     }
 }

--- a/Tests/EditMode/Parser/ThemeParseTests.cs
+++ b/Tests/EditMode/Parser/ThemeParseTests.cs
@@ -152,6 +152,15 @@ namespace PromptUGUI.Tests.Parser
         }
 
         [Test]
+        public void Gradient_Invalid_Bottom_Segment_Throws()
+        {
+            // bad token in the bottom segment → invalid color literal
+            var ex = Assert.Throws<ParseException>(() => UIDocumentParser.Parse(
+                Header + "<Theme name='l'><Color name='g' value='red,badtoken'/></Theme>" + Footer));
+            StringAssert.Contains("invalid color literal", ex.Message);
+        }
+
+        [Test]
         public void Gradient_Alpha_Suffix_In_Segment_Throws()
         {
             // /alpha not allowed at definition site; #fff/0.5 fails TryParseHtmlString

--- a/Tests/PlayMode/Controls/GradientPlayTests.cs
+++ b/Tests/PlayMode/Controls/GradientPlayTests.cs
@@ -1,0 +1,69 @@
+using System.Collections;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using R3;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityImage = UnityEngine.UI.Image;
+
+namespace PromptUGUI.Tests.PlayMode.Controls
+{
+    // PlayMode smoke: verifies the gradient BASE + solid hoverModulate premultiply path
+    // survives a real frame loop (Awake, layout, mesh rebuild).  The EditMode suite already
+    // covers the full state matrix; this test just confirms nothing breaks under Play.
+    public class GradientPlayTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            StateTintReactor.TestForceInstant = true;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UI.ResetForTests();
+            StateTintReactor.TestForceInstant = false;
+        }
+
+        [UnityTest]
+        public IEnumerator GradientBtn_HasEnabledGradientTintAndIsClickable()
+        {
+            // Gradient BASE (#ffffff top, #000000 bottom) + solid hoverModulate — exercises
+            // the gradient-base × modulate premultiply path in StateTintReactor.
+            UI.LoadDocument("t", @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Btn id='b' color='#ffffff,#000000' hoverModulate='#808080'>Go</Btn>
+</Screen></PromptUGUI>");
+            var screen = UI.Open("S");
+
+            // Two frames: let Awake + layout settle.
+            yield return null;
+            yield return null;
+
+            var btn = screen.Get<Btn>("b");
+            var bg = btn.GameObject.GetComponent<UnityImage>();
+            Assert.IsNotNull(bg, "Btn must have a background Image");
+
+            // Gradient tint must be present and ENABLED (baseline = Normal state, gradient base).
+            var tint = bg.GetComponent<GradientTint>();
+            Assert.IsNotNull(tint, "GradientTint component must be present on Btn bg");
+            Assert.IsTrue(tint.enabled, "GradientTint must be enabled at rest (Normal state)");
+
+            // Verify the gradient stops match the authored values (#ffffff top, #000000 bottom).
+            Assert.AreEqual(Color.white, tint.Top,
+                "Top stop must be white (#ffffff) at rest");
+            Assert.AreEqual(Color.black, tint.Bottom,
+                "Bottom stop must be black (#000000) at rest");
+
+            // Btn must be interactable and clickable.
+            int clickCount = 0;
+            btn.OnClick.Subscribe(_ => clickCount++);
+            btn.GameObject.GetComponent<UnityEngine.UI.Button>().onClick.Invoke();
+            Assert.AreEqual(1, clickCount, "Btn.OnClick must fire when Button.onClick is invoked");
+        }
+    }
+}

--- a/Tests/PlayMode/Controls/GradientPlayTests.cs.meta
+++ b/Tests/PlayMode/Controls/GradientPlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 26c2b4faedb29bb419ad6e3c37b8ef22

--- a/docs~/superpowers/plans/2026-06-13-gradient-color.md
+++ b/docs~/superpowers/plans/2026-06-13-gradient-color.md
@@ -1,0 +1,633 @@
+# 渐变色支持 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 颜色值语法新增"逗号分隔双色 = 上下渐变"（`color="#ffe08a,#b8860b"`），覆盖所有给 Graphic 上色的属性与状态色，不新增 XML 属性。
+
+**Architecture:** 解析层 `ColorParser.TrySplitGradient`（纯 C#，lint 共享）→ 值模型 `ColorSpec`（`Runtime/Application/`）→ `UI.Theme.ResolveSpec` 统一解析 → 应用层 `ColorApplier`（纯色写 `Graphic.color`；渐变写 `GradientTint : BaseMeshEffect` 顶点色 + `Graphic.color=white`）；Text 走 TMP 原生 `colorGradient`；状态色把 `StateColorSet` 槽位从 `Color?` 拓宽为 `ColorSpec?`，reactor 预乘 Modulate 后经 ColorApplier 落地。
+
+**Tech Stack:** Unity 6 uGUI / TMP / LitMotion（现有 tween）。测试经 UnityMCP（`refresh_unity` → `run_tests`，详见 CLAUDE.md），lint 经 `.lint/` dotnet format + UIXmlLint CLI。
+
+**Spec:** `docs~/superpowers/specs/2026-06-13-gradient-color-design.md`（先通读，尤其 §2 定义处/引用处区别、§5 预乘与 Peek、§6 不支持名单）。
+
+**约定（每个 Task 通用，不再重复写步骤）：**
+- 测试跑法：先 `mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)`，再 `mcp__UnityMCP__read_console(action="get", types=["error"])` 确认零编译错误，然后 `mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["<测试类名>"])`，轮询 `get_test_job` 到完成。**Task 12 跑全量，不带 group 过滤。**
+- 每个 Task 结尾：`cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx`（首次需先 `dotnet restore PromptUGUI.Lint.slnx`），然后 git commit（feature 分支，永不碰 main）。
+- 新建 .cs 文件后 refresh 会生成 `.meta`——**commit 时连同 `.meta` 一起提交**（PR #60 的教训）。
+- EditMode 测试类碰 `UI` 的，`[SetUp]`/`[TearDown]` 都要 `UI.ResetForTests()`。
+
+---
+
+### Task 0: 建分支 + 提交 spec
+
+**Files:** 无代码。
+
+- [ ] **Step 1:** `git checkout -b feat/gradient-color`
+- [ ] **Step 2:** `git add docs~/superpowers/specs/2026-06-13-gradient-color-design.md docs~/superpowers/plans/2026-06-13-gradient-color.md && git commit -m "docs: gradient color spec + plan"`
+
+---
+
+### Task 1: `ColorParser.TrySplitGradient`（纯 C# 切分，lint 共享）
+
+**Files:**
+- Modify: `Runtime/Core/Parser/ColorParser.cs`
+- Test: `Tests/EditMode/Parser/ColorParserGradientTests.cs`（新建）
+
+- [ ] **Step 1: 写失败测试**
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.EditMode.Parser
+{
+    public class ColorParserGradientTests
+    {
+        [Test]
+        public void NoComma_ReturnsSingleSegment()
+        {
+            Assert.IsTrue(ColorParser.TrySplitGradient("black/0.5", out var top, out var bottom, out var err));
+            Assert.AreEqual("black/0.5", top);
+            Assert.IsNull(bottom);
+            Assert.IsNull(err);
+        }
+
+        [Test]
+        public void TwoSegments_SplitAndTrimmed()
+        {
+            Assert.IsTrue(ColorParser.TrySplitGradient("#ffe08a, #b8860b", out var top, out var bottom, out _));
+            Assert.AreEqual("#ffe08a", top);
+            Assert.AreEqual("#b8860b", bottom);
+        }
+
+        [TestCase("a,b,c")]
+        [TestCase("a,")]
+        [TestCase(",b")]
+        [TestCase(",")]
+        public void Malformed_Fails(string raw)
+        {
+            Assert.IsFalse(ColorParser.TrySplitGradient(raw, out _, out _, out var err));
+            StringAssert.Contains("gradient", err);
+        }
+
+        [Test]
+        public void Empty_IsSingleNullSegment_HandledByCaller()
+        {
+            Assert.IsTrue(ColorParser.TrySplitGradient("", out var top, out var bottom, out _));
+            Assert.AreEqual("", top);
+            Assert.IsNull(bottom);
+        }
+    }
+}
+```
+
+- [ ] **Step 2:** refresh + 跑 `group_names=["ColorParserGradientTests"]`，预期 FAIL（方法不存在 → 编译错，先确认 console 报 CS 错误即为"红"）。
+- [ ] **Step 3: 实现**（加在 `TrySplitAlpha` 后面）
+
+```csharp
+/// <summary>
+/// Splits an optional two-stop gradient value on ','. <c>"#fff,#000"</c> → top <c>"#fff"</c>,
+/// bottom <c>"#000"</c>; no comma → top = raw, bottom = null. Segments are trimmed (authors
+/// write <c>"a, b"</c>). Each segment still carries its own token / <c>/alpha</c> form —
+/// this method does NOT validate segment contents, only the split shape.
+/// Returns false when there are &gt;2 segments or any segment is empty.
+/// </summary>
+public static bool TrySplitGradient(string raw, out string top, out string bottom, out string error)
+{
+    top = raw;
+    bottom = null;
+    error = null;
+    if (string.IsNullOrEmpty(raw)) return true;   // empty handled by caller
+
+    var comma = raw.IndexOf(',');
+    if (comma < 0) return true;
+
+    if (raw.IndexOf(',', comma + 1) >= 0)
+    {
+        error = $"color \"{raw}\": gradient supports exactly two colours (top,bottom)";
+        return false;
+    }
+
+    var head = raw.Substring(0, comma).Trim();
+    var tail = raw.Substring(comma + 1).Trim();
+    if (head.Length == 0 || tail.Length == 0)
+    {
+        error = $"color \"{raw}\": gradient segment is empty — expected \"top,bottom\"";
+        return false;
+    }
+
+    top = head;
+    bottom = tail;
+    return true;
+}
+```
+
+- [ ] **Step 4:** refresh + 跑同 group，预期 PASS。
+- [ ] **Step 5:** lint + commit `feat: ColorParser.TrySplitGradient comma split`
+
+---
+
+### Task 2: `ColorSpec` 值模型 + `ThemeStore` 拓宽 + 定义处校验
+
+**Files:**
+- Create: `Runtime/Application/ColorSpec.cs`
+- Modify: `Runtime/Application/ThemeStore.cs`（`Entry.Colors`、`Register`、`ReplaceFromSrc`、`LookupChained`）
+- Modify: `Runtime/Application/UI.cs` `RegisterThemesAndAutoSet`（~line 916：每个 token 值过 `TrySplitGradient` 后逐段 `ColorUtility.TryParseHtmlString`）
+- Modify: `Runtime/Application/UI.cs` `Theme.Lookup`（LookupChained 返回类型变了；public 签名保持 `Color?`，渐变 token 返回 `Top`，加 doc 注释）
+- Modify: `Runtime/Core/Parser/UIDocumentParser.cs` ParseTheme（~line 116：`ColorParser.TryParseHtmlString(cv)` 改为先 `TrySplitGradient` 再逐段校验；段带 `/` 或非字面量 → 现有 "invalid color literal" 错误文案补充段信息）
+- Modify: `Runtime/Editor` 若 HotReload 路径调 `ReplaceFromSrc`（grep `ReplaceFromSrc` 调用方，签名跟随拓宽）
+- Test: `Tests/EditMode/Application/ThemeGradientTests.cs`（新建）；`Tests/EditMode/Parser/` 现有 Theme 解析测试类追加定义处错误用例
+
+**`ColorSpec` 完整代码：**
+
+```csharp
+using UnityEngine;
+
+namespace PromptUGUI.Application
+{
+    /// <summary>
+    /// A resolved colour value: solid, or a two-stop vertical gradient (Top → Bottom).
+    /// Produced by <see cref="UI.Theme.ResolveSpec"/>; applied by <c>ColorApplier</c>
+    /// (vertex-tint slot) or the TMP vertex-gradient path in <c>Text</c>.
+    /// Solid values keep <see cref="Bottom"/> == <see cref="Top"/> so consumers that
+    /// only need one colour can read Top unconditionally.
+    /// </summary>
+    internal readonly struct ColorSpec
+    {
+        public readonly Color Top;
+        public readonly Color Bottom;
+        public readonly bool IsGradient;
+
+        private ColorSpec(Color top, Color bottom, bool isGradient)
+        {
+            Top = top;
+            Bottom = bottom;
+            IsGradient = isGradient;
+        }
+
+        public static ColorSpec Solid(Color c) => new(c, c, false);
+        public static ColorSpec Gradient(Color top, Color bottom) => new(top, bottom, true);
+
+        /// <summary>Component-wise multiply both stops (modulate premultiply, spec §5).</summary>
+        public ColorSpec Multiply(Color m) => new(Top * m, Bottom * m, IsGradient);
+    }
+}
+```
+
+**ThemeStore 拓宽要点**（机械替换 `Color` → `ColorSpec`）：
+- `Entry.Colors`: `Dictionary<string, ColorSpec>`
+- `Register(string name, string baseName, IReadOnlyDictionary<string, ColorSpec> colors, string src)`
+- `ReplaceFromSrc` 元组里的 `colors` 同步拓宽
+- `LookupChained(string, string)` 返回 `ColorSpec?`
+
+**`RegisterThemesAndAutoSet` 内层改为：**
+
+```csharp
+foreach (var ce in theme.Colors)
+{
+    Parser.ColorParser.TrySplitGradient(ce.Value, out var topRaw, out var bottomRaw, out _);
+    UnityEngine.ColorUtility.TryParseHtmlString(topRaw, out var top);
+    if (bottomRaw == null)
+    {
+        colors[ce.Name] = ColorSpec.Solid(top);
+    }
+    else
+    {
+        UnityEngine.ColorUtility.TryParseHtmlString(bottomRaw, out var bottom);
+        colors[ce.Name] = ColorSpec.Gradient(top, bottom);
+    }
+}
+```
+
+（坏值在 ParseTheme 已拦截，这里沿用现有"信任 parser"风格不再报错。）
+
+**ParseTheme 校验改为：**
+
+```csharp
+if (!ColorParser.TrySplitGradient(cv, out var gTop, out var gBottom, out var gErr))
+    throw new ParseException($"<Color name=\"{cn}\" value=\"{cv}\">: {gErr}");
+if (!ColorParser.TryParseHtmlString(gTop)
+    || (gBottom != null && !ColorParser.TryParseHtmlString(gBottom)))
+    throw new ParseException(
+        $"<Color name=\"{cn}\" value=\"{cv}\">: invalid color literal" +
+        (gBottom != null ? " (each gradient segment must be a hex/named literal — no tokens, no /alpha)" : ""));
+```
+
+- [ ] **Step 1: 写失败测试**（ThemeGradientTests：注册含渐变 token 的主题 → `ThemeStore.Instance.LookupChained("t","grad")` 拿到 IsGradient + 两端值；base 链上的渐变 token 可继承；solid token 不回归。Parser 侧：`value="#fff,#000,#111"`、`value="#fff,"`、`value="gold,black"`（token 段）、`value="#fff/0.5,#000"`（/alpha 段）各报 ParseException 且文案含 "gradient" 或 "invalid color literal"。fake-files 模式参照 `Tests/EditMode/Application/UIThemeTests.cs`。）
+- [ ] **Step 2:** refresh + 跑红（编译错或断言失败均可）。
+- [ ] **Step 3:** 按上述实现；grep `LookupChained\|ThemeStore.Instance.Register\|ReplaceFromSrc` 修齐所有编译错（含 `Theme.Lookup` 返回 `hit?.Top`）。
+- [ ] **Step 4:** refresh + 跑 `group_names=["ThemeGradientTests","UIThemeTests"]` 及被改的 parser 测试类，PASS。
+- [ ] **Step 5:** lint + commit `feat: ColorSpec + ThemeStore gradient tokens`
+
+---
+
+### Task 3: `UI.Theme.ResolveSpec` + 旧 `Resolve` 拒绝渐变
+
+**Files:**
+- Modify: `Runtime/Application/UI.cs` `Theme` 类（~line 448）
+- Test: `Tests/EditMode/Application/ThemeGradientTests.cs`（追加）
+
+**实现（替换现有 `Resolve`，`ResolveBase` 保留不动）：**
+
+```csharp
+/// <summary>
+/// Resolve a colour value that may be a two-stop vertical gradient ("top,bottom").
+/// Each segment independently supports theme tokens, hex/named literals and the
+/// /alpha suffix. A whole-value token may itself BE a gradient token; "/alpha" on
+/// it replaces BOTH stops' alpha. A gradient token used as a segment is an error
+/// (no nested gradients).
+/// </summary>
+internal static ColorSpec ResolveSpec(string value)
+{
+    if (string.IsNullOrEmpty(value))
+        throw new System.Exception("empty color value");
+
+    if (!Parser.ColorParser.TrySplitGradient(value, out var topRaw, out var bottomRaw, out var gErr))
+        throw new System.Exception(gErr);
+
+    if (bottomRaw == null)
+        return ResolveSingle(topRaw, allowGradientToken: true);
+
+    var top = ResolveSingle(topRaw, allowGradientToken: false);
+    var bottom = ResolveSingle(bottomRaw, allowGradientToken: false);
+    return ColorSpec.Gradient(top.Top, bottom.Top);
+}
+
+/// <summary>One segment: token / literal + optional /alpha. Solid unless the whole
+/// segment is a gradient token AND allowGradientToken.</summary>
+private static ColorSpec ResolveSingle(string value, bool allowGradientToken)
+{
+    if (!Parser.ColorParser.TrySplitAlpha(value, out var baseValue, out var alpha, out var err))
+        throw new System.Exception(err);
+
+    var spec = ResolveBaseSpec(baseValue);
+    if (spec.IsGradient && !allowGradientToken)
+        throw new System.Exception(
+            $"color \"{value}\": token resolves to a gradient — gradients cannot nest inside a gradient");
+    if (alpha.HasValue)
+    {
+        var t = spec.Top; t.a = alpha.Value;
+        var b = spec.Bottom; b.a = alpha.Value;
+        spec = spec.IsGradient ? ColorSpec.Gradient(t, b) : ColorSpec.Solid(t);
+    }
+    return spec;
+}
+
+public static UnityEngine.Color Resolve(string value)
+{
+    var spec = ResolveSpec(value);
+    if (spec.IsGradient)
+        throw new System.Exception(
+            $"color \"{value}\": this attribute does not support gradient colors");
+    return spec.Top;
+}
+```
+
+`ResolveBaseSpec` = 现有 `ResolveBase` 的 ColorSpec 版：theme 命中返回 `LookupChained` 的 `ColorSpec`；hex/named → `ColorSpec.Solid`；soft-fail 路径返回 `ColorSpec.Solid(white)`。把现 `ResolveBase` 的函数体改造为它（原 `ResolveBase` 删除或改为 `ResolveBaseSpec(value).Top`——只剩 `Lookup` 用得到的话直接删）。
+
+- [ ] **Step 1: 失败测试**（追加到 ThemeGradientTests）：
+  - `ResolveSpec("#fff,#000")` → IsGradient、Top=white、Bottom=black
+  - `ResolveSpec("gold-grad")`（注册过的渐变 token）→ IsGradient
+  - `ResolveSpec("gold-grad/0.5")` → 两端 a==0.5
+  - `ResolveSpec("accent,accent-dark/0.5")`（两 token，第二段带 alpha）→ Bottom.a==0.5
+  - `ResolveSpec("gold-grad,black")` → throws，文案含 "cannot nest"
+  - `Resolve("#fff,#000")` / `Resolve("gold-grad")` → throws，文案含 "does not support gradient"
+  - `ResolveSpec("plain-token")`（纯色 token）→ !IsGradient（不回归）
+  - 未注册主题 soft-fail：`Theme.Set("nope")` 后 `ResolveSpec("sometoken")` → Solid(white)
+- [ ] **Step 2:** refresh + 红。
+- [ ] **Step 3:** 实现如上。
+- [ ] **Step 4:** refresh + 跑 `group_names=["ThemeGradientTests","UIThemeTests"]` PASS。**另跑一次全量 EditMode**：`Resolve` 行为变化（逗号值从"ColorUtility 解析失败"变为明确 throw）可能影响现有负例测试。
+- [ ] **Step 5:** lint + commit `feat: UI.Theme.ResolveSpec gradient resolution`
+
+---
+
+### Task 4: `GradientTint` 顶点修改器
+
+**Files:**
+- Create: `Runtime/Controls/Internal/GradientTint.cs`
+- Test: `Tests/EditMode/Controls/GradientTintTests.cs`（新建）
+
+**完整代码：**
+
+```csharp
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Controls.Internal
+{
+    /// <summary>
+    /// Two-stop vertical gradient tint as a vertex-colour effect (spec §4.2). Multiplies
+    /// Lerp(Bottom, Top, normalizedY) into each vertex's existing colour, so the final
+    /// composite stays <c>texture × Graphic.color × gradient</c> — the Graphic.color slot
+    /// remains free for state modulates. Y is normalized across the actual mesh bounds
+    /// (Sliced/Tiled have &gt;4 verts; vertex order is not assumed). Lazy-added by
+    /// <see cref="ColorApplier"/> and toggled via <c>enabled</c>, never destroyed
+    /// (Variant/ReSolve round-trips, same convention as ApplyViewportMask).
+    /// </summary>
+    [RequireComponent(typeof(Graphic))]
+    internal sealed class GradientTint : BaseMeshEffect
+    {
+        private Color _top = Color.white;
+        private Color _bottom = Color.white;
+
+        public void Set(Color top, Color bottom)
+        {
+            if (_top == top && _bottom == bottom) return;
+            _top = top;
+            _bottom = bottom;
+            if (graphic != null) graphic.SetVerticesDirty();
+        }
+
+        public Color Top => _top;
+        public Color Bottom => _bottom;
+
+        public override void ModifyMesh(VertexHelper vh)
+        {
+            if (!IsActive() || vh.currentVertCount == 0) return;
+
+            var v = new UIVertex();
+            float minY = float.MaxValue, maxY = float.MinValue;
+            for (var i = 0; i < vh.currentVertCount; i++)
+            {
+                vh.PopulateUIVertex(ref v, i);
+                if (v.position.y < minY) minY = v.position.y;
+                if (v.position.y > maxY) maxY = v.position.y;
+            }
+
+            var h = maxY - minY;
+            for (var i = 0; i < vh.currentVertCount; i++)
+            {
+                vh.PopulateUIVertex(ref v, i);
+                var t = h > 0f ? (v.position.y - minY) / h : 1f;
+                v.color *= Color.Lerp(_bottom, _top, t);
+                vh.SetUIVertex(v, i);
+            }
+        }
+    }
+}
+```
+
+注意 `OnEnable`/`OnDisable`：`BaseMeshEffect` 基类已经在 enable/disable 时 `SetVerticesDirty`，不用自己写。
+
+- [ ] **Step 1: 失败测试**（EditMode 可直接驱动 `ModifyMesh`）：
+
+```csharp
+// 手工构造 VertexHelper：4 顶点 quad（y ∈ {0,100}，色全 white），
+// effect.Set(red, blue) 后 ModifyMesh，断言 y=100 顶点 color≈red、y=0 ≈blue。
+// 第二个用例：先把顶点色设为 (0.5,0.5,0.5,1)，断言乘法叠加（y=100 → 0.5*red）。
+// 第三个用例：enabled=false 时 ModifyMesh 不改顶点。
+// 第四个用例：Set 两次相同值不触发 SetVerticesDirty 副作用（可只断言值幂等）。
+// VertexHelper 用法：var vh = new VertexHelper(); vh.AddVert(pos, color, uv);
+// 读回：UIVertex v = default; vh.PopulateUIVertex(ref v, i);
+// 组件挂在带 Image 的 GameObject 上（RequireComponent），TearDown DestroyImmediate。
+```
+
+- [ ] **Step 2:** refresh + 红。
+- [ ] **Step 3:** 实现如上（含 .meta 提交）。
+- [ ] **Step 4:** refresh + `group_names=["GradientTintTests"]` PASS。
+- [ ] **Step 5:** lint + commit `feat: GradientTint vertex effect`
+
+---
+
+### Task 5: `ColorApplier`（Apply / Peek）
+
+**Files:**
+- Create: `Runtime/Controls/Internal/ColorApplier.cs`
+- Test: `Tests/EditMode/Controls/ColorApplierTests.cs`（新建）
+
+**完整代码：**
+
+```csharp
+using PromptUGUI.Application;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Controls.Internal
+{
+    /// <summary>
+    /// Single chokepoint for landing a resolved <see cref="ColorSpec"/> on a Graphic
+    /// (spec §4.1). Solid → <c>graphic.color</c> (and disables any GradientTint);
+    /// gradient → GradientTint vertex slot + <c>graphic.color = white</c> so the
+    /// Graphic.color slot stays free for state modulates. GradientTint is lazy-added
+    /// and toggled, never destroyed.
+    /// </summary>
+    internal static class ColorApplier
+    {
+        public static void Apply(Graphic g, ColorSpec spec)
+        {
+            if (spec.IsGradient)
+            {
+                var tint = g.GetComponent<GradientTint>() ?? g.gameObject.AddComponent<GradientTint>();
+                tint.Set(spec.Top, spec.Bottom);
+                tint.enabled = true;
+                g.color = Color.white;
+            }
+            else
+            {
+                var tint = g.GetComponent<GradientTint>();
+                if (tint != null) tint.enabled = false;
+                g.color = spec.Top;
+            }
+        }
+
+        /// <summary>Read back the currently-applied value — gradient if a GradientTint is
+        /// enabled, else the plain graphic colour. Used by StateTintReactor base capture.</summary>
+        public static ColorSpec Peek(Graphic g)
+        {
+            var tint = g.GetComponent<GradientTint>();
+            return tint != null && tint.enabled
+                ? ColorSpec.Gradient(tint.Top, tint.Bottom)
+                : ColorSpec.Solid(g.color);
+        }
+    }
+}
+```
+
+- [ ] **Step 1: 失败测试**：纯色 Apply 写 color；渐变 Apply 加组件 + enabled + color==white；渐变→纯色往返组件仍在但 disabled（**断言不被 Destroy**）；Peek 双态读回正确。
+- [ ] **Step 2:** refresh + 红。 **Step 3:** 实现。 **Step 4:** `group_names=["ColorApplierTests"]` PASS。 **Step 5:** lint + commit `feat: ColorApplier solid/gradient chokepoint`
+
+---
+
+### Task 6: Graphic 类 setter 全量切换（一档属性）
+
+**Files（全部 Modify，模式统一：`X.color = UI.Theme.Resolve(value)` → `ColorApplier.Apply(X, UI.Theme.ResolveSpec(value))`）：**
+
+| 文件 | 属性（行号当前值，执行时以 grep 为准） |
+|---|---|
+| `Runtime/Controls/Image.cs:48` | `Color`（_img） |
+| `Runtime/Controls/Icon.cs:48` | `Color`（_img） |
+| `Runtime/Controls/RawImage.cs:48` | `Color`（_raw） |
+| `Runtime/Controls/Btn.cs:167` | `Color`（_bg） |
+| `Runtime/Controls/Tab.cs:268` | `Color`（_bg） |
+| `Runtime/Controls/Toggle.cs:123` | `Color`（_bg） |
+| `Runtime/Controls/Dropdown.cs:193,221` | `Color`（_bg）、`PopupColor`（_templateBg） |
+| `Runtime/Controls/InputField.cs:232` | `Color`（_bg）——**仅 bg**；TextColor/PlaceholderColor/CaretColor/SelectionColor 保持旧 `Resolve`（spec 作用域注） |
+| `Runtime/Controls/Progress.cs:90,111,134` | `Color`（_fill）、`BgColor`（_bg）、`FrameColor`（_frame） |
+| `Runtime/Controls/ScrollList.cs:175,222` | `Color`（_bg）、`FrameColor`（EnsureFrame()） |
+| `Runtime/Controls/Slider.cs:117` | `BgColor`（_bg） |
+
+不动：`Carousel` dotColor/dotSelectedColor、`Tab/Toggle.SelectedColor`（Task 8 处理）、`*Modulate`（保持纯色，Task 8）、AnimationSpec、MarkdigRenderer。
+
+- Test: `Tests/EditMode/Controls/GradientColorAttrTests.cs`（新建，fake-files + `UI.LoadDocument` 模式参照现有 Controls 测试）
+
+- [ ] **Step 1: 失败测试**：
+  - `<Image color="#fff,#000">` → Open 后 `_img` 的 GameObject 上有 enabled 的 `GradientTint`（Top=white、Bottom=black）且 `_img.color==white`
+  - `<Icon ...>`、`<Btn color="#fff,#000">` 同型抽查（不必 11 个属性全写，每类代表 1 个：Image / Btn bg / Progress fill / ScrollList frame）
+  - 纯色不回归：`<Image color="#ff0000">` → color==red、无 enabled 的 GradientTint
+  - **ReSolve 往返**：Variant 把 `color.mobile="#fff"`（纯色）覆盖渐变基色 → 激活 Variant 后 GradientTint disabled、color==white→red；关 Variant 还原渐变（参照现有 Variants 测试的激活模式）
+  - `<Btn hoverModulate="#fff,#000">` → Open 抛错/LogError，文案含 "does not support gradient"（此时 Modulate 仍走旧 Resolve，自动正确）
+- [ ] **Step 2:** refresh + 红。 **Step 3:** 机械替换上表（各文件 `using PromptUGUI.Controls.Internal;` 已基本都在，缺则补）。 **Step 4:** `group_names=["GradientColorAttrTests"]` + **全量 EditMode**（防 setter 行为差异回归）。 **Step 5:** lint + commit `feat: gradient on all Graphic color attrs`
+
+---
+
+### Task 7: Text 的 TMP 渐变路径
+
+**Files:**
+- Modify: `Runtime/Controls/Text.cs:86-90`（`Color` setter）
+- Test: `Tests/EditMode/Controls/GradientColorAttrTests.cs`（追加）
+
+**实现：**
+
+```csharp
+[UIAttr(IsColor = true), Preserve]
+public string Color
+{
+    set
+    {
+        var spec = UI.Theme.ResolveSpec(value);
+        if (spec.IsGradient)
+        {
+            _tmp.enableVertexGradient = true;
+            _tmp.colorGradient = new TMPro.VertexGradient(spec.Top, spec.Top, spec.Bottom, spec.Bottom);
+            _tmp.color = UnityEngine.Color.white;
+        }
+        else
+        {
+            _tmp.enableVertexGradient = false;
+            _tmp.color = spec.Top;
+        }
+    }
+}
+```
+
+- [ ] **Step 1: 失败测试**：`<Text color="#fff,#000">` → `enableVertexGradient==true`、`colorGradient.topLeft==white`、`bottomRight==black`、`color==white`；纯色往返把 `enableVertexGradient` 关回 false。
+- [ ] **Step 2:** 红。 **Step 3:** 实现。 **Step 4:** group + PASS。 **Step 5:** lint + commit `feat: Text gradient via TMP VertexGradient`
+
+---
+
+### Task 8: 状态色拓宽（StateColorSet / StateTintReactor / Installer / Btn / Tab / Toggle）
+
+**Files:**
+- Modify: `Runtime/Controls/Internal/StateColorSet.cs` — 槽位 `Color?` → `ColorSpec?`；`Resolve` 拆成两个工厂：
+
+```csharp
+/// <summary>Absolute base overrides — gradients allowed (spec §5).</summary>
+public static StateColorSet ResolveAbsolutes(string hover, string pressed, string selected, string disabled)
+    => new(RSpec(hover), RSpec(pressed), RSpec(selected), RSpec(disabled));
+
+/// <summary>Relative multipliers — solid only; a gradient value throws (spec §6).</summary>
+public static StateColorSet ResolveModulates(string hover, string pressed, string selected, string disabled)
+    => new(RSolid(hover), RSolid(pressed), RSolid(selected), RSolid(disabled));
+
+private static ColorSpec? RSpec(string v)
+    => string.IsNullOrWhiteSpace(v) ? (ColorSpec?)null : UI.Theme.ResolveSpec(v);
+private static ColorSpec? RSolid(string v)
+    => string.IsNullOrWhiteSpace(v) ? (ColorSpec?)null : ColorSpec.Solid(UI.Theme.Resolve(v));
+```
+
+- Modify: `Runtime/Controls/Internal/StateTintReactor.cs`：
+  - `_baseColor`: `Color` → `ColorSpec`；捕获改 `_baseColor = ColorApplier.Peek(_graphic)`（`EnsureInit`，line 53-57）
+  - `_selectedBase`: `Color?` → `ColorSpec?`；`Configure` 参数同步
+  - `BaseFor` 返回 `ColorSpec`；`MultiplierFor` 返回 `Color`（mod 槽恒纯色，取 `.For(state)?.Top ?? white`）
+  - `OnState`：
+
+```csharp
+private void OnState(InteractState state)
+{
+    if (_graphic == null) return;
+    var target = BaseFor(state).Multiply(MultiplierFor(state));   // 预乘，spec §5
+
+    if (_handle.IsActive()) _handle.TryCancel();
+
+    var current = ColorApplier.Peek(_graphic);
+    // Gradients snap (no Color-lerp path for vertex gradients); solid↔solid keeps the tween.
+    if (TestForceInstant || _fade <= 0f
+        || target.IsGradient || current.IsGradient
+        || CrossesTransparency(current.Top, target.Top))
+    {
+        ColorApplier.Apply(_graphic, target);
+        return;
+    }
+
+    _handle = LMotion.Create(_graphic.color, target.Top, _fade)
+        .Bind(_graphic, static (c, g) => g.color = c);
+}
+```
+
+- Modify: `Runtime/Controls/Internal/StateTintInstaller.cs` — `selectedBase` 参数 `Color?` → `ColorSpec?`（line 22、48、76）
+- Modify: `Runtime/Controls/Btn.cs` / `Tab.cs` / `Toggle.cs` 的 `OnAfterApply`：`StateColorSet.Resolve(...)` 调用点 → abs 用 `ResolveAbsolutes`、mod 用 `ResolveModulates`；Tab/Toggle 的 `selectedBase` 解析 `UI.Theme.Resolve(_selectedColor)` → `UI.Theme.ResolveSpec(_selectedColor)`（grep `StateColorSet.Resolve` 找全调用点）
+- Test: `Tests/EditMode/Controls/StateGradientTests.cs`（新建；`StateTintReactor.TestForceInstant = true` 模式参照现有 state-visuals 测试）
+
+- [ ] **Step 1: 失败测试**：
+  - 渐变 `hoverColor`：`<Btn color="#888" hoverColor="#fff,#000">` → 驱动 broadcaster 进 Hover（参照现有 Btn state 测试的驱动方式）→ bg 有 enabled GradientTint(white,black)；回 Normal → disabled、color==#888 还原
+  - 渐变**基色** + 纯色 hoverColor：hover 时 GradientTint disabled、color==hoverColor；回 Normal 渐变还原（验证 Peek 基色捕获）
+  - 渐变基色 × `pressedModulate="#808080"`：Pressed 时 GradientTint 两端 ≈ 基色×0.5（预乘）
+  - 渐变 `selectedColor`（Tab isOn）→ 选中态顶点槽生效，hover 离开后保持
+  - ReSolve 后渐变状态不丢（模拟 re-Configure：参照 47d181b 的既有测试）
+  - `hoverModulate="#fff,#000"` → throw "does not support gradient"
+- [ ] **Step 2:** 红。 **Step 3:** 实现上述全部。 **Step 4:** `group_names=["StateGradientTests"]` + **全量 EditMode**（reactor 是高扇出热点，必须全量）。 **Step 5:** lint + commit `feat: gradient state colors (absolutes + selectedBase)`
+
+---
+
+### Task 9: Lint 规则更新（CLI + runtime 共享）
+
+**Files:**
+- Modify: `Runtime/Core/Lint/ColorLiteralRules.cs` — `Check` 开头先 `TrySplitGradient`：切分失败（>2 段 / 空段）→ 新 issue `PUI-COLOR-GRADIENT-MALFORMED`（静态可查，token 也逃不掉）；切分成功则对每段跑现有 alpha+hex 检查（提取 per-segment local func）。
+- Modify 同文件或新增 `GradientModulateRules.cs`：遍历 `node.Attributes` 中名字以 `Modulate` 结尾的属性，值含 `,` → `PUI-GRADIENT-MODULATE`（"Modulate is a multiplier — gradients are not supported"）。挂进 `IRWalker`（参照现有规则注册方式，纯 dispatch 零运行时成本）。
+- Test: `Tests/EditMode/Lint/`（参照现有 lint 测试文件命名，新建 `GradientLintTests.cs`）
+
+- [ ] **Step 1: 失败测试**：`color="#fff,#000,#111"` → MALFORMED；`color="#fff,#zzz"` → 现有 LITERAL-INVALID（段内）；`color="#fff,#000"` → 无 issue；`hoverModulate="a,b"` → GRADIENT-MODULATE；`hoverColor="a,b"` → 无 issue。
+- [ ] **Step 2:** 红。 **Step 3:** 实现。 **Step 4:** `group_names=["GradientLintTests"]` + 现有 lint 测试类 PASS；另跑 `dotnet run --project .lint/UIXmlLint -- Runtime/Resources/` 确认内置 XML 无新告警。 **Step 5:** lint + commit `feat: lint rules for gradient values`
+
+---
+
+### Task 10: XSD / EditorOnly 校验
+
+**Files:** 预期零改动（颜色属性在 XSD 是 `xs:string`）；若 EditorOnly 套件红了才动 `Editor/` 的 XSD 生成器。
+
+- [ ] **Step 1:** `mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])` → 预期 PASS。红了则按失败的 substring 断言修生成器，再 commit `fix: xsd for gradient values`。
+
+---
+
+### Task 11: SKILL 更新（英文，同 PR）
+
+**Files:**
+- Modify: `.claude/skills/authoring-promptugui-xml/SKILL.md` — Color tokens 一节加：逗号双色语法（第一色在顶）、定义处字面量 only vs 引用处 token+`/alpha`、`token/alpha` 作用于两端、不支持名单（`*Modulate`、char-color、InputField text/placeholder/caret/selection、Carousel dot*）、Text 是 TMP **逐字符**渐变语义、Frame 无 color 不适用。
+- Modify: `.claude/skills/authoring-promptugui-xml/reference/states.md` — `*Color`（含 `selectedColor`）接受渐变 + snap 不 tween；`*Modulate` 不接受。
+
+- [ ] **Step 1:** 写两处文档（对照 spec §2/§5/§6 核对每条）。
+- [ ] **Step 2:** commit `docs: gradient color in XML skill`
+
+---
+
+### Task 12: 全量验证 + PlayMode 冒烟
+
+**Files:**
+- Test: `Tests/PlayMode/` 新增 `GradientPlayTests.cs`（参照 `CarouselPlayTests` 的结构）：开一个 `<Btn color="#fff,#000" hoverModulate="#808080">` 屏，帧循环后断言 GradientTint enabled 且 Btn 可正常点击（EventSystem 真实路径——common-controls sample 的教训：state 链路要在真 play 下走一遍）。
+
+- [ ] **Step 1:** PlayMode 冒烟测试写好跑红→实现为绿（多半零实现，纯验证）。
+- [ ] **Step 2:** 三套全跑（**全量，不带 group**，feedback 教训）：
+  - `run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])`
+  - `run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])`
+  - `run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])`
+  - `read_console(types=["error"])` 零错误
+- [ ] **Step 3:** `cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx` + `dotnet run --project .lint/UIXmlLint -- Runtime/Resources/`
+- [ ] **Step 4:** commit + push 分支 + `gh pr create`（标题 `feat: gradient color value syntax`，body 引 spec 路径，结尾带 Claude Code 署名）。视觉 QA（金字标题 / 渐变按钮 hover）留给用户。
+
+---
+
+## 自检记录
+
+- **Spec 覆盖**：§2 语法→Task 1/3；§2.1 错误→Task 1/2/3/9；§3 值模型→Task 2/3；§4.1 helper→Task 5；§4.2 GradientTint→Task 4；§4.3 Text→Task 7；§5 状态色→Task 8；§6 不支持→Task 3（Resolve throw）+ Task 9（静态）+ Task 6 范围注；§7 ReSolve/Variant→Task 6/8 测试；§8 测试→各 Task + Task 12；§9 SKILL→Task 11。
+- **类型一致性**：`ColorSpec.Solid/Gradient/Multiply/IsGradient/Top/Bottom`、`ResolveSpec`、`ResolveSingle(allowGradientToken)`、`ColorApplier.Apply/Peek`、`GradientTint.Set/Top/Bottom`、`StateColorSet.ResolveAbsolutes/ResolveModulates` 在各 Task 间已对拍。
+- **已知执行期注意**：Task 3 改 `Resolve` 抛错路径后必须全量跑（负例测试可能依赖旧行为）；Task 8 的 `StateColorSet.Resolve` 旧名删除会把所有调用点变编译错——grep 找全（Btn/Tab/Toggle 至少六处）。

--- a/docs~/superpowers/specs/2026-06-13-gradient-color-design.md
+++ b/docs~/superpowers/specs/2026-06-13-gradient-color-design.md
@@ -1,0 +1,153 @@
+# 渐变色支持（颜色值语法扩展，非新属性）
+
+**日期**：2026-06-13
+**状态**：设计阶段（待 review，未进入实施）
+**作用域**：颜色**值语法**新增"逗号分隔双色 = 上下渐变"；不新增任何 XML 属性。所有"给某个 Graphic 上色"的属性（`color` / `frameColor` / `popupColor` / `progColor` / `bgColor` / `hoverColor` / `pressedColor` / `selectedColor` / `disabledColor` …）均接受渐变值。**保持纯色 only**（收到渐变值报错）：`*Modulate`、富文本 char-color、以及天生不是 Graphic 着色的属性——`InputField` 的 `textColor` / `placeholderColor` / `caretColor` / `selectionColor`（caret/selection 是 TMP 的 Color 字段，物理上无顶点可染；可编辑文本渐变无意义）、`Carousel` 的 `dotColor` / `dotSelectedColor`（几像素的圆点，CarouselView 内部以 Color 字段管理）。注：`<Frame>` 是纯容器没有 color 属性，不在范围内。
+**关联**：色值解析 chokepoint 沿用 `/alpha` 后缀的设计（[`UI.Theme.Resolve`](../../Runtime/Application/UI.cs)，PR #51）；状态色叠乘公式 `(abs ?? color) × (mod ?? white)` 来自 PR #45。颜色值语法变化 → `authoring-promptugui-xml` SKILL 必须更新（见 §9）。
+
+---
+
+## 1. 背景与目标
+
+主要需求是 Icon / 文字的渐变着色（标题金字、图标高光），未来扩展到 Frame / Image 大块背景的上下渐变。设计约束：
+
+1. **不加属性**。控件颜色属性已经很多（`hoverColor` / `pressedColor` / `*Modulate` …），渐变作为一种**颜色值写法**进入系统，所有现有属性、Variant 覆写、theme token 自动获得能力。
+2. 像素风游戏中渐变只用于 UI 小面积装饰，**平滑渐变即可**，不做色阶（banding）、不写 shader。
+3. v1 只做**纵向（上→下）双色**。方向 / 多色标留扩展位，不实现。
+
+## 2. 语法
+
+**颜色值含逗号 → 按逗号切成两段，每段独立走现有 token + `/alpha` 解析；第一段为顶部色，第二段为底部色。**
+
+```xml
+<!-- theme token 定义命名渐变（推荐主用法） -->
+<Color name="gold-grad" value="#ffe08a,#b8860b"/>
+
+<!-- 引用：和普通色 token 无区别 -->
+<Text color="gold-grad">标题</Text>
+
+<!-- 内联、token 混用、alpha 后缀均合法 -->
+<Icon name="coin" color="white,#aaa"/>
+<Image color="accent,accent-dark/0.5"/>
+```
+
+注意区分**定义处**与**引用处**：theme token 定义（`<Color value>`）维持今天的"字面量 only"规则——每段只能是 hex / CSS 命名色，不可引用其他 token、不可带 `/alpha`（要半透明用 `#RRGGBBAA`）。token 引用、`/alpha` 后缀、token 混 hex 只发生在属性引用处（`ResolveSpec`）。引用一个渐变 token 再加 `/alpha`（`gold-grad/0.5`）合法：alpha 同时替换两端的 a。
+
+语法选型记录：`A>B`（`>` 在 XML 属性里易被转义成 `&gt;`，且不常见）、`A-B`（与 kebab-case token 名如 `accent-dark` 冲突）、CSS `linear-gradient(A, B)`（语义最通用但太长）均被否决。逗号零歧义（token 名 / hex 中不可能出现）、最短、且正是 CSS 渐变色标的分隔符，对 LLM 作者直觉；未来扩三色 `A,B,C` 顺理成章。
+
+### 2.1 解析错误（全部 parse-time）
+
+| 输入 | 行为 |
+|---|---|
+| 逗号切出 >2 段 | error：目前只支持双色上下渐变 |
+| 任一段解析失败（坏 hex / 未知 token） | 现有单色错误路径，报错指明是哪一段 |
+| 段引用的 token 本身是渐变（`gold-grad,black`） | error：渐变不可嵌套 |
+| 渐变值写在 `*Modulate` / char-color 上 | error：见 §6 |
+| 空段（`a,` / `,b` / `,`） | error：渐变两段均不可为空 |
+
+## 3. 值模型
+
+```csharp
+// Runtime/Application/ColorSpec.cs。不能放 Core/Parser/：UIXmlLint CLI 把
+// Core/Parser/** 整个编译进纯 .NET 可执行文件，UnityEngine.Color 进不去。
+// 逗号切分的纯字符串逻辑（TrySplitGradient）放 ColorParser，lint 共享。
+internal readonly struct ColorSpec
+{
+    public readonly Color Top;
+    public readonly Color Bottom;   // 纯色时 == Top
+    public readonly bool IsGradient;
+}
+```
+
+- `UI.Theme` 新增 **internal** `ResolveSpec(string) → ColorSpec`：含逗号走渐变路径，否则等价于现有 `Resolve` 包成纯色 `ColorSpec`。不进公共 API 面（控件同程序集直接调）。
+- 现有 `public Color Resolve(string)` 保留，签名不变；输入含逗号时 throw "this attribute does not support gradients"——不支持渐变的属性（`*Modulate` 等）继续调它，错误信息自动正确。
+- **ThemeStore**：token 条目从 `Color` 拓宽为 `ColorSpec`，`LookupChained` 返回 `ColorSpec?`。渐变段引用 token 时只接受纯色结果（否则 §2.1 嵌套错误）。
+- 现有 soft-fail 行为保持：theme 未注册时 token 解析回退 `white`（纯色 ColorSpec），Theme.Changed 后 ReSolve 重算。
+
+## 4. 应用机制
+
+### 4.1 统一 helper（一档属性的"免费"来源）
+
+```csharp
+// Runtime/Controls/Internal/ColorApplier.cs
+internal static void Apply(Graphic g, ColorSpec spec)
+```
+
+- 纯色：`g.color = spec.Top`；若挂过 `GradientTint` 则 `enabled = false`。
+- 渐变：`g.color = Color.white`（把 Graphic.color 槽让给乘数，见 §5）；lazy-add `GradientTint`，写入 Top/Bottom，`enabled = true`。
+- **绝不 Destroy**（Variant / ReSolve 往返只 toggle，遵循 `ApplyViewportMask` 先例）。
+
+所有"直接给某个 Graphic 上色"的 setter（`Image.color`、`Icon.color`、`Frame.color`、`frameColor`、`popupColor`、`progColor`、`bgColor` …）改为调 helper，渐变全线生效，每属性边际成本≈一行。
+
+### 4.2 GradientTint（Image / Icon / Frame 及一切非文本 Graphic）
+
+`GradientTint : BaseMeshEffect`（`Runtime/Controls/Internal/`）：
+
+- `ModifyMesh` 先扫一遍顶点求 Y 范围（Sliced / Tiled 顶点数 >4，不能假设顺序），再按 `(y - minY) / (maxY - minY)` 归一化插值 `Lerp(Bottom, Top, t)`，**乘进**现有顶点色（`v.color *=`）。
+- 乘法保证最终合成为 `纹理 × Graphic.color × 顶点渐变`——渐变占"基础色"槽，`Graphic.color` 留给状态乘数，两者天然正交（见 §5）。
+- Top/Bottom 变更时 `SetVerticesDirty()`。
+- 仅在 mesh rebuild 时执行，无逐帧成本。
+
+### 4.3 Text（TMP 原生）
+
+不走 mesh effect，直接用 TMP 自带能力：
+
+- 渐变：`enableVertexGradient = true`，`colorGradient = new VertexGradient(Top, Top, Bottom, Bottom)`，`color = Color.white`。
+- 纯色回退：`enableVertexGradient = false`，`color = spec.Top`。
+- **语义注意**：TMP 的 VertexGradient 是**逐字符**渐变——每个字各自上 Top 下 Bottom（标题金字正是要这个效果），不是整段文本块从上到下。写进 SKILL。
+
+Markdown / Toast / 模态等复用 Text / Image 控件的地方自动继承，无额外工作。
+
+## 5. 状态色组合（二档：类型拓宽）
+
+`StateColorSet`（`Runtime/Controls/Internal/StateColorSet.cs`）四个槽从 `Color?` 拓宽为 `ColorSpec?`。**注意它被 `StateTintReactor` 两用**：一份装绝对基色（abs），一份装乘数（mod）——`Resolve` 需要区分两种模式：abs 集合走 `Theme.ResolveSpec`（接受渐变），mod 集合走旧 `Theme.Resolve`（遇逗号即按 §6 报错），例如 `Resolve(..., allowGradient:)` 或拆两个工厂方法。`StateTintReactor` 应用规则：
+
+| 槽位 | 现在 | 改后 |
+|---|---|---|
+| 绝对基色 abs（`hoverColor` 等，仅 targetGraphic） | 写 `Graphic.color` | 走 `ColorApplier.Apply`：纯色照旧；渐变 → 顶点槽 |
+| 乘数 mod（`*Modulate`，子树扇出） | 乘进 `Graphic.color` | 不变（拒绝渐变，§6） |
+
+合成公式不变：`最终 = 纹理 × (mod ?? white) × 基色`。实现上 reactor 直接把 mod **预乘**进基色两端（`ColorSpec(Top×m, Bottom×m)`）再交 `ColorApplier.Apply`——纯色路径退化为现状逐位相乘，渐变路径落顶点槽 + `Graphic.color=white`，视觉等价、簿记单一。reactor 的基色捕获改为 `ColorApplier.Peek(graphic)`（GradientTint enabled 时读它，否则读 `graphic.color`），否则作者渐变基色会被捕获成 white。状态切换的颜色 tween 仅在"from、to 均为纯色"时保留，任一端是渐变即 snap（沿用 CrossesTransparency 的 snap 先例）。状态切换时 reactor 调 helper 换槽——纯色基色 + 渐变 hoverColor、渐变基色 + 纯色 hoverColor 的混合往返都由 helper 的 enable/disable 收口。现有"re-Configure 时 `OnState(_source.Current)` 重刷"（47d181b）保证 ReSolve 后渐变状态色不丢。
+
+`selectedSprite` / `pressedSprite` / `disabledSprite`（overrideSprite 换图）与本设计正交，不动。
+
+## 6. 明确不支持（parse error，非静默降级）
+
+| 目标 | 原因 | 错误信息要点 |
+|---|---|---|
+| `*Modulate`（`hoverModulate` 等） | 乘数的实现就是 `Graphic.color` 槽 + 子树扇出；渐变乘数需双重逐顶点乘法，且"按住时上深下浅变暗"无真实需求 | "Modulate 是乘数，不支持渐变" |
+| 富文本 char-color（`<c=>` 段内色） | 需逐字符段写顶点色，TMP 另一套实现 | "char-color 不支持渐变" |
+
+收到渐变值时报错而不是取 Top 色——静默降级会让作者以为写法生效了。
+
+## 7. ReSolve / Variant / 运行时往返
+
+- 渐变是**值**，`color.mobile="a,b"` 等 Variant 覆写走同一 setter，零额外逻辑。
+- ReSolve 重放属性 → setter 调 helper → enable/disable 幂等，无 GameObject 重建。
+- `GradientTint` 组件一旦创建跟随 Graphic 存活整个 Screen 生命周期（同 Add 块 Strategy C 哲学）。
+
+## 8. 测试
+
+EditMode（沿用 `UI.ResetForTests` 约定）：
+
+1. **解析**：逗号切分；每段 token / hex / `/alpha` 组合；§2.1 全部错误用例；`Resolve`（旧签名）遇逗号 throw。
+2. **ThemeStore**：渐变 token 注册 / 链式查找 / 嵌套渐变报错；soft-fail 回退 white。
+3. **ColorApplier**：纯色↔渐变往返（enabled toggle、不 Destroy）；`Graphic.color` 槽让位正确。
+4. **GradientTint**：Simple 4 顶点上下两色断言；Sliced 多顶点按 Y 归一化连续；与 `Graphic.color` 乘法叠加。
+5. **Text**：VertexGradient 赋值 / 纯色回退 `enableVertexGradient=false`。
+6. **状态色**：渐变 `hoverColor` 进 hover 换顶点槽、回 Normal 还原；渐变基色 × 纯色 `pressedModulate` 叠乘；ReSolve 后状态渐变不丢（OnState 重刷路径）。
+7. **XSD**：颜色属性仍为 string，生成器无 pattern 收紧即可（substring 断言确认无回归）。
+
+PlayMode：一条渐变 Btn hover/pressed 交互冒烟（EventSystem 真实路径，参照 common-controls sample 的教训）。
+
+## 9. SKILL 更新（同 PR，英文）
+
+- `authoring-promptugui-xml/SKILL.md` Color tokens 一节：逗号渐变语法、第一色在顶、token / 内联 / alpha 后缀组合、不支持名单（`*Modulate` / char-color）、TMP 逐字符语义。
+- `authoring-promptugui-xml/reference/states.md`：`*Color` 接受渐变、`*Modulate` 不接受。
+- C# skill 不更新：`ColorSpec` / `ResolveSpec` 均 internal，公共 API 面零变化。
+
+## 10. 不做的事（YAGNI 记录）
+
+- 方向（横向 / 角度）、≥3 色标、径向渐变——语法已留位（逗号天然可扩段数；方向可加后缀），实现等真实需求。
+- 色阶 / dithering shader——像素风顾虑确认过：仅用于 UI 小面积，平滑可接受。
+- 渐变 Modulate、char-color 渐变——见 §6。


### PR DESCRIPTION
## 概要

颜色**值语法**新增"逗号分隔双色 = 上下纵向渐变"（`color="#ffe08a,#b8860b"`，第一色在顶）。这是值语法扩展，**不新增任何 XML 属性**——所有给 Graphic 上色的属性、状态色、theme token、Variant 覆写自动获得渐变能力。

主用法：theme 里定义命名渐变 token，控件按名引用。
```xml
<Color name="gold-grad" value="#ffe08a,#b8860b"/>
<Text color="gold-grad">标题</Text>
<Image color="accent,accent-dark/0.5"/>   <!-- 内联 + token + /alpha 混用 -->
```

## 设计与实现

- **解析层**：`ColorParser.TrySplitGradient`（纯 C#，lint 共享）→ `ColorSpec`（solid|gradient 值模型）→ `UI.Theme.ResolveSpec`（渐变感知）；旧 `Resolve` 遇渐变 throw，使纯色-only 属性自动拒绝。`<Color value>` 定义处逐段字面量校验。
- **应用层**：`GradientTint : BaseMeshEffect` 把渐变乘进顶点色（保留 `texture × Graphic.color × gradient` 合成，`Graphic.color` 槽留给状态乘数）；`ColorApplier.Apply/Peek` 是 solid|gradient 收口；15 处 Graphic 上色 setter 切到此 chokepoint。
- **Text**：用 TMP 原生 `colorGradient`（**逐字符**渐变，适合标题金字）。
- **状态色**：`StateColorSet` 拓宽为 `ColorSpec`，`StateTintReactor` base 经 `Peek` 捕获 + 预乘 modulate + 渐变端点 snap（无 fade）；`hoverColor`/`pressedColor`/`selectedColor`/`disabledColor` 支持渐变，`*Modulate` 保持纯色（遇渐变报错）。
- **不支持**（明确报错，非静默降级）：`*Modulate`、`char-color`、InputField text/placeholder/caret/selection、Carousel dots。
- **Lint**：`PUI-COLOR-GRADIENT-MALFORMED`（color 形状）+ `PUI-GRADIENT-MODULATE`（modulate 上的渐变）。
- **文档**：XML SKILL Color Tokens 新增 `### Gradients` + states.md。

设计/计划：`docs~/superpowers/specs|plans/2026-06-13-gradient-color*.md`。

## 测试

- EditMode **1751/1751**、EditorOnly **267/267**、PlayMode **137/137**（含新增渐变 Btn 冒烟）全绿
- UIXmlLint CLI 对内置 XML 无新告警；`dotnet format` clean
- 16 commits，逐任务 TDD（red→green）+ 两段评审 + opus 整体终审（Ready for PR）

## 视觉 QA（待用户）

- [ ] 金字标题（`<Text color="gold-grad">`）逐字符渐变观感
- [ ] 渐变背景 Btn 的 hover/pressed（gradient base × solid modulate）
- [ ] 渐变 Frame/Image 大色块上下过渡在像素风下的协调度

🤖 Generated with [Claude Code](https://claude.com/claude-code)