### PR TITLE
feat: Carousel peek 模式 + CenteredSlideBox 居中选择器模态

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -98,7 +98,7 @@ Pre-registered on `UI.Registry`. Use as XML tags by name. 速查目录如下；�
 | `<Progress>` | 只读线性进度条 |
 | `<TabBar>` | 互斥选项卡容器 |
 | `<Tab>` | 选项卡（`bind` 显隐 `<Frame>`） |
-| `<Carousel>` | 翻页轮播卡 |
+| `<Carousel>` | 翻页轮播卡（+ `fill="false"` 居中选择器） |
 | `<Show>` | 按状态显隐子树的无视觉 wrapper |
 | `<Markdown>` | Renders a Markdown document into a scrollable subtree  |
 
@@ -340,7 +340,7 @@ Tab 容器；私有 `ToggleGroup`（`allowSwitchOff=false`）+ `Horizontal` / `V
 
 ### `<Carousel>`
 
-水平翻页轮播卡容器：自动播放 + 拖动 + 无限循环 + 状态化指示点。卡片用 `itemTemplate` + C# `BindItems`（同 ScrollList / TabBar）或静态子卡。每张卡排成视口大小——卡片**不能**写 `anchor` / `margin` / `size`（`PUI-LAYOUT-ANCHOR` / `PUI-LAYOUT-MARGIN` / `PUI-CAROUSEL-CARD-SIZE`）。当前页 `current` 是**运行期独占状态**（resize / Variant / Theme 不重置）。**详见 [`reference/controls-carousel.md`](reference/controls-carousel.md)。**
+水平翻页轮播卡容器：自动播放 + 拖动 + 无限循环 + 状态化指示点。卡片用 `itemTemplate` + C# `BindItems`（同 ScrollList / TabBar）或静态子卡。默认 `fill="true"` 每张卡排成视口大小，卡片**不能**写 `size`（`PUI-CAROUSEL-CARD-SIZE`）；`fill="false"` 切「居中选择器」——卡片用自身 `size`、邻卡两侧露出、焦点卡可放大(`edgeScale`)/相邻渐隐(`edgeAlpha`)。卡片始终不能写 `anchor` / `margin`（`PUI-LAYOUT-ANCHOR` / `PUI-LAYOUT-MARGIN`）。当前页 `current` 是**运行期独占状态**（resize / Variant / Theme 不重置）。**详见 [`reference/controls-carousel.md`](reference/controls-carousel.md)。**
 
 | 属性 | 类型 / 取值 | 默认 | 说明 |
 |---|---|---|---|
@@ -348,6 +348,10 @@ Tab 容器；私有 `ToggleGroup`（`allowSwitchOff=false`）+ `Horizontal` / `V
 | `interval` | 秒 | `5` | `0`=关自动播放 |
 | `loop` | bool | `true` | |
 | `transition` | 秒 | `0.3` | 吸附补间 |
+| `fill` | bool | `true` | `false`=居中选择器（卡用自身 `size`，邻卡露出）；仅 `false` 时 `spacing`/`edgeScale`/`edgeAlpha` 生效 |
+| `spacing` | px | `0` | 相邻卡间距（仅 `fill="false"`） |
+| `edgeScale` | float | `1.0` | 边卡缩放，焦点卡 1，按距中心插值（仅 `fill="false"`） |
+| `edgeAlpha` | float | `1.0` | 边卡不透明度，焦点卡 1，按距中心插值（仅 `fill="false"`） |
 | `current` | int | — | 初始页；runtime-owned |
 | `dots` | anchor 关键字（如 `bottom-center`） | — | 空 / `none`=不显示；非法 → runtime 回退 `bottom-center` + `PUI-CAROUSEL-DOTS-ANCHOR` |
 | `dotSize` | `WxH` | `8x8` | |

--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -352,6 +352,7 @@ Tab 容器；私有 `ToggleGroup`（`allowSwitchOff=false`）+ `Horizontal` / `V
 | `spacing` | px | `0` | 相邻卡间距（仅 `fill="false"`） |
 | `edgeScale` | float | `1.0` | 边卡缩放，焦点卡 1，按距中心插值（仅 `fill="false"`） |
 | `edgeAlpha` | float | `1.0` | 边卡不透明度，焦点卡 1，按距中心插值（仅 `fill="false"`） |
+| `softness` | int | `0` | 视口左右边缘羽化淡出宽度（写视口 `RectMask2D.softness.x`，设计单位）：靠近视口边缘的卡片**像素**渐隐——空间淡出（溶进背景），区别于 `edgeAlpha` 的整卡变暗。不被 `fill` 门控 |
 | `current` | int | — | 初始页；runtime-owned |
 | `dots` | anchor 关键字（如 `bottom-center`） | — | 空 / `none`=不显示；非法 → runtime 回退 `bottom-center` + `PUI-CAROUSEL-DOTS-ANCHOR` |
 | `dotSize` | `WxH` | `8x8` | |

--- a/.claude/skills/authoring-promptugui-xml/reference/controls-carousel.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/controls-carousel.md
@@ -85,7 +85,7 @@ screen.Get<Carousel>("banner")
 ```xml
 <Frame anchor="stretch" color="black">          <!-- 全黑底 -->
   <Carousel id="sel" anchor="center" size="600x360"
-            fill="false" spacing="24" edgeScale="0.8" edgeAlpha="0.45"
+            fill="false" spacing="24" edgeScale="0.8" softness="120"
             interval="0" itemTemplate="LevelCard"
             dots="bottom-center" dotSprite="ui:dot"/>
   <!-- 左右翻页箭头：C# 端绑 car.Previous()/Next()，无需库改动 -->
@@ -107,6 +107,7 @@ screen.Get<Carousel>("banner")
 - **卡片必须有尺寸**：卡根写 `size=`（裸 `<Frame>`），或用自带原生尺寸的控件（`<Image>` = sprite 尺寸、`<Text>` = 量出）。无尺寸的容器卡（`Frame`/`VStack`/`HStack`/`Grid`）会兜成视口、不 peek（lint `PUI-CAROUSEL-PEEK-NO-SIZE` 提示）。
 - **peek 露出多少 = `(carousel 宽 − 卡宽)/2 − spacing`**，由卡尺寸 vs carousel 尺寸**隐式**决定，没有单独的 peek 属性。
 - `edgeScale`（默认 `1.0`）/ `edgeAlpha`（默认 `1.0`）：基准是**选中卡**——中心 = 声明尺寸 / 不透明，按距中心距离线性插值到边值。`1.0` = 无效果；`<1` 缩 / 淡；`edgeScale>1` 也允许（放大邻卡）。
+- `softness`（默认 `0`，设计单位 int）：视口**左右边缘的羽化淡出宽度**，直接写视口 `RectMask2D.softness.x`——靠近视口边缘的卡片**像素**渐隐（空间淡出、溶进背景），区别于 `edgeAlpha` 的「整卡按第几张统一变暗」。典型配 `fill="false"` 全屏选择器做边缘 fade（`CenteredSlideBox` 默认皮肤即用它）。注意它**不被 `fill` 门控**（直接作用于视口遮罩），但只有卡片溢出到视口边缘时才看得到。
 - `spacing`（默认 `0`，px）：相邻卡间距，步距 = 卡宽 + spacing。
 - 这三个属性**仅 `fill="false"` 生效**；`fill="true"` 下被忽略，行为与 v1 全幅逐字等价（变体把 fill 切回 true 也会复位缩放/透明）。
 - `fill="false"` 下 Carousel 占用卡根的 `localScale`（做 `edgeScale`）；卡根别再写 density `scale=`，要缩放写卡的里层节点。

--- a/.claude/skills/authoring-promptugui-xml/reference/controls-carousel.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/controls-carousel.md
@@ -64,7 +64,7 @@ screen.Get<Carousel>("banner")
 
 ## 卡片布局约束
 
-每张卡的 `RectTransform` 由控件内部排版——卡片不能写 `anchor` / `margin`（lint `PUI-LAYOUT-ANCHOR` / `PUI-LAYOUT-MARGIN`）或 `size`/`width`/`height`（lint **`PUI-CAROUSEL-CARD-SIZE`**，error）。
+每张卡的 `RectTransform` 由控件内部排版——卡片不能写 `anchor` / `margin`（lint `PUI-LAYOUT-ANCHOR` / `PUI-LAYOUT-MARGIN`）。默认 `fill="true"`（全幅翻页）下卡片也不能写 `size`/`width`/`height`（lint **`PUI-CAROUSEL-CARD-SIZE`**，error）——控件把每张卡撑满视口；`fill="false"`（peek，见下）反过来**要求**卡片自带尺寸。
 
 ```xml
 <!-- WRONG — 卡片自己写了 anchor，会触发 PUI-LAYOUT-ANCHOR -->
@@ -78,6 +78,40 @@ screen.Get<Carousel>("banner")
 </Carousel>
 ```
 
+## 居中选择 / peek 模式（`fill="false"`）
+
+默认 `fill="true"`：卡片撑满视口、一卡一页（banner，上面的用例）。`fill="false"` 切到**居中卡片选择器**——卡片用自身 `size`、两侧邻卡露出、焦点卡可放大、越往边越淡：
+
+```xml
+<Frame anchor="stretch" color="black">          <!-- 全黑底 -->
+  <Carousel id="sel" anchor="center" size="600x360"
+            fill="false" spacing="24" edgeScale="0.8" edgeAlpha="0.45"
+            interval="0" itemTemplate="LevelCard"
+            dots="bottom-center" dotSprite="ui:dot"/>
+  <!-- 左右翻页箭头：C# 端绑 car.Previous()/Next()，无需库改动 -->
+  <Btn id="prev" anchor="center-left"  size="48x48" margin="_,_,_,16">‹</Btn>
+  <Btn id="next" anchor="center-right" size="48x48" margin="_,16,_,_">›</Btn>
+</Frame>
+```
+
+```xml
+<Template name="LevelCard">
+  <Param name="title"/>
+  <Frame size="240x320">                         <!-- 焦点卡尺寸；fill=false 下卡片必须自定尺寸 -->
+    <Image anchor="stretch" sprite="ui:card_bg"/>
+    <Text id="title" anchor="bottom-stretch" height="40" align="center">{{title}}</Text>
+  </Frame>
+</Template>
+```
+
+- **卡片必须有尺寸**：卡根写 `size=`（裸 `<Frame>`），或用自带原生尺寸的控件（`<Image>` = sprite 尺寸、`<Text>` = 量出）。无尺寸的容器卡（`Frame`/`VStack`/`HStack`/`Grid`）会兜成视口、不 peek（lint `PUI-CAROUSEL-PEEK-NO-SIZE` 提示）。
+- **peek 露出多少 = `(carousel 宽 − 卡宽)/2 − spacing`**，由卡尺寸 vs carousel 尺寸**隐式**决定，没有单独的 peek 属性。
+- `edgeScale`（默认 `1.0`）/ `edgeAlpha`（默认 `1.0`）：基准是**选中卡**——中心 = 声明尺寸 / 不透明，按距中心距离线性插值到边值。`1.0` = 无效果；`<1` 缩 / 淡；`edgeScale>1` 也允许（放大邻卡）。
+- `spacing`（默认 `0`，px）：相邻卡间距，步距 = 卡宽 + spacing。
+- 这三个属性**仅 `fill="false"` 生效**；`fill="true"` 下被忽略，行为与 v1 全幅逐字等价（变体把 fill 切回 true 也会复位缩放/透明）。
+- `fill="false"` 下 Carousel 占用卡根的 `localScale`（做 `edgeScale`）；卡根别再写 density `scale=`，要缩放写卡的里层节点。
+- autoplay 与 fill 正交：选择器自己写 `interval="0"`。左右箭头 = `<Btn>` 绑 C# `car.Previous()` / `car.Next()`。
+
 ## `current` 是运行期独占状态
 
 `current=` 的值是**初始页**；一旦用户或代码在运行期切换了页面，resize / Variant / Theme 切换都不会把它打回声明值。`current.<variant>` 仍然有效：只要运行期没动过，切到该 Variant 会正常重应用覆盖值；动过之后用户的选择优先（同 Tab `isOn`）。
@@ -86,7 +120,8 @@ screen.Get<Carousel>("banner")
 
 | Code                        | 触发条件                                                                     | 级别    |
 | --------------------------- | ---------------------------------------------------------------------------- | ------- |
-| `PUI-CAROUSEL-CARD-SIZE`    | `<Carousel>` 的直接子卡写了 `size`/`width`/`height`                         | error   |
+| `PUI-CAROUSEL-CARD-SIZE`    | `<Carousel>`（`fill` 非 `"false"`，即默认全幅）的直接子卡写了 `size`/`width`/`height` | error   |
+| `PUI-CAROUSEL-PEEK-NO-SIZE` | `fill="false"` 的卡根是无原生尺寸容器（`Frame`/`VStack`/`HStack`/`Grid`）且没写 `size`（会兜成视口、不 peek） | warning |
 | `PUI-CAROUSEL-DOTS-ANCHOR`  | `dots=` 值不是合法的 anchor 关键字（如 `dots="center-center-wrong"`）        | warning（runtime 回退 `bottom-center`） |
 
 （`anchor`/`margin` 违规已由通用规则 `PUI-LAYOUT-ANCHOR` / `PUI-LAYOUT-MARGIN` 覆盖，Carousel 不额外重复）

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -593,7 +593,11 @@ MODAL          var r = await MessageBox.Open(text, MsgBtn.OK|MsgBtn.Cancel, icon
                await MarkdownBox.Open(loader, title, ...)  // loader: Func<CT,Awaitable<string>>
                               // 先显示 loadingText 占位,完成后热替换;关窗自动取消 loader 的 ct
                await MarkdownBox.OpenUrl(url, title, ...)  // 裸 GET 糖;鉴权内容用 Open(loader)
-               configure:     Action<IScreen> trailing arg on every Open (MessageBox/InputBox/Loading/MarkdownBox)
+               var lv = await CenteredSlideBox.Open(items, bind, title, confirmLabel, mode, configure, ct)
+                              // 居中卡片选择器(关卡/角色弹窗,内含 fill=false peek Carousel);T:class
+                              // 返回选中对象(取消 ×/背景/ESC → null);bind 填内置卡槽 cover/name(同 BindItems)
+                              // 点侧卡居中,点居中卡 or 确认按钮 = 确认;换皮 CenteredSlideBox.XmlSrc 指自己 XML
+               configure:     Action<IScreen> trailing arg on every Open (MessageBox/InputBox/Loading/MarkdownBox/CenteredSlideBox)
                               // post-bind hook → live Screen; reach any control w/o subclassing
                               // e.g. InputBox.Open(t, configure: s => s.Get<Btn>("ok").Interactable = false)
                               // base ModalRequest<T>.Configure field → custom modals get it free
@@ -605,6 +609,7 @@ MODAL          var r = await MessageBox.Open(text, MsgBtn.OK|MsgBtn.Cancel, icon
                               (do NOT call LoadDocument manually — auto via ModalDocCache.EnsureLoaded)
                required ids   text  title  ok  cancel  yes  no  close   (icon optional)
                               MarkdownBox required ids: title  markdown  close  backdrop  (backdrop = Image, click closes)
+                              CenteredSlideBox required ids: title  close  confirm  cards(Carousel fill=false itemTemplate)  backdrop  + 卡槽(默认 cover/name)
                backdrop       author writes <Image anchor="stretch"/> — NOT auto-injected
                UI.Modal.OpenAsync(new MyRequest(), ModalMode.Popup) custom ModalRequest<T>
                               override TryEscape(out T) to map ESC → result

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -712,6 +712,9 @@ var level = await CenteredSlideBox.Open(levels,
     title: UI.Tr("Select level"));
 if (level != null) game.StartLevel(level);            // got the whole object; id = level.Id
 
+// Default skin is a FINITE list (no wrap-around). Want a looping carousel instead?
+//   configure: s => s.Get<Carousel>("cards").Loop = true
+
 // Different card style? point CenteredSlideBox.XmlSrc at your own .ui, keeping the id
 // contract: backdrop / panel / title / close / confirm / cards (Carousel fill="false")
 // + your card template's slots.

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -649,10 +649,11 @@ ROUTER         UI.Router.Scheme = "myapp"                   optional scheme enfo
 
 ## Modal dialogs
 
-PromptUGUI ships a generic modal stack in `PromptUGUI.Application.Modals` plus four
+PromptUGUI ships a generic modal stack in `PromptUGUI.Application.Modals` plus five
 builtin overlays: a `MessageBox` dialog, an `InputBox` text prompt, a `MarkdownBox`
 read-only rich-text viewer (announcements / mail, built on the `<Markdown>` control),
-and a `Loading` spinner. **Every modal IS a real
+a `CenteredSlideBox` card selector (level / character picker, built on the `fill="false"`
+peek `<Carousel>`), and a `Loading` spinner. **Every modal IS a real
 `Screen` instantiated from `.ui.xml`** — anchor / margin / Variant / locale / `<Icon>`
 all work normally. The modal subsystem only adds: stack management, ESC handling, and a
 sortingOrder band above regular Screens.
@@ -698,6 +699,22 @@ await MarkdownBox.OpenUrl("https://cdn.example.com/notice.md", title: UI.Tr("Not
 
 // Authenticated content: bring your own loader (the ct is cancelled on close).
 await MarkdownBox.Open(ct => Api.FetchMailBodyAsync(mailId, ct), title: mail.Subject);
+
+// CenteredSlideBox: centered card selector (level / character picker). Generic items +
+// a bind callback (same shape as Carousel.BindItems). Returns the SELECTED item on
+// confirm, null on cancel (× / backdrop / ESC). Tap a side card to centre it; tap the
+// centred card or the confirm button to pick it. T must be a reference type.
+var level = await CenteredSlideBox.Open(levels,
+    bind: (card, lv) => {
+        card.Get<Text>("name").TextValue = lv.Name;   // fill the built-in card slots
+        card.Get<Image>("cover").Sprite  = lv.Cover;
+    },
+    title: UI.Tr("Select level"));
+if (level != null) game.StartLevel(level);            // got the whole object; id = level.Id
+
+// Different card style? point CenteredSlideBox.XmlSrc at your own .ui, keeping the id
+// contract: backdrop / panel / title / close / confirm / cards (Carousel fill="false")
+// + your card template's slots.
 ```
 
 ### API surface (`PromptUGUI.Application.Modals`)

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -288,6 +288,8 @@ car.OnCurrentChanged
    .AddTo(screen);                 // Observable<int>：任意来源的页变化，dedup 相同值
 ```
 
+> 居中选择器（`<Carousel fill="false">`，见 XML skill）的左右翻页箭头：放两个 `<Btn>`，`OnClick` 绑 `car.Previous()` / `car.Next()`——已是 public 方法，无需新 API。
+
 `current` is a **runtime-owned state** (same as Tab `isOn`): resize / Variant / Theme ReSolve does NOT reset the page. `current.<variant>` initial overrides still apply when the user has not navigated at runtime; once navigated, the user's choice wins.
 
 ### Markdown

--- a/Runtime/Application/Modals/CenteredSlideBoxRequest.cs
+++ b/Runtime/Application/Modals/CenteredSlideBoxRequest.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using PromptUGUI.Controls;
+using R3;
+
+namespace PromptUGUI.Application.Modals
+{
+    public sealed class CenteredSlideBoxRequest<T> : ModalRequest<T> where T : class
+    {
+        public IReadOnlyList<T> Items;
+        public Action<IControl, T> BindCard;
+        public string Title;
+        public string ConfirmLabel;
+        public string XmlSrcOverride;                       // 命名变体 facade 可传；null→静态默认
+
+        public override string XmlSrc => XmlSrcOverride ?? CenteredSlideBox.XmlSrc;
+
+        public override void Bind(IScreen screen, Action<T> close)
+        {
+            var titleCtl = screen.Get<Text>("title");
+            if (string.IsNullOrEmpty(Title)) titleCtl.GameObject.SetActive(false);
+            else titleCtl.TextValue = Title;
+
+            // 取消通道：×（背景 / ESC 在后续 Task 接）
+            screen.Get<Btn>("close").OnClick.Subscribe(_ => close(null)).AddTo(screen);
+
+            // null Items 视作空（Open(null,…) 不该在 Carousel.Rebuild 里 NRE；空列表「禁确认」是 Task 4）
+            Items ??= System.Array.Empty<T>();
+
+            var car = screen.Get<Carousel>("cards");
+            car.BindItems(
+                Observable.Return((IReadOnlyList<T>)Items),
+                (IControl card, T item) =>
+                {
+                    BindCard?.Invoke(card, item);
+                    // 卡片点击（A+C）在 Task 3 接：那时引入 per-card index + AttachCardClick
+                }).AddTo(screen);
+
+            var ok = screen.Get<Btn>("confirm");
+            if (!string.IsNullOrEmpty(ConfirmLabel)) ok.Text = ConfirmLabel;
+            ok.OnClick.Subscribe(_ =>
+            {
+                int cur = car.Current;
+                if (cur >= 0 && cur < Items.Count) close(Items[cur]);
+            }).AddTo(screen);
+        }
+    }
+
+    public static class CenteredSlideBox
+    {
+        // 必须带 .ui 后缀（Unity 只剥 .ui.xml 的最后 .xml）。可写 = 换皮入口。
+        public static string XmlSrc { get; set; } = "PromptUGUI/Modals/CenteredSlideBox.ui";
+
+        public static UnityEngine.Awaitable<T> Open<T>(
+            IReadOnlyList<T> items,
+            Action<IControl, T> bind,
+            string title = null,
+            string confirmLabel = null,
+            ModalMode mode = ModalMode.Popup,
+            Action<IScreen> configure = null,
+            System.Threading.CancellationToken ct = default
+        ) where T : class
+            => UI.Modal.OpenAsync(new CenteredSlideBoxRequest<T>
+            {
+                Items = items,
+                BindCard = bind,
+                Title = title,
+                ConfirmLabel = confirmLabel,
+                Configure = configure,
+            }, mode, ct);
+    }
+}

--- a/Runtime/Application/Modals/CenteredSlideBoxRequest.cs
+++ b/Runtime/Application/Modals/CenteredSlideBoxRequest.cs
@@ -46,6 +46,7 @@ namespace PromptUGUI.Application.Modals
 
             var ok = screen.Get<Btn>("confirm");
             if (!string.IsNullOrEmpty(ConfirmLabel)) ok.Text = ConfirmLabel;
+            if (Items.Count == 0) ok.Interactable = false;
             ok.OnClick.Subscribe(_ =>
             {
                 int cur = car.Current;

--- a/Runtime/Application/Modals/CenteredSlideBoxRequest.cs
+++ b/Runtime/Application/Modals/CenteredSlideBoxRequest.cs
@@ -15,14 +15,18 @@ namespace PromptUGUI.Application.Modals
 
         public override string XmlSrc => XmlSrcOverride ?? CenteredSlideBox.XmlSrc;
 
+        public override bool TryEscape(out T result) { result = null; return true; }
+
         public override void Bind(IScreen screen, Action<T> close)
         {
             var titleCtl = screen.Get<Text>("title");
             if (string.IsNullOrEmpty(Title)) titleCtl.GameObject.SetActive(false);
             else titleCtl.TextValue = Title;
 
-            // 取消通道：×（背景 / ESC 在后续 Task 接）
+            // 取消通道：× / 背景 / ESC → null
             screen.Get<Btn>("close").OnClick.Subscribe(_ => close(null)).AddTo(screen);
+            screen.Get<PromptUGUI.Controls.Image>("backdrop")
+                .OnPointerDown.Subscribe(_ => close(null)).AddTo(screen);
 
             // null Items 视作空（Open(null,…) 不该在 Carousel.Rebuild 里 NRE；空列表「禁确认」是 Task 4）
             Items ??= System.Array.Empty<T>();

--- a/Runtime/Application/Modals/CenteredSlideBoxRequest.cs
+++ b/Runtime/Application/Modals/CenteredSlideBoxRequest.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
 using R3;
+using UnityImage = UnityEngine.UI.Image;
 
 namespace PromptUGUI.Application.Modals
 {
@@ -32,12 +34,14 @@ namespace PromptUGUI.Application.Modals
             Items ??= System.Array.Empty<T>();
 
             var car = screen.Get<Carousel>("cards");
+            int idx = 0;
             car.BindItems(
                 Observable.Return((IReadOnlyList<T>)Items),
                 (IControl card, T item) =>
                 {
+                    int i = idx++;
                     BindCard?.Invoke(card, item);
-                    // 卡片点击（A+C）在 Task 3 接：那时引入 per-card index + AttachCardClick
+                    AttachCardClick(card, i, car, close);
                 }).AddTo(screen);
 
             var ok = screen.Get<Btn>("confirm");
@@ -47,6 +51,24 @@ namespace PromptUGUI.Application.Modals
                 int cur = car.Current;
                 if (cur >= 0 && cur < Items.Count) close(Items[cur]);
             }).AddTo(screen);
+        }
+
+        // 每张卡挂透明 raycast catcher + PuiButton：click(非拖动) → 居中或确认。
+        // 点居中卡 = 确认；点侧卡 = GoTo 居中。拖动不被 PuiButton 处理 → 冒泡给 CarouselView。
+        private void AttachCardClick(IControl card, int i, Carousel car, Action<T> close)
+        {
+            var go = card.GameObject;
+            var img = go.GetComponent<UnityImage>() ?? go.AddComponent<UnityImage>();
+            img.color = new UnityEngine.Color(0f, 0f, 0f, 0f);   // 透明，仅 raycast
+            img.raycastTarget = true;
+            // 卡 GO 每次 BindItems 重建都是全新的（旧的由 ClearCards 销毁），故无条件 AddComponent 安全、不重复挂。
+            var btn = go.AddComponent<PuiButton>();
+            btn.targetGraphic = img;
+            btn.onClick.AddListener(() =>
+            {
+                if (car.Current == i) close(Items[i]);     // 点居中卡 = 确认
+                else car.GoTo(i, animated: true);          // 点侧卡 = 居中
+            });
         }
     }
 

--- a/Runtime/Application/Modals/CenteredSlideBoxRequest.cs.meta
+++ b/Runtime/Application/Modals/CenteredSlideBoxRequest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0e4ceea4be3ca50488dcc9a5960b52aa

--- a/Runtime/Application/ScreenInstantiator.cs
+++ b/Runtime/Application/ScreenInstantiator.cs
@@ -283,7 +283,7 @@ namespace PromptUGUI.Application
             foreach (var c in node.Children)
             {
                 if (node.Tag == "Carousel")
-                    foreach (var issue in PromptUGUI.Lint.CarouselRules.CheckCard(c))
+                    foreach (var issue in PromptUGUI.Lint.CarouselRules.CheckCard(node, c))
                         Debug.LogWarning(issue.Message);
                 InstantiateRecursive(c, control.ChildHostTransform, selfIsLayoutGroup, childScope, nodeMap,
                                      parentControl: control, applyOrder: applyOrder);

--- a/Runtime/Controls/Carousel.cs
+++ b/Runtime/Controls/Carousel.cs
@@ -80,6 +80,9 @@ namespace PromptUGUI.Controls
         [UIAttr, Preserve]
         public float EdgeScale { set => _view.SetEdgeScale(value); }
 
+        [UIAttr, Preserve]
+        public float EdgeAlpha { set => _view.SetEdgeAlpha(value); }
+
         [UIAttr, Preserve] public string Dots { set => _dotsAnchor = value; }
         [UIAttr, Preserve]
         public string DotSize

--- a/Runtime/Controls/Carousel.cs
+++ b/Runtime/Controls/Carousel.cs
@@ -83,6 +83,10 @@ namespace PromptUGUI.Controls
         [UIAttr, Preserve]
         public float EdgeAlpha { set => _view.SetEdgeAlpha(value); }
 
+        // 视口左右边缘的羽化淡出宽度(softness.x,设计单位)：卡片靠近屏幕边缘的像素渐隐。
+        [UIAttr, Preserve]
+        public int Softness { set => _view.SetSoftness(value); }
+
         [UIAttr, Preserve] public string Dots { set => _dotsAnchor = value; }
         [UIAttr, Preserve]
         public string DotSize

--- a/Runtime/Controls/Carousel.cs
+++ b/Runtime/Controls/Carousel.cs
@@ -77,6 +77,9 @@ namespace PromptUGUI.Controls
         [UIAttr, Preserve]
         public float Spacing { set => _view.SetSpacing(value); }
 
+        [UIAttr, Preserve]
+        public float EdgeScale { set => _view.SetEdgeScale(value); }
+
         [UIAttr, Preserve] public string Dots { set => _dotsAnchor = value; }
         [UIAttr, Preserve]
         public string DotSize

--- a/Runtime/Controls/Carousel.cs
+++ b/Runtime/Controls/Carousel.cs
@@ -71,6 +71,12 @@ namespace PromptUGUI.Controls
         [UIAttr, Preserve]
         public float Transition { set => _view.SetTransition(value); }
 
+        [UIAttr, Preserve]
+        public bool Fill { set => _view.SetFill(value); }
+
+        [UIAttr, Preserve]
+        public float Spacing { set => _view.SetSpacing(value); }
+
         [UIAttr, Preserve] public string Dots { set => _dotsAnchor = value; }
         [UIAttr, Preserve]
         public string DotSize

--- a/Runtime/Controls/Internal/CarouselView.cs
+++ b/Runtime/Controls/Internal/CarouselView.cs
@@ -36,6 +36,13 @@ namespace PromptUGUI.Controls.Internal
         private float _pageWidth = 1f;
         private float _pageHeight = 1f;
 
+        // peek 布局（CAR-D25/D27）
+        private bool _fill = true;          // 默认 v1 全幅
+        private float _spacing = 0f;        // fill=false 时相邻卡间距
+        private float _cardW = 1f;          // 卡槽宽（fill=true → 视口；false → resolved 卡尺寸）
+        private float _cardH = 1f;
+        private float _stride = 1f;         // 相邻卡中心距（fill=true → 视口宽；false → _cardW+_spacing）
+
         // 行为参数
         private float _interval = 5f;
         private bool _loop = true;
@@ -98,6 +105,8 @@ namespace PromptUGUI.Controls.Internal
         public void SetInterval(float v) => _interval = v;
         public void SetLoop(bool v) => _loop = v;
         public void SetTransition(float v) => _transition = Mathf.Max(0f, v);
+        public void SetFill(bool v) => _fill = v;
+        public void SetSpacing(float v) => _spacing = Mathf.Max(0f, v);
 
         // —— 卡片管理 ——
         // 首次 OnAfterApply 把已建好的静态子卡（在 Strip 下）收进 _cards；只跑一次，
@@ -375,10 +384,25 @@ namespace PromptUGUI.Controls.Internal
                 rt.anchorMin = new Vector2(0.5f, 0.5f);
                 rt.anchorMax = new Vector2(0.5f, 0.5f);
                 rt.pivot = new Vector2(0.5f, 0.5f);
-                rt.sizeDelta = new Vector2(_pageWidth, _pageHeight);
-                rt.anchoredPosition = new Vector2(off * _pageWidth, 0f);
+                rt.sizeDelta = new Vector2(_cardW, _cardH);
+                rt.anchoredPosition = new Vector2(off * _stride, 0f);
             }
             RefreshDotSelection();
+        }
+
+        // peek 假定卡等尺寸：取第 0 张卡的 resolved 尺寸作槽位（在 Reposition 之前调，
+        // 此时卡的 size= 已由 apply 落到 sizeDelta）。落空（裸 Frame）兜视口，永不为 0。
+        // 注：读 rect —— 仅对 point-anchored 卡 == 作者声明尺寸；stretch-anchored 卡会量到
+        // Strip 尺寸而非卡自身尺寸（spec 假定卡等尺寸、不写 anchor，可接受）。
+        private void MeasureCard(out float w, out float h)
+        {
+            w = _pageWidth; h = _pageHeight;
+            if (_cards.Count > 0 && _cards[0] is Control c0 && c0.GameObject != null)
+            {
+                var rect = c0.RectTransform.rect;
+                if (rect.width > 0f) w = rect.width;
+                if (rect.height > 0f) h = rect.height;
+            }
         }
 
         // 重算页宽高 + 重排卡片。OnAfterApply（初始 / ReSolve）与 resize 都调它。
@@ -391,6 +415,8 @@ namespace PromptUGUI.Controls.Internal
             var r = _root.rect;
             _pageWidth = r.width > 0f ? r.width : 1f;
             _pageHeight = r.height > 0f ? r.height : 1f;
+            if (_fill) { _cardW = _pageWidth; _cardH = _pageHeight; _stride = _pageWidth; }
+            else { MeasureCard(out _cardW, out _cardH); _stride = _cardW + _spacing; }
             if (_cards.Count > 0)
                 _current = _loop ? ((_current % _cards.Count) + _cards.Count) % _cards.Count
                                  : Mathf.Clamp(_current, 0, _cards.Count - 1);

--- a/Runtime/Controls/Internal/CarouselView.cs
+++ b/Runtime/Controls/Internal/CarouselView.cs
@@ -24,6 +24,7 @@ namespace PromptUGUI.Controls.Internal
         private RectTransform _viewport;
         private RectTransform _strip;
         private RectTransform _indicator;
+        private RectMask2D _mask;   // 视口裁剪遮罩(Carousel.OnAttached 建)；softness.x = 水平边缘羽化
 
         private readonly List<IControl> _cards = new();
         private readonly List<UnityImage> _dotImages = new();
@@ -101,6 +102,7 @@ namespace PromptUGUI.Controls.Internal
             _viewport = viewport;
             _strip = strip;
             _indicator = indicator;
+            _mask = viewport.GetComponent<RectMask2D>();
         }
 
         // —— 行为参数 setter（Carousel 转发）——
@@ -111,6 +113,13 @@ namespace PromptUGUI.Controls.Internal
         public void SetSpacing(float v) => _spacing = Mathf.Max(0f, v);
         public void SetEdgeScale(float v) => _edgeScale = Mathf.Max(0f, v);   // 挡负值（负 localScale 翻转几何）；允许 >1
         public void SetEdgeAlpha(float v) => _edgeAlpha = Mathf.Clamp01(v);
+        // 视口 RectMask2D 的水平边缘羽化(softness.x)：靠近视口左右边缘的卡片像素渐隐——
+        // 空间淡出(融进背景)，区别于 edgeAlpha 的整卡变暗。y 保持 0(只左右淡，不切顶底)。
+        public void SetSoftness(int v)
+        {
+            if (_mask == null) return;
+            _mask.softness = new Vector2Int(Mathf.Max(0, v), _mask.softness.y);
+        }
 
         // —— 卡片管理 ——
         // 首次 OnAfterApply 把已建好的静态子卡（在 Strip 下）收进 _cards；只跑一次，

--- a/Runtime/Controls/Internal/CarouselView.cs
+++ b/Runtime/Controls/Internal/CarouselView.cs
@@ -390,13 +390,12 @@ namespace PromptUGUI.Controls.Internal
                 rt.pivot = new Vector2(0.5f, 0.5f);
                 rt.sizeDelta = new Vector2(_cardW, _cardH);
                 rt.anchoredPosition = new Vector2(off * _stride, 0f);
-                // CAR-D32: unconditional write — when _edgeScale==1 this resolves to 1 on every pass,
-                // which self-resets any scale left by a previous peek configuration (fill=true or edgeScale=1
-                // variant) without needing an explicit reset path.
+                // 总是写 localScale/alpha（每帧自复位）；值按 _fill 门控：fill=true → 强制 1
+                // （edge* 仅 fill=false 生效，CAR-D27/D29），既保 v1 逐字等价、又复位上一轮 peek 残留。
                 float t = Mathf.Clamp01(Mathf.Abs(off));
-                float s = Mathf.Lerp(1f, _edgeScale, t);
-                rt.localScale = new Vector3(s, s, 1f);   // z=1（uGUI 约定，同 Screen.cs）；省每帧临时 Vector3
-                ApplyAlpha(card, Mathf.Lerp(1f, _edgeAlpha, t));
+                float s = _fill ? 1f : Mathf.Lerp(1f, _edgeScale, t);
+                rt.localScale = new Vector3(s, s, 1f);
+                ApplyAlpha(card, _fill ? 1f : Mathf.Lerp(1f, _edgeAlpha, t));
             }
             RefreshDotSelection();
         }

--- a/Runtime/Controls/Internal/CarouselView.cs
+++ b/Runtime/Controls/Internal/CarouselView.cs
@@ -39,6 +39,7 @@ namespace PromptUGUI.Controls.Internal
         // peek 布局（CAR-D25/D27）
         private bool _fill = true;          // 默认 v1 全幅
         private float _spacing = 0f;        // fill=false 时相邻卡间距
+        private float _edgeScale = 1f;      // CAR-D32: 边卡缩放；焦点卡 1，邻卡线性插值到此值
         private float _cardW = 1f;          // 卡槽宽（fill=true → 视口；false → resolved 卡尺寸）
         private float _cardH = 1f;
         private float _stride = 1f;         // 相邻卡中心距（fill=true → 视口宽；false → _cardW+_spacing）
@@ -107,6 +108,7 @@ namespace PromptUGUI.Controls.Internal
         public void SetTransition(float v) => _transition = Mathf.Max(0f, v);
         public void SetFill(bool v) => _fill = v;
         public void SetSpacing(float v) => _spacing = Mathf.Max(0f, v);
+        public void SetEdgeScale(float v) => _edgeScale = Mathf.Max(0f, v);   // 挡负值（负 localScale 翻转几何）；允许 >1
 
         // —— 卡片管理 ——
         // 首次 OnAfterApply 把已建好的静态子卡（在 Strip 下）收进 _cards；只跑一次，
@@ -386,6 +388,12 @@ namespace PromptUGUI.Controls.Internal
                 rt.pivot = new Vector2(0.5f, 0.5f);
                 rt.sizeDelta = new Vector2(_cardW, _cardH);
                 rt.anchoredPosition = new Vector2(off * _stride, 0f);
+                // CAR-D32: unconditional write — when _edgeScale==1 this resolves to 1 on every pass,
+                // which self-resets any scale left by a previous peek configuration (fill=true or edgeScale=1
+                // variant) without needing an explicit reset path.
+                float t = Mathf.Clamp01(Mathf.Abs(off));
+                float s = Mathf.Lerp(1f, _edgeScale, t);
+                rt.localScale = new Vector3(s, s, 1f);   // z=1（uGUI 约定，同 Screen.cs）；省每帧临时 Vector3
             }
             RefreshDotSelection();
         }

--- a/Runtime/Controls/Internal/CarouselView.cs
+++ b/Runtime/Controls/Internal/CarouselView.cs
@@ -40,6 +40,7 @@ namespace PromptUGUI.Controls.Internal
         private bool _fill = true;          // 默认 v1 全幅
         private float _spacing = 0f;        // fill=false 时相邻卡间距
         private float _edgeScale = 1f;      // CAR-D32: 边卡缩放；焦点卡 1，邻卡线性插值到此值
+        private float _edgeAlpha = 1f;      // 边卡透明度；焦点卡 1，邻卡线性插值到此值（懒加 CanvasGroup）
         private float _cardW = 1f;          // 卡槽宽（fill=true → 视口；false → resolved 卡尺寸）
         private float _cardH = 1f;
         private float _stride = 1f;         // 相邻卡中心距（fill=true → 视口宽；false → _cardW+_spacing）
@@ -109,6 +110,7 @@ namespace PromptUGUI.Controls.Internal
         public void SetFill(bool v) => _fill = v;
         public void SetSpacing(float v) => _spacing = Mathf.Max(0f, v);
         public void SetEdgeScale(float v) => _edgeScale = Mathf.Max(0f, v);   // 挡负值（负 localScale 翻转几何）；允许 >1
+        public void SetEdgeAlpha(float v) => _edgeAlpha = Mathf.Clamp01(v);
 
         // —— 卡片管理 ——
         // 首次 OnAfterApply 把已建好的静态子卡（在 Strip 下）收进 _cards；只跑一次，
@@ -394,8 +396,27 @@ namespace PromptUGUI.Controls.Internal
                 float t = Mathf.Clamp01(Mathf.Abs(off));
                 float s = Mathf.Lerp(1f, _edgeScale, t);
                 rt.localScale = new Vector3(s, s, 1f);   // z=1（uGUI 约定，同 Screen.cs）；省每帧临时 Vector3
+                ApplyAlpha(card, Mathf.Lerp(1f, _edgeAlpha, t));
             }
             RefreshDotSelection();
+        }
+
+        // a<1 才设 alpha；a==1 时复位回不透明（focus / peek→fill 切换 / fill 模式）。
+        // 注：卡片通常已带 CanvasGroup（Control.Interactable 在 ApplyCommon 里预建），故 AddComponent
+        // 分支只是防御性兜底（极少触发）；只写 alpha，不碰 interactable/blocksRaycasts。
+        private static void ApplyAlpha(Control card, float a)
+        {
+            var go = card.GameObject;
+            var cg = go.GetComponent<CanvasGroup>();
+            if (a < 1f)
+            {
+                if (cg == null) cg = go.AddComponent<CanvasGroup>();
+                cg.alpha = a;
+            }
+            else if (cg != null)
+            {
+                cg.alpha = 1f;
+            }
         }
 
         // peek 假定卡等尺寸：取第 0 张卡的 resolved 尺寸作槽位（在 Reposition 之前调，

--- a/Runtime/Controls/Internal/CarouselView.cs
+++ b/Runtime/Controls/Internal/CarouselView.cs
@@ -61,8 +61,8 @@ namespace PromptUGUI.Controls.Internal
         // 同一坐标系，CanvasScaler.scaleFactor≠1 时也 1:1 跟手，不变快/变慢——同 ScrollRect 的做法）
         private float _dragStartScroll;
         private Vector2 _dragStartLocal;   // 按下时指针在 viewport 本地坐标
-        private float _dragLocalX;         // 距按下点的本地 X 位移（钳进 ±一页），EndDrag 判翻页用
-        private const float SnapThreshold = 0.2f;   // 翻页所需位移占页宽比例
+        private float _dragLocalX;         // 距按下点的本地 X 位移（钳进 ±一步距），EndDrag 判翻页用
+        private const float SnapThreshold = 0.2f;   // 翻页所需位移占卡步距比例（fill=true 时步距==视口宽）
 
         // 指示点样式
         private string _dotsAnchor;
@@ -515,11 +515,11 @@ namespace PromptUGUI.Controls.Internal
                     _viewport, e.position, e.pressEventCamera, out var local))
                 return;
             float dxLocal = local.x - _dragStartLocal.x;     // 只取 X（与滚动轴一致）
-            // Clamp the drag to ±1 page: you can reveal at most the neighbour, never slide to a far
+            // Clamp the drag to ±1 card stride: you can reveal at most the neighbour, never slide to a far
             // page and then snap back to the adjacent one. dxLocal 是相对按下点的绝对位移（非累加），
             // 反向拖会立即减小 |dxLocal| → 跟手不黏。
-            _dragLocalX = Mathf.Clamp(dxLocal, -_pageWidth, _pageWidth);
-            _scroll = _dragStartScroll - _dragLocalX / _pageWidth;   // 右拖(dx>0)显示上一张 → _scroll 减小
+            _dragLocalX = Mathf.Clamp(dxLocal, -_stride, _stride);
+            _scroll = _dragStartScroll - _dragLocalX / _stride;   // 右拖(dx>0)显示上一张 → _scroll 减小
             Reposition();
         }
 
@@ -528,8 +528,8 @@ namespace PromptUGUI.Controls.Internal
             ForwardToParent(e, ExecuteEvents.endDragHandler);
             _dragging = false;
             int target = _current;
-            if (_dragLocalX <= -_pageWidth * SnapThreshold) target = _current + 1;
-            else if (_dragLocalX >= _pageWidth * SnapThreshold) target = _current - 1;
+            if (_dragLocalX <= -_stride * SnapThreshold) target = _current + 1;
+            else if (_dragLocalX >= _stride * SnapThreshold) target = _current - 1;
             GoTo(target, animated: true);
         }
 

--- a/Runtime/Core/Lint/CarouselRules.cs
+++ b/Runtime/Core/Lint/CarouselRules.cs
@@ -43,18 +43,43 @@ namespace PromptUGUI.Lint
                     $"<Carousel id='{n.Id}'>: dots='{d}' is not an anchor keyword (e.g. bottom-center) or empty/none. Runtime falls back to bottom-center.");
         }
 
-        // parent-relative: 检查 Carousel 的一个直接子（卡片）是否写了 size/width/height。
-        public static IEnumerable<LintIssue> CheckCard(ElementNode child)
+        public const string PeekNoSizeCode = "PUI-CAROUSEL-PEEK-NO-SIZE";
+
+        // 无 GetNativeSize() override 的纯容器（Control 基类返回 null）：peek 模式下这种卡根
+        // 不写 size 会兜成视口尺寸（不 peek）。Image/Text/Progress/Icon 等自带原生尺寸，放过。
+        private static readonly HashSet<string> NoNativeSizeContainers = new HashSet<string>
+        { "Frame", "VStack", "HStack", "Grid" };
+
+        private static bool HasOwnSize(ElementNode n)
+            => n.Attributes.ContainsKey("size")
+            || n.Attributes.ContainsKey("width")
+            || n.Attributes.ContainsKey("height")
+            || n.VariantOverrides.ContainsKey("size")
+            || n.VariantOverrides.ContainsKey("width")
+            || n.VariantOverrides.ContainsKey("height");
+
+        // parent-relative：检查 Carousel 的一个直接子（卡片）。需要父 Carousel 读 `fill`：
+        // fill=true（默认）禁止卡片写 size；fill="false"（peek）放开，但对「无原生尺寸容器且没写 size」
+        // 的卡给 warning。fill 只读基础属性（base）——peek carousel 的 fill="false" 一定写在 base。
+        public static IEnumerable<LintIssue> CheckCard(ElementNode carousel, ElementNode child)
         {
-            if (child.Attributes.ContainsKey("size")
-                || child.Attributes.ContainsKey("width")
-                || child.Attributes.ContainsKey("height")
-                || child.VariantOverrides.ContainsKey("size")
-                || child.VariantOverrides.ContainsKey("width")
-                || child.VariantOverrides.ContainsKey("height"))
+            bool peek = carousel.Attributes.TryGetValue("fill", out var f) && f == "false";
+            if (!peek)
+            {
+                if (HasOwnSize(child))
+                    yield return new LintIssue(
+                        CardSizeCode, child.Tag, child.Id,
+                        $"<{child.Tag} id='{child.Id}'>: a Carousel card is sized to the viewport by the control; " +
+                        "remove size/width/height (or set fill=\"false\" for a peek selector).");
+            }
+            else if (!HasOwnSize(child) && NoNativeSizeContainers.Contains(child.Tag))
+            {
                 yield return new LintIssue(
-                    CardSizeCode, child.Tag, child.Id,
-                    $"<{child.Tag} id='{child.Id}'>: a Carousel card is sized to the viewport by the control; remove size/width/height.");
+                    PeekNoSizeCode, child.Tag, child.Id,
+                    $"<{child.Tag} id='{child.Id}'>: fill=\"false\" card has no size and no native size; " +
+                    "it will fill the viewport and neighbours won't peek. Add size= on the card root, " +
+                    "or use a control with a native size (e.g. <Image>).");
+            }
         }
     }
 }

--- a/Runtime/Core/Lint/CarouselRules.cs
+++ b/Runtime/Core/Lint/CarouselRules.cs
@@ -45,8 +45,10 @@ namespace PromptUGUI.Lint
 
         public const string PeekNoSizeCode = "PUI-CAROUSEL-PEEK-NO-SIZE";
 
-        // 无 GetNativeSize() override 的纯容器（Control 基类返回 null）：peek 模式下这种卡根
-        // 不写 size 会兜成视口尺寸（不 peek）。Image/Text/Progress/Icon 等自带原生尺寸，放过。
+        // peek 模式下「无原生尺寸的常见容器卡根」：不写 size 会兜成视口、不 peek，故提示。
+        // 这是精选的常见容器子集，并非全部 null-native tag —— SafeArea/TabBar/Tab/Markdown 等也
+        // 无 GetNativeSize override，但作为轮播卡根极罕见，不在此列（runtime 仍优雅兜底为视口）。
+        // Image/Text/Progress/Icon 等自带原生尺寸，放过。
         private static readonly HashSet<string> NoNativeSizeContainers = new HashSet<string>
         { "Frame", "VStack", "HStack", "Grid" };
 

--- a/Runtime/Core/Lint/IRWalker.cs
+++ b/Runtime/Core/Lint/IRWalker.cs
@@ -122,7 +122,7 @@ namespace PromptUGUI.Lint
                     foreach (var issue in LayoutGroupChildRules.CheckNonLayoutChild(child))
                         yield return issue;
                 if (node.Tag == "Carousel")
-                    foreach (var issue in CarouselRules.CheckCard(child))
+                    foreach (var issue in CarouselRules.CheckCard(node, child))
                         yield return issue;
                 // CLI-only: a direct <Grid> child's own size/width/height is overridden by cellSize.
                 // Grid-specific (V/HStack children's size IS meaningful), so gated on the parent tag here.

--- a/Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml
+++ b/Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml
@@ -12,7 +12,7 @@
       <Text id="title" anchor="top-stretch" height="48" align="center" tr="false"/>
       <Btn  id="close" anchor="top-right" size="36x36" margin="6,6,_,_">x</Btn>
       <Carousel id="cards" anchor="stretch" margin="56,16,72,16"
-                fill="false" interval="0" loop="true"
+                fill="false" interval="0" loop="false"
                 spacing="24" edgeScale="0.82" edgeAlpha="0.45"
                 itemTemplate="Card"
                 dots="bottom-center" dotColor="#666666" dotSelectedColor="#ffffff"/>

--- a/Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml
+++ b/Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml
@@ -8,7 +8,7 @@
   </Template>
   <Screen name="PromptUGUI/Modals/CenteredSlideBox.ui">
     <Image id="backdrop" anchor="stretch" color="#000000A0"/>
-    <Frame id="panel" anchor="center" size="720x460">
+    <Frame id="panel" anchor="stretch">
       <Text id="title" anchor="top-stretch" height="48" align="center" tr="false"/>
       <Btn  id="close" anchor="top-right" size="36x36" margin="6,6,_,_">x</Btn>
       <Carousel id="cards" anchor="stretch" margin="56,16,72,16"

--- a/Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml
+++ b/Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PromptUGUI version="1">
+  <Template name="Card">
+    <Frame size="240x320">
+      <Image id="cover" anchor="stretch"/>
+      <Text  id="name"  anchor="bottom-stretch" height="40" align="center" tr="false"/>
+    </Frame>
+  </Template>
+  <Screen name="CenteredSlideBox">
+    <Image id="backdrop" anchor="stretch" color="#000000A0"/>
+    <Frame id="panel" anchor="center" size="720x460">
+      <Text id="title" anchor="top-stretch" height="48" align="center" tr="false"/>
+      <Btn  id="close" anchor="top-right" size="36x36" margin="6,6,_,_">x</Btn>
+      <Carousel id="cards" anchor="stretch" margin="56,16,72,16"
+                fill="false" interval="0" loop="true"
+                spacing="24" edgeScale="0.82" edgeAlpha="0.45"
+                itemTemplate="Card"
+                dots="bottom-center" dotColor="#666666" dotSelectedColor="#ffffff"/>
+      <Btn id="confirm" anchor="bottom-center" size="160x48" margin="_,_,12,_">OK</Btn>
+    </Frame>
+  </Screen>
+</PromptUGUI>

--- a/Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml
+++ b/Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml
@@ -6,7 +6,7 @@
       <Text  id="name"  anchor="bottom-stretch" height="40" align="center" tr="false"/>
     </Frame>
   </Template>
-  <Screen name="CenteredSlideBox">
+  <Screen name="PromptUGUI/Modals/CenteredSlideBox.ui">
     <Image id="backdrop" anchor="stretch" color="#000000A0"/>
     <Frame id="panel" anchor="center" size="720x460">
       <Text id="title" anchor="top-stretch" height="48" align="center" tr="false"/>

--- a/Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml
+++ b/Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml
@@ -13,7 +13,7 @@
       <Btn  id="close" anchor="top-right" size="36x36" margin="6,6,_,_">x</Btn>
       <Carousel id="cards" anchor="stretch" margin="56,16,72,16"
                 fill="false" interval="0" loop="false"
-                spacing="24" edgeScale="0.82" edgeAlpha="0.45"
+                spacing="24" edgeScale="0.82" softness="240"
                 itemTemplate="Card"
                 dots="bottom-center" dotColor="#666666" dotSelectedColor="#ffffff"/>
       <Btn id="confirm" anchor="bottom-center" size="160x48" margin="_,_,12,_">OK</Btn>

--- a/Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml.meta
+++ b/Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5766b6d556ee08d48948feb3ba8b3b91
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Controls/CarouselDragTests.cs
+++ b/Tests/EditMode/Controls/CarouselDragTests.cs
@@ -146,6 +146,23 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
+        public void Peek_EdgeScale_Interpolates_Linearly_At_Fractional_Offset()
+        {
+            // 半步距拖动 → _scroll≈0.5，焦点卡 off≈-0.5 → t=0.5 → scale=Lerp(1,0.6,0.5)=0.8。
+            // 端点 0/1 已有 CarouselPeekTests 覆盖；这里钉住 CAR-D32 的「线性」中间值（防 edgeEase 重构悄悄破坏）。
+            var car = OpenCards("fill='false' spacing='0' edgeScale='0.6' interval='0'",
+                "<Frame size='100x80'/><Frame size='100x80'/><Frame size='100x80'/>");
+            var view = car.GameObject.GetComponent<CarouselView>();
+            var p0 = ScreenAt(view, Vector2.zero);
+            var pHalf = ScreenAt(view, new Vector2(-50f, 0f));   // 半个 100px 步距
+            ((IBeginDragHandler)view).OnBeginDrag(Ev(p0, Vector2.zero));
+            ((IDragHandler)view).OnDrag(Ev(pHalf, pHalf - p0));   // 不 End，保留分数 _scroll
+            var card0 = (RectTransform)view.StripRect.GetChild(0);
+            Assert.AreEqual(0.8f, card0.localScale.x, 0.01f,
+                "edgeScale interpolates linearly at fractional offset (Lerp(1,0.6,0.5)=0.8)");
+        }
+
+        [Test]
         public void Vertical_Drag_Forwarded_To_Parent()
         {
             var car = Open("interval='0'");

--- a/Tests/EditMode/Controls/CarouselDragTests.cs
+++ b/Tests/EditMode/Controls/CarouselDragTests.cs
@@ -27,6 +27,16 @@ namespace PromptUGUI.Tests.EditMode.Controls
             return UI.Open("S").Get<Carousel>("car");
         }
 
+        private static Carousel OpenCards(string attrs, string cards)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Carousel id='car' size='200x100' {attrs}>{cards}</Carousel>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S").Get<Carousel>("car");
+        }
+
         private static RectTransform Viewport(CarouselView v) => (RectTransform)v.StripRect.parent;
 
         // viewport 本地坐标点 → 屏幕点（overlay: world==screen px；含 lossyScale）。
@@ -122,6 +132,17 @@ namespace PromptUGUI.Tests.EditMode.Controls
             ((IEndDragHandler)view).OnEndDrag(Ev(pLeft, Vector2.zero));
             Assert.AreEqual(1, car.Current,
                 "a drag starting vertical then going horizontal still advances (no first-frame axis lock-out)");
+        }
+
+        [Test]
+        public void Peek_Drag_Threshold_Scales_With_Card_Stride()
+        {
+            // 视口 200，卡宽 100，spacing 0 → 步距 100、阈值 0.2*100 = 20。
+            // 拖 -30：> 卡步距阈值（翻页），但 < 旧视口阈值 0.2*200=40（旧逻辑会回弹）。
+            var car = OpenCards("fill='false' spacing='0' interval='0'",
+                "<Frame size='100x80'/><Frame size='100x80'/><Frame size='100x80'/>");
+            DragLocal(car.GameObject.GetComponent<CarouselView>(), -30f);
+            Assert.AreEqual(1, car.Current, "drag threshold uses card stride (100), not viewport width (200)");
         }
 
         [Test]

--- a/Tests/EditMode/Controls/CarouselPeekTests.cs
+++ b/Tests/EditMode/Controls/CarouselPeekTests.cs
@@ -127,5 +127,17 @@ namespace PromptUGUI.Tests.EditMode.Controls
             view.InvokeRectChangedForTests();
             Assert.AreEqual(1, card1.GetComponents<CanvasGroup>().Length, "no duplicate CanvasGroup across reflows");
         }
+
+        [Test]
+        public void Softness_Sets_Viewport_RectMask2D_Softness_X()
+        {
+            var car = Open("<Carousel id='car' size='400x100' fill='false' softness='120'>" +
+                           "<Frame size='120x80'/><Frame size='120x80'/></Carousel>");
+            var mask = car.GameObject.transform.Find("Viewport")
+                .GetComponent<UnityEngine.UI.RectMask2D>();
+            Assert.IsNotNull(mask, "viewport carries the RectMask2D");
+            Assert.AreEqual(120, mask.softness.x, "softness attr drives horizontal edge-fade (softness.x)");
+            Assert.AreEqual(0, mask.softness.y, "vertical softness stays 0 (edges fade left/right only)");
+        }
     }
 }

--- a/Tests/EditMode/Controls/CarouselPeekTests.cs
+++ b/Tests/EditMode/Controls/CarouselPeekTests.cs
@@ -49,5 +49,24 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.AreEqual(200f, Card(car, 1).anchoredPosition.x, 0.5f,
                 "fill-mode neighbour at one full viewport (stride==viewport, regression lock)");
         }
+
+        [Test]
+        public void Peek_EdgeScale_Shrinks_Neighbours_Focus_Full()
+        {
+            var car = Open("<Carousel id='car' size='400x100' fill='false' edgeScale='0.8' loop='true'>" +
+                           "<Frame size='120x80'/><Frame size='120x80'/><Frame size='120x80'/></Carousel>");
+            Assert.AreEqual(1f, Card(car, 0).localScale.x, 0.001f, "focus card (off 0) full scale");
+            Assert.AreEqual(0.8f, Card(car, 1).localScale.x, 0.001f, "neighbour (off 1) shrunk to edgeScale");
+        }
+
+        [Test]
+        public void Peek_EdgeScale_Reapplied_On_GoTo_Self_Resets()
+        {
+            var car = Open("<Carousel id='car' size='400x100' fill='false' edgeScale='0.8' loop='true'>" +
+                           "<Frame size='120x80'/><Frame size='120x80'/><Frame size='120x80'/></Carousel>");
+            Assert.AreEqual(0.8f, Card(car, 1).localScale.x, 0.001f, "initially a neighbour");
+            car.GoTo(1, animated: false);   // card1 becomes focus
+            Assert.AreEqual(1f, Card(car, 1).localScale.x, 0.001f, "scale re-written every Reposition (self-resets to 1)");
+        }
     }
 }

--- a/Tests/EditMode/Controls/CarouselPeekTests.cs
+++ b/Tests/EditMode/Controls/CarouselPeekTests.cs
@@ -68,5 +68,36 @@ namespace PromptUGUI.Tests.EditMode.Controls
             car.GoTo(1, animated: false);   // card1 becomes focus
             Assert.AreEqual(1f, Card(car, 1).localScale.x, 0.001f, "scale re-written every Reposition (self-resets to 1)");
         }
+
+        [Test]
+        public void Peek_EdgeAlpha_Fades_Neighbours_Via_CanvasGroup()
+        {
+            var car = Open("<Carousel id='car' size='400x100' fill='false' edgeAlpha='0.4' loop='true'>" +
+                           "<Frame size='120x80'/><Frame size='120x80'/><Frame size='120x80'/></Carousel>");
+            var cg = Card(car, 1).GetComponent<CanvasGroup>();
+            Assert.IsTrue(cg != null, "neighbour gets a CanvasGroup for fading");
+            Assert.AreEqual(0.4f, cg.alpha, 0.001f, "neighbour faded to edgeAlpha");
+        }
+
+        [Test]
+        public void Peek_Focus_Card_Full_Alpha()
+        {
+            var car = Open("<Carousel id='car' size='400x100' fill='false' edgeAlpha='0.4' loop='true'>" +
+                           "<Frame size='120x80'/><Frame size='120x80'/><Frame size='120x80'/></Carousel>");
+            var cg = Card(car, 0).GetComponent<CanvasGroup>();
+            Assert.IsTrue(cg != null, "card carries a CanvasGroup");
+            Assert.AreEqual(1f, cg.alpha, 0.001f, "focus card fully opaque");
+        }
+
+        [Test]
+        public void Fill_Mode_EdgeAlpha_Inert_Cards_Full_Alpha()
+        {
+            // fill=true, no edgeAlpha attr → _edgeAlpha=1f → Lerp(1,1,t)=1 for all t → alpha stays 1
+            var car = Open("<Carousel id='car' size='200x100'><Image/><Image/></Carousel>");
+            var cg0 = Card(car, 0).GetComponent<CanvasGroup>();
+            var cg1 = Card(car, 1).GetComponent<CanvasGroup>();
+            Assert.AreEqual(1f, cg0.alpha, 0.001f, "fill-mode focus card alpha is 1 (edgeAlpha inert)");
+            Assert.AreEqual(1f, cg1.alpha, 0.001f, "fill-mode neighbour card alpha is 1 (edgeAlpha inert)");
+        }
     }
 }

--- a/Tests/EditMode/Controls/CarouselPeekTests.cs
+++ b/Tests/EditMode/Controls/CarouselPeekTests.cs
@@ -99,5 +99,33 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.AreEqual(1f, cg0.alpha, 0.001f, "fill-mode focus card alpha is 1 (edgeAlpha inert)");
             Assert.AreEqual(1f, cg1.alpha, 0.001f, "fill-mode neighbour card alpha is 1 (edgeAlpha inert)");
         }
+
+        [Test]
+        public void Fill_Toggled_Via_Variant_Resets_Scale_And_Alpha()
+        {
+            var car = Open("<Carousel id='car' size='400x100' fill='false' fill.big='true' " +
+                           "edgeScale='0.8' edgeAlpha='0.4' loop='true'>" +
+                           "<Frame size='120x80'/><Frame size='120x80'/><Frame size='120x80'/></Carousel>");
+            Assert.AreEqual(0.8f, Card(car, 1).localScale.x, 0.001f, "peek: neighbour shrunk");
+
+            UI.Variants.Set("big", true);   // fill -> true -> ReSolve -> Reposition resets
+
+            Assert.AreEqual(1f, Card(car, 1).localScale.x, 0.001f, "fill=true resets card scale to 1");
+            var cg = Card(car, 1).GetComponent<CanvasGroup>();
+            Assert.IsTrue(cg != null, "card carries a CanvasGroup");
+            Assert.AreEqual(1f, cg.alpha, 0.001f, "fill=true resets card alpha to 1");
+        }
+
+        [Test]
+        public void Resize_Does_Not_Duplicate_CanvasGroup()
+        {
+            var car = Open("<Carousel id='car' size='400x100' fill='false' edgeAlpha='0.4' loop='true'>" +
+                           "<Frame size='120x80'/><Frame size='120x80'/><Frame size='120x80'/></Carousel>");
+            var card1 = (RectTransform)car.GameObject.transform.Find("Viewport/Strip").GetChild(1);
+            var view = car.GameObject.GetComponent<CarouselView>();
+            view.InvokeRectChangedForTests();
+            view.InvokeRectChangedForTests();
+            Assert.AreEqual(1, card1.GetComponents<CanvasGroup>().Length, "no duplicate CanvasGroup across reflows");
+        }
     }
 }

--- a/Tests/EditMode/Controls/CarouselPeekTests.cs
+++ b/Tests/EditMode/Controls/CarouselPeekTests.cs
@@ -1,0 +1,53 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class CarouselPeekTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static Carousel Open(string innerXml)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{innerXml}</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S").Get<Carousel>("car");
+        }
+
+        private static RectTransform Card(Carousel car, int i)
+            => (RectTransform)car.GameObject.transform.Find("Viewport/Strip").GetChild(i);
+
+        [Test]
+        public void Peek_Honors_Card_Size_Not_Viewport()
+        {
+            var car = Open("<Carousel id='car' size='200x100' fill='false'>" +
+                           "<Frame size='120x80'/><Frame size='120x80'/></Carousel>");
+            Assert.AreEqual(120f, Card(car, 0).rect.width, 0.5f, "peek card keeps its own width (not viewport 200)");
+            Assert.AreEqual(80f, Card(car, 0).rect.height, 0.5f);
+        }
+
+        [Test]
+        public void Peek_Stride_Is_CardWidth_Plus_Spacing()
+        {
+            var car = Open("<Carousel id='car' size='200x100' fill='false' spacing='10'>" +
+                           "<Frame size='120x80'/><Frame size='120x80'/><Frame size='120x80'/></Carousel>");
+            Assert.AreEqual(0f, Card(car, 0).anchoredPosition.x, 0.5f, "focus card centered at x=0");
+            Assert.AreEqual(130f, Card(car, 1).anchoredPosition.x, 0.5f, "neighbour at cardWidth+spacing = 130");
+        }
+
+        [Test]
+        public void Fill_Mode_Default_Unchanged()
+        {
+            var car = Open("<Carousel id='car' size='200x100'><Image/><Image/><Image/></Carousel>");
+            Assert.AreEqual(200f, Card(car, 0).rect.width, 0.5f, "fill=true (default) still sizes cards to viewport");
+            Assert.AreEqual(0f, Card(car, 0).anchoredPosition.x, 0.5f, "focus card centered");
+            Assert.AreEqual(200f, Card(car, 1).anchoredPosition.x, 0.5f,
+                "fill-mode neighbour at one full viewport (stride==viewport, regression lock)");
+        }
+    }
+}

--- a/Tests/EditMode/Controls/CarouselPeekTests.cs.meta
+++ b/Tests/EditMode/Controls/CarouselPeekTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3be3c920e80621e4e83090978196fbde

--- a/Tests/EditMode/Editor/XsdGeneratorTests.cs
+++ b/Tests/EditMode/Editor/XsdGeneratorTests.cs
@@ -44,6 +44,19 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
+        public void Carousel_peek_attributes_appear_in_xsd()
+        {
+            // peek-mode attrs are [UIAttr] on Carousel → reflected through the customs path.
+            var r = new ControlRegistry();
+            r.Register<Carousel>("Carousel", null);
+            var xsd = XsdGenerator.Generate(r);
+            StringAssert.Contains("name=\"fill\"", xsd);
+            StringAssert.Contains("name=\"spacing\"", xsd);
+            StringAssert.Contains("name=\"edgeScale\"", xsd);
+            StringAssert.Contains("name=\"edgeAlpha\"", xsd);
+        }
+
+        [Test]
         public void Generate_to_file_produces_readable_file()
         {
             var r = new ControlRegistry();

--- a/Tests/EditMode/Lint/CarouselRulesTests.cs
+++ b/Tests/EditMode/Lint/CarouselRulesTests.cs
@@ -48,5 +48,57 @@ namespace PromptUGUI.Tests.EditMode.Lint
             Assert.IsFalse(issues.Any(i => i.Code == CarouselRules.CardSizeCode),
                 "anchor must NOT trigger the size rule");
         }
+
+        [Test]
+        public void Peek_Card_With_Size_Does_Not_Trigger_CardSize()
+        {
+            var issues = IRWalker.Walk(Doc("<Carousel fill='false'><Frame width='120'/></Carousel>")).ToList();
+            Assert.IsFalse(issues.Any(i => i.Code == CarouselRules.CardSizeCode),
+                "fill=false allows a card to declare its own size");
+        }
+
+        [Test]
+        public void Peek_Bare_Container_Card_Triggers_PeekNoSize()
+        {
+            var issues = IRWalker.Walk(Doc("<Carousel fill='false'><Frame/></Carousel>")).ToList();
+            Assert.That(issues.Any(i => i.Code == CarouselRules.PeekNoSizeCode),
+                "bare Frame in peek mode has no resolvable size -> warning");
+        }
+
+        [Test]
+        public void Peek_Image_Card_Without_Size_Does_Not_Trigger_PeekNoSize()
+        {
+            var issues = IRWalker.Walk(Doc("<Carousel fill='false'><Image/></Carousel>")).ToList();
+            Assert.IsFalse(issues.Any(i => i.Code == CarouselRules.PeekNoSizeCode),
+                "Image carries a native (sprite) size -> not flagged");
+        }
+
+        // 守护整套 no-native-size 容器集合：只测 Frame 时，集合里漏掉 VStack/HStack/Grid 的回归
+        // 不会被前面的测试抓到。
+        [TestCase("VStack")]
+        [TestCase("HStack")]
+        [TestCase("Grid")]
+        public void Peek_Bare_NoNativeSize_Container_Triggers_PeekNoSize(string tag)
+        {
+            var issues = IRWalker.Walk(Doc($"<Carousel fill='false'><{tag}/></Carousel>")).ToList();
+            Assert.That(issues.Any(i => i.Code == CarouselRules.PeekNoSizeCode),
+                $"<{tag}> in peek mode has no native size -> warning");
+        }
+
+        [Test]
+        public void Peek_Card_With_Only_Height_Does_Not_Trigger_PeekNoSize()
+        {
+            var issues = IRWalker.Walk(Doc("<Carousel fill='false'><Frame height='80'/></Carousel>")).ToList();
+            Assert.IsFalse(issues.Any(i => i.Code == CarouselRules.PeekNoSizeCode),
+                "height alone counts as a declared size");
+        }
+
+        [Test]
+        public void Fill_Mode_Card_With_Size_Still_Triggers_CardSize()
+        {
+            var issues = IRWalker.Walk(Doc("<Carousel><Image width='50'/></Carousel>")).ToList();
+            Assert.That(issues.Any(i => i.Code == CarouselRules.CardSizeCode),
+                "default fill=true keeps the v1 card-size error");
+        }
     }
 }

--- a/Tests/EditMode/Modals/CenteredSlideBoxDefaultSkinTests.cs
+++ b/Tests/EditMode/Modals/CenteredSlideBoxDefaultSkinTests.cs
@@ -39,5 +39,20 @@ namespace PromptUGUI.Tests.Modals
             Assert.AreSame(items[0], task.GetAwaiter().GetResult(),
                 "确认返回居中(默认 current=0)项");
         }
+
+        [Test]
+        public void Default_Skin_Does_Not_Loop()
+        {
+            var items = new[] { "1", "2", "3" };
+            var task = CenteredSlideBox.Open(items, (card, s) => { });
+            var cards = UI.Modal.TopScreen.Get<Carousel>("cards");
+
+            cards.GoTo(99, animated: false);   // 远超界
+            Assert.AreEqual(2, cards.Current,
+                "默认皮肤应关闭循环:越界 GoTo 钳位到末张(2),而非环绕回 0");
+
+            UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();
+            task.GetAwaiter().GetResult();
+        }
     }
 }

--- a/Tests/EditMode/Modals/CenteredSlideBoxDefaultSkinTests.cs
+++ b/Tests/EditMode/Modals/CenteredSlideBoxDefaultSkinTests.cs
@@ -1,0 +1,43 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using PromptUGUI.Controls;
+using PBtn = PromptUGUI.Controls.Btn;
+
+namespace PromptUGUI.Tests.Modals
+{
+    // 直连真实默认皮肤(Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml)的回归测试。
+    // 其余 CenteredSlideBox 测试都把 XmlSrc override 成测试 key、并让 <Screen name> 与之对齐，
+    // 因此从不验证「默认 XML 的 <Screen name> 是否等于默认 XmlSrc」。这条 bug(name 写成短名
+    // "CenteredSlideBox" → OpenModalScreen 按完整路径查 _docs 落空 → "not loaded")正落在盲区里。
+    public class CenteredSlideBoxDefaultSkinTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            // 显式恢复默认 XmlSrc:它是 static 可变属性,别的模态测试类会把它改成测试 key。
+            CenteredSlideBox.XmlSrc = "PromptUGUI/Modals/CenteredSlideBox.ui";
+            // 不设 SourceResolver:内置模态(PromptUGUI/ 前缀)走 Resources.Load,不经 resolver。
+        }
+
+        [TearDown]
+        public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Open_With_Default_Skin_Loads_And_Confirms()
+        {
+            var items = new[] { "1", "2", "3" };
+            var task = CenteredSlideBox.Open(items, (card, s) => { }, title: "123");
+
+            Assert.IsTrue(UI.Modal.IsAnyOpen,
+                "默认皮肤应正常打开;若 <Screen name> 与默认 XmlSrc 不一致会 'not loaded' → 此处 false");
+            Assert.IsNotNull(UI.Modal.TopScreen.Get<Carousel>("cards"),
+                "应能取到默认皮肤里的 cards Carousel");
+
+            UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();
+            Assert.AreSame(items[0], task.GetAwaiter().GetResult(),
+                "确认返回居中(默认 current=0)项");
+        }
+    }
+}

--- a/Tests/EditMode/Modals/CenteredSlideBoxDefaultSkinTests.cs.meta
+++ b/Tests/EditMode/Modals/CenteredSlideBoxDefaultSkinTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b2f8c4a1e6d34f0789a1c5e2b7d49f03

--- a/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
+++ b/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
@@ -4,9 +4,11 @@ using PromptUGUI.Application;
 using PromptUGUI.Application.Modals;
 using PromptUGUI.Controls;
 using PromptUGUI.Controls.Internal;
+using TMPro;
 using UnityEngine.EventSystems;
 using PBtn = PromptUGUI.Controls.Btn;
 using PImage = PromptUGUI.Controls.Image;
+using PText = PromptUGUI.Controls.Text;
 
 namespace PromptUGUI.Tests.Modals
 {
@@ -143,6 +145,58 @@ namespace PromptUGUI.Tests.Modals
             CardButton(2).onClick.Invoke();        // 点侧卡 2 → 居中它
             Assert.AreEqual(2, car.Current, "side-card tap centers it");
             Assert.IsTrue(UI.Modal.IsAnyOpen, "side-card tap must NOT confirm/close");
+        }
+
+        [Test]
+        public void Null_Title_Hides_Title_Node()
+        {
+            UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+            { Items = ThreeLevels(), BindCard = (c, l) => { }, Title = null });
+            Assert.IsFalse(UI.Modal.TopScreen.Get<PText>("title").GameObject.activeSelf);
+        }
+
+        [Test]
+        public void ConfirmLabel_Overrides_Button_Text()
+        {
+            UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+            { Items = ThreeLevels(), BindCard = (c, l) => { }, ConfirmLabel = "开始" });
+            Assert.AreEqual("开始",
+                UI.Modal.TopScreen.Get<PBtn>("confirm").GameObject.GetComponentInChildren<TMP_Text>().text);
+        }
+
+        [Test]
+        public void Empty_Items_Disables_Confirm()
+        {
+            UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+            { Items = new List<Lv>(), BindCard = (c, l) => { } });
+            Assert.IsFalse(UI.Modal.TopScreen.Get<PBtn>("confirm").Interactable);
+        }
+
+        [Test]
+        public void Bind_Fills_Card_Slots()
+        {
+            var items = ThreeLevels();
+            UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+            {
+                Items = items,
+                BindCard = (card, lv) => card.Get<PText>("name").TextValue = lv.Name,
+            });
+            var card0 = (UnityEngine.RectTransform)Cards().GameObject.transform.Find("Viewport/Strip").GetChild(0);
+            Assert.AreEqual("Alpha", card0.GetComponentInChildren<TMP_Text>().text);
+        }
+
+        [Test]
+        public void Configure_Runs_After_Bind()
+        {
+            var bindRan = false;
+            var configureSawBind = false;
+            UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+            {
+                Items = ThreeLevels(),
+                BindCard = (c, l) => bindRan = true,
+                Configure = _ => configureSawBind = bindRan,   // configure 在 Bind 之后跑 → bindRan 已 true
+            });
+            Assert.IsTrue(configureSawBind, "Configure hook runs AFTER Bind (BindCard 已执行)");
         }
     }
 }

--- a/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
+++ b/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using PromptUGUI.Application;
 using PromptUGUI.Application.Modals;
 using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
 using UnityEngine.EventSystems;
 using PBtn = PromptUGUI.Controls.Btn;
 using PImage = PromptUGUI.Controls.Image;
@@ -77,7 +78,7 @@ namespace PromptUGUI.Tests.Modals
         public void Click_Close_Returns_Null()
         {
             var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
-                { Items = ThreeLevels(), BindCard = (c, l) => { } });
+            { Items = ThreeLevels(), BindCard = (c, l) => { } });
             UI.Modal.TopScreen.Get<PBtn>("close").SimulateClick();
             Assert.IsNull(task.GetAwaiter().GetResult());
             Assert.IsFalse(UI.Modal.IsAnyOpen);
@@ -87,7 +88,7 @@ namespace PromptUGUI.Tests.Modals
         public void Backdrop_PointerDown_Returns_Null()
         {
             var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
-                { Items = ThreeLevels(), BindCard = (c, l) => { } });
+            { Items = ThreeLevels(), BindCard = (c, l) => { } });
             var backdrop = UI.Modal.TopScreen.Get<PImage>("backdrop");
             ExecuteEvents.Execute(backdrop.GameObject,
                 new PointerEventData(EventSystem.current), ExecuteEvents.pointerDownHandler);
@@ -99,7 +100,7 @@ namespace PromptUGUI.Tests.Modals
         public void Escape_Via_Listener_Returns_Null_And_Closes()
         {
             var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
-                { Items = ThreeLevels(), BindCard = (c, l) => { } });
+            { Items = ThreeLevels(), BindCard = (c, l) => { } });
             var listener = UI.Modal.TopScreen.RootGameObject.GetComponent<ModalEscapeListener>();
             Assert.IsNotNull(listener);
             listener.FireForTests();
@@ -113,6 +114,35 @@ namespace PromptUGUI.Tests.Modals
             var req = new CenteredSlideBoxRequest<Lv>();
             Assert.IsTrue(req.TryEscape(out var r));
             Assert.IsNull(r);
+        }
+
+        // 取卡 i 的 PuiButton（AttachCardClick 挂在卡根）。
+        private static PuiButton CardButton(int i)
+            => UI.Modal.TopScreen.Get<Carousel>("cards").GameObject
+                 .transform.Find("Viewport/Strip").GetChild(i)
+                 .GetComponent<PuiButton>();
+
+        [Test]
+        public void Tap_Centered_Card_Returns_It()
+        {
+            var items = ThreeLevels();
+            var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+            { Items = items, BindCard = (c, l) => { } });
+            // current 默认 0；点第 0 张（居中）→ 确认返回它
+            CardButton(0).onClick.Invoke();
+            Assert.AreSame(items[0], task.GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public void Tap_Side_Card_Centers_It_Without_Returning()
+        {
+            var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+            { Items = ThreeLevels(), BindCard = (c, l) => { } });
+            var car = Cards();
+            Assert.AreEqual(0, car.Current);
+            CardButton(2).onClick.Invoke();        // 点侧卡 2 → 居中它
+            Assert.AreEqual(2, car.Current, "side-card tap centers it");
+            Assert.IsTrue(UI.Modal.IsAnyOpen, "side-card tap must NOT confirm/close");
         }
     }
 }

--- a/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
+++ b/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
@@ -206,7 +206,7 @@ namespace PromptUGUI.Tests.Modals
         {
             var items = new List<Lv> { new Lv { Id = "solo", Name = "Solo" } };
             var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
-                { Items = items, BindCard = (c, l) => { } });
+            { Items = items, BindCard = (c, l) => { } });
             UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();
             Assert.AreSame(items[0], task.GetAwaiter().GetResult());
         }

--- a/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
+++ b/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
@@ -3,7 +3,9 @@ using NUnit.Framework;
 using PromptUGUI.Application;
 using PromptUGUI.Application.Modals;
 using PromptUGUI.Controls;
+using UnityEngine.EventSystems;
 using PBtn = PromptUGUI.Controls.Btn;
+using PImage = PromptUGUI.Controls.Image;
 
 namespace PromptUGUI.Tests.Modals
 {
@@ -69,6 +71,48 @@ namespace PromptUGUI.Tests.Modals
             UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();
             Assert.AreSame(items[1], task.GetAwaiter().GetResult(),
                 "confirm returns the centered item");
+        }
+
+        [Test]
+        public void Click_Close_Returns_Null()
+        {
+            var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+                { Items = ThreeLevels(), BindCard = (c, l) => { } });
+            UI.Modal.TopScreen.Get<PBtn>("close").SimulateClick();
+            Assert.IsNull(task.GetAwaiter().GetResult());
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+
+        [Test]
+        public void Backdrop_PointerDown_Returns_Null()
+        {
+            var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+                { Items = ThreeLevels(), BindCard = (c, l) => { } });
+            var backdrop = UI.Modal.TopScreen.Get<PImage>("backdrop");
+            ExecuteEvents.Execute(backdrop.GameObject,
+                new PointerEventData(EventSystem.current), ExecuteEvents.pointerDownHandler);
+            Assert.IsNull(task.GetAwaiter().GetResult());
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+
+        [Test]
+        public void Escape_Via_Listener_Returns_Null_And_Closes()
+        {
+            var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+                { Items = ThreeLevels(), BindCard = (c, l) => { } });
+            var listener = UI.Modal.TopScreen.RootGameObject.GetComponent<ModalEscapeListener>();
+            Assert.IsNotNull(listener);
+            listener.FireForTests();
+            Assert.IsNull(task.GetAwaiter().GetResult());
+            Assert.IsFalse(UI.Modal.IsAnyOpen);
+        }
+
+        [Test]
+        public void TryEscape_Returns_Null_And_True()
+        {
+            var req = new CenteredSlideBoxRequest<Lv>();
+            Assert.IsTrue(req.TryEscape(out var r));
+            Assert.IsNull(r);
         }
     }
 }

--- a/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
+++ b/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
@@ -190,13 +190,25 @@ namespace PromptUGUI.Tests.Modals
         {
             var bindRan = false;
             var configureSawBind = false;
+            Carousel cardsFromConfigure = null;
             UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
             {
                 Items = ThreeLevels(),
                 BindCard = (c, l) => bindRan = true,
-                Configure = _ => configureSawBind = bindRan,   // configure 在 Bind 之后跑 → bindRan 已 true
+                Configure = s => { configureSawBind = bindRan; cardsFromConfigure = s.Get<Carousel>("cards"); },
             });
             Assert.IsTrue(configureSawBind, "Configure hook runs AFTER Bind (BindCard 已执行)");
+            Assert.IsNotNull(cardsFromConfigure, "Configure 能够到控件（如 carousel）去调 peek 参数");
+        }
+
+        [Test]
+        public void Single_Item_Confirm_Returns_It()
+        {
+            var items = new List<Lv> { new Lv { Id = "solo", Name = "Solo" } };
+            var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+                { Items = items, BindCard = (c, l) => { } });
+            UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();
+            Assert.AreSame(items[0], task.GetAwaiter().GetResult());
         }
     }
 }

--- a/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
+++ b/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using PromptUGUI.Controls;
+using PBtn = PromptUGUI.Controls.Btn;
+
+namespace PromptUGUI.Tests.Modals
+{
+    public class CenteredSlideBoxTests
+    {
+        private sealed class Lv { public string Id; public string Name; }
+
+        // 测试用模态 XML：backdrop 与 panel **同级**；卡模板写在顶层（<Template> 必须与 <Screen> 同级）。
+        private const string SlideBoxXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Card'>
+    <Frame size='160x200'>
+      <Image id='cover' anchor='stretch'/>
+      <Text  id='name'  anchor='bottom-stretch' height='24' align='center'/>
+    </Frame>
+  </Template>
+  <Screen name='test/SlideBox1'>
+    <Image id='backdrop' anchor='stretch' color='#000000A0'/>
+    <Frame id='panel' anchor='center' size='600x400'>
+      <Text id='title' anchor='top-stretch' height='40' align='center'/>
+      <Btn  id='close' anchor='top-right' size='32x32'>x</Btn>
+      <Carousel id='cards' anchor='stretch' margin='48,8,64,8'
+                fill='false' interval='0' itemTemplate='Card'/>
+      <Btn  id='confirm' anchor='bottom-center' size='140x40'>OK</Btn>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+
+        private Dictionary<string, string> _files;
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            _files = new Dictionary<string, string> { ["test/SlideBox1"] = SlideBoxXml };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(_files.TryGetValue(src, out var v) ? v : null);
+            CenteredSlideBox.XmlSrc = "test/SlideBox1";
+        }
+
+        [TearDown]
+        public void TearDown() => UI.ResetForTests();
+
+        private static List<Lv> ThreeLevels() => new List<Lv>
+        {
+            new Lv { Id = "a", Name = "Alpha" },
+            new Lv { Id = "b", Name = "Bravo" },
+            new Lv { Id = "c", Name = "Charlie" },
+        };
+
+        private static Carousel Cards() => UI.Modal.TopScreen.Get<Carousel>("cards");
+
+        [Test]
+        public void Confirm_Returns_Centered_Item()
+        {
+            var items = ThreeLevels();
+            var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+            {
+                Items = items,
+                BindCard = (card, lv) => { },
+            });
+            Cards().GoTo(1, animated: false);                  // 把第 1 项居中
+            UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();
+            Assert.AreSame(items[1], task.GetAwaiter().GetResult(),
+                "confirm returns the centered item");
+        }
+    }
+}

--- a/Tests/EditMode/Modals/CenteredSlideBoxTests.cs.meta
+++ b/Tests/EditMode/Modals/CenteredSlideBoxTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8829f0a5bc4ce86479f9eee4a074d85b

--- a/Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs
+++ b/Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs
@@ -32,7 +32,8 @@ namespace PromptUGUI.Tests.PlayMode.Modals
   </Screen>
 </PromptUGUI>";
 
-        [SetUp] public void SetUp()
+        [SetUp]
+        public void SetUp()
         {
             UI.ResetForTests();
             var files = new Dictionary<string, string> { ["test/SlideBoxP"] = Xml };
@@ -46,7 +47,7 @@ namespace PromptUGUI.Tests.PlayMode.Modals
         {
             var items = new List<Lv> { new Lv { Id = "a" }, new Lv { Id = "b" }, new Lv { Id = "c" } };
             var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
-                { Items = items, BindCard = (c, l) => { } });
+            { Items = items, BindCard = (c, l) => { } });
             UI.Modal.TopScreen.Get<Carousel>("cards").GoTo(2, animated: false);
             UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();
             Assert.AreSame(items[2], task.GetAwaiter().GetResult());

--- a/Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs
+++ b/Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using PromptUGUI.Controls;
+using PBtn = PromptUGUI.Controls.Btn;
+
+namespace PromptUGUI.Tests.PlayMode.Modals
+{
+    public class CenteredSlideBoxPlayTests
+    {
+        private sealed class Lv { public string Id; public string Name; }
+
+        // <Template> 必须与 <Screen> 同级（文档顶层），不能嵌进 <Screen>。
+        private const string Xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Card'>
+    <Frame size='160x200'>
+      <Image id='cover' anchor='stretch'/>
+      <Text id='name' anchor='bottom-stretch' height='24'/>
+    </Frame>
+  </Template>
+  <Screen name='test/SlideBoxP'>
+    <Image id='backdrop' anchor='stretch' color='#000000A0'/>
+    <Frame id='panel' anchor='center' size='600x400'>
+      <Text id='title' anchor='top-stretch' height='40' align='center'/>
+      <Btn  id='close' anchor='top-right' size='32x32'>x</Btn>
+      <Carousel id='cards' anchor='stretch' margin='48,8,64,8'
+                fill='false' interval='0' itemTemplate='Card'/>
+      <Btn  id='confirm' anchor='bottom-center' size='140x40'>OK</Btn>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+
+        [SetUp] public void SetUp()
+        {
+            UI.ResetForTests();
+            var files = new Dictionary<string, string> { ["test/SlideBoxP"] = Xml };
+            UI.SourceResolver = src => AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            CenteredSlideBox.XmlSrc = "test/SlideBoxP";
+        }
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Open_GoTo_Confirm_Returns_Item_NoCrash()
+        {
+            var items = new List<Lv> { new Lv { Id = "a" }, new Lv { Id = "b" }, new Lv { Id = "c" } };
+            var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+                { Items = items, BindCard = (c, l) => { } });
+            UI.Modal.TopScreen.Get<Carousel>("cards").GoTo(2, animated: false);
+            UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();
+            Assert.AreSame(items[2], task.GetAwaiter().GetResult());
+        }
+    }
+}

--- a/Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs.meta
+++ b/Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6f87227d12ba17e4dbcc72bf43a88048

--- a/docs~/superpowers/plans/2026-06-15-carousel-peek-mode.md
+++ b/docs~/superpowers/plans/2026-06-15-carousel-peek-mode.md
@@ -1,0 +1,755 @@
+# Carousel peek / 居中选择模式 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 给现有 `<Carousel>` 加 `fill="false"` 居中卡片选择器排版——卡片用自身尺寸、邻卡两侧露出（peek）、焦点卡最大最亮、越往边越小越淡（`edgeScale` / `edgeAlpha`）、卡间 `spacing`——不拆控件，复用 v1 全部机制。
+
+**Architecture:** 唯一实质改动在 `CarouselView`：把「卡尺寸」与「步距」从 v1 混用的一个 `_pageWidth` 拆成 `_cardW`/`_cardH`（卡尺寸）+ `_stride`（相邻卡中心距），`Reposition()` 按 `|off|` 给每张卡叠 `localScale`/`CanvasGroup.alpha`。`fill="true"`（默认）是该算法的退化特例（卡=视口、spacing=0、edge*=1），与 v1 逐字等价。lint `PUI-CAROUSEL-CARD-SIZE` 改为仅 fill=true 触发，新增 warning `PUI-CAROUSEL-PEEK-NO-SIZE`。
+
+**Tech Stack:** Unity 6 uGUI, C# 9（Unity Mono，禁用 C# 10+ 语法）, R3, LitMotion, NUnit + Unity Test Framework, Unity MCP 跑测。
+
+**Spec:** `docs~/superpowers/specs/2026-06-15-carousel-peek-mode-design.md`（决策 CAR-D24..D32）。承接 v1：`docs~/superpowers/specs/2026-06-04-carousel-design.md`。
+
+**关键约定（务必遵守）：**
+- **分支已建好：`feat/carousel-peek-mode`**（spec 已提交在上面）。全程在此分支，**禁止向 main 提交**。
+- 每次写完 `.cs` → `mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)` → `mcp__UnityMCP__read_console(action="get", types=["error"])` 确认编译通过，再跑测。
+- 跑测：`mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])` 返回 `job_id`，轮询 `mcp__UnityMCP__get_test_job(job_id=...)`。聚焦单类用 `group_names=["CarouselPeekTests"]`（**没有** `filter` 参数）。
+- EditMode 测试类碰 `UI` 必须 `[SetUp]`/`[TearDown]` 调 `UI.ResetForTests()`。
+- 所有 `[UIAttr]` 必须配 `[Preserve]`（IL2CPP stripping）。
+- 禁用 .NET 线程；用 Unity `Update` / LitMotion / R3。
+- 每个 Task 末尾 commit；commit message 末尾加 `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`。
+- lint：改完 `Runtime/Core/Lint/*.cs` 后 `cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx`（按需先 `dotnet format whitespace`）。
+- **关键事实（已核实，照此实现，别再质疑）：**
+  - 卡片在 Carousel 下走**自由定位**（Strip 没有真正的 `LayoutGroup` 组件，`Control.ApplyCommon` 的 LayoutElement 通道按真实组件 `LayoutHost.parent.GetComponent<LayoutGroup>()` 判定 → 走 free-positioning），所以卡片的 `size=` 会落到 `RectTransform.sizeDelta`，`Reposition` 之前就能读到（v1 只是之后用 `_pageWidth` 覆盖）。
+  - ReSolve（resize / Variant / Theme）经 `ControlAttributeApplier.Apply`（初次与 ReSolve 共用）在 `ControlAttributeApplier.cs:115` 重跑 `control.OnAfterApply()` → `RelayoutNow()` → `Reposition()`。所以「每次 Reposition 都重写 localScale/alpha」即可自复位，无需额外 ReSolve 钩子。
+  - `[UIAttr]` setter 仅在 XML/Variant 写了该属性时才被调用；没写则字段默认值生效（v1 `loop` 默认 true 即靠此）。
+
+**参考实现（照抄模式）：** 现有 `Runtime/Controls/Internal/CarouselView.cs`（`Reposition`/`RelayoutNow`/`OnDrag`/`OnEndDrag`）、`Runtime/Controls/Carousel.cs`（`[UIAttr]` 转发 `_view`）、`Tests/EditMode/Controls/CarouselTests.cs` + `CarouselDragTests.cs`（测试夹具）、`Tests/EditMode/Lint/CarouselRulesTests.cs`（lint 测试）。
+
+---
+
+## 文件结构
+
+| 文件 | 职责 | 动作 |
+|---|---|---|
+| `Runtime/Core/Lint/CarouselRules.cs` | `CheckCard` 改签名（拿父 `fill`）+ fill 门控 CARD-SIZE + 新增 `PUI-CAROUSEL-PEEK-NO-SIZE` | 改 |
+| `Runtime/Core/Lint/IRWalker.cs` | `CheckCard(child)` → `CheckCard(node, child)`（`:125`） | 改 |
+| `Runtime/Application/ScreenInstantiator.cs` | `CheckCard(c)` → `CheckCard(node, c)`（`:286`） | 改 |
+| `Runtime/Controls/Carousel.cs` | 新增 4 个 `[UIAttr]`：`Fill`/`Spacing`/`EdgeScale`/`EdgeAlpha` → 转写 `_view` | 改 |
+| `Runtime/Controls/Internal/CarouselView.cs` | `_fill`/`_spacing`/`_edgeScale`/`_edgeAlpha`/`_cardW`/`_cardH`/`_stride` 字段 + setters + `MeasureCard` + 改 `RelayoutNow`/`Reposition`/`OnDrag`/`OnEndDrag` + `ApplyAlpha` | 改 |
+| `Tests/EditMode/Lint/CarouselRulesTests.cs` | peek 模式 lint 用例 | 改 |
+| `Tests/EditMode/Controls/CarouselPeekTests.cs` | size/stride/edgeScale/edgeAlpha/ReSolve 复位 | 新建 |
+| `Tests/EditMode/Controls/CarouselDragTests.cs` | peek 拖动步距 | 改 |
+| `Tests/EditMode/Editor/XsdGeneratorTests.cs` | 4 个新属性出现在 XSD 的 substring 断言 | 改 |
+| `.claude/skills/authoring-promptugui-xml/reference/controls-carousel.md` | peek 小节 + lint 表 | 改 |
+| `.claude/skills/authoring-promptugui-xml/SKILL.md` | Carousel 行补 4 属性 | 改 |
+| `.claude/skills/scripting-promptugui-csharp/SKILL.md` | 一句：左右箭头 = `<Btn>` 绑 `Previous()`/`Next()` | 改 |
+| `docs~/superpowers/specs/2026-06-04-carousel-design.md` | Out-of-Scope 的 peek 项标记 v2 已做 + 反链 | 改 |
+
+---
+
+## Task 1: Lint —— CARD-SIZE 按 fill 门控 + 新增 PEEK-NO-SIZE
+
+**Files:**
+- Modify: `Runtime/Core/Lint/CarouselRules.cs`
+- Modify: `Runtime/Core/Lint/IRWalker.cs:125`
+- Modify: `Runtime/Application/ScreenInstantiator.cs:286`
+- Test: `Tests/EditMode/Lint/CarouselRulesTests.cs`
+
+> 先做 lint：peek 卡要写 `size=`，若不先放开门控，后续 peek 布局测试会在 ScreenInstantiator 喷 `PUI-CAROUSEL-CARD-SIZE` 警告（无害但误导）。
+
+- [ ] **Step 1: 写失败测试**（追加到 `CarouselRulesTests.cs`，类内）
+
+```csharp
+[Test]
+public void Peek_Card_With_Size_Does_Not_Trigger_CardSize()
+{
+    var issues = IRWalker.Walk(Doc("<Carousel fill='false'><Frame width='120'/></Carousel>")).ToList();
+    Assert.IsFalse(issues.Any(i => i.Code == CarouselRules.CardSizeCode),
+        "fill=false allows a card to declare its own size");
+}
+
+[Test]
+public void Peek_Bare_Container_Card_Triggers_PeekNoSize()
+{
+    var issues = IRWalker.Walk(Doc("<Carousel fill='false'><Frame/></Carousel>")).ToList();
+    Assert.That(issues.Any(i => i.Code == CarouselRules.PeekNoSizeCode),
+        "bare Frame in peek mode has no resolvable size -> warning");
+}
+
+[Test]
+public void Peek_Image_Card_Without_Size_Does_Not_Trigger_PeekNoSize()
+{
+    var issues = IRWalker.Walk(Doc("<Carousel fill='false'><Image/></Carousel>")).ToList();
+    Assert.IsFalse(issues.Any(i => i.Code == CarouselRules.PeekNoSizeCode),
+        "Image carries a native (sprite) size -> not flagged");
+}
+
+[Test]
+public void Fill_Mode_Card_With_Size_Still_Triggers_CardSize()
+{
+    var issues = IRWalker.Walk(Doc("<Carousel><Image width='50'/></Carousel>")).ToList();
+    Assert.That(issues.Any(i => i.Code == CarouselRules.CardSizeCode),
+        "default fill=true keeps the v1 card-size error");
+}
+```
+
+- [ ] **Step 2: 跑测确认失败**
+
+`refresh_unity` → `read_console(types=["error"])`（此时编译会因 `PeekNoSizeCode` 不存在而**编译失败** → 预期；下一步实现后再跑）。
+`run_tests(EditMode, group_names=["CarouselRulesTests"])`
+预期：编译错误 `'CarouselRules' does not contain a definition for 'PeekNoSizeCode'`。
+
+- [ ] **Step 3: 实现** —— 替换 `CarouselRules.cs` 的 `CheckCard`，加常量与 helper
+
+把现有 `public static IEnumerable<LintIssue> CheckCard(ElementNode child)`（`CarouselRules.cs:47-58`）整段替换为：
+
+```csharp
+        public const string PeekNoSizeCode = "PUI-CAROUSEL-PEEK-NO-SIZE";
+
+        // 无 GetNativeSize() override 的纯容器（Control 基类返回 null）：peek 模式下这种卡根
+        // 不写 size 会兜成视口尺寸（不 peek）。Image/Text/Progress/Icon 等自带原生尺寸，放过。
+        private static readonly HashSet<string> NoNativeSizeContainers = new HashSet<string>
+        { "Frame", "VStack", "HStack", "Grid" };
+
+        private static bool HasOwnSize(ElementNode n)
+            => n.Attributes.ContainsKey("size")
+            || n.Attributes.ContainsKey("width")
+            || n.Attributes.ContainsKey("height")
+            || n.VariantOverrides.ContainsKey("size")
+            || n.VariantOverrides.ContainsKey("width")
+            || n.VariantOverrides.ContainsKey("height");
+
+        // parent-relative：检查 Carousel 的一个直接子（卡片）。需要父 Carousel 读 `fill`：
+        // fill=true（默认）禁止卡片写 size；fill="false"（peek）放开，但对「无原生尺寸容器且没写 size」
+        // 的卡给 warning。fill 只读基础属性（base）——peek carousel 的 fill="false" 一定写在 base。
+        public static IEnumerable<LintIssue> CheckCard(ElementNode carousel, ElementNode child)
+        {
+            bool peek = carousel.Attributes.TryGetValue("fill", out var f) && f == "false";
+            if (!peek)
+            {
+                if (HasOwnSize(child))
+                    yield return new LintIssue(
+                        CardSizeCode, child.Tag, child.Id,
+                        $"<{child.Tag} id='{child.Id}'>: a Carousel card is sized to the viewport by the control; " +
+                        "remove size/width/height (or set fill=\"false\" for a peek selector).");
+            }
+            else if (!HasOwnSize(child) && NoNativeSizeContainers.Contains(child.Tag))
+            {
+                yield return new LintIssue(
+                    PeekNoSizeCode, child.Tag, child.Id,
+                    $"<{child.Tag} id='{child.Id}'>: fill=\"false\" card has no size and no native size; " +
+                    "it will fill the viewport and neighbours won't peek. Add size= on the card root, " +
+                    "or use a control with a native size (e.g. <Image>).");
+            }
+        }
+```
+
+更新 `IRWalker.cs:125`：
+
+```csharp
+                if (node.Tag == "Carousel")
+                    foreach (var issue in CarouselRules.CheckCard(node, child))
+                        yield return issue;
+```
+
+更新 `ScreenInstantiator.cs:285-287`：
+
+```csharp
+                if (node.Tag == "Carousel")
+                    foreach (var issue in PromptUGUI.Lint.CarouselRules.CheckCard(node, c))
+                        Debug.LogWarning(issue.Message);
+```
+
+- [ ] **Step 4: 跑测确认通过**
+
+`refresh_unity` → `read_console(types=["error"])`（应无编译错误）
+`run_tests(EditMode, group_names=["CarouselRulesTests"])`
+预期：全 PASS（含既有 5 个 + 新 4 个）。
+
+- [ ] **Step 5: lint + commit**
+
+```bash
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+cd .. && git add Runtime/Core/Lint/CarouselRules.cs Runtime/Core/Lint/IRWalker.cs Runtime/Application/ScreenInstantiator.cs Tests/EditMode/Lint/CarouselRulesTests.cs
+git commit -m "$(printf 'feat(carousel): gate CARD-SIZE on fill, add PUI-CAROUSEL-PEEK-NO-SIZE\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 2: peek 布局核心 —— `fill`/`spacing` + 卡尺寸 + 步距
+
+**Files:**
+- Modify: `Runtime/Controls/Carousel.cs`
+- Modify: `Runtime/Controls/Internal/CarouselView.cs`
+- Test: `Tests/EditMode/Controls/CarouselPeekTests.cs`（新建）
+
+- [ ] **Step 1: 写失败测试**（新建 `CarouselPeekTests.cs`）
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class CarouselPeekTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static Carousel Open(string innerXml)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{innerXml}</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S").Get<Carousel>("car");
+        }
+
+        private static RectTransform Card(Carousel car, int i)
+            => (RectTransform)car.GameObject.transform.Find("Viewport/Strip").GetChild(i);
+
+        [Test]
+        public void Peek_Honors_Card_Size_Not_Viewport()
+        {
+            var car = Open("<Carousel id='car' size='200x100' fill='false'>" +
+                           "<Frame size='120x80'/><Frame size='120x80'/></Carousel>");
+            Assert.AreEqual(120f, Card(car, 0).rect.width, 0.5f, "peek card keeps its own width (not viewport 200)");
+            Assert.AreEqual(80f, Card(car, 0).rect.height, 0.5f);
+        }
+
+        [Test]
+        public void Peek_Stride_Is_CardWidth_Plus_Spacing()
+        {
+            var car = Open("<Carousel id='car' size='200x100' fill='false' spacing='10'>" +
+                           "<Frame size='120x80'/><Frame size='120x80'/><Frame size='120x80'/></Carousel>");
+            Assert.AreEqual(0f, Card(car, 0).anchoredPosition.x, 0.5f, "focus card centered at x=0");
+            Assert.AreEqual(130f, Card(car, 1).anchoredPosition.x, 0.5f, "neighbour at cardWidth+spacing = 130");
+        }
+
+        [Test]
+        public void Fill_Mode_Default_Unchanged()
+        {
+            var car = Open("<Carousel id='car' size='200x100'><Image/><Image/></Carousel>");
+            Assert.AreEqual(200f, Card(car, 0).rect.width, 0.5f, "fill=true (default) still sizes cards to viewport");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 跑测确认失败**
+
+`run_tests(EditMode, group_names=["CarouselPeekTests"])`
+预期：`Peek_*` FAIL（卡片仍被强制视口尺寸 200、x 间距 200）；`Fill_Mode_Default_Unchanged` PASS。
+
+- [ ] **Step 3: 实现** —— Carousel 加 2 属性 + CarouselView 拆尺寸/步距
+
+`Carousel.cs`：在既有 `Loop`/`Transition` setter 附近（`Carousel.cs:69` 之后）加：
+
+```csharp
+        [UIAttr, Preserve]
+        public bool Fill { set => _view.SetFill(value); }
+
+        [UIAttr, Preserve]
+        public float Spacing { set => _view.SetSpacing(value); }
+```
+
+`CarouselView.cs`：
+
+(a) 字段区（`_pageWidth`/`_pageHeight` 旁，`CarouselView.cs:37-38`）加：
+
+```csharp
+        private bool _fill = true;          // CAR-D25：默认 v1 全幅
+        private float _spacing = 0f;        // CAR-D27
+        private float _cardW = 1f;          // 卡槽尺寸（fill=true → 视口；false → resolved 卡尺寸）
+        private float _cardH = 1f;
+        private float _stride = 1f;          // 相邻卡中心距（fill=true → 视口宽；false → _cardW+_spacing）
+```
+
+(b) setter（`SetLoop` 旁，`CarouselView.cs:99`）加：
+
+```csharp
+        public void SetFill(bool v) => _fill = v;
+        public void SetSpacing(float v) => _spacing = Mathf.Max(0f, v);
+```
+
+(c) `MeasureCard`（新方法，放 `RelayoutNow` 上方）：
+
+```csharp
+        // peek 假定卡等尺寸：取第 0 张卡的 resolved 尺寸作槽位（在 Reposition 之前调，
+        // 此时卡的 size= 已由 apply 落到 sizeDelta）。落空（裸 Frame）兜视口，永不为 0。
+        private void MeasureCard(out float w, out float h)
+        {
+            w = _pageWidth; h = _pageHeight;
+            if (_cards.Count > 0 && _cards[0] is Control c0 && c0.GameObject != null)
+            {
+                var rect = c0.RectTransform.rect;
+                if (rect.width > 0f) w = rect.width;
+                if (rect.height > 0f) h = rect.height;
+            }
+        }
+```
+
+(d) `RelayoutNow`（`CarouselView.cs:385`）—— 在算完 `_pageWidth`/`_pageHeight` 之后、clamp `_current` 之前插入：
+
+```csharp
+            if (_fill) { _cardW = _pageWidth; _cardH = _pageHeight; _stride = _pageWidth; }
+            else { MeasureCard(out _cardW, out _cardH); _stride = _cardW + _spacing; }
+```
+
+(e) `Reposition`（`CarouselView.cs:378-379`）—— 把这两行：
+
+```csharp
+                rt.sizeDelta = new Vector2(_pageWidth, _pageHeight);
+                rt.anchoredPosition = new Vector2(off * _pageWidth, 0f);
+```
+
+改成：
+
+```csharp
+                rt.sizeDelta = new Vector2(_cardW, _cardH);
+                rt.anchoredPosition = new Vector2(off * _stride, 0f);
+```
+
+- [ ] **Step 4: 跑测确认通过**
+
+`refresh_unity` → `read_console(types=["error"])`
+`run_tests(EditMode, group_names=["CarouselPeekTests"])` → 全 PASS
+`run_tests(EditMode, group_names=["CarouselTests"])` → 全 PASS（fill=true 回归，§Architecture 的逐字等价）
+
+- [ ] **Step 5: commit**
+
+```bash
+git add Runtime/Controls/Carousel.cs Runtime/Controls/Internal/CarouselView.cs Tests/EditMode/Controls/CarouselPeekTests.cs
+git commit -m "$(printf 'feat(carousel): fill=false honors card size + spacing stride\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 3: `edgeScale` —— 焦点卡满、边卡缩（每帧重写自复位）
+
+**Files:**
+- Modify: `Runtime/Controls/Carousel.cs`
+- Modify: `Runtime/Controls/Internal/CarouselView.cs`
+- Test: `Tests/EditMode/Controls/CarouselPeekTests.cs`
+
+- [ ] **Step 1: 写失败测试**（追加到 `CarouselPeekTests.cs`）
+
+```csharp
+[Test]
+public void Peek_EdgeScale_Shrinks_Neighbours_Focus_Full()
+{
+    var car = Open("<Carousel id='car' size='400x100' fill='false' edgeScale='0.8' loop='true'>" +
+                   "<Frame size='120x80'/><Frame size='120x80'/><Frame size='120x80'/></Carousel>");
+    Assert.AreEqual(1f, Card(car, 0).localScale.x, 0.001f, "focus card (off 0) full scale");
+    Assert.AreEqual(0.8f, Card(car, 1).localScale.x, 0.001f, "neighbour (off 1) shrunk to edgeScale");
+}
+
+[Test]
+public void Peek_EdgeScale_Reapplied_On_GoTo_Self_Resets()
+{
+    var car = Open("<Carousel id='car' size='400x100' fill='false' edgeScale='0.8' loop='true'>" +
+                   "<Frame size='120x80'/><Frame size='120x80'/><Frame size='120x80'/></Carousel>");
+    Assert.AreEqual(0.8f, Card(car, 1).localScale.x, 0.001f, "initially a neighbour");
+    car.GoTo(1, animated: false);   // card1 becomes focus
+    Assert.AreEqual(1f, Card(car, 1).localScale.x, 0.001f, "scale re-written every Reposition (self-resets to 1)");
+}
+```
+
+- [ ] **Step 2: 跑测确认失败**
+
+`run_tests(EditMode, group_names=["CarouselPeekTests"])`
+预期：编译失败（`EdgeScale` 不存在）→ 实现后再跑。
+
+- [ ] **Step 3: 实现**
+
+`Carousel.cs`：加
+
+```csharp
+        [UIAttr, Preserve]
+        public float EdgeScale { set => _view.SetEdgeScale(value); }
+```
+
+`CarouselView.cs`：
+- 字段加 `private float _edgeScale = 1f;`
+- setter 加 `public void SetEdgeScale(float v) => _edgeScale = v;`
+- `Reposition` 循环里，`anchoredPosition` 那行**之后**加（`localScale` 总是写、不短路 → fill=true / edgeScale=1 时 `s=1` 自复位）：
+
+```csharp
+                float t = Mathf.Clamp01(Mathf.Abs(off));          // CAR-D32 线性
+                rt.localScale = Vector3.one * Mathf.Lerp(1f, _edgeScale, t);
+```
+
+- [ ] **Step 4: 跑测确认通过**
+
+`run_tests(EditMode, group_names=["CarouselPeekTests"])` → 全 PASS
+`run_tests(EditMode, group_names=["CarouselTests"])` → 全 PASS（fill=true 下 edgeScale=1 → localScale 恒 1，不破坏 v1）
+
+- [ ] **Step 5: commit**
+
+```bash
+git add Runtime/Controls/Carousel.cs Runtime/Controls/Internal/CarouselView.cs Tests/EditMode/Controls/CarouselPeekTests.cs
+git commit -m "$(printf 'feat(carousel): edgeScale shrinks peek neighbours toward edges\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 4: `edgeAlpha` —— 边卡渐隐（懒加 / 复用 CanvasGroup）
+
+**Files:**
+- Modify: `Runtime/Controls/Carousel.cs`
+- Modify: `Runtime/Controls/Internal/CarouselView.cs`
+- Test: `Tests/EditMode/Controls/CarouselPeekTests.cs`
+
+- [ ] **Step 1: 写失败测试**（追加到 `CarouselPeekTests.cs`）
+
+```csharp
+[Test]
+public void Peek_EdgeAlpha_Fades_Neighbours_Via_CanvasGroup()
+{
+    var car = Open("<Carousel id='car' size='400x100' fill='false' edgeAlpha='0.4' loop='true'>" +
+                   "<Frame size='120x80'/><Frame size='120x80'/><Frame size='120x80'/></Carousel>");
+    var cg = Card(car, 1).GetComponent<CanvasGroup>();
+    Assert.IsTrue(cg != null, "neighbour gets a CanvasGroup for fading");
+    Assert.AreEqual(0.4f, cg.alpha, 0.001f, "neighbour faded to edgeAlpha");
+}
+
+[Test]
+public void Peek_Focus_Card_Full_Alpha()
+{
+    var car = Open("<Carousel id='car' size='400x100' fill='false' edgeAlpha='0.4' loop='true'>" +
+                   "<Frame size='120x80'/><Frame size='120x80'/><Frame size='120x80'/></Carousel>");
+    var cg = Card(car, 0).GetComponent<CanvasGroup>();
+    Assert.IsTrue(cg == null || Mathf.Approximately(cg.alpha, 1f), "focus card fully opaque");
+}
+
+[Test]
+public void Fill_Mode_Adds_No_CanvasGroup()
+{
+    var car = Open("<Carousel id='car' size='200x100'><Image/><Image/></Carousel>");
+    Assert.IsTrue(Card(car, 0).GetComponent<CanvasGroup>() == null,
+        "fill-mode cards never get a CanvasGroup (edgeAlpha inert)");
+}
+```
+
+- [ ] **Step 2: 跑测确认失败**
+
+`run_tests(EditMode, group_names=["CarouselPeekTests"])`
+预期：编译失败（`EdgeAlpha` 不存在）→ 实现后再跑。
+
+- [ ] **Step 3: 实现**
+
+`Carousel.cs`：加
+
+```csharp
+        [UIAttr, Preserve]
+        public float EdgeAlpha { set => _view.SetEdgeAlpha(value); }
+```
+
+`CarouselView.cs`：
+- 字段加 `private float _edgeAlpha = 1f;`
+- setter 加 `public void SetEdgeAlpha(float v) => _edgeAlpha = v;`
+- `Reposition` 循环里，`localScale` 那行之后加：
+
+```csharp
+                ApplyAlpha(card, Mathf.Lerp(1f, _edgeAlpha, t));
+```
+
+- 新方法（放 `Reposition` 下方）：
+
+```csharp
+        // a<1 才懒加 CanvasGroup 并设 alpha；a==1 时若已有则复位（不新挂）——纯 fill carousel
+        // 永不挂 CanvasGroup；peek→fill 切换 / 焦点变化时已有的 group 被复位回不透明。
+        private static void ApplyAlpha(Control card, float a)
+        {
+            var go = card.GameObject;
+            var cg = go.GetComponent<CanvasGroup>();
+            if (a < 1f)
+            {
+                if (cg == null) cg = go.AddComponent<CanvasGroup>();
+                cg.alpha = a;
+            }
+            else if (cg != null)
+            {
+                cg.alpha = 1f;
+            }
+        }
+```
+
+- [ ] **Step 4: 跑测确认通过**
+
+`run_tests(EditMode, group_names=["CarouselPeekTests"])` → 全 PASS
+`run_tests(EditMode, group_names=["CarouselTests"])` → 全 PASS
+
+- [ ] **Step 5: commit**
+
+```bash
+git add Runtime/Controls/Carousel.cs Runtime/Controls/Internal/CarouselView.cs Tests/EditMode/Controls/CarouselPeekTests.cs
+git commit -m "$(printf 'feat(carousel): edgeAlpha fades peek neighbours via CanvasGroup\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 5: 拖动 / 吸附改用步距（peek 阈值）
+
+**Files:**
+- Modify: `Runtime/Controls/Internal/CarouselView.cs`
+- Test: `Tests/EditMode/Controls/CarouselDragTests.cs`
+
+> v1 拖动把本地位移除以 `_pageWidth`、阈值用 `_pageWidth * SnapThreshold`。peek 模式步距是卡宽而非视口宽，必须换成 `_stride`，否则窄卡的拖动手感/翻页阈值全错（按 200 而非卡宽算）。
+
+- [ ] **Step 1: 写失败测试**（追加到 `CarouselDragTests.cs`，类内）
+
+先在类里加一个带尺寸卡的 Open 辅助（放现有 `Open` 旁）：
+
+```csharp
+        private static Carousel OpenCards(string attrs, string cards)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Carousel id='car' size='200x100' {attrs}>{cards}</Carousel>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S").Get<Carousel>("car");
+        }
+```
+
+再加测试：
+
+```csharp
+[Test]
+public void Peek_Drag_Threshold_Scales_With_Card_Stride()
+{
+    // 视口 200，卡宽 100，spacing 0 → 步距 100、阈值 0.2*100 = 20。
+    // 拖 -30：> 卡步距阈值（翻页），但 < 旧视口阈值 0.2*200=40（旧逻辑会回弹）。
+    var car = OpenCards("fill='false' spacing='0' interval='0'",
+        "<Frame size='100x80'/><Frame size='100x80'/><Frame size='100x80'/>");
+    DragLocal(car.GameObject.GetComponent<CarouselView>(), -30f);
+    Assert.AreEqual(1, car.Current, "drag threshold uses card stride (100), not viewport width (200)");
+}
+```
+
+- [ ] **Step 2: 跑测确认失败**
+
+`run_tests(EditMode, group_names=["CarouselDragTests"])`
+预期：`Peek_Drag_Threshold_Scales_With_Card_Stride` FAIL（`Current==0`，因仍用 `_pageWidth=200`、阈值 40 > 30 → 回弹）。
+
+- [ ] **Step 3: 实现** —— `CarouselView.cs` 把拖动里的 `_pageWidth` 换成 `_stride`
+
+`OnDrag`（`CarouselView.cs:466-467`）：
+
+```csharp
+            _dragLocalX = Mathf.Clamp(dxLocal, -_stride, _stride);
+            _scroll = _dragStartScroll - _dragLocalX / _stride;
+```
+
+`OnEndDrag`（`CarouselView.cs:476-477`）：
+
+```csharp
+            if (_dragLocalX <= -_stride * SnapThreshold) target = _current + 1;
+            else if (_dragLocalX >= _stride * SnapThreshold) target = _current - 1;
+```
+
+> fill=true 时 `_stride == _pageWidth`，v1 拖动测试逐字不变。
+
+- [ ] **Step 4: 跑测确认通过**
+
+`run_tests(EditMode, group_names=["CarouselDragTests"])` → 全 PASS（含 v1 的 6 个 + 新 1 个）
+
+- [ ] **Step 5: commit**
+
+```bash
+git add Runtime/Controls/Internal/CarouselView.cs Tests/EditMode/Controls/CarouselDragTests.cs
+git commit -m "$(printf 'feat(carousel): drag/snap use card stride in peek mode\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 6: ReSolve 幂等 —— fill 经 Variant 切换复位 scale/alpha
+
+**Files:**
+- Test: `Tests/EditMode/Controls/CarouselPeekTests.cs`
+
+> 这是**守护测试**：验证 Task 3/4 的「每帧重写 localScale + ApplyAlpha 复位已有 CanvasGroup」在真实 ReSolve 通道下能把 peek 视觉复位。若全过（无需新生产代码），说明自复位实现正确；若失败，根因必是 `Reposition` 里对 scale/alpha 做了 `if(!_fill)` 短路——删掉短路即可。
+
+- [ ] **Step 1: 写测试**（追加到 `CarouselPeekTests.cs`）
+
+```csharp
+[Test]
+public void Fill_Toggled_Via_Variant_Resets_Scale_And_Alpha()
+{
+    var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Carousel id='car' size='400x100' fill='false' fill.big='true'
+            edgeScale='0.8' edgeAlpha='0.4' loop='true'>
+    <Frame size='120x80'/><Frame size='120x80'/><Frame size='120x80'/>
+  </Carousel>
+</Screen></PromptUGUI>";
+    UI.LoadDocument("t", xml);
+    var car = UI.Open("S").Get<Carousel>("car");
+    var card1 = (RectTransform)car.GameObject.transform.Find("Viewport/Strip").GetChild(1);
+    Assert.AreEqual(0.8f, card1.localScale.x, 0.001f, "peek: neighbour shrunk");
+
+    UI.Variants.Set("big", true);   // fill -> true -> ReSolve -> Reposition resets
+
+    Assert.AreEqual(1f, card1.localScale.x, 0.001f, "fill=true resets card scale to 1");
+    var cg = card1.GetComponent<CanvasGroup>();
+    Assert.IsTrue(cg == null || Mathf.Approximately(cg.alpha, 1f), "fill=true resets card alpha to 1");
+}
+
+[Test]
+public void Resize_Does_Not_Duplicate_CanvasGroup()
+{
+    var car = Open("<Carousel id='car' size='400x100' fill='false' edgeAlpha='0.4' loop='true'>" +
+                   "<Frame size='120x80'/><Frame size='120x80'/><Frame size='120x80'/></Carousel>");
+    var card1 = (RectTransform)car.GameObject.transform.Find("Viewport/Strip").GetChild(1);
+    var view = car.GameObject.GetComponent<CarouselView>();
+    view.InvokeRectChangedForTests();
+    view.InvokeRectChangedForTests();
+    Assert.AreEqual(1, card1.GetComponents<CanvasGroup>().Length, "no duplicate CanvasGroup across reflows");
+}
+```
+
+- [ ] **Step 2: 跑测**
+
+`run_tests(EditMode, group_names=["CarouselPeekTests"])`
+预期：PASS（Task 3/4 已实现自复位）。**若 FAIL** → 检查 `Reposition`：localScale 必须每帧无条件写、`ApplyAlpha` 的 `a==1` 分支必须复位已有 CanvasGroup（按 Task 3/4 Step 3）。修正后再跑。
+
+- [ ] **Step 3: commit**
+
+```bash
+git add Tests/EditMode/Controls/CarouselPeekTests.cs
+git commit -m "$(printf 'test(carousel): peek scale/alpha self-reset across ReSolve\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 7: XSD —— 4 个新属性出现在生成的 schema
+
+**Files:**
+- Modify: `Tests/EditMode/Editor/XsdGeneratorTests.cs`
+- Modify: 已提交的 `.xsd` 工件（如有）
+
+> XSD 生成器反射 `[UIAttr]`，属性加好后生成结果自动含这 4 个；只需加 substring 断言 + 重生成提交工件。
+
+- [ ] **Step 1: 找现有 Carousel 的 XSD 断言锚点**
+
+`mcp__UnityMCP__find_in_file` 或 grep：在 `Tests/EditMode/Editor/XsdGeneratorTests.cs` 里搜 `Carousel` / `interval` 找到既有的针对 Carousel 属性的 `StringAssert.Contains` 测试方法，照它的风格在同一方法（或新方法）加：
+
+```csharp
+StringAssert.Contains("fill", xsd);
+StringAssert.Contains("spacing", xsd);
+StringAssert.Contains("edgeScale", xsd);
+StringAssert.Contains("edgeAlpha", xsd);
+```
+
+（`xsd` 为该测试里已生成的 schema 字符串变量名；用现有变量名，别新造。）
+
+- [ ] **Step 2: 跑测确认通过**
+
+`run_tests(EditMode, assembly_names=["PromptUGUI.Tests.EditorOnly"], group_names=["XsdGeneratorTests"])`
+预期：PASS（生成器已含新属性）。若该测试断言的是某个**固定 .xsd 文件内容**而非内存生成串，则先做 Step 3 重生成，再跑。
+
+- [ ] **Step 3: 重生成并提交 .xsd 工件**
+
+若仓库里有签入的 `.xsd`（grep `*.xsd` 找路径），用菜单重生成：
+`mcp__UnityMCP__execute_menu_item(menu_path="Tools/PromptUGUI/Schema/Generate XSD")`（路径以实际菜单为准；**不是**禁用的 Reimport All）。
+然后 `git add` 变更的 `.xsd`。
+
+- [ ] **Step 4: commit**
+
+```bash
+git add Tests/EditMode/Editor/XsdGeneratorTests.cs
+# 若有重生成的 .xsd 一并 add
+git commit -m "$(printf 'test(carousel): XSD covers fill/spacing/edgeScale/edgeAlpha\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 8: 文档 —— XML reference + 主 catalog + spec 反链
+
+**Files:**
+- Modify: `.claude/skills/authoring-promptugui-xml/reference/controls-carousel.md`
+- Modify: `.claude/skills/authoring-promptugui-xml/SKILL.md`
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md`
+- Modify: `docs~/superpowers/specs/2026-06-04-carousel-design.md`
+
+> CLAUDE.md 硬性要求：功能变更必须同 PR 更新相关 skill。**匹配每个目标文件现有的语言**（`controls-carousel.md` 是中文；`SKILL.md` 看现状跟随）。无测试，纯文档。
+
+- [ ] **Step 1: `reference/controls-carousel.md` 加 peek 小节**
+
+在「卡片布局约束」小节后插入新小节（中文，匹配该文件风格）：
+
+```markdown
+## 居中选择 / peek 模式（`fill="false"`）
+
+默认 `fill="true"`：卡片撑满视口、一卡一页（banner）。`fill="false"` 切到**居中卡片选择器**——卡片用自身 `size`、两侧邻卡露出、焦点卡最大最亮、越往边越小越淡：
+
+​```xml
+<Carousel id="sel" anchor="center" size="600x360"
+          fill="false" spacing="24" edgeScale="0.8" edgeAlpha="0.45"
+          interval="0" itemTemplate="LevelCard"/>
+​```
+
+- `fill="false"` 下卡片**必须有尺寸**：卡根写 `size=`（裸 `<Frame>`），或用自带原生尺寸的控件（`<Image>`/`<Text>`）。无尺寸的容器卡会兜成视口、不 peek（lint `PUI-CAROUSEL-PEEK-NO-SIZE` 提示）。
+- peek 露出多少 = `(carousel 宽 − 卡宽)/2 − spacing`，**由卡尺寸 vs carousel 尺寸隐式决定**，没有单独的 peek 属性。
+- `edgeScale`（默认 `1.0`，不缩）/ `edgeAlpha`（默认 `1.0`，不淡）：基准是**选中卡**——中心 = 声明尺寸/不透明，按距中心距离线性插值到边值。
+- `spacing`（默认 `0`）：相邻卡间距 px，仅 `fill="false"` 生效。
+- `fill="false"` 下 Carousel 占用卡根的 `localScale`（做 edgeScale）；卡根别再写 density `scale=`，要缩放写卡的里层节点。
+- autoplay 与 fill 正交：选择器自己写 `interval="0"`。左右翻页箭头 = 放 `<Btn>` 绑 C# `Previous()`/`Next()`。
+```
+
+把该文件「Lint 规则」表更新为：`PUI-CAROUSEL-CARD-SIZE` 标注「仅 `fill="true"` 触发」；新增一行 `PUI-CAROUSEL-PEEK-NO-SIZE`（warning，`fill="false"` 卡根是无原生尺寸容器且没写 size）。
+
+- [ ] **Step 2: 主文档 `SKILL.md` 的 Carousel 行补属性**
+
+在内置控件表 `<Carousel>` 行的属性列补 `fill` / `spacing` / `edgeScale` / `edgeAlpha`（一句话各自语义，详情指向 reference）。
+
+- [ ] **Step 3: `scripting-promptugui-csharp/SKILL.md` 补一句**
+
+在 Carousel 的 C# 速查处加：「居中选择器的左右箭头 = `<Btn>` 绑 `car.Previous()` / `car.Next()`（已是 public 方法，无需新 API）」。
+
+- [ ] **Step 4: v1 spec 反链**
+
+`docs~/superpowers/specs/2026-06-04-carousel-design.md` §12 Out of Scope 里「peek 露边」「cross-fade / 缩放转场」「per-card 自有尺寸」三项，各加一句「→ v2 已做，见 `2026-06-15-carousel-peek-mode-design.md`」。
+
+- [ ] **Step 5: 验证 docs 内引用的 XML 能过 lint CLI**
+
+```bash
+cd .lint && dotnet run --project UIXmlLint -- ../Runtime/Resources/   # 确认没引入回归（peek 是新增、不影响既有资源）
+```
+
+- [ ] **Step 6: commit**
+
+```bash
+git add .claude/skills/authoring-promptugui-xml/reference/controls-carousel.md \
+        .claude/skills/authoring-promptugui-xml/SKILL.md \
+        .claude/skills/scripting-promptugui-csharp/SKILL.md \
+        "docs~/superpowers/specs/2026-06-04-carousel-design.md"
+git commit -m "$(printf 'docs(carousel): document fill=false peek mode in skills + spec backlink\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## 最终验证（全量，不靠 targeted group 宣称绿）
+
+> 经验教训：别只跑 targeted group 就说全绿——曾漏跑 PlayMode 回归。下面三个全量都要亲跑。
+
+- [ ] `refresh_unity(compile="request", mode="force", scope="all")` → `read_console(types=["error"])` 无错
+- [ ] `run_tests(EditMode, assembly_names=["PromptUGUI.Tests.EditMode"])` 全量轮询到完成，全绿
+- [ ] `run_tests(EditMode, assembly_names=["PromptUGUI.Tests.EditorOnly"])` 全绿（XSD）
+- [ ] `run_tests(PlayMode, assembly_names=["PromptUGUI.Tests.PlayMode"])` 全绿（含 `CarouselPlayTests` 自动播放回归——autoplay 与 fill 正交，应不受影响）
+- [ ] `cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx` 干净
+- [ ] `dotnet run --project .lint/UIXmlLint -- Runtime/Resources/` 无新增 error
+- [ ] 视觉 QA（用户）：在宿主工程摆一个 `fill="false"` 选择器，确认邻卡露边、焦点放大、边缘淡出、拖动吸附、左右按钮（绑 Next/Previous）观感正确
+
+---
+
+## Self-Review（写计划时已核对）
+
+- **Spec 覆盖**：CAR-D25 `fill`→T2；D26 卡尺寸回退+lint→T1/T2；D27 `spacing`→T2；D28 `edgeScale`/`edgeAlpha`→T3/T4；D29 localScale/CanvasGroup→T3/T4；D30 autoplay 正交→无代码（文档 T8）；D31 PEEK-NO-SIZE→T1；D32 线性插值→T3/T4；§6.5 拖动步距→T5；§8 向后兼容→T2/T3/T4 的 CarouselTests 回归 + 最终全量；ReSolve 复位→T6。
+- **类型一致**：`SetFill(bool)`/`SetSpacing(float)`/`SetEdgeScale(float)`/`SetEdgeAlpha(float)`；字段 `_fill bool`、`_spacing/_edgeScale/_edgeAlpha/_cardW/_cardH/_stride float`；`MeasureCard(out float,out float)`；`ApplyAlpha(Control,float)`——各 Task 引用一致。
+- **占位**：无 TBD；XSD 的「找锚点 / 实际菜单路径」是因生成器实现需现场确认的真实步骤，非占位（给了 grep/find 指令）。
+- **lint 双调用点**：`CheckCard` 签名改动同步 IRWalker:125 + ScreenInstantiator:286（T1 Step 3 都列了）。

--- a/docs~/superpowers/plans/2026-06-15-centered-slide-box.md
+++ b/docs~/superpowers/plans/2026-06-15-centered-slide-box.md
@@ -1,0 +1,667 @@
+# CenteredSlideBox 居中选择器模态 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增第 4 个内置模态 `CenteredSlideBox.Open<T>(items, bind, …) → Awaitable<T>`——把 `fill="false"` peek Carousel 包成「居中卡片选择器」弹窗：泛型数据 + bind 填卡，A+C 选中（点侧卡居中 / 点居中卡确认 / 确认按钮），取消三通道（× / 背景 / ESC）→ `null`，返回选中对象。
+
+**Architecture:** `CenteredSlideBoxRequest<T> : ModalRequest<T>`（照 `MarkdownBoxRequest`）持 items/bind/title/confirmLabel；`Bind(screen, close)` 里 `car.BindItems(Observable.Return(items), …)` 建卡、每卡挂透明 raycast + `PuiButton`（click→居中/确认）、确认按钮→`close(items[car.Current])`、×/背景→`close(null)`；`TryEscape→null`。卡片 `<Template name="Card">` 写在内置 `CenteredSlideBox.ui.xml` **自己文档里**，Carousel 用 v1 `itemTemplate` 解析（同文档，无跨文档）。**Carousel/BuiltinTags/lint/XSD 零改动。**
+
+**Tech Stack:** Unity 6 uGUI, C# 9, R3 (`Observable.Return` / `.Subscribe` / `.AddTo`), Unity `Awaitable`, NUnit + Unity Test Framework, Unity MCP 跑测。
+
+**Spec:** `docs~/superpowers/specs/2026-06-15-centered-slide-box-design.md`（CSB-D1..D11）。建立在 peek Carousel（同分支前序工作）。
+
+**关键约定（务必遵守）：**
+- **同分支 `feat/carousel-peek-mode`**（spec 已提交在上面）。**禁止向 main 提交**。
+- 每写完 `.cs` → `mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)` → `mcp__UnityMCP__read_console(action="get", types=["error"])` 确认无编译错误，再跑测。
+- 跑测：`mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["CenteredSlideBoxTests"])` → 轮询 `mcp__UnityMCP__get_test_job(job_id=..., wait_timeout=40)`。**无 `filter` 参数**，用 `group_names`。
+- 模态 EditMode 测试**不依赖 Resources**：用 `UI.SourceResolver` 注入假 XML + 把 `CenteredSlideBox.XmlSrc` 指到测试 key（照 `Tests/EditMode/Modals/InputBoxTests.cs`）。Resources 里的真 XML 仅供生产 + UIXmlLint。
+- 所有模态测试 `[SetUp]`/`[TearDown]` 调 `UI.ResetForTests()`。
+- 每个 Task 末尾 commit；message 末尾加 `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`。
+- **已核实事实（照此实现，别质疑）：**
+  - `ModalRequest<TResult>`：`abstract string XmlSrc`、`Action<IScreen> Configure`、`abstract void Bind(IScreen, Action<TResult> close)`、`virtual bool TryEscape(out TResult)`。`UI.Modal.OpenAsync<TResult>(ModalRequest<TResult> req, ModalMode mode, CancellationToken ct) → Awaitable<TResult>`。
+  - `IControl` 暴露 `GameObject` / `RectTransform` / `Interactable` / `Get<T>(id)`（`IControl.cs:4-17`）。
+  - `Carousel.BindItems<T>(Observable<IReadOnlyList<T>> source, Action<IControl,T> bind)` —— **收 Observable，不是裸 list**；裸 list 用 `R3.Observable.Return((IReadOnlyList<T>)items)` 包。`Carousel.Current`(get)、`GoTo(int, bool animated)` 都有；EditMode 下 `GoTo(animated:true)` 走 instant 分支。
+  - `PuiButton`（`Runtime/Controls/Internal/PuiButton.cs`，internal `: Button`）有 `onClick`（uGUI UnityEvent）+ `targetGraphic`；同 Carousel dot 的点击装配。
+  - `Btn.SimulateClick()`（internal 测试 seam）；backdrop 点击测试用 `ExecuteEvents.Execute(go, new PointerEventData(EventSystem.current), ExecuteEvents.pointerDownHandler)`（照 `MarkdownBoxTests.Backdrop_pointer_down_closes`）；ESC 用 `TopScreen.RootGameObject.GetComponent<ModalEscapeListener>().FireForTests()`。
+  - **backdrop 必须与 panel 同级**（兄弟，backdrop 在前/底层、panel 在后/顶层），**不能嵌套**——否则点 panel 冒泡到 backdrop 的 OnPointerDown 会误关（照 InputBox/MarkdownBox 测试 XML 结构）。
+
+**参考实现（照抄模式）：** `Runtime/Application/Modals/MarkdownBoxRequest.cs`（request + facade + 背景/×/ESC）、`Runtime/Application/Modals/MessageBoxRequest.cs`（Bind + 按钮）、`Tests/EditMode/Modals/InputBoxTests.cs` + `MarkdownBoxTests.cs`（测试夹具）。
+
+---
+
+## 文件结构
+
+| 文件 | 职责 | 动作 |
+|---|---|---|
+| `Runtime/Application/Modals/CenteredSlideBoxRequest.cs` | `CenteredSlideBoxRequest<T> : ModalRequest<T>` + `CenteredSlideBox` facade + `AttachCardClick` | 新建 |
+| `Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml`(+.meta) | backdrop + panel(title/close/Carousel/confirm) + `<Template name="Card">` | 新建 |
+| `Tests/EditMode/Modals/CenteredSlideBoxTests.cs` | EditMode：确认/点卡/取消/边界/bind | 新建 |
+| `Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs` | PlayMode 烟雾 | 新建 |
+| `.claude/skills/scripting-promptugui-csharp/SKILL.md` | `CenteredSlideBox.Open` 用法 | 改 |
+
+---
+
+## Task 1: 模态骨架 + 确认按钮返回居中项
+
+**Files:**
+- Create: `Runtime/Application/Modals/CenteredSlideBoxRequest.cs`
+- Create: `Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml`
+- Test: `Tests/EditMode/Modals/CenteredSlideBoxTests.cs`（新建）
+
+- [ ] **Step 1: 写失败测试**（新建 `CenteredSlideBoxTests.cs`）
+
+```csharp
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using PromptUGUI.Controls;
+using PBtn = PromptUGUI.Controls.Btn;
+
+namespace PromptUGUI.Tests.Modals
+{
+    public class CenteredSlideBoxTests
+    {
+        private sealed class Lv { public string Id; public string Name; }
+
+        // 测试用模态 XML：backdrop 与 panel **同级**；卡模板写在同文档。
+        private const string SlideBoxXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/SlideBox1'>
+    <Image id='backdrop' anchor='stretch' color='#000000A0'/>
+    <Frame id='panel' anchor='center' size='600x400'>
+      <Text id='title' anchor='top-stretch' height='40' align='center'/>
+      <Btn  id='close' anchor='top-right' size='32x32'>x</Btn>
+      <Carousel id='cards' anchor='stretch' margin='48,8,64,8'
+                fill='false' interval='0' itemTemplate='Card'/>
+      <Btn  id='confirm' anchor='bottom-center' size='140x40'>OK</Btn>
+    </Frame>
+    <Template name='Card'>
+      <Frame size='160x200'>
+        <Image id='cover' anchor='stretch'/>
+        <Text  id='name'  anchor='bottom-stretch' height='24' align='center'/>
+      </Frame>
+    </Template>
+  </Screen>
+</PromptUGUI>";
+
+        private Dictionary<string, string> _files;
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            _files = new Dictionary<string, string> { ["test/SlideBox1"] = SlideBoxXml };
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(_files.TryGetValue(src, out var v) ? v : null);
+            CenteredSlideBox.XmlSrc = "test/SlideBox1";
+        }
+
+        [TearDown]
+        public void TearDown() => UI.ResetForTests();
+
+        private static List<Lv> ThreeLevels() => new()
+        {
+            new Lv { Id = "a", Name = "Alpha" },
+            new Lv { Id = "b", Name = "Bravo" },
+            new Lv { Id = "c", Name = "Charlie" },
+        };
+
+        private static Carousel Cards() => UI.Modal.TopScreen.Get<Carousel>("cards");
+
+        [Test]
+        public void Confirm_Returns_Centered_Item()
+        {
+            var items = ThreeLevels();
+            var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+            {
+                Items = items,
+                BindCard = (card, lv) => { },
+            });
+            Cards().GoTo(1, animated: false);                  // 把第 1 项居中
+            UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();
+            Assert.AreSame(items[1], task.GetAwaiter().GetResult(),
+                "confirm returns the centered item");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 跑测确认失败**
+
+`run_tests(EditMode, group_names=["CenteredSlideBoxTests"])`
+预期：编译失败（`CenteredSlideBoxRequest` / `CenteredSlideBox` 不存在）。
+
+- [ ] **Step 3: 实现** —— 新建 `CenteredSlideBoxRequest.cs`
+
+```csharp
+using System;
+using System.Collections.Generic;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using R3;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityImage = UnityEngine.UI.Image;
+
+namespace PromptUGUI.Application.Modals
+{
+    public sealed class CenteredSlideBoxRequest<T> : ModalRequest<T> where T : class
+    {
+        public IReadOnlyList<T> Items;
+        public Action<IControl, T> BindCard;
+        public string Title;
+        public string ConfirmLabel;
+        public string XmlSrcOverride;                       // 命名变体 facade 可传；null→静态默认
+
+        public override string XmlSrc => XmlSrcOverride ?? CenteredSlideBox.XmlSrc;
+
+        public override void Bind(IScreen screen, Action<T> close)
+        {
+            var titleCtl = screen.Get<Text>("title");
+            if (string.IsNullOrEmpty(Title)) titleCtl.GameObject.SetActive(false);
+            else titleCtl.TextValue = Title;
+
+            // 取消通道：×（背景 / ESC 在后续 Task 接）
+            screen.Get<Btn>("close").OnClick.Subscribe(_ => close(null)).AddTo(screen);
+
+            var car = screen.Get<Carousel>("cards");
+            int idx = 0;
+            car.BindItems(Observable.Return((IReadOnlyList<T>)Items), (IControl card, T item) =>
+            {
+                int i = idx++;
+                BindCard?.Invoke(card, item);
+                // 卡片点击在 Task 3 接；这里先只建卡
+            }).AddTo(screen);
+
+            var ok = screen.Get<Btn>("confirm");
+            if (!string.IsNullOrEmpty(ConfirmLabel)) ok.Text = ConfirmLabel;
+            ok.OnClick.Subscribe(_ =>
+            {
+                int cur = car.Current;
+                if (cur >= 0 && cur < Items.Count) close(Items[cur]);
+            }).AddTo(screen);
+        }
+    }
+
+    public static class CenteredSlideBox
+    {
+        // 必须带 .ui 后缀（Unity 只剥 .ui.xml 的最后 .xml）。可写 = 换皮入口。
+        public static string XmlSrc { get; set; } = "PromptUGUI/Modals/CenteredSlideBox.ui";
+
+        public static UnityEngine.Awaitable<T> Open<T>(
+            IReadOnlyList<T> items,
+            Action<IControl, T> bind,
+            string title = null,
+            string confirmLabel = null,
+            ModalMode mode = ModalMode.Popup,
+            Action<IScreen> configure = null,
+            System.Threading.CancellationToken ct = default
+        ) where T : class
+            => UI.Modal.OpenAsync(new CenteredSlideBoxRequest<T>
+            {
+                Items = items,
+                BindCard = bind,
+                Title = title,
+                ConfirmLabel = confirmLabel,
+                Configure = configure,
+            }, mode, ct);
+    }
+}
+```
+
+新建 `Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml`（生产版；backdrop 与 panel **同级**）：
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<PromptUGUI version="1">
+  <Screen name="CenteredSlideBox">
+    <Image id="backdrop" anchor="stretch" color="#000000A0"/>
+    <Frame id="panel" anchor="center" size="720x460">
+      <Text id="title" anchor="top-stretch" height="48" align="center" tr="false"/>
+      <Btn  id="close" anchor="top-right" size="36x36" margin="6,6,_,_">x</Btn>
+      <Carousel id="cards" anchor="stretch" margin="56,16,72,16"
+                fill="false" interval="0" loop="true"
+                spacing="24" edgeScale="0.82" edgeAlpha="0.45"
+                itemTemplate="Card"
+                dots="bottom-center" dotColor="#666666" dotSelectedColor="#ffffff"/>
+      <Btn id="confirm" anchor="bottom-center" size="160x48" margin="_,_,12,_">OK</Btn>
+    </Frame>
+    <Template name="Card">
+      <Frame size="240x320">
+        <Image id="cover" anchor="stretch"/>
+        <Text  id="name"  anchor="bottom-stretch" height="40" align="center" tr="false"/>
+      </Frame>
+    </Template>
+  </Screen>
+</PromptUGUI>
+```
+
+- [ ] **Step 4: 跑测确认通过**
+
+`refresh_unity` → `read_console(types=["error"])`（无错）
+`run_tests(EditMode, group_names=["CenteredSlideBoxTests"])` → PASS
+
+- [ ] **Step 5: 跑 UIXmlLint（生产 XML 吃自己的 peek 狗粮）+ commit**
+
+```bash
+cd .lint && dotnet run --project UIXmlLint -- ../Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml ; cd ..
+git add Runtime/Application/Modals/CenteredSlideBoxRequest.cs Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml.meta Tests/EditMode/Modals/CenteredSlideBoxTests.cs
+git commit -m "$(printf 'feat(modal): CenteredSlideBox skeleton — confirm returns centered item\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+> `.meta`：Unity 首次导入新资源会生成 `.ui.xml.meta`，刷新后一并 `git add`（若刷新后才出现，本步 add 它）。
+
+---
+
+## Task 2: 取消三通道（× / 背景 / ESC → null）
+
+**Files:**
+- Modify: `Runtime/Application/Modals/CenteredSlideBoxRequest.cs`
+- Test: `Tests/EditMode/Modals/CenteredSlideBoxTests.cs`
+
+- [ ] **Step 1: 写失败测试**（追加到 `CenteredSlideBoxTests.cs`；补 usings）
+
+类顶部补：
+
+```csharp
+using PromptUGUI.Controls;
+using UnityEngine.EventSystems;
+using PImage = PromptUGUI.Controls.Image;
+```
+
+测试：
+
+```csharp
+[Test]
+public void Click_Close_Returns_Null()
+{
+    var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+        { Items = ThreeLevels(), BindCard = (c, l) => { } });
+    UI.Modal.TopScreen.Get<PBtn>("close").SimulateClick();
+    Assert.IsNull(task.GetAwaiter().GetResult());
+}
+
+[Test]
+public void Backdrop_PointerDown_Returns_Null()
+{
+    var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+        { Items = ThreeLevels(), BindCard = (c, l) => { } });
+    var backdrop = UI.Modal.TopScreen.Get<PImage>("backdrop");
+    ExecuteEvents.Execute(backdrop.GameObject,
+        new PointerEventData(EventSystem.current), ExecuteEvents.pointerDownHandler);
+    Assert.IsNull(task.GetAwaiter().GetResult());
+}
+
+[Test]
+public void Escape_Via_Listener_Returns_Null_And_Closes()
+{
+    var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+        { Items = ThreeLevels(), BindCard = (c, l) => { } });
+    var listener = UI.Modal.TopScreen.RootGameObject.GetComponent<ModalEscapeListener>();
+    Assert.IsNotNull(listener);
+    listener.FireForTests();
+    Assert.IsNull(task.GetAwaiter().GetResult());
+    Assert.IsFalse(UI.Modal.IsAnyOpen);
+}
+
+[Test]
+public void TryEscape_Returns_Null_And_True()
+{
+    var req = new CenteredSlideBoxRequest<Lv> { Items = ThreeLevels() };
+    Assert.IsTrue(req.TryEscape(out var r));
+    Assert.IsNull(r);
+}
+```
+
+- [ ] **Step 2: 跑测确认失败**
+
+`run_tests(EditMode, group_names=["CenteredSlideBoxTests"])`
+预期：`Backdrop_*` FAIL（背景未接 → 点它不关）、`Escape_*` / `TryEscape_*` FAIL（`TryEscape` 默认 return false → ESC 不关、out r 默认）。`Click_Close_*` 已 PASS（Task 1 接了 ×）。
+
+- [ ] **Step 3: 实现** —— `CenteredSlideBoxRequest.cs`
+
+在 `Bind` 里 `close` 的 × 订阅旁，加背景订阅：
+
+```csharp
+            screen.Get<Btn>("close").OnClick.Subscribe(_ => close(null)).AddTo(screen);
+            screen.Get<UnityImageControl>("backdrop")    // 见下：用 PromptUGUI.Controls.Image
+                .OnPointerDown.Subscribe(_ => close(null)).AddTo(screen);
+```
+
+（实际写法：`screen.Get<PromptUGUI.Controls.Image>("backdrop").OnPointerDown.Subscribe(_ => close(null)).AddTo(screen);`——`PromptUGUI.Controls.Image` 有 `OnPointerDown`，同 MarkdownBox。）
+
+并在类里加 `TryEscape` override：
+
+```csharp
+        public override bool TryEscape(out T result) { result = null; return true; }
+```
+
+- [ ] **Step 4: 跑测确认通过**
+
+`run_tests(EditMode, group_names=["CenteredSlideBoxTests"])` → 全 PASS
+
+- [ ] **Step 5: commit**
+
+```bash
+git add Runtime/Application/Modals/CenteredSlideBoxRequest.cs Tests/EditMode/Modals/CenteredSlideBoxTests.cs
+git commit -m "$(printf 'feat(modal): CenteredSlideBox cancel via close/backdrop/ESC -> null\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 3: A+C 卡片点击（点居中卡确认 / 点侧卡居中）
+
+**Files:**
+- Modify: `Runtime/Application/Modals/CenteredSlideBoxRequest.cs`
+- Test: `Tests/EditMode/Modals/CenteredSlideBoxTests.cs`
+
+- [ ] **Step 1: 写失败测试**（追加；补 `using PromptUGUI.Controls.Internal;`）
+
+辅助 + 测试：
+
+```csharp
+// 取卡 i 的 PuiButton（AttachCardClick 挂在卡根）。
+private static PromptUGUI.Controls.Internal.PuiButton CardButton(int i)
+    => (PromptUGUI.Controls.Internal.PuiButton)
+       UI.Modal.TopScreen.Get<Carousel>("cards").GameObject
+         .transform.Find("Viewport/Strip").GetChild(i)
+         .GetComponent<PromptUGUI.Controls.Internal.PuiButton>();
+
+[Test]
+public void Tap_Centered_Card_Returns_It()
+{
+    var items = ThreeLevels();
+    var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+        { Items = items, BindCard = (c, l) => { } });
+    // current 默认 0；点第 0 张（居中）→ 确认返回它
+    CardButton(0).onClick.Invoke();
+    Assert.AreSame(items[0], task.GetAwaiter().GetResult());
+}
+
+[Test]
+public void Tap_Side_Card_Centers_It_Without_Returning()
+{
+    var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+        { Items = ThreeLevels(), BindCard = (c, l) => { } });
+    var car = Cards();
+    Assert.AreEqual(0, car.Current);
+    CardButton(2).onClick.Invoke();        // 点侧卡 2 → 居中它
+    Assert.AreEqual(2, car.Current, "side-card tap centers it");
+    Assert.IsTrue(UI.Modal.IsAnyOpen, "side-card tap must NOT confirm/close");
+}
+```
+
+- [ ] **Step 2: 跑测确认失败**
+
+`run_tests(EditMode, group_names=["CenteredSlideBoxTests"])`
+预期：`Tap_*` FAIL（`CardButton(i)` 为 null —— 还没给卡挂 PuiButton；`GetComponent` 返回 null → 空引用/断言失败）。
+
+- [ ] **Step 3: 实现** —— 给卡装配点击
+
+在 `Bind` 的 BindItems 回调里，`BindCard?.Invoke` 之后加 `AttachCardClick(card, i, car, close);`：
+
+```csharp
+            car.BindItems(Observable.Return((IReadOnlyList<T>)Items), (IControl card, T item) =>
+            {
+                int i = idx++;
+                BindCard?.Invoke(card, item);
+                AttachCardClick(card, i, car, close);
+            }).AddTo(screen);
+```
+
+并加方法（A+C；透明 raycast + PuiButton，click 语义、拖动冒泡给 CarouselView）：
+
+```csharp
+        // 每张卡挂透明 raycast catcher + PuiButton：click(非拖动) → 居中或确认。
+        // 点居中卡 = 确认；点侧卡 = GoTo 居中。拖动不被 PuiButton 处理 → 冒泡给 CarouselView。
+        private void AttachCardClick(IControl card, int i, Carousel car, Action<T> close)
+        {
+            var go = card.GameObject;
+            var img = go.GetComponent<UnityImage>() ?? go.AddComponent<UnityImage>();
+            img.color = new Color(0f, 0f, 0f, 0f);   // 透明，仅 raycast
+            img.raycastTarget = true;
+            var btn = go.AddComponent<PuiButton>();
+            btn.targetGraphic = img;
+            btn.onClick.AddListener(() =>
+            {
+                if (car.Current == i) close(Items[i]);     // 点居中卡 = 确认
+                else car.GoTo(i, animated: true);          // 点侧卡 = 居中
+            });
+        }
+```
+
+- [ ] **Step 4: 跑测确认通过**
+
+`run_tests(EditMode, group_names=["CenteredSlideBoxTests"])` → 全 PASS（含 Task 1/2 的）
+
+- [ ] **Step 5: commit**
+
+```bash
+git add Runtime/Application/Modals/CenteredSlideBoxRequest.cs Tests/EditMode/Modals/CenteredSlideBoxTests.cs
+git commit -m "$(printf 'feat(modal): CenteredSlideBox A+C card tap (center/confirm)\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 4: chrome 细节（title 隐藏 / confirmLabel / 空列表禁确认 / bind 填槽 / configure）
+
+**Files:**
+- Modify: `Runtime/Application/Modals/CenteredSlideBoxRequest.cs`
+- Test: `Tests/EditMode/Modals/CenteredSlideBoxTests.cs`
+
+- [ ] **Step 1: 写失败测试**（追加；补 `using PText = PromptUGUI.Controls.Text;` 和 `using PromptUGUI.Controls;` 若缺）
+
+```csharp
+[Test]
+public void Null_Title_Hides_Title_Node()
+{
+    UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+        { Items = ThreeLevels(), BindCard = (c, l) => { }, Title = null });
+    Assert.IsFalse(UI.Modal.TopScreen.Get<PText>("title").GameObject.activeSelf);
+}
+
+[Test]
+public void ConfirmLabel_Overrides_Button_Text()
+{
+    UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+        { Items = ThreeLevels(), BindCard = (c, l) => { }, ConfirmLabel = "开始" });
+    Assert.AreEqual("开始", UI.Modal.TopScreen.Get<PBtn>("confirm").Text);
+}
+
+[Test]
+public void Empty_Items_Disables_Confirm()
+{
+    UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+        { Items = new List<Lv>(), BindCard = (c, l) => { } });
+    Assert.IsFalse(UI.Modal.TopScreen.Get<PBtn>("confirm").Interactable);
+}
+
+[Test]
+public void Bind_Fills_Card_Slots()
+{
+    var items = ThreeLevels();
+    UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+    {
+        Items = items,
+        BindCard = (card, lv) => card.Get<PText>("name").TextValue = lv.Name,
+    });
+    var card0 = (RectTransform)Cards().GameObject.transform.Find("Viewport/Strip").GetChild(0);
+    Assert.AreEqual("Alpha", card0.GetComponentInChildren<TMPro.TMP_Text>().text);
+}
+
+[Test]
+public void Configure_Runs_After_Bind()
+{
+    var ran = false;
+    UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+    {
+        Items = ThreeLevels(), BindCard = (c, l) => { },
+        Configure = _ => ran = true,
+    });
+    Assert.IsTrue(ran, "Configure hook runs (invoked by the modal pump after Bind)");
+}
+```
+
+（补 `using TMPro;`。）
+
+- [ ] **Step 2: 跑测确认失败**
+
+预期：`Empty_Items_Disables_Confirm` FAIL（空列表没禁确认）；其余可能已过（title 隐藏 + confirmLabel 在 Task 1 已实现；`Configure` 由基类管线跑，应已过；`Bind_Fills_Card_Slots` 应已过）。**只为没过的写实现**——若全过说明 Task 1 已覆盖，仅 `Empty_*` 要补。
+
+- [ ] **Step 3: 实现** —— 空列表禁确认
+
+在 `Bind` 里 `var ok = screen.Get<Btn>("confirm");` 之后、订阅之前加：
+
+```csharp
+            if (Items == null || Items.Count == 0) ok.Interactable = false;
+```
+
+（title 隐藏、confirmLabel、bind 填槽、configure 已在 Task 1 / 基类管线中实现；本步只补空列表门。）
+
+- [ ] **Step 4: 跑测确认通过**
+
+`run_tests(EditMode, group_names=["CenteredSlideBoxTests"])` → 全 PASS
+
+- [ ] **Step 5: commit**
+
+```bash
+git add Runtime/Application/Modals/CenteredSlideBoxRequest.cs Tests/EditMode/Modals/CenteredSlideBoxTests.cs
+git commit -m "$(printf 'feat(modal): CenteredSlideBox chrome — title/confirmLabel/empty-disable/bind\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 5: PlayMode 烟雾
+
+**Files:**
+- Test: `Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs`（新建）
+
+- [ ] **Step 1: 写测试**（PlayMode；同步驱动，不需真定时）
+
+```csharp
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using PromptUGUI.Controls;
+using PBtn = PromptUGUI.Controls.Btn;
+
+namespace PromptUGUI.Tests.PlayMode.Modals
+{
+    public class CenteredSlideBoxPlayTests
+    {
+        private sealed class Lv { public string Id; public string Name; }
+
+        private const string Xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/SlideBoxP'>
+    <Image id='backdrop' anchor='stretch' color='#000000A0'/>
+    <Frame id='panel' anchor='center' size='600x400'>
+      <Text id='title' anchor='top-stretch' height='40' align='center'/>
+      <Btn  id='close' anchor='top-right' size='32x32'>x</Btn>
+      <Carousel id='cards' anchor='stretch' margin='48,8,64,8'
+                fill='false' interval='0' itemTemplate='Card'/>
+      <Btn  id='confirm' anchor='bottom-center' size='140x40'>OK</Btn>
+    </Frame>
+    <Template name='Card'>
+      <Frame size='160x200'><Image id='cover' anchor='stretch'/>
+        <Text id='name' anchor='bottom-stretch' height='24'/></Frame>
+    </Template>
+  </Screen>
+</PromptUGUI>";
+
+        [SetUp] public void SetUp()
+        {
+            UI.ResetForTests();
+            var files = new Dictionary<string, string> { ["test/SlideBoxP"] = Xml };
+            UI.SourceResolver = src => AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+            CenteredSlideBox.XmlSrc = "test/SlideBoxP";
+        }
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void Open_GoTo_Confirm_Returns_Item_NoCrash()
+        {
+            var items = new List<Lv> { new() { Id = "a" }, new() { Id = "b" }, new() { Id = "c" } };
+            var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
+                { Items = items, BindCard = (c, l) => { } });
+            UI.Modal.TopScreen.Get<Carousel>("cards").GoTo(2, animated: false);
+            UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();
+            Assert.AreSame(items[2], task.GetAwaiter().GetResult());
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 跑测**
+
+`run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], group_names=["CenteredSlideBoxPlayTests"], init_timeout=120000)` → 轮询 → PASS
+
+- [ ] **Step 3: commit**
+
+```bash
+git add Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs
+git commit -m "$(printf 'test(modal): CenteredSlideBox PlayMode smoke\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 6: C# SKILL 文档
+
+**Files:**
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md`
+
+- [ ] **Step 1: 在模态小节加 `CenteredSlideBox`**（找到 InputBox/MarkdownBox 的模态段，照风格加；匹配文件现有语言）
+
+加一段：
+
+```markdown
+### CenteredSlideBox（居中选择器模态）
+
+居中卡片选择弹窗（内部是 `fill="false"` peek Carousel）。泛型数据 + bind 填卡（同 `Carousel.BindItems`），await 返回**选中的对象**（取消 = `null`）。
+
+​```csharp
+record Level(string Id, string Name, Sprite Cover);
+
+var picked = await CenteredSlideBox.Open(
+    levels,
+    bind: (card, lv) => { card.Get<Text>("name").TextValue = lv.Name;
+                          card.Get<Image>("cover").Sprite   = lv.Cover; },
+    title: "选择关卡");
+if (picked != null) StartLevel(picked);   // 要 id 就 picked.Id
+​```
+
+- 选中交互：拖动 / dots 浏览；**点侧卡居中**、**点居中卡确认**、**确认按钮**确认居中卡；**× / 点背景 / ESC** 取消 → `null`。
+- 卡片槽位由内置 `CenteredSlideBox.ui.xml` 的 `<Template name="Card">` 决定（默认 `cover`(Image) + `name`(Text)）；bind 填你用到的槽。
+- 换一种卡片样式：`CenteredSlideBox.XmlSrc = "你的.ui";`（保持 id 契约 `backdrop/panel/title/close/confirm/cards` + 卡槽）；或抄 facade 传不同 `XmlSrcOverride`。
+- `where T : class`（取消用 `null` 哨兵）；`title`/`confirmLabel`/`mode`/`configure`/`ct` 同其它模态。
+```
+
+- [ ] **Step 2: commit**
+
+```bash
+git add .claude/skills/scripting-promptugui-csharp/SKILL.md
+git commit -m "$(printf 'docs: document CenteredSlideBox.Open in C# skill\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## 最终验证（全量）
+
+- [ ] `refresh_unity(mode="force", scope="all")` → `read_console(types=["error"])` 无错
+- [ ] `run_tests(EditMode, assembly_names=["PromptUGUI.Tests.EditMode"])` 全绿（含 `CenteredSlideBoxTests` + 既有 carousel-peek 全套）
+- [ ] `run_tests(EditMode, assembly_names=["PromptUGUI.Tests.EditorOnly"])` 全绿
+- [ ] `run_tests(PlayMode, assembly_names=["PromptUGUI.Tests.PlayMode"])` 全绿（含 `CenteredSlideBoxPlayTests`）
+- [ ] `cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx` 干净
+- [ ] `dotnet run --project .lint/UIXmlLint -- Runtime/Resources/` 无 error（生产 CenteredSlideBox.ui.xml 含 fill=false + 带 size 卡 → 验证 peek lint 门控）
+- [ ] 视觉 QA（用户）：宿主工程 `CenteredSlideBox.Open` 关卡选择——居中放大/淡出、拖动、点侧卡居中、点居中卡/确认返回、×/背景/ESC 取消
+
+---
+
+## Self-Review（写计划时已核对）
+
+- **Spec 覆盖**：CSB-D1 模态形态→T1；D2 泛型+bind→T1（`BindItems(Observable.Return)`）；D3 返回 T/null→T1（confirm）+T2（cancel）；D4 卡模板进 XmlSrc 同文档→T1（XML + Carousel itemTemplate）；D5 cover/name 槽→T4（bind 填槽测试）；D6 换皮 XmlSrc/XmlSrcOverride→T1（字段）+T6（文档）；D7 A+C→T3；D8 透明 raycast+PuiButton→T3；D9 取消三通道→T2；D10 title/confirmLabel/configure→T1+T4；D11 空列表禁确认→T4。
+- **类型一致**：`CenteredSlideBoxRequest<T> where T:class`（Items/BindCard/Title/ConfirmLabel/XmlSrcOverride/XmlSrc/Bind/TryEscape/AttachCardClick）+ facade `CenteredSlideBox.Open<T>`/`XmlSrc`——各 Task 引用一致。`BindItems` 用 `Observable.Return`、backdrop 用 `PromptUGUI.Controls.Image.OnPointerDown`、card 用 `PuiButton.onClick`——均已核实。
+- **占位**：无 TBD；T4 Step 2 的「若已过仅补 Empty_*」是真实 TDD 观察（title/confirmLabel/configure/bind 在 T1+基类已实现），非占位。
+- **结构**：backdrop 与 panel 同级（防误关）已在 T1 XML + 约定块强调。

--- a/docs~/superpowers/specs/2026-06-04-carousel-design.md
+++ b/docs~/superpowers/specs/2026-06-04-carousel-design.md
@@ -555,9 +555,9 @@ self-check 入口追加 `Carousel` 分支调用 `CarouselRules`。
 ## 12. Out of Scope
 
 - **竖向轮播 / `direction`**——CAR-D19 留 v2；web banner 全横向。
-- **「peek」露边**（同时露出相邻卡的一小条）——v1 全幅翻页；以后可加 `peek` / `padding` 属性。
-- **cross-fade / 缩放等转场**——v1 只有 slide；要 fade 后续加 `transition-style`。
-- **per-card 不同尺寸 / 自适应高度**——所有卡 = 视口尺寸。
+- **「peek」露边**（同时露出相邻卡的一小条）——v1 全幅翻页；→ **v2 已做**（`fill="false"`），见 [`2026-06-15-carousel-peek-mode-design.md`](2026-06-15-carousel-peek-mode-design.md)。
+- **cross-fade / 缩放等转场**——v1 只有 slide 吸附；卡间 cross-fade（`transition-style`）仍未做，但**焦点缩放 + 邻卡渐隐**已由 v2 `edgeScale` / `edgeAlpha` 实现，见 [`2026-06-15-carousel-peek-mode-design.md`](2026-06-15-carousel-peek-mode-design.md)。
+- **per-card 不同尺寸 / 自适应高度**——v1 所有卡 = 视口尺寸；v2 peek 模式卡片用**自身** `size`（但仍假定各卡等尺寸——非等尺寸卡未支持），见 [`2026-06-15-carousel-peek-mode-design.md`](2026-06-15-carousel-peek-mode-design.md)。
 - **指示点用数字 / 缩略图 / 进度条形态**——v1 只有点（sprite + 状态色）；复杂指示器自己用 `OnCurrentChanged` 画。
 - **键盘 / 手柄导航**——v1 只有指针拖动 + dot 点击；要方向键自己接 `Next`/`Previous`。
 - **嵌套 Carousel**——不阻拦；carousel 只取 X 轴 + 整段转发（CAR-D11），同向嵌套（横向 carousel 套横向滚动）语义模糊，需作者自理。

--- a/docs~/superpowers/specs/2026-06-15-carousel-peek-mode-design.md
+++ b/docs~/superpowers/specs/2026-06-15-carousel-peek-mode-design.md
@@ -182,6 +182,7 @@ for each card i:
 - **localScale 总是写、不短路**：fill=true 或 `edgeScale=1` 时 `s=1`，正好把上一轮 peek 留下的缩放复位——避免 Variant 把 `fill` 从 false 切回 true 时卡片卡在缩放态（本仓库典型的 ReSolve/variant 复位坑，见 [[project_variant_control_attr_needs_base]] 同类）。代价仅一次廉价赋值。
 - `ApplyAlpha(card, a)`：`a < 1` 时才 `EnsureCanvasGroup`（懒加、缓存、不 Destroy）并设 alpha；`a == 1` 时若卡上**已有** CanvasGroup 则复位 alpha=1，否则不挂。→ 纯 fill carousel 永不挂 CanvasGroup；peek→fill 切换时已有的 CanvasGroup 被复位。
 - 于是 `fill="true"`（`_stride=_cardW=_pageWidth`、`edge*=1`）→ 与 v1 `Reposition` **视觉逐字等价**：localScale 复位 1、无新增 CanvasGroup。
+- **严格 byte-identity 注脚**：fill=true 下 `Reposition` 每帧仍把卡根 `localScale` 写成 `(1,1,1)`（v1 从不碰 localScale）。对正常卡根（无 `scale=`）是 no-op；但若 fill 卡根带 density `scale=`，会被下一次 drag/autoplay/GoTo 的 Reposition 覆盖（这些路径后面不跟 ApplyScales）。这是退化情形（视口大小的 banner 卡根写 density scale 本就溢出 mask、下条也劝阻），换来的是 Variant 把 fill 切回 true 时复位 peek 残留缩放（ReSolve 幂等）——此权衡刻意保留，不为它放弃复位。
 - **localScale 归属**：fill=false 下 Carousel 写卡根 localScale，作者别在卡根再用 density `scale=`（会被覆盖）；要 density 缩放写卡的里层节点。文档 + CAR-D31 邻近处提示。
 
 ### 6.4 `MeasureCard()`（CAR-D26）
@@ -220,7 +221,7 @@ fill=true 时 `_stride == _pageWidth`，拖动行为逐字不变。其余（像�
 1. **`PUI-CAROUSEL-CARD-SIZE` 加 fill 门控**（`CheckCard`）：仅当父 Carousel **未声明 `fill="false"`**（即 fill=true 缺省）时，才对卡片的 `size`/`width`/`height` 报 error。`fill="false"` 下卡片写尺寸合法、不报。
    - 注意 `CheckCard` 现在按「直接子」单独检查（`CarouselRules.cs:47`），拿不到父的 `fill`。实现上让父 self-check（`CheckCarousel`）把 `fill` 读出来，遍历直接子时按模式决定是否对每个子跑 `CheckCard` 的 size 分支——即把 size 检查从「子规则」上移到「父驱动子」，与现有 `IRWalker` 的父子遍历一致。plan 阶段定具体串法（IRWalker 已持父节点）。
 2. **新增 `PUI-CAROUSEL-PEEK-NO-SIZE`（warning，CAR-D31）**：`fill="false"` 的直接子卡既无 `size`/`width`/`height`（含 variant 覆盖）→ warning「该卡无尺寸，将兜成视口大小、邻卡不会 peek；给卡根写 size= 或换自带原生尺寸的控件（如 Image）」。
-   - 局限：lint 是纯 IR 静态分析，看不到运行期 `GetNativeSize()`。故只对「XML 里没写 size 的卡」warn；其中 `<Image src=...>` 这种其实有原生尺寸的会被误 warn。**折中**：只在卡根 tag 是「已知无原生尺寸」的容器（`Frame` / `VStack` / `HStack` / `Grid`）时才 warn，其余 tag 放过。这样既抓住主坑（裸 Frame），又不误伤 Image/Text 卡。tag 白名单与 `BuiltinTags` 同源。
+   - 局限：lint 是纯 IR 静态分析，看不到运行期 `GetNativeSize()`。故只对「XML 里没写 size 的卡」warn；其中 `<Image src=...>` 这种其实有原生尺寸的会被误 warn。**折中**：只在卡根 tag 是「已知无原生尺寸」的容器（`Frame` / `VStack` / `HStack` / `Grid`）时才 warn，其余 tag 放过。这样既抓住主坑（裸 Frame），又不误伤 Image/Text 卡。该白名单是**精选常见容器子集**——SafeArea/TabBar/Tab/Markdown 等也无 native size，但作为轮播卡根极罕见，不列入（runtime 仍优雅兜底为视口）。
 
 更新后规则表：
 

--- a/docs~/superpowers/specs/2026-06-15-carousel-peek-mode-design.md
+++ b/docs~/superpowers/specs/2026-06-15-carousel-peek-mode-design.md
@@ -1,0 +1,306 @@
+# `<Carousel fill>` 居中选择 / peek 模式设计
+
+**日期**: 2026-06-15
+**状态**: 设计阶段（待 review，未进入实施）
+**承接**: [`2026-06-04-carousel-design.md`](2026-06-04-carousel-design.md)（v1 全幅翻页轮播）。本文把 v1 §12 Out of Scope 里列的三项扶正成 v2：「peek 露边」「缩放 / 淡出转场」「per-card 自有尺寸」。决策编号续 v1 的 `CAR-Dxx`（v1 到 CAR-D23，本文 CAR-D24 起）。
+
+**一句话**: 给现有 `<Carousel>` 加一个非占满的「居中卡片选择器」排版——卡片用自身尺寸、两侧邻卡露出（peek）、焦点卡最大最亮、越往边越小越淡。**不拆控件**，复用 v1 全部机制（拖动 / 吸附 / loop / autoplay / dots / BindItems / 运行期 `current`）。
+
+**作用域**:
+1. `Runtime/Controls/Carousel.cs`：新增 4 个 `[UIAttr]`（`fill` / `spacing` / `edgeScale` / `edgeAlpha`），转写进 `CarouselView`。
+2. `Runtime/Controls/Internal/CarouselView.cs`：改 `Reposition()` / `RelayoutNow()`——区分「卡尺寸」与「步距」，叠加 `localScale` / `CanvasGroup.alpha`；拖动 / 吸附的「页宽」换成「步距」。可选把排版数学抽成内部 `CarouselLayout` helper（CAR-D24）。
+3. `Runtime/Core/Lint/CarouselRules.cs`：`PUI-CAROUSEL-CARD-SIZE` 改为**仅 `fill="true"`（缺省）时**触发；新增可选 warning `PUI-CAROUSEL-PEEK-NO-SIZE`。
+4. `authoring-promptugui-xml` SKILL：`reference/controls-carousel.md` 加 peek 小节 + 主文档属性表补 4 行。
+5. 主 spec `2026-05-07-...` §5 控件行无需改（仍是同一个 `<Carousel>`）；本文作为 carousel 的 v2 设计被 v1 spec 引用。
+6. XSD 随新 `[UIAttr]` 手动 regenerate。
+
+**依赖**: 无新增包。复用：现有 size 分轴回退（`Control.cs:287/377`）、`CanvasGroup`（uGUI 内建）、LitMotion（已在 CarouselView 用于吸附）、`CarouselRules` / `IRWalker` lint 框架。
+
+---
+
+## 1. 背景与动机
+
+v1 `<Carousel>` 是**全幅翻页**：每张卡被 `CarouselView.Reposition()`（`CarouselView.cs:364`）强制设成视口尺寸 `_pageWidth × _pageHeight`，相邻卡正好相隔一个视口宽（`off * _pageWidth`），静止时只有当前卡可见、邻卡恰好滑出屏外被 `RectMask2D` 裁掉。适合广告 banner。
+
+但「关卡 / 角色选择」这类界面是另一种形态——业界叫 **coverflow / center-mode（居中焦点）轮播**：
+
+- 屏幕中间一张焦点卡，**两侧能瞄到相邻卡的一部分**；
+- 用户左右拖动选卡，可配左右箭头按钮（v1 已有 `Next()` / `Previous()` public 方法，直接 `<Btn>` 绑即可，本文不涉及）；
+- 越靠边缘的卡越小、越淡（焦点强调）。
+
+这套排版在 v1 里**拼不出来**：卡宽被锁成视口宽（窄卡也不会 peek，只会整张滑出留空隙），且 `Reposition` 从不碰 `localScale` / alpha。两个缺口都落在 `Reposition` 这一个每帧排版咽喉里——纯 XML 组合无法触及。
+
+### 1.1 为什么不拆 `PeekCarousel`（CAR-D24 的前情）
+
+头脑风暴里认真评估过「抽 `CarouselBase` + 派生 `Carousel` / `PeekCarousel`」。否决，理由见 CAR-D24：**共用的 base 其实已经是 `CarouselView`**——`Carousel` Control 类只是层薄壳，全部滚动 / 吸附 / loop / autoplay / dots / BindItems / 运行期状态都在 `CarouselView` 一个内部类里。fill 与 peek **唯一**真正分叉的是 `Reposition()` 这一个方法。拆成两个公开标签 = 同一个 CarouselView 上的两个薄壳，内部该分叉的 `Reposition` 照样得分叉，分支没消除、只是换了存放处，却多出两份注册 / XSD / lint / SKILL / 测试。净亏。
+
+---
+
+## 2. 决策一览（续 v1）
+
+| # | 决策 | 选择 | 理由 |
+|---|---|---|---|
+| CAR-D24 | 控件形态 | **不拆**，单一 `<Carousel>` 参数化（`fill` 开关）；DRY 缝落在内部（必要时抽 `CarouselLayout` helper），不开第二个公开标签 | 共用 base 已是 `CarouselView`；唯一分叉是 `Reposition` 一个方法；拆标签不消分支只增公开面（§1.1）。且 fill 是 peek 的退化特例（CAR-D25），本就是一个连续谱上的同一控件 |
+| CAR-D25 | 模式开关 | `fill` 布尔，默认 `true`（= v1 全幅翻页）。`false` = 卡用自身尺寸 + 邻卡 peek + 焦点强调 | 默认 true → 现有所有 `<Carousel>` 逐字不变；`fill="false"` 直白对应「不占满屏」。**fill=true 是 peek 排版的退化特例**：卡=视口、`spacing=0`、`edgeScale=edgeAlpha=1.0` 时算出来与 v1 逐字一样 |
+| CAR-D26 | 卡片尺寸来源（fill=false） | 走 PromptUGUI 既有的**分轴回退**：显式 `size=` → 控件 `GetNativeSize()` → 落空用视口尺寸兜底（永不为 0）。`Reposition` 不再强制卡尺寸，改读卡 resolved 尺寸 | 与全库一致（`Control.cs:287/377`）；`<Image>`/`<Text>`/`<InputField>` 卡可不写 size 用原生（sprite/量出/160×44）；`<Frame>` 基类 native 为 `null`（`Control.cs:177`，无 override），故 Frame 卡**必须**写 `size=`，否则兜成视口（即不 peek，见 CAR-D31 的 lint 提示） |
+| CAR-D27 | 卡间距 | `spacing`（px，默认 `0`）；步距 = 卡宽 + spacing。仅 fill=false 生效 | 复用 layout-group 的 `spacing` 词汇（HStack/VStack/Grid），与 Carousel 自身 `dotSpacing` 成「主角 / 点」对，不引入新词 |
+| CAR-D28 | 焦点强调基准 = **选中卡**（模型 B） | 声明 `size` = 中心（焦点）卡的尺寸；两侧卡从它**缩 + 淡**下去。`edgeScale`（默认 `1.0`=不缩）、`edgeAlpha`（默认 `1.0`=不淡），按 `|off|` 距中心距离插值 | coverflow 惯例「你正看的那张 = 设计稿尺寸」最直觉；几何安全——焦点卡恒等于声明尺寸，不会因放大顶破视口或压邻卡（模型 A「中心放大」反而易超界）。两套属性默认都 `1.0`=无差别=今天 |
+| CAR-D29 | 强调落地手段 | `edgeScale` → 卡根 `localScale`；`edgeAlpha` → 卡上**懒加 `CanvasGroup`** 的 `alpha`（不 Destroy，跨 ReSolve 存活） | localScale 整卡均匀缩放、不重排子节点；CanvasGroup 整子树统一淡入淡出。约定：fill=false 下 Carousel **拥有卡根 localScale**，density `scale=` 别写在卡根（写里层），见 §6.3 |
+| CAR-D30 | autoplay 与 fill **不联动** | `interval` 仍默认 `5`、与 `fill` 正交；居中选择器按惯例自己写 `interval="0"` | 「模式相关的隐藏默认」在本仓库 applier / ReSolve / variant 机制里反复出过坑（属性应用顺序、默认值复位）；保持 interval 单一默认更稳。代价仅一句文档：选择器写 `interval="0"` |
+| CAR-D31 | peek 无尺寸提示 | 新增**可选** lint warning `PUI-CAROUSEL-PEEK-NO-SIZE`：`fill="false"` 的卡既无 `size=` 又无原生尺寸（如裸 `<Frame>`）→ 提示会兜成视口、邻卡不 peek | CAR-D26 的兜底是「graceful 但可能意外（看着没生效）」；一条 warning 把它显式化，省一轮「为啥没 peek」的排查。runtime 不报错、照常兜底 |
+| CAR-D32 | 插值曲线 | `edgeScale` / `edgeAlpha` 按 `clamp(|off|, 0, 1)` **线性** lerp：`off=0`→`1.0`，`|off|≥1`→声明值。不加缓动属性 | YAGNI；线性在 ±1 页范围内观感够用；要曲线后续再加 `edgeEase` |
+
+---
+
+## 3. XML 形态
+
+### 3.1 居中卡片选择器（主新用例）
+
+```xml
+<!-- 全黑底 + 居中选卡；卡 240×320，相邻露边、越边越小越淡；手动拖动无自动播放 -->
+<Frame anchor="stretch" color="black">
+  <Carousel id="levelSelect" anchor="center" size="600x360"
+            fill="false" spacing="24"
+            edgeScale="0.8" edgeAlpha="0.45"
+            interval="0" loop="true"
+            itemTemplate="LevelCard"
+            dots="bottom-center" dotSprite="UI:dot"
+            dotColor="#555" dotSelectedColor="#fff"/>
+
+  <!-- 左右箭头：绑 v1 已有的 Previous()/Next()，无需库改动 -->
+  <Btn id="prev" anchor="center-left"  size="48x48" margin="_,_,_,16">‹</Btn>
+  <Btn id="next" anchor="center-right" size="48x48" margin="_,16,_,_">›</Btn>
+</Frame>
+```
+
+```xml
+<Template name="LevelCard">
+  <Param name="title"/>
+  <Frame size="240x320">                       <!-- ← 焦点卡尺寸；fill=false 下卡片必须自定尺寸 -->
+    <Image anchor="stretch" sprite="UI:card_bg"/>
+    <Text id="title" anchor="bottom-stretch" height="40" align="center">{{title}}</Text>
+  </Frame>
+</Template>
+```
+
+- peek 露出多少 = `(carousel 宽 − 卡宽)/2 − spacing`，**由卡尺寸 vs carousel 尺寸隐式决定，没有单独的 `peek` 属性**（这正是头脑风暴里嫌 `peek`/`cardWidth` 不直观的解法：根本不需要它们）。
+- 箭头按钮的 C# 接法（不在本 spec 作用域，仅示意）：`screen.Get<Btn>("prev").OnClick.Subscribe(_ => car.Previous()).AddTo(screen);`
+
+### 3.2 与 v1 全幅模式的对照（默认不变）
+
+```xml
+<!-- 不写 fill（默认 true）= v1 全幅 banner，逐字不变 -->
+<Carousel id="banner" anchor="top-stretch" height="100"
+          itemTemplate="BannerCard" interval="5" dots="bottom-center"/>
+```
+
+### 3.3 动态卡片（BindItems，同 v1）
+
+`fill="false"` 与 `itemTemplate` + `BindItems` 正交，照常用（§5）。卡片模板根写 `size=` 即可。
+
+---
+
+## 4. 新增属性表（并入主文档 Carousel 行）
+
+| 属性 | 取值 | 默认 | 作用 |
+|---|---|---|---|
+| `fill` | bool | `true` | `true` = 卡撑满视口、一卡一页（v1）。`false` = 卡用自身尺寸、邻卡 peek、焦点强调（CAR-D25） |
+| `spacing` | float（px） | `0` | 相邻卡间距；步距 = 卡宽 + spacing。**仅 `fill="false"`**（CAR-D27） |
+| `edgeScale` | float | `1.0` | 边卡缩放（中心 `1.0`=声明尺寸，越远越小）。**仅 `fill="false"`**（CAR-D28） |
+| `edgeAlpha` | float | `1.0` | 边卡不透明度（中心 `1.0`，越远越淡）。**仅 `fill="false"`**（CAR-D28） |
+
+约束补充（并入既有约束块）：
+
+- `fill="false"` 时卡片**可以**写 `size`/`width`/`height`（CAR-D26）；`fill="true"`（缺省）仍**不能**（lint error，见 §7）。
+- 卡片仍**不能**写 `anchor` / `margin`（不分模式，沿用 `PUI-LAYOUT-ANCHOR` / `PUI-LAYOUT-MARGIN`）——卡片定位永远由控件托管。
+- `spacing` / `edgeScale` / `edgeAlpha` 在 `fill="true"` 下无效果（被忽略）。
+
+---
+
+## 5. C# API 增量
+
+`Carousel` 仅新增 4 个 `[UIAttr]` setter，转写进 `_view`：
+
+```csharp
+[UIAttr, Preserve] public bool  Fill      { set => _view.SetFill(value); }       // 默认 true
+[UIAttr, Preserve] public float Spacing   { set => _view.SetSpacing(value); }    // 默认 0
+[UIAttr, Preserve] public float EdgeScale { set => _view.SetEdgeScale(value); }  // 默认 1.0
+[UIAttr, Preserve] public float EdgeAlpha { set => _view.SetEdgeAlpha(value); }  // 默认 1.0
+```
+
+- 既有 public 面（`BindItems` / `Current` / `GoTo` / `Next` / `Previous` / `Playing` / `OnCurrentChanged` / `Count`）**一律不变**。peek 选择器的左右按钮就接现成的 `Next()` / `Previous()`，无新方法。
+- `GetNativeSize()` 仍 `200×120`（控件自身，与卡片尺寸无关）。
+- 不新增运行期状态：焦点页仍是已有的 `current`（runtimeStateAttr，resize 不重置）；`edgeScale`/`edgeAlpha`/`spacing`/`fill` 都是普通幂等属性，ReSolve 正常重应用。
+
+---
+
+## 6. 内部架构（CarouselView）
+
+唯一实质改动在排版。v1 的 `Reposition()`（`CarouselView.cs:364`）把「卡尺寸」与「步距」混为一个 `_pageWidth`；peek 模式要把它们拆开。
+
+### 6.1 新增 / 拆分的字段
+
+```
+_fill       : bool   = true       // CAR-D25
+_spacing    : float  = 0          // CAR-D27
+_edgeScale  : float  = 1          // CAR-D28
+_edgeAlpha  : float  = 1
+_cardW/_cardH : float             // 卡的「槽位尺寸」（fill=true → 视口；fill=false → resolved 卡尺寸）
+_stride     : float               // 相邻卡中心距（fill=true → 视口宽；fill=false → _cardW + _spacing）
+```
+
+`_pageWidth`/`_pageHeight`（v1 既有）保留作「视口尺寸」语义；新增 `_cardW/_cardH`、`_stride` 区分「卡尺寸」「步距」。
+
+### 6.2 `RelayoutNow()` 改动（`CarouselView.cs:385`）
+
+```
+viewport 尺寸 → _pageWidth/_pageHeight（同 v1）
+if (_fill) {
+    _cardW = _pageWidth;  _cardH = _pageHeight;  _stride = _pageWidth;     // 退化 = v1
+} else {
+    (_cardW, _cardH) = MeasureCard();        // 见 §6.4：resolved 卡尺寸，回退视口
+    _stride = _cardW + _spacing;
+}
+_scroll = _current;  Reposition();
+```
+
+### 6.3 `Reposition()` 改动（核心，`CarouselView.cs:364`）
+
+```
+for each card i:
+    off = i - _scroll                                  // loop 时 Mathf.Repeat 折进 [-N/2, N/2)（同 v1）
+    rt.anchor/pivot = center                           // 同 v1
+    rt.sizeDelta   = (_cardW, _cardH)                  // fill=true → 视口；fill=false → 卡尺寸
+    rt.anchoredPos = (off * _stride, 0)                // 步距换成 _stride（v1 是 _pageWidth）
+    // —— 焦点强调 —— 总是算、总是写（自复位），不短路：
+    t = clamp(|off|, 0, 1)                             // CAR-D32 线性
+    s = lerp(1, _edgeScale, t);  a = lerp(1, _edgeAlpha, t)
+    rt.localScale = Vector3.one * s                    // fill=true / edge*=1 时 s=1，自动复位
+    ApplyAlpha(card, a)                                // a<1 才懒加 CanvasGroup；见下
+```
+
+- **localScale 总是写、不短路**：fill=true 或 `edgeScale=1` 时 `s=1`，正好把上一轮 peek 留下的缩放复位——避免 Variant 把 `fill` 从 false 切回 true 时卡片卡在缩放态（本仓库典型的 ReSolve/variant 复位坑，见 [[project_variant_control_attr_needs_base]] 同类）。代价仅一次廉价赋值。
+- `ApplyAlpha(card, a)`：`a < 1` 时才 `EnsureCanvasGroup`（懒加、缓存、不 Destroy）并设 alpha；`a == 1` 时若卡上**已有** CanvasGroup 则复位 alpha=1，否则不挂。→ 纯 fill carousel 永不挂 CanvasGroup；peek→fill 切换时已有的 CanvasGroup 被复位。
+- 于是 `fill="true"`（`_stride=_cardW=_pageWidth`、`edge*=1`）→ 与 v1 `Reposition` **视觉逐字等价**：localScale 复位 1、无新增 CanvasGroup。
+- **localScale 归属**：fill=false 下 Carousel 写卡根 localScale，作者别在卡根再用 density `scale=`（会被覆盖）；要 density 缩放写卡的里层节点。文档 + CAR-D31 邻近处提示。
+
+### 6.4 `MeasureCard()`（CAR-D26）
+
+peek 模式假定**卡片等尺寸**（整数索引 + 连续 `_scroll` 的吸附模型要求步距恒定）。取代表卡 = **第 0 张**（卡等尺寸量哪张都一样，第 0 张在 BindItems 重建后始终存在）的 resolved 尺寸：
+
+```
+读第 0 张卡 rt.rect 尺寸：
+  w = rect.width  > 0 ? rect.width  : _pageWidth     // 落空（裸 Frame sizeDelta=0）兜视口
+  h = rect.height > 0 ? rect.height : _pageHeight
+```
+
+卡尺寸已在属性 apply 阶段（`Reposition` 之前）由既有 size 分轴回退算好（显式 / native）。混用不同尺寸卡 = 未定义（out of scope，§9），与 v1「所有卡 = 视口」的等尺寸前提一脉相承。
+
+### 6.5 拖动 / 吸附（步距替换）
+
+v1 的拖动把本地位移除以 `_pageWidth` 换算成 scroll 单位、并 clamp 到 ±1 页（`CarouselView.cs:466-467`），吸附阈值用 `_pageWidth * SnapThreshold`（`:476-477`）。**全部把 `_pageWidth` 换成 `_stride`**：
+
+```
+_scroll = _dragStartScroll - clamp(dxLocal, -_stride, _stride) / _stride
+EndDrag: |_dragLocalX| ≥ _stride * SnapThreshold → 翻页
+```
+
+fill=true 时 `_stride == _pageWidth`，拖动行为逐字不变。其余（像素级跟手 `ScreenPointToLocalPointInRectangle`、整段转发外层、无主轴锁）一行不动。
+
+### 6.6 可选重构（CAR-D24 的「内部 base」）
+
+若 `Reposition` / `RelayoutNow` 两条路（fill / peek）在实现时显得臃肿，把「给定 `_scroll` / 模式 / 尺寸 → 每卡 (pos, size, scale, alpha)」的纯数学抽成内部 `CarouselLayout`（无 MonoBehaviour 依赖、可单测）。这是头脑风暴里「CarouselBase」DRY 直觉的落点——**内部 helper，不是公开标签**。plan 阶段按代码量定要不要抽。
+
+---
+
+## 7. Lint 改动
+
+`Runtime/Core/Lint/CarouselRules.cs`：
+
+1. **`PUI-CAROUSEL-CARD-SIZE` 加 fill 门控**（`CheckCard`）：仅当父 Carousel **未声明 `fill="false"`**（即 fill=true 缺省）时，才对卡片的 `size`/`width`/`height` 报 error。`fill="false"` 下卡片写尺寸合法、不报。
+   - 注意 `CheckCard` 现在按「直接子」单独检查（`CarouselRules.cs:47`），拿不到父的 `fill`。实现上让父 self-check（`CheckCarousel`）把 `fill` 读出来，遍历直接子时按模式决定是否对每个子跑 `CheckCard` 的 size 分支——即把 size 检查从「子规则」上移到「父驱动子」，与现有 `IRWalker` 的父子遍历一致。plan 阶段定具体串法（IRWalker 已持父节点）。
+2. **新增 `PUI-CAROUSEL-PEEK-NO-SIZE`（warning，CAR-D31）**：`fill="false"` 的直接子卡既无 `size`/`width`/`height`（含 variant 覆盖）→ warning「该卡无尺寸，将兜成视口大小、邻卡不会 peek；给卡根写 size= 或换自带原生尺寸的控件（如 Image）」。
+   - 局限：lint 是纯 IR 静态分析，看不到运行期 `GetNativeSize()`。故只对「XML 里没写 size 的卡」warn；其中 `<Image src=...>` 这种其实有原生尺寸的会被误 warn。**折中**：只在卡根 tag 是「已知无原生尺寸」的容器（`Frame` / `VStack` / `HStack` / `Grid`）时才 warn，其余 tag 放过。这样既抓住主坑（裸 Frame），又不误伤 Image/Text 卡。tag 白名单与 `BuiltinTags` 同源。
+
+更新后规则表：
+
+| Code | 触发条件 | 级别 |
+|---|---|---|
+| `PUI-CAROUSEL-CARD-SIZE` | 卡片写 `size`/`width`/`height` **且父 `fill` 非 false** | error |
+| `PUI-CAROUSEL-PEEK-NO-SIZE` | `fill="false"` 卡根是无原生尺寸容器（Frame/VStack/HStack/Grid）且未写尺寸 | warning |
+| `PUI-CAROUSEL-DOTS-ANCHOR`（v1） | `dots=` 非法锚点 | warning |
+
+`anchor`/`margin` 仍由 `PUI-LAYOUT-ANCHOR` / `PUI-LAYOUT-MARGIN` 覆盖（Carousel 在 `selfIsLayoutGroup` 名单，不分模式）。
+
+---
+
+## 8. 向后兼容
+
+- `fill` 默认 `true`、`spacing`/`edgeScale`/`edgeAlpha` 默认全是「无效果」值 → **现有所有 `<Carousel>` 行为逐字不变**。
+- `Reposition`/`RelayoutNow`/拖动在 fill=true 分支与 v1 逐字等价（§6.3/6.5），有回归测试钉死。
+- v1 文档示例（卡根 `<Frame>` 撑满、`<Image sprite>` 卡）继续工作：fill=true 仍强制视口尺寸，CARD-SIZE lint 仍对它们生效。
+- lint：现有写了 `size` 的卡（若有）在 fill=true 下仍报 error，行为不变；只有显式 `fill="false"` 才放开。
+
+---
+
+## 9. Out of Scope（v2 仍不做）
+
+- **不等尺寸卡片**：peek 假定卡等尺寸（步距恒定）。混用不同 size 的卡 = 未定义（§6.4）。
+- **3D / 旋转 coverflow**（卡片透视倾斜）：v2 只有平面缩放 + 淡出。
+- **缓动曲线属性**（`edgeEase`）：v2 线性（CAR-D32）。
+- **多于相邻一张的可见层数控制**：可见张数由卡宽 vs carousel 宽隐式决定，无显式「slidesPerView」。
+- **固定屏边渐变遮罩**（不跟卡、纯 vignette）：这个本来就能用两个渐变 `<Image>` 盖在 Carousel 上拼出来（头脑风暴里确认过），不进控件。
+- **竖向 peek**：沿用 v1 CAR-D19，横向 only。
+- **左右箭头按钮内建**：v1 `Next()`/`Previous()` 已够，作者自己放 `<Btn>` 绑（§3.1 示意），不进控件。
+
+---
+
+## 10. 测试计划
+
+EditMode（`Tests/EditMode/Controls/Carousel*Tests.cs`，复用既有夹具）:
+
+- **fill=true 回归**：`Reposition` 后各卡 pos/size 与 v1 逐字相同；localScale 恒 1、无 CanvasGroup。
+- **peek 排版数学**：fill=false 下卡 sizeDelta=声明尺寸、`anchoredPos = off*(cardW+spacing)`、焦点卡 scale=1/alpha=1、`|off|=1` 卡 scale=edgeScale/alpha=edgeAlpha；中间值线性。
+- **MeasureCard 兜底**：fill=false + 裸 Frame 无 size → 兜视口尺寸（不为 0、不 NaN）。
+- **拖动 / 吸附用步距**：fill=false 下拖动换算与阈值用 `_stride`；拖 >0.2 步距翻页、不足回弹。
+- **属性正交**：`spacing`/`edgeScale`/`edgeAlpha` 在 fill=true 下被忽略（无 CanvasGroup、scale 不变）。
+- **ReSolve 幂等**：resize / Variant 重应用后 peek 视觉不变、`current` 不重置、CanvasGroup 不重复挂。
+- **fill 经 Variant 切换复位**：`fill.portrait` 把 false→true 后卡 `localScale` 复位 1、已有 CanvasGroup alpha 复位 1（不卡在缩放 / 半透明态）。
+- **lint**：CARD-SIZE 在 fill=true 报 / fill=false 不报；PEEK-NO-SIZE 对裸 Frame warn、对 Image 卡不 warn。
+
+PlayMode（`Tests/PlayMode/Controls/CarouselPlayTests.cs`）:
+
+- fill=false 下拖动翻页落在正确焦点；autoplay（若开）+ peek 不崩；CanvasGroup alpha 随焦点平滑变化（采样两帧）。
+
+---
+
+## 11. SKILL / docs 整合
+
+### 11.1 `authoring-promptugui-xml/reference/controls-carousel.md`
+- 加「居中选择 / peek 模式」小节：§3.1 用例、`fill`/`spacing`/`edgeScale`/`edgeAlpha` 语义、peek 量隐式（卡宽 vs 控件宽）、「fill=false 卡片须自定尺寸，裸 Frame 写 size、Image/Text 可用原生」、「Carousel 占卡根 localScale，density scale 写里层」。
+- Lint 表加 `PUI-CAROUSEL-PEEK-NO-SIZE`，并标注 `PUI-CAROUSEL-CARD-SIZE` 现仅 fill=true。
+
+### 11.2 主文档 `SKILL.md`
+- Built-in primitives 表 `<Carousel>` 行补 `fill` / `spacing` / `edgeScale` / `edgeAlpha` 四属性（stub 指向 reference）。
+
+### 11.3 `scripting-promptugui-csharp/SKILL.md`
+- 无新 C# 方法（左右按钮用现成 `Next()`/`Previous()`）；可加一句「居中选择器的左右箭头 = `<Btn>` 绑 `Previous()`/`Next()`」。
+
+### 11.4 XSD
+- 随 4 个新 `[UIAttr]` 手动 regenerate；生成器测试加 `fill`/`edgeScale` 等 substring 断言（同既有约定）。
+
+---
+
+## 12. 风险与回滚
+
+| 风险 | 缓解 |
+|---|---|
+| fill=true 分支被改出回归 | §6 全程把 fill=true 设计成 v1 逐字特例 + §10 回归测试钉死；`Reposition` 里 `if(!_fill)` 短路强调逻辑 |
+| `MeasureCard` 在属性 apply 之前跑 → 卡尺寸还没 resolved | `RelayoutNow` 由 `OnAfterApply`（apply 之后）与 resize 触发，与 v1 时序一致；落空再兜视口 |
+| CanvasGroup 与卡内已有 CanvasGroup / Add 块 SetActive 冲突 | `EnsureCanvasGroup` 复用已有组件（GetComponent 优先）；alpha 是乘性视觉、不碰 active |
+| `fill` 经 Variant/ReSolve 从 false 切 true，卡片卡在 peek 的 scale/alpha | `Reposition` **总写** localScale（lerp 自复位）；已有 CanvasGroup 即复位 alpha=1（§6.3） |
+| localScale 与卡内 density `scale=` 打架 | 约定 + 文档：fill=false 下 Carousel 拥有卡根 localScale，density 写里层（CAR-D29/§6.3） |
+| 不等尺寸卡导致吸附错位 | 文档声明等尺寸前提（§6.4/§9）；`MeasureCard` 取代表卡，混用未定义但不崩 |
+| PEEK-NO-SIZE 误伤有原生尺寸的卡 | 只对已知无原生尺寸容器 tag（Frame/VStack/HStack/Grid）warn（§7） |
+| CARD-SIZE 门控要拿父 `fill`，但 `CheckCard` 现按子单独跑 | 把 size 检查上移到父驱动（IRWalker 已持父节点）；plan 阶段定串法 |
+| XSD 不自动更新 | 同所有新 `[UIAttr]`，手动 regenerate（CLAUDE.md 已说明） |

--- a/docs~/superpowers/specs/2026-06-15-centered-slide-box-design.md
+++ b/docs~/superpowers/specs/2026-06-15-centered-slide-box-design.md
@@ -167,31 +167,31 @@ facade 见 §3（`CenteredSlideBox.Open` 就是它，照 MessageBox 风格）。
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <PromptUGUI version="1">
+  <!-- 通用卡片：封面 + 标题。⚠️ <Template> 必须是文档顶层元素（<Screen> 的兄弟，
+       不能嵌进 <Screen> —— 解析器只从 <PromptUGUI> 直接子提取模板）。换皮 = 换这段 + 整个 XmlSrc（CSB-D6）-->
+  <Template name="Card">
+    <Frame size="240x320">
+      <Image id="cover" anchor="stretch"/>
+      <Text  id="name"  anchor="bottom-stretch" height="40" align="center" tr="false"/>
+    </Frame>
+  </Template>
+
   <Screen name="CenteredSlideBox">
-    <!-- 全屏 backdrop（点它取消）；半透明黑 -->
-    <Image id="backdrop" anchor="stretch" color="#000000A0">
-      <!-- panel：居中容器 -->
-      <Frame id="panel" anchor="center" size="720x460">
-        <Text id="title" anchor="top-stretch" height="48" align="center" tr="false"/>
-        <Btn  id="close" anchor="top-right" size="36x36" margin="6,6,_,_">×</Btn>
+    <!-- ⚠️ backdrop 与 panel 是兄弟（backdrop 在底层、panel 在上层），不能把 panel 嵌进 backdrop——
+         否则点 panel 任意处都会冒泡到 backdrop 的 OnPointerDown 误关。点 backdrop 空白区取消。 -->
+    <Image id="backdrop" anchor="stretch" color="#000000A0"/>
+    <Frame id="panel" anchor="center" size="720x460">
+      <Text id="title" anchor="top-stretch" height="48" align="center" tr="false"/>
+      <Btn  id="close" anchor="top-right" size="36x36" margin="6,6,_,_">×</Btn>
 
-        <Carousel id="cards" anchor="stretch" margin="56,16,72,16"
-                  fill="false" interval="0" loop="true"
-                  spacing="24" edgeScale="0.82" edgeAlpha="0.45"
-                  itemTemplate="Card"
-                  dots="bottom-center" dotColor="#666" dotSelectedColor="#fff"/>
+      <Carousel id="cards" anchor="stretch" margin="56,16,72,16"
+                fill="false" interval="0" loop="true"
+                spacing="24" edgeScale="0.82" edgeAlpha="0.45"
+                itemTemplate="Card"
+                dots="bottom-center" dotColor="#666" dotSelectedColor="#fff"/>
 
-        <Btn id="confirm" anchor="bottom-center" size="160x48" margin="_,_,12,_">OK</Btn>
-      </Frame>
-    </Image>
-
-    <!-- 通用卡片：封面 + 标题。换皮 = 换这段 + 整个 XmlSrc（CSB-D6）-->
-    <Template name="Card">
-      <Frame size="240x320">
-        <Image id="cover" anchor="stretch"/>
-        <Text  id="name"  anchor="bottom-stretch" height="40" align="center" tr="false"/>
-      </Frame>
-    </Template>
+      <Btn id="confirm" anchor="bottom-center" size="160x48" margin="_,_,12,_">OK</Btn>
+    </Frame>
   </Screen>
 </PromptUGUI>
 ```

--- a/docs~/superpowers/specs/2026-06-15-centered-slide-box-design.md
+++ b/docs~/superpowers/specs/2026-06-15-centered-slide-box-design.md
@@ -93,7 +93,7 @@ if (picked != null) StartLevel(picked);     // 选中对象；要 id 就 picked.
 ## 4. 内部：`CenteredSlideBoxRequest<T>`
 
 ```csharp
-internal sealed class CenteredSlideBoxRequest<T> : ModalRequest<T> where T : class
+public sealed class CenteredSlideBoxRequest<T> : ModalRequest<T> where T : class   // public（同其它 modal request）：命名变体 facade / 测试直接 new
 {
     public IReadOnlyList<T> Items;
     public Action<IControl, T> BindCard;
@@ -196,7 +196,7 @@ facade 见 §3（`CenteredSlideBox.Open` 就是它，照 MessageBox 风格）。
 </PromptUGUI>
 ```
 
-**id 契约**（换皮 XML 必须保留）：`backdrop`(Image) / `panel` / `title`(Text) / `close`(Btn) / `confirm`(Btn) / `cards`(Carousel `fill="false" itemTemplate="…"`) + 卡模板里 bind 用到的槽位（默认 `cover`/`name`）。卡模板根的 `size=` 决定卡尺寸（peek MeasureCard 读它）。尺寸/配色/peek 参数都是合理默认，想调走 `configure`。
+**id 契约**（换皮 XML 必须保留）：`backdrop`(Image) / `panel` / `title`(Text) / `close`(Btn) / `confirm`(Btn) / `cards`(Carousel `fill="false" itemTemplate="…"`) + 卡模板里 bind 用到的槽位（默认 `cover`/`name`）。卡模板根的 `size=` 决定卡尺寸（peek MeasureCard 读它）。⚠️ **换皮卡片的根应是无 Graphic 的容器**（`<Frame>`/Stack）——`AttachCardClick` 会给卡根补一层透明 raycast `Image`（color 置 0）；若卡根本身是带可见 sprite 的 `<Image>`，会被这层置成透明。尺寸/配色/peek 参数都是合理默认，想调走 `configure`。
 
 > 内置 XML 会过 UIXmlLint（吃自己的 `fill="false"` + 带 `size` 的卡 = 狗粮验证 peek 模式 lint 门控正确）。
 

--- a/docs~/superpowers/specs/2026-06-15-centered-slide-box-design.md
+++ b/docs~/superpowers/specs/2026-06-15-centered-slide-box-design.md
@@ -1,0 +1,277 @@
+# `CenteredSlideBox` 居中选择器模态设计
+
+**日期**: 2026-06-15
+**状态**: 设计阶段（待 review，未进入实施）
+**建立在**: peek Carousel（[`2026-06-15-carousel-peek-mode-design.md`](2026-06-15-carousel-peek-mode-design.md)，`fill="false"`）+ 现有模态体系 `ModalRequest<TResult>`（MessageBox / InputBox / MarkdownBox / Loading 同款）。同分支 `feat/carousel-peek-mode`——是 peek 的应用层。决策编号 `CSB-Dx`。
+
+**一句话**: 第 4 个内置模态 `CenteredSlideBox.Open<T>(items, bind, …) → Awaitable<T>`——一个居中卡片选择器弹窗：内部塞一个 `fill="false"` Carousel，用户传**强类型**数据 + bind 回调填卡，`await` 等用户选中，返回**选中的对象**（取消 = `null`）。
+
+**作用域**:
+1. 新增 `Runtime/Application/Modals/CenteredSlideBoxRequest.cs`：`CenteredSlideBoxRequest<T> : ModalRequest<T>` + 静态 `CenteredSlideBox` facade + 卡片点击装配。
+2. 新增 `Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml`（+ `.meta`）：backdrop + panel chrome + **内置卡片 `<Template>`** + `<Carousel fill="false">`。
+3. `.claude/skills/scripting-promptugui-csharp/SKILL.md`：加 `CenteredSlideBox.Open` 用法（新公开 C# API）。
+4. 测试：`Tests/EditMode/.../CenteredSlideBoxTests.cs` + `Tests/PlayMode/.../CenteredSlideBoxPlayTests.cs`。
+
+**Carousel / BuiltinTags / lint / XSD：零改动**——CenteredSlideBox 是 C# 模态 API，不是新 XML 标签；卡模板用现有内置标签。
+
+**依赖**: 无新增包。复用 `ModalRequest<TResult>` / `UI.Modal.OpenAsync` / `Configure` 钩子 / `TryEscape`（同 MarkdownBox），`Carousel.BindItems` + `fill="false"` peek，`PuiButton`（同 Carousel dot 的点击装配）。
+
+---
+
+## 1. 背景与动机
+
+游戏常见「关卡 / 角色选择」弹窗：黑底、中间居中卡片、左右拖选、确认。peek Carousel（`fill="false"`）已经提供了视觉与交互骨架，但每个游戏都手糊一遍「模态壳 + Carousel + 选中→关闭 + await 结果」是样板。把它收成一个内置模态，和 `MessageBox.Open` / `InputBox.Open` 一个味道：一行 `await` 拿到选中结果。
+
+为什么是模态而不是普通 Screen？因为调用语义是**阻塞式问答**（"选哪个？"→ await → 拿答案），正是模态体系 `ModalRequest<TResult>` 的形状。
+
+---
+
+## 2. 决策一览
+
+| # | 决策 | 选择 | 理由 |
+|---|---|---|---|
+| CSB-D1 | 控件形态 | 第 4 个内置模态，照 MarkdownBox：`CenteredSlideBoxRequest<T> : ModalRequest<T>` + 静态 facade + `XmlSrc` 指向内置 `.ui.xml` + `UI.Modal.OpenAsync` | 复用全套模态机制（层级/排序/ESC/背景/configure/ct）；零新框架 |
+| CSB-D2 | 数据传入 | 泛型 `Open<T>(IReadOnlyList<T> items, Action<IControl,T> bind, …)`，**同 `Carousel.BindItems`**。`T` 任意（强类型 / `Dictionary` / `JObject`），bind 回调填卡 | PromptUGUI 惯用法、类型安全、零魔法、用户已熟。**「JSON」不是特例**：调用方先反序列化成自己的类型；库这层不碰 JSON（是特性不是缺陷） |
+| CSB-D3 | 返回值 | `Awaitable<T>`，返回**选中的对象**；`where T : class`，取消 = `null` | 比返回 `string id` 更通用（`picked?.Id` 即 id），无需额外 `idOf`/tuple 管线；`null` 取消干净（同 InputBox） |
+| CSB-D4 | 卡片模板位置 | 卡片 `<Template name="Card">` 写在 **`CenteredSlideBox.ui.xml` 自己文档里**，Carousel 用 **v1 现成的 `itemTemplate` 机制**（同文档 `ResolveFactory`）解析 | **绕开跨文档难题**：模态走 `UI.LoadDocument`（同步，不合并 commons/imports，见 `ModalDocCache`），调用方文档里的模板模态看不见——但同文档的 `<Template>` 解析正常。于是 `(cardSrc,cardTemplate)` / async 模板加载 / Carousel 的 `SetItemFactory` 钩子全部不需要，**Carousel 零改动** |
+| CSB-D5 | 通用卡片槽位 | 内置卡 = `cover`(Image，stretch) + `name`(Text，底部)；bind 填这俩，用不到的不碰 | 「封面 + 标题」覆盖大多数关卡/角色选择；保持「简易」 |
+| CSB-D6 | 换一种卡片样式 | `XmlSrc` 是**可写静态**（同所有模态）→ 指向你自己的 XML（保持 id 契约）。命名变体 = 抄 ~10 行 facade、传不同 `XmlSrc`（`CenteredSlideBoxRequest<T>` 持 `XmlSrc` 字段） | 用户想要的「新建一种 CenteredSlideBox」；比 subclass 轻，无继承 |
+| CSB-D7 | 选中交互（A+C） | **点侧卡** → 居中它（`car.GoTo(i)`，不确认）；**点居中卡** → 确认（`close(items[i])`）；**确认按钮** → 确认居中（`close(items[car.Current])`） | coverflow 直觉（点哪个看哪个）+ 显式确认按钮（可发现性）；用户选定 A+C |
+| CSB-D8 | 卡片点击装配 | 每张卡挂**透明 raycast catcher + `PuiButton`**，`onClick` → 居中/确认（**click 语义**，非 OnPointerDown）；拖动不实现 `IDragHandler` → 冒泡给 `CarouselView` | 必须区分「点」与「拖」：`PuiButton.onClick` 只在 click（无拖动）触发，同 Carousel dot 的装配；拖动照常翻页（同 CAR-D12） |
+| CSB-D9 | 取消（三通道） | `×` Btn / 背景 Image / ESC → `close(null)`；`TryEscape(out r){ r=null; return true; }` | 照 MarkdownBox；选择器永远可取消 |
+| CSB-D10 | chrome 参数 | `title`（空→隐藏）/ `confirmLabel`（空→内置 XML 的 confirm 默认文案，如 `"OK"`；要本地化自己传 tr 后的串）/ `configure`（post-bind 钩子，够到 panel/carousel 调 peek 参数）/ `mode` / `ct` | 镜像 MessageBox 的可定制面；peek 参数（spacing/edgeScale/edgeAlpha）烤进内置 XML 默认，想调走 configure |
+| CSB-D11 | 边界 | 空 `items` → carousel 空 + 确认 `Interactable=false`（只能取消）；1 卡 → 居中无邻卡，确认返回它；`ct` 取消 → null | 选择器无项时不该能「确认」；单项是合法退化 |
+
+---
+
+## 3. 公开 API
+
+```csharp
+namespace PromptUGUI.Application.Modals
+{
+    public static class CenteredSlideBox
+    {
+        // 必须带 .ui 后缀（Unity 只剥 .ui.xml 的最后 .xml）。可写 = 换皮入口（CSB-D6）。
+        public static string XmlSrc { get; set; } = "PromptUGUI/Modals/CenteredSlideBox.ui";
+
+        public static UnityEngine.Awaitable<T> Open<T>(
+            System.Collections.Generic.IReadOnlyList<T> items,
+            System.Action<IControl, T> bind,
+            string title = null,
+            string confirmLabel = null,
+            ModalMode mode = ModalMode.Popup,
+            System.Action<IScreen> configure = null,
+            System.Threading.CancellationToken ct = default
+        ) where T : class
+            => UI.Modal.OpenAsync(new CenteredSlideBoxRequest<T>
+            {
+                Items = items,
+                BindCard = bind,
+                Title = title,
+                ConfirmLabel = confirmLabel,
+                Configure = configure,
+            }, mode, ct);
+    }
+}
+```
+
+调用：
+
+```csharp
+record Level(string Id, string Name, Sprite Cover);
+
+var picked = await CenteredSlideBox.Open(
+    levels,
+    bind: (card, lv) => { card.Get<Text>("name").TextValue = lv.Name;
+                          card.Get<Image>("cover").Sprite   = lv.Cover; },
+    title: "选择关卡");
+if (picked != null) StartLevel(picked);     // 选中对象；要 id 就 picked.Id
+```
+
+---
+
+## 4. 内部：`CenteredSlideBoxRequest<T>`
+
+```csharp
+internal sealed class CenteredSlideBoxRequest<T> : ModalRequest<T> where T : class
+{
+    public IReadOnlyList<T> Items;
+    public Action<IControl, T> BindCard;
+    public string Title;
+    public string ConfirmLabel;
+    public string XmlSrcOverride;                    // CSB-D6：命名变体 facade 可传；null→静态默认
+
+    public override string XmlSrc => XmlSrcOverride ?? CenteredSlideBox.XmlSrc;
+
+    public override void Bind(IScreen screen, Action<T> close)
+    {
+        // —— title ——
+        var titleCtl = screen.Get<Text>("title");
+        if (string.IsNullOrEmpty(Title)) titleCtl.GameObject.SetActive(false);
+        else titleCtl.TextValue = Title;
+
+        // —— 取消三通道（CSB-D9）——
+        screen.Get<Btn>("close").OnClick.Subscribe(_ => close(null)).AddTo(screen);
+        screen.Get<Image>("backdrop").OnPointerDown.Subscribe(_ => close(null)).AddTo(screen);
+
+        // —— carousel + 卡 ——
+        var car = screen.Get<Carousel>("cards");
+        int idx = 0;
+        car.BindItems(Items, (IControl card, T item) =>
+        {
+            int i = idx++;                            // BindItems 按 0..n-1 顺序回调
+            BindCard?.Invoke(card, item);
+            AttachCardClick(card, i, car, close);     // CSB-D7/D8
+        }).AddTo(screen);
+
+        // —— 确认按钮（CSB-D7）——
+        var ok = screen.Get<Btn>("confirm");
+        if (!string.IsNullOrEmpty(ConfirmLabel)) ok.Text = ConfirmLabel;
+        if (Items.Count == 0) ok.Interactable = false;            // CSB-D11
+        ok.OnClick.Subscribe(_ =>
+        {
+            int cur = car.Current;
+            if (cur >= 0 && cur < Items.Count) close(Items[cur]);
+        }).AddTo(screen);
+    }
+
+    // ESC / 背景 → 取消（CSB-D9）
+    public override bool TryEscape(out T result) { result = null; return true; }
+
+    // 每张卡：透明 raycast catcher + PuiButton，click（非拖动）→ 居中或确认。
+    private void AttachCardClick(IControl card, int i, Carousel car, Action<T> close)
+    {
+        var go = card.GameObject;
+        var img = go.GetComponent<UnityEngine.UI.Image>() ?? go.AddComponent<UnityEngine.UI.Image>();
+        img.color = new Color(0, 0, 0, 0);            // 透明，仅 raycast
+        img.raycastTarget = true;
+        var btn = go.AddComponent<PuiButton>();        // onClick = click 语义；拖动冒泡给 CarouselView
+        btn.targetGraphic = img;
+        btn.onClick.AddListener(() =>
+        {
+            if (car.Current == i) close(Items[i]);     // 点居中卡 = 确认
+            else car.GoTo(i, animated: true);          // 点侧卡 = 居中
+        });
+    }
+}
+```
+
+> 卡根（默认 `<Frame>`）本无 Graphic；`AttachCardClick` 给它补一个**透明 raycast Image**（不挡视觉、不挡拖动——drag 不被 PuiButton 处理，沿用 Carousel 的 viewport 冒泡）。这也使「点击命中整张卡」与卡的具体槽位无关（换皮卡无需特意留点击面）。代价：卡内若有自己的按钮会被这层吃掉——v1 选择器整卡即选，可接受；需要卡内交互属高级场景（自定 XmlSrc 自理）。
+
+facade 见 §3（`CenteredSlideBox.Open` 就是它，照 MessageBox 风格）。**命名变体** = 复制这 ~10 行、给 request 传不同 `XmlSrcOverride`（CSB-D6）。
+
+---
+
+## 5. 内置 `CenteredSlideBox.ui.xml`
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<PromptUGUI version="1">
+  <Screen name="CenteredSlideBox">
+    <!-- 全屏 backdrop（点它取消）；半透明黑 -->
+    <Image id="backdrop" anchor="stretch" color="#000000A0">
+      <!-- panel：居中容器 -->
+      <Frame id="panel" anchor="center" size="720x460">
+        <Text id="title" anchor="top-stretch" height="48" align="center" tr="false"/>
+        <Btn  id="close" anchor="top-right" size="36x36" margin="6,6,_,_">×</Btn>
+
+        <Carousel id="cards" anchor="stretch" margin="56,16,72,16"
+                  fill="false" interval="0" loop="true"
+                  spacing="24" edgeScale="0.82" edgeAlpha="0.45"
+                  itemTemplate="Card"
+                  dots="bottom-center" dotColor="#666" dotSelectedColor="#fff"/>
+
+        <Btn id="confirm" anchor="bottom-center" size="160x48" margin="_,_,12,_">OK</Btn>
+      </Frame>
+    </Image>
+
+    <!-- 通用卡片：封面 + 标题。换皮 = 换这段 + 整个 XmlSrc（CSB-D6）-->
+    <Template name="Card">
+      <Frame size="240x320">
+        <Image id="cover" anchor="stretch"/>
+        <Text  id="name"  anchor="bottom-stretch" height="40" align="center" tr="false"/>
+      </Frame>
+    </Template>
+  </Screen>
+</PromptUGUI>
+```
+
+**id 契约**（换皮 XML 必须保留）：`backdrop`(Image) / `panel` / `title`(Text) / `close`(Btn) / `confirm`(Btn) / `cards`(Carousel `fill="false" itemTemplate="…"`) + 卡模板里 bind 用到的槽位（默认 `cover`/`name`）。卡模板根的 `size=` 决定卡尺寸（peek MeasureCard 读它）。尺寸/配色/peek 参数都是合理默认，想调走 `configure`。
+
+> 内置 XML 会过 UIXmlLint（吃自己的 `fill="false"` + 带 `size` 的卡 = 狗粮验证 peek 模式 lint 门控正确）。
+
+---
+
+## 6. 交互流（A+C，CSB-D7/D8/D9）
+
+```
+开窗 → BindItems 建卡（每卡挂透明 raycast + PuiButton）→ 居中默认页(current=0)
+用户拖动 / 左右（无内置箭头，但 dots 可点）→ 翻页，焦点卡放大不淡（peek）
+点侧卡  → car.GoTo(i) 居中它（动画），不返回
+点居中卡 → close(items[i]) → await 返回该项
+点确认  → close(items[car.Current])
+× / 点背景 / ESC → close(null) → await 返回 null
+```
+
+`UI.Modal.OpenAsync` 负责：加载内置 XML（`ModalDocCache`）、实例化模态 Screen、跑 `Bind` 再跑 `Configure`、ESC 监听调 `TryEscape`、`close(result)` → 关窗 + 完成 `Awaitable<T>`。
+
+---
+
+## 7. 边界 / 错误处理（CSB-D11）
+
+| 场景 | 处理 |
+|---|---|
+| `items` 空 | carousel 空；确认 `Interactable=false`（灰）；只能 ×/ESC/背景 取消 → null |
+| `items` 1 张 | 居中、无邻卡 peek；确认/点它返回该项 |
+| `bind` 为 null | 卡只有模板默认外观（不填槽）；不报错 |
+| `ct` 取消 | `UI.Modal.OpenAsync` 关窗 + Awaitable 取消（同其它模态） |
+| 换皮 XML 缺 id（如无 `confirm`） | `screen.Get<Btn>("confirm")` 抛 `KeyNotFoundException`——契约违例，开发期即炸（同 MessageBox 对必备 id 的假设） |
+| 卡模板根无 `size`（fill=false） | peek 兜成视口尺寸 + lint `PUI-CAROUSEL-PEEK-NO-SIZE`（内置卡有 size，不触发） |
+
+---
+
+## 8. 测试
+
+EditMode（照 `MessageBoxRequest` / `InputBoxRequest` 的模态驱动套路 + `UI.ResetForTests`；内置 XML 走 Resources）:
+
+- **确认按钮 → 返回居中项**：Open 拿 Awaitable；先 `GoTo(k)`（或拖）把第 k 项居中；点 confirm；await == `items[k]`。
+- **点居中卡 → 返回该项**：点 current 卡的 PuiButton；await == `items[current]`。
+- **点侧卡 → 居中不返回**：点非 current 卡；`car.Current` 变成该索引；Awaitable 未完成。
+- **取消三通道**：点 `close` / 点 `backdrop` / 触发 ESC（`TryEscape`）→ await == `null`。
+- **空列表**：确认 `Interactable==false`；ESC → null。
+- **title=null** → title 隐藏；**confirmLabel** → 按钮文案改。
+- **bind 填槽**：bind 设 `name`/`cover`，断言卡上对应控件值。
+
+PlayMode：烟雾——开窗、拖一格、点确认，结果非空不崩。
+
+---
+
+## 9. 文件结构
+
+| 文件 | 职责 | 动作 |
+|---|---|---|
+| `Runtime/Application/Modals/CenteredSlideBoxRequest.cs` | `CenteredSlideBoxRequest<T>` + `CenteredSlideBox` facade + `AttachCardClick` | 新建 |
+| `Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml`(+.meta) | backdrop + panel + title/close/confirm + `<Carousel fill="false">` + `<Template name="Card">` | 新建 |
+| `Tests/EditMode/Application/Modals/CenteredSlideBoxTests.cs` | §8 EditMode | 新建 |
+| `Tests/PlayMode/Application/Modals/CenteredSlideBoxPlayTests.cs` | §8 PlayMode 烟雾 | 新建 |
+| `.claude/skills/scripting-promptugui-csharp/SKILL.md` | `CenteredSlideBox.Open` 用法 + 槽位契约 + 换皮 | 改 |
+
+---
+
+## 10. Out of Scope
+
+- **内置左右箭头按钮**：用户要的话自己在 panel 加 `<Btn>` 绑 `car.Previous()/Next()`（换皮 XML 里加）；不进默认 chrome。
+- **多选**：v1 单选（选一个返回）。多选另设计。
+- **卡内交互元素**（卡里再放按钮）：被整卡点击层吃掉；高级场景自定 XmlSrc 自理（CSB-D8 注）。
+- **per-call 换皮参数**：v1 靠静态 `XmlSrc` / 命名变体 facade；不加 `Open(..., xmlSrc)` 参数（保持签名简单，YAGNI）。
+- **非 class 的 `T`（值类型）**：`where T : class` 限定（取消用 null 哨兵）；值类型数据包一层引用类型。
+- **搜索 / 分组 / 分页**：简易选择器，大量项请自建 ScrollList 界面。
+
+---
+
+## 11. 跟现有体系的整合点
+
+- `scripting-promptugui-csharp/SKILL.md`：模态小节加 `CenteredSlideBox.Open<T>`（数据=items+bind 同 BindItems、返回选中对象 null=取消、A+C 交互、槽位契约 cover/name、换皮 XmlSrc）。
+- XML / Addressables skill：无关，不动。
+- 主 spec / XSD / lint：无新 XML 标签或属性，不动。
+- 复用 peek Carousel（本分支前序工作）——CenteredSlideBox 是它落地的第一个「成品级」用例。


### PR DESCRIPTION
两个高度相关的特性，同分支一起交付（**CenteredSlideBox 建立在 peek Carousel 之上**）。

---

## 1. `<Carousel fill="false">` 居中选择 / peek 模式

给现有 `<Carousel>` 加**居中卡片选择器**（coverflow）排版——卡片用自身 `size`、两侧邻卡露出、焦点卡可放大、越往边越淡。**不拆控件**，复用 v1 全部机制（拖动/吸附/loop/autoplay/dots/BindItems/运行期 `current`）。

| 属性 | 默认 | 说明 |
|---|---|---|
| `fill` | `true` | `false` = 居中选择器（卡用自身 `size`、邻卡露出）；仅 `false` 时下面三个生效 |
| `spacing` | `0` | 相邻卡间距 px；步距 = 卡宽 + spacing |
| `edgeScale` | `1.0` | 边卡缩放，焦点卡 1，按距中心线性插值 |
| `edgeAlpha` | `1.0` | 边卡不透明度，焦点卡 1，按距中心线性插值 |

唯一实质改动是 `CarouselView.Reposition()`（拆卡尺寸/步距、按 `|off|` 叠 `localScale`/`CanvasGroup.alpha`，值按 `_fill` 门控）。`fill="true"` 是退化特例，与 v1 **逐字等价**。Lint：`PUI-CAROUSEL-CARD-SIZE` 改为仅 fill=true 触发 + 新 warning `PUI-CAROUSEL-PEEK-NO-SIZE`。设计：`docs~/.../2026-06-15-carousel-peek-mode-design.md`（CAR-D24..D32）。

## 2. `CenteredSlideBox` 居中选择器模态（第 4 个内置模态）

```csharp
var picked = await CenteredSlideBox.Open(
    levels, bind: (card, lv) => { card.Get<Text>("name").TextValue = lv.Name;
                                  card.Get<Image>("cover").Sprite   = lv.Cover; },
    title: "选择关卡");
if (picked != null) StartLevel(picked);   // 返回选中对象；取消 = null
```

把 peek Carousel 包成模态（照 `MarkdownBox` 范式：`ModalRequest<T>` + facade + `XmlSrc`）。**泛型数据 + bind 填卡**（同 `Carousel.BindItems`，JSON 自己反序列化、库不碰）；await 返回**选中对象**（`where T:class`，取消 = `null`）。**A+C 交互**：点侧卡居中 / 点居中卡确认 / 确认按钮；取消三通道 × / 背景 / ESC。卡模板写在 `CenteredSlideBox.ui.xml` 自己文档里（Carousel 用 v1 `itemTemplate` 解析 → **Carousel 零改动**）；换皮靠 `XmlSrc`。设计：`docs~/.../2026-06-15-centered-slide-box-design.md`（CSB-D1..D11）。

---

## 测试 / 验证

- **EditMode 1841/1841 · EditorOnly 268/268** 全绿 · UIXmlLint 0 问题 · `dotnet format` 干净
- 全程 superpowers TDD（brainstorming→spec→plan→subagent-driven，每 task spec 合规 + 代码质量双评审 + 整体最终评审 Ready-to-merge）
- PlayMode：peek 的 `CarouselPlayTests` + 新 `CenteredSlideBoxPlayTests` 跑过时绿；本环境的全量 PlayMode MCP runner 后段退化成 0-tests/ssw_re_client（已知环境问题，非回归——合并前请重启 Unity 手动确认 PlayMode）

## 视觉 QA（待在宿主工程验收）

- [ ] peek：`fill="false"` 邻卡露边 / 焦点放大 / 边缘渐隐 / 拖动吸附 / resize 不重置
- [ ] 默认 `fill="true"` 现有 banner 轮播零变化（向后兼容）
- [ ] CenteredSlideBox：关卡选择弹窗——居中放大淡出、点侧卡居中、点居中卡/确认返回、× / 背景 / ESC 取消、空列表确认禁用
- [ ] PlayMode 手动确认（环境 runner 退化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)