### PR TITLE
feat: CenteredSlideBox 多按钮 (SlideSelection<T> + 自定义按钮行)

### DIFF
--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -600,7 +600,7 @@ MODAL          var r = await MessageBox.Open(text, MsgBtn.OK|MsgBtn.Cancel, icon
                var (item,key) = await CenteredSlideBox.Open(items, bind, buttons, title, mode, configure, ct)
                               // multi-button overload → SlideSelection<T>(.Item/.Button/.Cancelled)
                               // ≥2 buttons: tap-centred-card shortcut disabled (must click a button); side-tap still centres
-                              // label i18n-translated; key is stable branch discriminator; cancel → .Cancelled(Button==null)
+                              // label shown as-is (wrap UI.Tr for i18n); key = stable branch discriminator; cancel → .Cancelled(Button==null)
                               // default skin: button0..button4 (5 slots); >5 → InvalidOperationException; empty → ArgumentException
                               // custom XmlSrc: add button{i} ids; skin id changed confirm→button0 vs single-button overload
                configure:     Action<IScreen> trailing arg on every Open (MessageBox/InputBox/Loading/MarkdownBox/CenteredSlideBox)
@@ -723,7 +723,7 @@ if (level != null) game.StartLevel(level);            // got the whole object; i
 //   configure: s => s.Get<Carousel>("cards").Loop = true
 
 // Multi-button overload: returns SlideSelection<T> (.Item, .Button, .Cancelled).
-// label is i18n-translated; key is the stable branch discriminator (never use label as key).
+// label is shown as-is — wrap in UI.Tr(...) for i18n; key is the stable branch discriminator (never use label as key).
 // With ≥2 buttons the "tap centred card = confirm" shortcut is auto-disabled — the user
 // MUST click a button. Tapping a side card still centres it. Cancel (× / backdrop / ESC)
 // → result.Cancelled == true (Button == null, Item == null).
@@ -823,7 +823,7 @@ public static class CenteredSlideBox {
 
     // Multi-button overload: returns SlideSelection<T>.
     // ≥2 buttons disables the "tap centred card" shortcut — user must click a button.
-    // label is displayed (i18n-translated); key is the stable branch discriminator.
+    // label is shown as-is (wrap in UI.Tr for i18n); key is the stable branch discriminator.
     // Default skin exposes button0..button4 (5 slots).
     // Throws InvalidOperationException if buttons.Count exceeds available skin slots.
     // Throws ArgumentException if buttons is empty.

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -597,6 +597,12 @@ MODAL          var r = await MessageBox.Open(text, MsgBtn.OK|MsgBtn.Cancel, icon
                               // 居中卡片选择器(关卡/角色弹窗,内含 fill=false peek Carousel);T:class
                               // 返回选中对象(取消 ×/背景/ESC → null);bind 填内置卡槽 cover/name(同 BindItems)
                               // 点侧卡居中,点居中卡 or 确认按钮 = 确认;换皮 CenteredSlideBox.XmlSrc 指自己 XML
+               var (item,key) = await CenteredSlideBox.Open(items, bind, buttons, title, mode, configure, ct)
+                              // multi-button overload → SlideSelection<T>(.Item/.Button/.Cancelled)
+                              // ≥2 buttons: tap-centred-card shortcut disabled (must click a button); side-tap still centres
+                              // label i18n-translated; key is stable branch discriminator; cancel → .Cancelled(Button==null)
+                              // default skin: button0..button4 (5 slots); >5 → InvalidOperationException; empty → ArgumentException
+                              // custom XmlSrc: add button{i} ids; skin id changed confirm→button0 vs single-button overload
                configure:     Action<IScreen> trailing arg on every Open (MessageBox/InputBox/Loading/MarkdownBox/CenteredSlideBox)
                               // post-bind hook → live Screen; reach any control w/o subclassing
                               // e.g. InputBox.Open(t, configure: s => s.Get<Btn>("ok").Interactable = false)
@@ -609,7 +615,8 @@ MODAL          var r = await MessageBox.Open(text, MsgBtn.OK|MsgBtn.Cancel, icon
                               (do NOT call LoadDocument manually — auto via ModalDocCache.EnsureLoaded)
                required ids   text  title  ok  cancel  yes  no  close   (icon optional)
                               MarkdownBox required ids: title  markdown  close  backdrop  (backdrop = Image, click closes)
-                              CenteredSlideBox required ids: title  close  confirm  cards(Carousel fill=false itemTemplate)  backdrop  + 卡槽(默认 cover/name)
+                              CenteredSlideBox required ids: title  close  button0..button4  cards(Carousel fill=false itemTemplate)  backdrop  + 卡槽(默认 cover/name)
+                              // both overloads use button0..; single-button's confirmLabel just sets button0's text (no separate confirm id)
                backdrop       author writes <Image anchor="stretch"/> — NOT auto-injected
                UI.Modal.OpenAsync(new MyRequest(), ModalMode.Popup) custom ModalRequest<T>
                               override TryEscape(out T) to map ESC → result
@@ -715,8 +722,24 @@ if (level != null) game.StartLevel(level);            // got the whole object; i
 // Default skin is a FINITE list (no wrap-around). Want a looping carousel instead?
 //   configure: s => s.Get<Carousel>("cards").Loop = true
 
+// Multi-button overload: returns SlideSelection<T> (.Item, .Button, .Cancelled).
+// label is i18n-translated; key is the stable branch discriminator (never use label as key).
+// With ≥2 buttons the "tap centred card = confirm" shortcut is auto-disabled — the user
+// MUST click a button. Tapping a side card still centres it. Cancel (× / backdrop / ESC)
+// → result.Cancelled == true (Button == null, Item == null).
+// Default skin provides button0..button4 (5 slots). Passing more → InvalidOperationException
+// (override XmlSrc and add button{i} ids). Empty buttons list → ArgumentException.
+// NOTE: custom skins from the single-button era used id="confirm" — rename it to "button0".
+var (level, action) = await CenteredSlideBox.Open(
+    levels, BindCard,
+    buttons: new[] { (UI.Tr("Play now"), "play"), (UI.Tr("Harder difficulty"), "hard") },
+    title: UI.Tr("Pick a level"));
+if (action == null) return;            // cancelled
+if (action == "play") StartLevel(level);
+// else action == "hard" → StartLevel(level, hard: true)
+
 // Different card style? point CenteredSlideBox.XmlSrc at your own .ui, keeping the id
-// contract: backdrop / panel / title / close / confirm / cards (Carousel fill="false")
+// contract: backdrop / panel / title / close / button0..buttonN / cards (Carousel fill="false")
 // + your card template's slots.
 ```
 
@@ -783,6 +806,43 @@ public static class MarkdownBox {
         CancellationToken ct = default);
     // Plain unauthenticated GET sugar over Open(loader).
     public static Awaitable OpenUrl(string url, /* same trailing params */);
+}
+
+public static class CenteredSlideBox {
+    public static string XmlSrc { get; set; } = "PromptUGUI/Modals/CenteredSlideBox.ui";
+
+    // Single-button overload: returns the selected item, or null on cancel.
+    // Tap a side card to centre it; tap the centred card OR the confirm button to pick.
+    public static Awaitable<T> Open<T>(
+        IReadOnlyList<T> items, Action<IControl, T> bind,
+        string title         = null,
+        string confirmLabel  = null,
+        ModalMode mode       = ModalMode.Popup,
+        Action<IScreen> configure = null,
+        CancellationToken ct = default) where T : class;
+
+    // Multi-button overload: returns SlideSelection<T>.
+    // ≥2 buttons disables the "tap centred card" shortcut — user must click a button.
+    // label is displayed (i18n-translated); key is the stable branch discriminator.
+    // Default skin exposes button0..button4 (5 slots).
+    // Throws InvalidOperationException if buttons.Count exceeds available skin slots.
+    // Throws ArgumentException if buttons is empty.
+    public static Awaitable<SlideSelection<T>> Open<T>(
+        IReadOnlyList<T> items, Action<IControl, T> bind,
+        IEnumerable<(string label, string key)> buttons,
+        string title         = null,
+        ModalMode mode       = ModalMode.Popup,
+        Action<IScreen> configure = null,
+        CancellationToken ct = default) where T : class;
+}
+
+// Result of the multi-button CenteredSlideBox.Open overload.
+// Supports deconstruction: var (item, key) = await CenteredSlideBox.Open(...).
+public readonly struct SlideSelection<T> where T : class {
+    public T    Item      { get; }   // selected object; null if cancelled
+    public string Button  { get; }   // clicked button key; null if cancelled
+    public bool Cancelled { get; }   // == Button == null; true on ×/backdrop/ESC
+    public void Deconstruct(out T item, out string button);
 }
 
 [Flags] public enum MsgBtn { None=0, OK=1, Cancel=2, Yes=4, No=8, Close=16 }

--- a/Runtime/Application/Modals/CenteredSlideBoxRequest.cs
+++ b/Runtime/Application/Modals/CenteredSlideBoxRequest.cs
@@ -7,56 +7,72 @@ using UnityImage = UnityEngine.UI.Image;
 
 namespace PromptUGUI.Application.Modals
 {
-    public sealed class CenteredSlideBoxRequest<T> : ModalRequest<T> where T : class
+    // 共享 Bind 逻辑：单/多按钮 request 都委托这里。onConfirm/onCancel 抽掉结果类型差异。
+    internal static class CenteredSlideBoxBinder
     {
-        public IReadOnlyList<T> Items;
-        public Action<IControl, T> BindCard;
-        public string Title;
-        public string ConfirmLabel;
-        public string XmlSrcOverride;                       // 命名变体 facade 可传；null→静态默认
-
-        public override string XmlSrc => XmlSrcOverride ?? CenteredSlideBox.XmlSrc;
-
-        public override bool TryEscape(out T result) { result = null; return true; }
-
-        public override void Bind(IScreen screen, Action<T> close)
+        // buttons 至少 1 个（两个 request 各自保证）。
+        public static void Bind<T>(
+            IScreen screen, IReadOnlyList<T> items, Action<IControl, T> bindCard, string title,
+            IReadOnlyList<(string label, string key)> buttons, string xmlSrcForError,
+            Action<T, string> onConfirm, Action onCancel) where T : class
         {
+            // —— title ——
             var titleCtl = screen.Get<Text>("title");
-            if (string.IsNullOrEmpty(Title)) titleCtl.GameObject.SetActive(false);
-            else titleCtl.TextValue = Title;
+            if (string.IsNullOrEmpty(title)) titleCtl.GameObject.SetActive(false);
+            else titleCtl.TextValue = title;
 
-            // 取消通道：× / 背景 / ESC → null
-            screen.Get<Btn>("close").OnClick.Subscribe(_ => close(null)).AddTo(screen);
+            // —— 取消三通道（CSB-D9）——
+            screen.Get<Btn>("close").OnClick.Subscribe(_ => onCancel()).AddTo(screen);
             screen.Get<PromptUGUI.Controls.Image>("backdrop")
-                .OnPointerDown.Subscribe(_ => close(null)).AddTo(screen);
+                .OnPointerDown.Subscribe(_ => onCancel()).AddTo(screen);
 
-            // null Items 视作空（Open(null,…) 不该在 Carousel.Rebuild 里 NRE；空列表「禁确认」是 Task 4）
-            Items ??= System.Array.Empty<T>();
+            items ??= Array.Empty<T>();
+            bool autoConfirm = buttons.Count == 1;                  // CSB-D16
+            string soleKey = autoConfirm ? buttons[0].key : null;
 
+            // —— carousel + 卡 ——
             var car = screen.Get<Carousel>("cards");
             int idx = 0;
             car.BindItems(
-                Observable.Return((IReadOnlyList<T>)Items),
+                Observable.Return(items),
                 (IControl card, T item) =>
                 {
                     int i = idx++;
-                    BindCard?.Invoke(card, item);
-                    AttachCardClick(card, i, car, close);
+                    bindCard?.Invoke(card, item);
+                    AttachCardClick(card, i, car, items, onConfirm, autoConfirm, soleKey);
                 }).AddTo(screen);
 
-            var ok = screen.Get<Btn>("confirm");
-            if (!string.IsNullOrEmpty(ConfirmLabel)) ok.Text = ConfirmLabel;
-            if (Items.Count == 0) ok.Interactable = false;
-            ok.OnClick.Subscribe(_ =>
+            // —— 探测皮肤按钮槽（CSB-D17）——
+            var slots = new List<Btn>();
+            for (int i = 0; ; i++)
             {
-                int cur = car.Current;
-                if (cur >= 0 && cur < Items.Count) close(Items[cur]);
-            }).AddTo(screen);
+                try { slots.Add(screen.Get<Btn>($"button{i}")); }
+                catch (KeyNotFoundException) { break; }
+            }
+            if (buttons.Count > slots.Count)
+                throw new InvalidOperationException(
+                    $"CenteredSlideBox skin '{xmlSrcForError}' provides {slots.Count} button slot(s) but " +
+                    $"{buttons.Count} buttons were passed; override XmlSrc with more 'button{{i}}' slots.");
+
+            // —— 映射 buttons[i] → slot i，隐藏多余槽 ——
+            for (int i = 0; i < slots.Count; i++)
+            {
+                var slot = slots[i];
+                if (i >= buttons.Count) { slot.GameObject.SetActive(false); continue; }
+                var (label, key) = buttons[i];
+                if (!string.IsNullOrEmpty(label)) slot.Text = label;   // null/空 → 保留皮肤默认（button0 的 "OK"）
+                if (items.Count == 0) slot.Interactable = false;       // CSB-D11
+                slot.OnClick.Subscribe(_ =>
+                {
+                    int cur = car.Current;
+                    if (cur >= 0 && cur < items.Count) onConfirm(items[cur], key);
+                }).AddTo(screen);
+            }
         }
 
-        // 每张卡挂透明 raycast catcher + PuiButton：click(非拖动) → 居中或确认。
-        // 点居中卡 = 确认；点侧卡 = GoTo 居中。拖动不被 PuiButton 处理 → 冒泡给 CarouselView。
-        private void AttachCardClick(IControl card, int i, Carousel car, Action<T> close)
+        // 每张卡：透明 raycast catcher + PuiButton。click（非拖动）→ 居中导航或（仅单按钮）确认。
+        private static void AttachCardClick<T>(IControl card, int i, Carousel car, IReadOnlyList<T> items,
+            Action<T, string> onConfirm, bool autoConfirm, string soleKey) where T : class
         {
             var go = card.GameObject;
             var img = go.GetComponent<UnityImage>() ?? go.AddComponent<UnityImage>();
@@ -67,10 +83,29 @@ namespace PromptUGUI.Application.Modals
             btn.targetGraphic = img;
             btn.onClick.AddListener(() =>
             {
-                if (car.Current == i) close(Items[i]);     // 点居中卡 = 确认
-                else car.GoTo(i, animated: true);          // 点侧卡 = 居中
+                if (car.Current == i) { if (autoConfirm) onConfirm(items[i], soleKey); }   // 单按钮：点居中卡=确认；多按钮：无操作
+                else car.GoTo(i, animated: true);                                          // 点侧卡=居中
             });
         }
+    }
+
+    public sealed class CenteredSlideBoxRequest<T> : ModalRequest<T> where T : class
+    {
+        public IReadOnlyList<T> Items;
+        public Action<IControl, T> BindCard;
+        public string Title;
+        public string ConfirmLabel;                 // 单个按钮的 label（空→皮肤默认 "OK"）
+        public string XmlSrcOverride;               // 命名变体 facade 可传；null→静态默认
+
+        public override string XmlSrc => XmlSrcOverride ?? CenteredSlideBox.XmlSrc;
+
+        public override bool TryEscape(out T result) { result = null; return true; }
+
+        public override void Bind(IScreen screen, Action<T> close)
+            => CenteredSlideBoxBinder.Bind(screen, Items, BindCard, Title,
+                   new[] { (ConfirmLabel, (string)null) }, XmlSrc,     // 1 个隐式按钮；key 忽略
+                   onConfirm: (item, _) => close(item),
+                   onCancel: () => close(null));
     }
 
     public static class CenteredSlideBox
@@ -78,6 +113,7 @@ namespace PromptUGUI.Application.Modals
         // 必须带 .ui 后缀（Unity 只剥 .ui.xml 的最后 .xml）。可写 = 换皮入口。
         public static string XmlSrc { get; set; } = "PromptUGUI/Modals/CenteredSlideBox.ui";
 
+        // 单按钮 → 返回选中对象 / null（向后兼容，非 async 直传）。
         public static UnityEngine.Awaitable<T> Open<T>(
             IReadOnlyList<T> items,
             Action<IControl, T> bind,

--- a/Runtime/Application/Modals/CenteredSlideBoxRequest.cs
+++ b/Runtime/Application/Modals/CenteredSlideBoxRequest.cs
@@ -16,6 +16,9 @@ namespace PromptUGUI.Application.Modals
             IReadOnlyList<(string label, string key)> buttons, string xmlSrcForError,
             Action<T, string> onConfirm, Action onCancel) where T : class
         {
+            if (buttons == null || buttons.Count == 0)        // facade 已挡空；这是直接 new request 的兜底（CSB-D14）
+                throw new ArgumentException("CenteredSlideBox requires at least one button.", nameof(buttons));
+
             // —— title ——
             var titleCtl = screen.Get<Text>("title");
             if (string.IsNullOrEmpty(title)) titleCtl.GameObject.SetActive(false);
@@ -108,6 +111,25 @@ namespace PromptUGUI.Application.Modals
                    onCancel: () => close(null));
     }
 
+    // 多按钮：返回 SlideSelection<T>（选中卡 + 按钮 key）。
+    public sealed class CenteredSlideBoxMultiRequest<T> : ModalRequest<SlideSelection<T>> where T : class
+    {
+        public IReadOnlyList<T> Items;
+        public Action<IControl, T> BindCard;
+        public string Title;
+        public IReadOnlyList<(string label, string key)> Buttons;   // facade 保证非空
+        public string XmlSrcOverride;
+
+        public override string XmlSrc => XmlSrcOverride ?? CenteredSlideBox.XmlSrc;
+
+        public override bool TryEscape(out SlideSelection<T> result) { result = default; return true; }
+
+        public override void Bind(IScreen screen, Action<SlideSelection<T>> close)
+            => CenteredSlideBoxBinder.Bind(screen, Items, BindCard, Title, Buttons, XmlSrc,
+                   onConfirm: (item, key) => close(new SlideSelection<T>(item, key)),
+                   onCancel: () => close(default));
+    }
+
     public static class CenteredSlideBox
     {
         // 必须带 .ui 后缀（Unity 只剥 .ui.xml 的最后 .xml）。可写 = 换皮入口。
@@ -131,5 +153,30 @@ namespace PromptUGUI.Application.Modals
                 ConfirmLabel = confirmLabel,
                 Configure = configure,
             }, mode, ct);
+
+        // 多按钮 → 返回 (选中对象, 按钮 key)。buttons 必填且非空。
+        public static UnityEngine.Awaitable<SlideSelection<T>> Open<T>(
+            IReadOnlyList<T> items,
+            Action<IControl, T> bind,
+            IEnumerable<(string label, string key)> buttons,
+            string title = null,
+            ModalMode mode = ModalMode.Popup,
+            Action<IScreen> configure = null,
+            System.Threading.CancellationToken ct = default
+        ) where T : class
+        {
+            var list = new List<(string label, string key)>(
+                buttons ?? throw new ArgumentNullException(nameof(buttons)));
+            if (list.Count == 0)
+                throw new ArgumentException("buttons must be non-empty", nameof(buttons));
+            return UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<T>
+            {
+                Items = items,
+                BindCard = bind,
+                Title = title,
+                Buttons = list,
+                Configure = configure,
+            }, mode, ct);
+        }
     }
 }

--- a/Runtime/Application/Modals/SlideSelection.cs
+++ b/Runtime/Application/Modals/SlideSelection.cs
@@ -1,0 +1,18 @@
+namespace PromptUGUI.Application.Modals
+{
+    /// <summary>
+    /// 多按钮 <c>CenteredSlideBox.Open</c> 的返回值：选中的卡 + 点击的按钮 key。
+    /// 取消（×/背景/ESC）→ <c>default</c>（Item=null, Button=null）。
+    /// <c>Cancelled</c> 只看 <c>Button == null</c>（单按钮内部确认路径会出现 Item 有值、Button=null）。
+    /// </summary>
+    public readonly struct SlideSelection<T> where T : class
+    {
+        public readonly T Item;         // 选中的对象；取消时 null
+        public readonly string Button;  // 点的按钮 key；取消时 null
+
+        public SlideSelection(T item, string button) { Item = item; Button = button; }
+
+        public bool Cancelled => Button == null;
+        public void Deconstruct(out T item, out string button) { item = Item; button = Button; }
+    }
+}

--- a/Runtime/Application/Modals/SlideSelection.cs.meta
+++ b/Runtime/Application/Modals/SlideSelection.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 632840afd1a603a4392a56c79963315d

--- a/Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml
+++ b/Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml
@@ -16,7 +16,13 @@
                 spacing="24" edgeScale="0.82" softness="240"
                 itemTemplate="Card"
                 dots="bottom-center" dotColor="#666666" dotSelectedColor="#ffffff"/>
-      <Btn id="confirm" anchor="bottom-center" size="160x48" margin="_,_,12,_">OK</Btn>
+      <HStack id="buttons" anchor="bottom-center" height="48" margin="_,_,16,_" spacing="16">
+        <Btn id="button0" size="160x48">OK</Btn>
+        <Btn id="button1" size="160x48"/>
+        <Btn id="button2" size="160x48"/>
+        <Btn id="button3" size="160x48"/>
+        <Btn id="button4" size="160x48"/>
+      </HStack>
     </Frame>
   </Screen>
 </PromptUGUI>

--- a/Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml
+++ b/Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml
@@ -6,7 +6,7 @@
       <Text  id="name"  anchor="bottom-stretch" height="40" align="center" tr="false"/>
     </Frame>
   </Template>
-  <Screen name="PromptUGUI/Modals/CenteredSlideBox.ui">
+  <Screen name="PromptUGUI/Modals/CenteredSlideBox.ui" reference="1920x1080" reference.portrait="1080x1920">
     <Image id="backdrop" anchor="stretch" color="#000000A0"/>
     <Frame id="panel" anchor="stretch">
       <Text id="title" anchor="top-stretch" height="48" align="center" tr="false"/>

--- a/Tests/EditMode/Modals/CenteredSlideBoxDefaultSkinTests.cs
+++ b/Tests/EditMode/Modals/CenteredSlideBoxDefaultSkinTests.cs
@@ -35,7 +35,7 @@ namespace PromptUGUI.Tests.Modals
             Assert.IsNotNull(UI.Modal.TopScreen.Get<Carousel>("cards"),
                 "应能取到默认皮肤里的 cards Carousel");
 
-            UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();
+            UI.Modal.TopScreen.Get<PBtn>("button0").SimulateClick();
             Assert.AreSame(items[0], task.GetAwaiter().GetResult(),
                 "确认返回居中(默认 current=0)项");
         }
@@ -61,7 +61,7 @@ namespace PromptUGUI.Tests.Modals
             Assert.AreEqual(2f, scaler.scaleFactor, 1e-6f,
                 "像素模式下应按 reference=1920x1080 算出整数因子 2;若为 1 说明默认皮肤缺 reference 走了兜底");
 
-            UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();
+            UI.Modal.TopScreen.Get<PBtn>("button0").SimulateClick();
             task.GetAwaiter().GetResult();
         }
 
@@ -76,7 +76,7 @@ namespace PromptUGUI.Tests.Modals
             Assert.AreEqual(2, cards.Current,
                 "默认皮肤应关闭循环:越界 GoTo 钳位到末张(2),而非环绕回 0");
 
-            UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();
+            UI.Modal.TopScreen.Get<PBtn>("button0").SimulateClick();
             task.GetAwaiter().GetResult();
         }
     }

--- a/Tests/EditMode/Modals/CenteredSlideBoxDefaultSkinTests.cs
+++ b/Tests/EditMode/Modals/CenteredSlideBoxDefaultSkinTests.cs
@@ -41,6 +41,31 @@ namespace PromptUGUI.Tests.Modals
         }
 
         [Test]
+        public void Default_Skin_Pixel_Mode_Honors_Reference_Not_Error_Fallback()
+        {
+            // 复现宿主(像素游戏 DefaultScaleMode=Pixel)报的错:默认皮肤
+            // CenteredSlideBox.ui.xml 缺 reference → ApplyPixel 落到 LogError +
+            // scaleFactor=1 的兜底分支(Screen.cs ApplyPixel)。其余 6 个内置 <Screen>
+            // 都声明 reference="1920x1080"。3840x2160 画布 / 1920x1080 设计 = 整数因子 2;
+            // 缺 reference 时为 1(且记一条 error 让本测试自动失败)。
+            UI.DefaultScaleMode = ScaleMode.Pixel;
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(3840f, 2160f);
+
+            var items = new[] { "1", "2", "3" };
+            var task = CenteredSlideBox.Open(items, (card, s) => { });
+
+            var scaler = UI.Modal.TopScreen.RootGameObject
+                .GetComponent<UnityEngine.UI.CanvasScaler>();
+            Assert.AreEqual(UnityEngine.UI.CanvasScaler.ScaleMode.ConstantPixelSize,
+                scaler.uiScaleMode);
+            Assert.AreEqual(2f, scaler.scaleFactor, 1e-6f,
+                "像素模式下应按 reference=1920x1080 算出整数因子 2;若为 1 说明默认皮肤缺 reference 走了兜底");
+
+            UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();
+            task.GetAwaiter().GetResult();
+        }
+
+        [Test]
         public void Default_Skin_Does_Not_Loop()
         {
             var items = new[] { "1", "2", "3" };

--- a/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
+++ b/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
@@ -282,6 +282,20 @@ namespace PromptUGUI.Tests.Modals
         }
 
         [Test]
+        public void Multi_Button_Empty_Items_Disables_All_Visible_Buttons()
+        {
+            UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
+            {
+                Items = new List<Lv>(),
+                BindCard = (c, l) => { },
+                Buttons = new[] { ("A", "a"), ("B", "b") },   // §7：空 items → 所有可见按钮禁用
+            });
+            var top = UI.Modal.TopScreen;
+            Assert.IsFalse(top.Get<PBtn>("button0").Interactable);
+            Assert.IsFalse(top.Get<PBtn>("button1").Interactable);
+        }
+
+        [Test]
         public void Multi_Button_Over_Count_Throws()
         {
             // 测试 XML 只有 3 槽；传 4 个 → binder 抛 InvalidOperationException。

--- a/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
+++ b/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
@@ -221,7 +221,8 @@ namespace PromptUGUI.Tests.Modals
             var items = ThreeLevels();
             var task = UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
             {
-                Items = items, BindCard = (c, l) => { },
+                Items = items,
+                BindCard = (c, l) => { },
                 Buttons = new[] { ("A", "a"), ("B", "b") },
             });
             Cards().GoTo(1, animated: false);
@@ -236,7 +237,8 @@ namespace PromptUGUI.Tests.Modals
         {
             UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
             {
-                Items = ThreeLevels(), BindCard = (c, l) => { },
+                Items = ThreeLevels(),
+                BindCard = (c, l) => { },
                 Buttons = new[] { ("A", "a"), ("B", "b") },
             });
             var car = Cards();
@@ -251,7 +253,8 @@ namespace PromptUGUI.Tests.Modals
         {
             var task = UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
             {
-                Items = ThreeLevels(), BindCard = (c, l) => { },
+                Items = ThreeLevels(),
+                BindCard = (c, l) => { },
                 Buttons = new[] { ("A", "a"), ("B", "b") },
             });
             UI.Modal.TopScreen.Get<PBtn>("close").SimulateClick();
@@ -266,7 +269,8 @@ namespace PromptUGUI.Tests.Modals
         {
             UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
             {
-                Items = ThreeLevels(), BindCard = (c, l) => { },
+                Items = ThreeLevels(),
+                BindCard = (c, l) => { },
                 Buttons = new[] { ("A", "a"), ("B", "b") },   // 2 个 → button2 隐藏
             });
             var top = UI.Modal.TopScreen;
@@ -286,7 +290,8 @@ namespace PromptUGUI.Tests.Modals
             {
                 var task = UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
                 {
-                    Items = ThreeLevels(), BindCard = (c, l) => { },
+                    Items = ThreeLevels(),
+                    BindCard = (c, l) => { },
                     Buttons = new[] { ("A", "a"), ("B", "b"), ("C", "c"), ("D", "d") },
                 });
                 task.GetAwaiter().GetResult();
@@ -309,7 +314,8 @@ namespace PromptUGUI.Tests.Modals
             {
                 var task = UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
                 {
-                    Items = ThreeLevels(), BindCard = (c, l) => { },
+                    Items = ThreeLevels(),
+                    BindCard = (c, l) => { },
                     Buttons = System.Array.Empty<(string, string)>(),
                 });
                 task.GetAwaiter().GetResult();

--- a/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
+++ b/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
@@ -214,5 +214,118 @@ namespace PromptUGUI.Tests.Modals
             UI.Modal.TopScreen.Get<PBtn>("button0").SimulateClick();
             Assert.AreSame(items[0], task.GetAwaiter().GetResult());
         }
+
+        [Test]
+        public void Multi_Button_Click_Returns_Item_And_Key()
+        {
+            var items = ThreeLevels();
+            var task = UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
+            {
+                Items = items, BindCard = (c, l) => { },
+                Buttons = new[] { ("A", "a"), ("B", "b") },
+            });
+            Cards().GoTo(1, animated: false);
+            UI.Modal.TopScreen.Get<PBtn>("button1").SimulateClick();
+            var sel = task.GetAwaiter().GetResult();
+            Assert.AreSame(items[1], sel.Item);
+            Assert.AreEqual("b", sel.Button);
+        }
+
+        [Test]
+        public void Multi_Button_Tap_Centered_Card_Is_NoOp()
+        {
+            UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
+            {
+                Items = ThreeLevels(), BindCard = (c, l) => { },
+                Buttons = new[] { ("A", "a"), ("B", "b") },
+            });
+            var car = Cards();
+            Assert.AreEqual(0, car.Current);
+            CardButton(0).onClick.Invoke();                 // 多按钮点居中卡 → 无操作
+            Assert.AreEqual(0, car.Current);
+            Assert.IsTrue(UI.Modal.IsAnyOpen, "多按钮时点居中卡不该确认/关闭");
+        }
+
+        [Test]
+        public void Multi_Button_Cancel_Returns_Cancelled()
+        {
+            var task = UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
+            {
+                Items = ThreeLevels(), BindCard = (c, l) => { },
+                Buttons = new[] { ("A", "a"), ("B", "b") },
+            });
+            UI.Modal.TopScreen.Get<PBtn>("close").SimulateClick();
+            var sel = task.GetAwaiter().GetResult();
+            Assert.IsTrue(sel.Cancelled);
+            Assert.IsNull(sel.Item);
+            Assert.IsNull(sel.Button);
+        }
+
+        [Test]
+        public void Multi_Button_Hides_Unused_Slots()
+        {
+            UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
+            {
+                Items = ThreeLevels(), BindCard = (c, l) => { },
+                Buttons = new[] { ("A", "a"), ("B", "b") },   // 2 个 → button2 隐藏
+            });
+            var top = UI.Modal.TopScreen;
+            Assert.IsTrue(top.Get<PBtn>("button0").GameObject.activeSelf);
+            Assert.IsTrue(top.Get<PBtn>("button1").GameObject.activeSelf);
+            Assert.IsFalse(top.Get<PBtn>("button2").GameObject.activeSelf);
+            Assert.AreEqual("A", top.Get<PBtn>("button0").GameObject.GetComponentInChildren<TMP_Text>().text);
+            Assert.AreEqual("B", top.Get<PBtn>("button1").GameObject.GetComponentInChildren<TMP_Text>().text);
+        }
+
+        [Test]
+        public void Multi_Button_Over_Count_Throws()
+        {
+            // 测试 XML 只有 3 槽；传 4 个 → binder 抛 InvalidOperationException。
+            // 整个 OpenAsync 放进 lambda：无论同步抛还是 faulted awaitable 都被捕获。
+            Assert.Throws<System.InvalidOperationException>(() =>
+            {
+                var task = UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
+                {
+                    Items = ThreeLevels(), BindCard = (c, l) => { },
+                    Buttons = new[] { ("A", "a"), ("B", "b"), ("C", "c"), ("D", "d") },
+                });
+                task.GetAwaiter().GetResult();
+            });
+        }
+
+        [Test]
+        public void Multi_Button_Empty_List_Throws_ArgumentException()
+        {
+            Assert.Throws<System.ArgumentException>(() =>
+                CenteredSlideBox.Open(ThreeLevels(), (c, l) => { },
+                    buttons: System.Array.Empty<(string, string)>()));
+        }
+
+        [Test]
+        public void Multi_Request_Empty_Buttons_Throws_From_Binder()
+        {
+            // 绕过 facade 直接 new request、Buttons 空 → binder 兜底抛 ArgumentException（faulted awaitable）。
+            Assert.Throws<System.ArgumentException>(() =>
+            {
+                var task = UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
+                {
+                    Items = ThreeLevels(), BindCard = (c, l) => { },
+                    Buttons = System.Array.Empty<(string, string)>(),
+                });
+                task.GetAwaiter().GetResult();
+            });
+        }
+
+        [Test]
+        public void Multi_Button_Facade_Returns_Key()
+        {
+            var items = ThreeLevels();
+            var task = CenteredSlideBox.Open(items, (c, l) => { },
+                buttons: new[] { ("A", "a"), ("B", "b") });
+            UI.Modal.TopScreen.Get<PBtn>("button0").SimulateClick();
+            var sel = task.GetAwaiter().GetResult();
+            Assert.AreSame(items[0], sel.Item);
+            Assert.AreEqual("a", sel.Button);
+        }
     }
 }

--- a/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
+++ b/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
@@ -32,7 +32,11 @@ namespace PromptUGUI.Tests.Modals
       <Btn  id='close' anchor='top-right' size='32x32'>x</Btn>
       <Carousel id='cards' anchor='stretch' margin='48,8,64,8'
                 fill='false' interval='0' itemTemplate='Card'/>
-      <Btn  id='confirm' anchor='bottom-center' size='140x40'>OK</Btn>
+      <HStack id='buttons' anchor='bottom-center' height='40' spacing='8'>
+        <Btn id='button0' size='140x40'>OK</Btn>
+        <Btn id='button1' size='140x40'/>
+        <Btn id='button2' size='140x40'/>
+      </HStack>
     </Frame>
   </Screen>
 </PromptUGUI>";
@@ -71,7 +75,7 @@ namespace PromptUGUI.Tests.Modals
                 BindCard = (card, lv) => { },
             });
             Cards().GoTo(1, animated: false);                  // 把第 1 项居中
-            UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();
+            UI.Modal.TopScreen.Get<PBtn>("button0").SimulateClick();
             Assert.AreSame(items[1], task.GetAwaiter().GetResult(),
                 "confirm returns the centered item");
         }
@@ -161,7 +165,7 @@ namespace PromptUGUI.Tests.Modals
             UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
             { Items = ThreeLevels(), BindCard = (c, l) => { }, ConfirmLabel = "开始" });
             Assert.AreEqual("开始",
-                UI.Modal.TopScreen.Get<PBtn>("confirm").GameObject.GetComponentInChildren<TMP_Text>().text);
+                UI.Modal.TopScreen.Get<PBtn>("button0").GameObject.GetComponentInChildren<TMP_Text>().text);
         }
 
         [Test]
@@ -169,7 +173,7 @@ namespace PromptUGUI.Tests.Modals
         {
             UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
             { Items = new List<Lv>(), BindCard = (c, l) => { } });
-            Assert.IsFalse(UI.Modal.TopScreen.Get<PBtn>("confirm").Interactable);
+            Assert.IsFalse(UI.Modal.TopScreen.Get<PBtn>("button0").Interactable);
         }
 
         [Test]
@@ -207,7 +211,7 @@ namespace PromptUGUI.Tests.Modals
             var items = new List<Lv> { new Lv { Id = "solo", Name = "Solo" } };
             var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
             { Items = items, BindCard = (c, l) => { } });
-            UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();
+            UI.Modal.TopScreen.Get<PBtn>("button0").SimulateClick();
             Assert.AreSame(items[0], task.GetAwaiter().GetResult());
         }
     }

--- a/Tests/EditMode/Modals/SlideSelectionTests.cs
+++ b/Tests/EditMode/Modals/SlideSelectionTests.cs
@@ -1,0 +1,46 @@
+using NUnit.Framework;
+using PromptUGUI.Application.Modals;
+
+namespace PromptUGUI.Tests.Modals
+{
+    public class SlideSelectionTests
+    {
+        private sealed class Item { public string Id; }
+
+        [Test]
+        public void Holds_Item_And_Button()
+        {
+            var it = new Item { Id = "x" };
+            var sel = new SlideSelection<Item>(it, "play");
+            Assert.AreSame(it, sel.Item);
+            Assert.AreEqual("play", sel.Button);
+            Assert.IsFalse(sel.Cancelled);
+        }
+
+        [Test]
+        public void Default_Is_Cancelled()
+        {
+            SlideSelection<Item> sel = default;
+            Assert.IsNull(sel.Item);
+            Assert.IsNull(sel.Button);
+            Assert.IsTrue(sel.Cancelled);
+        }
+
+        [Test]
+        public void Deconstructs()
+        {
+            var it = new Item { Id = "x" };
+            var (item, button) = new SlideSelection<Item>(it, "hard");
+            Assert.AreSame(it, item);
+            Assert.AreEqual("hard", button);
+        }
+
+        [Test]
+        public void Cancelled_Tracks_Button_Null_Only()
+        {
+            // 单按钮路径内部会出现 (item, null)；Cancelled 以 Button==null 为准（item 设了也算）
+            var sel = new SlideSelection<Item>(new Item(), null);
+            Assert.IsTrue(sel.Cancelled);
+        }
+    }
+}

--- a/Tests/EditMode/Modals/SlideSelectionTests.cs.meta
+++ b/Tests/EditMode/Modals/SlideSelectionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 89e2d3d9361aa0f4789a89bf211f5037

--- a/Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs
+++ b/Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs
@@ -63,7 +63,8 @@ namespace PromptUGUI.Tests.PlayMode.Modals
             var items = new List<Lv> { new Lv { Id = "a" }, new Lv { Id = "b" }, new Lv { Id = "c" } };
             var task = UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
             {
-                Items = items, BindCard = (c, l) => { },
+                Items = items,
+                BindCard = (c, l) => { },
                 Buttons = new[] { ("Go", "go"), ("Hard", "hard") },
             });
             UI.Modal.TopScreen.Get<Carousel>("cards").GoTo(2, animated: false);

--- a/Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs
+++ b/Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs
@@ -27,7 +27,11 @@ namespace PromptUGUI.Tests.PlayMode.Modals
       <Btn  id='close' anchor='top-right' size='32x32'>x</Btn>
       <Carousel id='cards' anchor='stretch' margin='48,8,64,8'
                 fill='false' interval='0' itemTemplate='Card'/>
-      <Btn  id='confirm' anchor='bottom-center' size='140x40'>OK</Btn>
+      <HStack id='buttons' anchor='bottom-center' height='40' spacing='8'>
+        <Btn id='button0' size='140x40'>OK</Btn>
+        <Btn id='button1' size='140x40'/>
+        <Btn id='button2' size='140x40'/>
+      </HStack>
     </Frame>
   </Screen>
 </PromptUGUI>";
@@ -49,8 +53,24 @@ namespace PromptUGUI.Tests.PlayMode.Modals
             var task = UI.Modal.OpenAsync(new CenteredSlideBoxRequest<Lv>
             { Items = items, BindCard = (c, l) => { } });
             UI.Modal.TopScreen.Get<Carousel>("cards").GoTo(2, animated: false);
-            UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();
+            UI.Modal.TopScreen.Get<PBtn>("button0").SimulateClick();
             Assert.AreSame(items[2], task.GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public void Multi_Button_GoTo_Click_Returns_Item_And_Key_NoCrash()
+        {
+            var items = new List<Lv> { new Lv { Id = "a" }, new Lv { Id = "b" }, new Lv { Id = "c" } };
+            var task = UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
+            {
+                Items = items, BindCard = (c, l) => { },
+                Buttons = new[] { ("Go", "go"), ("Hard", "hard") },
+            });
+            UI.Modal.TopScreen.Get<Carousel>("cards").GoTo(2, animated: false);
+            UI.Modal.TopScreen.Get<PBtn>("button1").SimulateClick();
+            var sel = task.GetAwaiter().GetResult();
+            Assert.AreSame(items[2], sel.Item);
+            Assert.AreEqual("hard", sel.Button);
         }
     }
 }

--- a/docs~/superpowers/plans/2026-06-16-centered-slide-box-multi-button.md
+++ b/docs~/superpowers/plans/2026-06-16-centered-slide-box-multi-button.md
@@ -1,0 +1,714 @@
+# CenteredSlideBox 多按钮 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 给内置模态 `CenteredSlideBox` 加多个自定义动作按钮，多按钮返回具名 `SlideSelection<T>`（选中卡 + 点击按钮 key），按钮 ≥2 时去掉「点居中卡=确认」捷径；单按钮 API 完全不变。
+
+**Architecture:** 抽出共享静态 `CenteredSlideBoxBinder`（所有 Bind 逻辑 + 按钮槽探测 + 超量报错），由两个瘦 request 委托：`CenteredSlideBoxRequest<T> : ModalRequest<T>`（单按钮，原样返回 `T`）与新 `CenteredSlideBoxMultiRequest<T> : ModalRequest<SlideSelection<T>>`（多按钮）。binder 用 `onConfirm(item,key)`/`onCancel()` 回调抽掉结果类型差异。默认皮肤底部单按钮换成 `<HStack>` + `button0..button4` 槽位行。
+
+**Tech Stack:** Unity 6 / uGUI / R3 (Cysharp Observable) / Unity `Awaitable`（非 Task）/ NUnit (EditMode + PlayMode) / Unity MCP 跑测试 / `dotnet format` + UIXmlLint 跑 lint。
+
+**Spec:** [`docs~/superpowers/specs/2026-06-16-centered-slide-box-multi-button-design.md`](../specs/2026-06-16-centered-slide-box-multi-button-design.md)（CSB-D12..D18）。
+
+**前置约束:**
+- 已在分支 `feat/centered-slide-box-multi-button`（**禁止提交 main**）。
+- 每改 C#/XML 后：先 `refresh_unity`，再 `read_console` 查编译错误，**再** `run_tests`。`run_tests` 异步→拿 `job_id`→轮询 `get_test_job`。
+- 若 Unity MCP 不可用：尝试重连或让用户重启 MCP（见 CLAUDE.md）。
+
+**Unity MCP 工具加载（每个新 session 先做一次）:**
+```
+ToolSearch(query="select:mcp__UnityMCP__run_tests,mcp__UnityMCP__get_test_job,mcp__UnityMCP__refresh_unity,mcp__UnityMCP__read_console", max_results=4)
+```
+
+---
+
+### Task 1: `SlideSelection<T>` 返回结构体
+
+**Files:**
+- Create: `Runtime/Application/Modals/SlideSelection.cs` (+ `.meta` — Unity 生成)
+- Test: `Tests/EditMode/Modals/SlideSelectionTests.cs` (+ `.meta`)
+
+- [ ] **Step 1: 写失败测试**
+
+Create `Tests/EditMode/Modals/SlideSelectionTests.cs`:
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application.Modals;
+
+namespace PromptUGUI.Tests.Modals
+{
+    public class SlideSelectionTests
+    {
+        private sealed class Item { public string Id; }
+
+        [Test]
+        public void Holds_Item_And_Button()
+        {
+            var it = new Item { Id = "x" };
+            var sel = new SlideSelection<Item>(it, "play");
+            Assert.AreSame(it, sel.Item);
+            Assert.AreEqual("play", sel.Button);
+            Assert.IsFalse(sel.Cancelled);
+        }
+
+        [Test]
+        public void Default_Is_Cancelled()
+        {
+            SlideSelection<Item> sel = default;
+            Assert.IsNull(sel.Item);
+            Assert.IsNull(sel.Button);
+            Assert.IsTrue(sel.Cancelled);
+        }
+
+        [Test]
+        public void Deconstructs()
+        {
+            var it = new Item { Id = "x" };
+            var (item, button) = new SlideSelection<Item>(it, "hard");
+            Assert.AreSame(it, item);
+            Assert.AreEqual("hard", button);
+        }
+
+        [Test]
+        public void Cancelled_Tracks_Button_Null_Only()
+        {
+            // 单按钮路径内部会出现 (item, null)；Cancelled 以 Button==null 为准（item 设了也算）
+            var sel = new SlideSelection<Item>(new Item(), null);
+            Assert.IsTrue(sel.Cancelled);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败（编译红：类型不存在）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: 编译错误 `The type or namespace name 'SlideSelection<>' could not be found`。
+
+- [ ] **Step 3: 写实现**
+
+Create `Runtime/Application/Modals/SlideSelection.cs`:
+
+```csharp
+namespace PromptUGUI.Application.Modals
+{
+    /// <summary>
+    /// 多按钮 <c>CenteredSlideBox.Open</c> 的返回值：选中的卡 + 点击的按钮 key。
+    /// 取消（×/背景/ESC）→ <c>default</c>：Item=null, Button=null, Cancelled=true。
+    /// </summary>
+    public readonly struct SlideSelection<T> where T : class
+    {
+        public readonly T Item;         // 选中的对象；取消时 null
+        public readonly string Button;  // 点的按钮 key；取消时 null
+
+        public SlideSelection(T item, string button) { Item = item; Button = button; }
+
+        public bool Cancelled => Button == null;
+        public void Deconstruct(out T item, out string button) { item = Item; button = Button; }
+    }
+}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["SlideSelectionTests"])
+mcp__UnityMCP__get_test_job(job_id="<返回的 id>")
+```
+Expected: 4/4 PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Application/Modals/SlideSelection.cs Runtime/Application/Modals/SlideSelection.cs.meta \
+        Tests/EditMode/Modals/SlideSelectionTests.cs Tests/EditMode/Modals/SlideSelectionTests.cs.meta
+git commit -m "feat: SlideSelection<T> 多按钮返回结构体 (CSB-D12)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: 抽共享 binder + 单按钮委托 + 默认皮肤按钮行（重构，回归网兜底）
+
+把现有 `CenteredSlideBoxRequest<T>` 的 Bind 逻辑搬进共享 `CenteredSlideBoxBinder`（顺带实现多按钮槽探测/超量报错/autoConfirm 条件化——这些分支由 Task 3 的多按钮测试验证）。单按钮 request 改为委托 binder，**基类 / 字段 / 返回 `T` 全不变**。默认皮肤 `confirm` → `<HStack>` + `button0..button4`。现有单按钮测试只改 `confirm`→`button0` id，作为重构回归网。
+
+**Files:**
+- Modify: `Runtime/Application/Modals/CenteredSlideBoxRequest.cs`（整体重写为下方内容）
+- Modify: `Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml`（按钮行）
+- Modify: `Tests/EditMode/Modals/CenteredSlideBoxTests.cs`（XML const + 4 处 id）
+- Modify: `Tests/EditMode/Modals/CenteredSlideBoxDefaultSkinTests.cs`（3 处 id）
+
+- [ ] **Step 1: 重写 `CenteredSlideBoxRequest.cs`（binder + 单按钮 request + facade）**
+
+把整个文件替换为：
+
+```csharp
+using System;
+using System.Collections.Generic;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using R3;
+using UnityImage = UnityEngine.UI.Image;
+
+namespace PromptUGUI.Application.Modals
+{
+    // 共享 Bind 逻辑：单/多按钮 request 都委托这里。onConfirm/onCancel 抽掉结果类型差异。
+    internal static class CenteredSlideBoxBinder
+    {
+        // buttons 至少 1 个（两个 request 各自保证）。
+        public static void Bind<T>(
+            IScreen screen, IReadOnlyList<T> items, Action<IControl, T> bindCard, string title,
+            IReadOnlyList<(string label, string key)> buttons, string xmlSrcForError,
+            Action<T, string> onConfirm, Action onCancel) where T : class
+        {
+            // —— title ——
+            var titleCtl = screen.Get<Text>("title");
+            if (string.IsNullOrEmpty(title)) titleCtl.GameObject.SetActive(false);
+            else titleCtl.TextValue = title;
+
+            // —— 取消三通道（CSB-D9）——
+            screen.Get<Btn>("close").OnClick.Subscribe(_ => onCancel()).AddTo(screen);
+            screen.Get<PromptUGUI.Controls.Image>("backdrop")
+                .OnPointerDown.Subscribe(_ => onCancel()).AddTo(screen);
+
+            items ??= Array.Empty<T>();
+            bool autoConfirm = buttons.Count == 1;                  // CSB-D16
+            string soleKey = autoConfirm ? buttons[0].key : null;
+
+            // —— carousel + 卡 ——
+            var car = screen.Get<Carousel>("cards");
+            int idx = 0;
+            car.BindItems(
+                Observable.Return(items),
+                (IControl card, T item) =>
+                {
+                    int i = idx++;
+                    bindCard?.Invoke(card, item);
+                    AttachCardClick(card, i, car, items, onConfirm, autoConfirm, soleKey);
+                }).AddTo(screen);
+
+            // —— 探测皮肤按钮槽（CSB-D17）——
+            var slots = new List<Btn>();
+            for (int i = 0; ; i++)
+            {
+                try { slots.Add(screen.Get<Btn>($"button{i}")); }
+                catch (KeyNotFoundException) { break; }
+            }
+            if (buttons.Count > slots.Count)
+                throw new InvalidOperationException(
+                    $"CenteredSlideBox skin '{xmlSrcForError}' provides {slots.Count} button slot(s) but " +
+                    $"{buttons.Count} buttons were passed; override XmlSrc with more 'button{{i}}' slots.");
+
+            // —— 映射 buttons[i] → slot i，隐藏多余槽 ——
+            for (int i = 0; i < slots.Count; i++)
+            {
+                var slot = slots[i];
+                if (i >= buttons.Count) { slot.GameObject.SetActive(false); continue; }
+                var (label, key) = buttons[i];
+                if (!string.IsNullOrEmpty(label)) slot.Text = label;   // null/空 → 保留皮肤默认（button0 的 "OK"）
+                if (items.Count == 0) slot.Interactable = false;       // CSB-D11
+                slot.OnClick.Subscribe(_ =>
+                {
+                    int cur = car.Current;
+                    if (cur >= 0 && cur < items.Count) onConfirm(items[cur], key);
+                }).AddTo(screen);
+            }
+        }
+
+        // 每张卡：透明 raycast catcher + PuiButton。click（非拖动）→ 居中导航或（仅单按钮）确认。
+        private static void AttachCardClick<T>(IControl card, int i, Carousel car, IReadOnlyList<T> items,
+            Action<T, string> onConfirm, bool autoConfirm, string soleKey) where T : class
+        {
+            var go = card.GameObject;
+            var img = go.GetComponent<UnityImage>() ?? go.AddComponent<UnityImage>();
+            img.color = new UnityEngine.Color(0f, 0f, 0f, 0f);   // 透明，仅 raycast
+            img.raycastTarget = true;
+            var btn = go.AddComponent<PuiButton>();
+            btn.targetGraphic = img;
+            btn.onClick.AddListener(() =>
+            {
+                if (car.Current == i) { if (autoConfirm) onConfirm(items[i], soleKey); }   // 单按钮：点居中卡=确认；多按钮：无操作
+                else car.GoTo(i, animated: true);                                          // 点侧卡=居中
+            });
+        }
+    }
+
+    public sealed class CenteredSlideBoxRequest<T> : ModalRequest<T> where T : class
+    {
+        public IReadOnlyList<T> Items;
+        public Action<IControl, T> BindCard;
+        public string Title;
+        public string ConfirmLabel;                 // 单个按钮的 label（空→皮肤默认 "OK"）
+        public string XmlSrcOverride;               // 命名变体 facade 可传；null→静态默认
+
+        public override string XmlSrc => XmlSrcOverride ?? CenteredSlideBox.XmlSrc;
+
+        public override bool TryEscape(out T result) { result = null; return true; }
+
+        public override void Bind(IScreen screen, Action<T> close)
+            => CenteredSlideBoxBinder.Bind(screen, Items, BindCard, Title,
+                   new[] { (ConfirmLabel, (string)null) }, XmlSrc,     // 1 个隐式按钮；key 忽略
+                   onConfirm: (item, _) => close(item),
+                   onCancel: () => close(null));
+    }
+
+    public static class CenteredSlideBox
+    {
+        // 必须带 .ui 后缀（Unity 只剥 .ui.xml 的最后 .xml）。可写 = 换皮入口。
+        public static string XmlSrc { get; set; } = "PromptUGUI/Modals/CenteredSlideBox.ui";
+
+        // 单按钮 → 返回选中对象 / null（向后兼容，非 async 直传）。
+        public static UnityEngine.Awaitable<T> Open<T>(
+            IReadOnlyList<T> items,
+            Action<IControl, T> bind,
+            string title = null,
+            string confirmLabel = null,
+            ModalMode mode = ModalMode.Popup,
+            Action<IScreen> configure = null,
+            System.Threading.CancellationToken ct = default
+        ) where T : class
+            => UI.Modal.OpenAsync(new CenteredSlideBoxRequest<T>
+            {
+                Items = items,
+                BindCard = bind,
+                Title = title,
+                ConfirmLabel = confirmLabel,
+                Configure = configure,
+            }, mode, ct);
+    }
+}
+```
+
+- [ ] **Step 2: 改默认皮肤按钮行**
+
+In `Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml`, replace:
+
+```xml
+      <Btn id="confirm" anchor="bottom-center" size="160x48" margin="_,_,12,_">OK</Btn>
+```
+
+with:
+
+```xml
+      <HStack id="buttons" anchor="bottom-center" height="48" margin="_,_,16,_" spacing="16">
+        <Btn id="button0" size="160x48">OK</Btn>
+        <Btn id="button1" size="160x48"/>
+        <Btn id="button2" size="160x48"/>
+        <Btn id="button3" size="160x48"/>
+        <Btn id="button4" size="160x48"/>
+      </HStack>
+```
+
+- [ ] **Step 3: 改现有 EditMode 测试 XML const + id（`CenteredSlideBoxTests.cs`）**
+
+In `Tests/EditMode/Modals/CenteredSlideBoxTests.cs`, replace in the `SlideBoxXml` const:
+
+```xml
+      <Btn  id='confirm' anchor='bottom-center' size='140x40'>OK</Btn>
+```
+
+with（**3 槽**，供多按钮 + 超量测试用）:
+
+```xml
+      <HStack id='buttons' anchor='bottom-center' height='40' spacing='8'>
+        <Btn id='button0' size='140x40'>OK</Btn>
+        <Btn id='button1' size='140x40'/>
+        <Btn id='button2' size='140x40'/>
+      </HStack>
+```
+
+然后把这 4 处 `Get<PBtn>("confirm")` 改成 `Get<PBtn>("button0")`：
+- `Confirm_Returns_Centered_Item`（`UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();`）
+- `ConfirmLabel_Overrides_Button_Text`（`UI.Modal.TopScreen.Get<PBtn>("confirm").GameObject.GetComponentInChildren<TMP_Text>().text`）
+- `Empty_Items_Disables_Confirm`（`UI.Modal.TopScreen.Get<PBtn>("confirm").Interactable`）
+- `Single_Item_Confirm_Returns_It`（`UI.Modal.TopScreen.Get<PBtn>("confirm").SimulateClick();`）
+
+- [ ] **Step 4: 改 `CenteredSlideBoxDefaultSkinTests.cs` 的 3 处 id**
+
+In `Tests/EditMode/Modals/CenteredSlideBoxDefaultSkinTests.cs`, 把 3 处 `Get<PBtn>("confirm")` 改成 `Get<PBtn>("button0")`（`Open_With_Default_Skin_Loads_And_Confirms` / `Default_Skin_Pixel_Mode_Honors_Reference_Not_Error_Fallback` / `Default_Skin_Does_Not_Loop` 各一处）。
+
+- [ ] **Step 5: 刷新 + 查编译 + 跑回归（两套）确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["CenteredSlideBoxTests"])
+mcp__UnityMCP__get_test_job(job_id="<id>")
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["CenteredSlideBoxDefaultSkinTests"])
+mcp__UnityMCP__get_test_job(job_id="<id>")
+```
+Expected: 两套全 PASS（`CenteredSlideBoxTests` 13 + `CenteredSlideBoxDefaultSkinTests` 3）。单按钮行为零变化 = 重构正确。
+
+- [ ] **Step 6: lint XML + 提交**
+
+```bash
+dotnet run --project .lint/UIXmlLint -- Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml
+```
+Expected: exit 0（无 layout-group 非法属性等）。
+
+```bash
+git add Runtime/Application/Modals/CenteredSlideBoxRequest.cs \
+        Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml \
+        Tests/EditMode/Modals/CenteredSlideBoxTests.cs \
+        Tests/EditMode/Modals/CenteredSlideBoxDefaultSkinTests.cs
+git commit -m "refactor: CenteredSlideBox 抽共享 binder + 按钮行皮肤 (CSB-D15/D18)
+
+confirm->button0..button4 HStack; 单按钮 request 委托 binder, 返回 T 不变.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: 多按钮 request + facade 重载（TDD）
+
+**Files:**
+- Modify: `Runtime/Application/Modals/CenteredSlideBoxRequest.cs`（加 `CenteredSlideBoxMultiRequest<T>` + facade ② 重载）
+- Modify: `Tests/EditMode/Modals/CenteredSlideBoxTests.cs`（加多按钮用例）
+
+- [ ] **Step 1: 写失败测试（编译红：`CenteredSlideBoxMultiRequest` / facade ② 不存在）**
+
+在 `CenteredSlideBoxTests.cs` 的 class 内追加（用 `private static List<Lv> ThreeLevels()`、`Cards()`、`CardButton(int)` 现成 helper）:
+
+```csharp
+        [Test]
+        public void Multi_Button_Click_Returns_Item_And_Key()
+        {
+            var items = ThreeLevels();
+            var task = UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
+            {
+                Items = items, BindCard = (c, l) => { },
+                Buttons = new[] { ("A", "a"), ("B", "b") },
+            });
+            Cards().GoTo(1, animated: false);
+            UI.Modal.TopScreen.Get<PBtn>("button1").SimulateClick();
+            var sel = task.GetAwaiter().GetResult();
+            Assert.AreSame(items[1], sel.Item);
+            Assert.AreEqual("b", sel.Button);
+        }
+
+        [Test]
+        public void Multi_Button_Tap_Centered_Card_Is_NoOp()
+        {
+            UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
+            {
+                Items = ThreeLevels(), BindCard = (c, l) => { },
+                Buttons = new[] { ("A", "a"), ("B", "b") },
+            });
+            var car = Cards();
+            Assert.AreEqual(0, car.Current);
+            CardButton(0).onClick.Invoke();                 // 多按钮点居中卡 → 无操作
+            Assert.AreEqual(0, car.Current);
+            Assert.IsTrue(UI.Modal.IsAnyOpen, "多按钮时点居中卡不该确认/关闭");
+        }
+
+        [Test]
+        public void Multi_Button_Cancel_Returns_Cancelled()
+        {
+            var task = UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
+            {
+                Items = ThreeLevels(), BindCard = (c, l) => { },
+                Buttons = new[] { ("A", "a"), ("B", "b") },
+            });
+            UI.Modal.TopScreen.Get<PBtn>("close").SimulateClick();
+            var sel = task.GetAwaiter().GetResult();
+            Assert.IsTrue(sel.Cancelled);
+            Assert.IsNull(sel.Item);
+            Assert.IsNull(sel.Button);
+        }
+
+        [Test]
+        public void Multi_Button_Hides_Unused_Slots()
+        {
+            UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
+            {
+                Items = ThreeLevels(), BindCard = (c, l) => { },
+                Buttons = new[] { ("A", "a"), ("B", "b") },   // 2 个 → button2 隐藏
+            });
+            var top = UI.Modal.TopScreen;
+            Assert.IsTrue(top.Get<PBtn>("button0").GameObject.activeSelf);
+            Assert.IsTrue(top.Get<PBtn>("button1").GameObject.activeSelf);
+            Assert.IsFalse(top.Get<PBtn>("button2").GameObject.activeSelf);
+            Assert.AreEqual("A", top.Get<PBtn>("button0").GameObject.GetComponentInChildren<TMP_Text>().text);
+            Assert.AreEqual("B", top.Get<PBtn>("button1").GameObject.GetComponentInChildren<TMP_Text>().text);
+        }
+
+        [Test]
+        public void Multi_Button_Over_Count_Throws()
+        {
+            // 测试 XML 只有 3 槽；传 4 个 → binder 抛 InvalidOperationException（faulted awaitable，见 spec §7）
+            var task = UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
+            {
+                Items = ThreeLevels(), BindCard = (c, l) => { },
+                Buttons = new[] { ("A", "a"), ("B", "b"), ("C", "c"), ("D", "d") },
+            });
+            Assert.Throws<System.InvalidOperationException>(() => task.GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public void Multi_Button_Empty_List_Throws_ArgumentException()
+        {
+            Assert.Throws<System.ArgumentException>(() =>
+                CenteredSlideBox.Open(ThreeLevels(), (c, l) => { },
+                    buttons: System.Array.Empty<(string, string)>()));
+        }
+
+        [Test]
+        public void Multi_Button_Facade_Returns_Key()
+        {
+            var items = ThreeLevels();
+            var task = CenteredSlideBox.Open(items, (c, l) => { },
+                buttons: new[] { ("A", "a"), ("B", "b") });
+            UI.Modal.TopScreen.Get<PBtn>("button0").SimulateClick();
+            var sel = task.GetAwaiter().GetResult();
+            Assert.AreSame(items[0], sel.Item);
+            Assert.AreEqual("a", sel.Button);
+        }
+```
+
+- [ ] **Step 2: 跑确认红（编译失败）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: 编译错误 `'CenteredSlideBoxMultiRequest<>' could not be found` + facade ② 重载缺失（`Open(..., buttons:)`）。
+
+- [ ] **Step 3: 实现多按钮 request + facade 重载**
+
+In `Runtime/Application/Modals/CenteredSlideBoxRequest.cs`, 在 `CenteredSlideBoxRequest<T>` 类之后、`public static class CenteredSlideBox` 之前插入：
+
+```csharp
+    // 多按钮：返回 SlideSelection<T>（选中卡 + 按钮 key）。
+    public sealed class CenteredSlideBoxMultiRequest<T> : ModalRequest<SlideSelection<T>> where T : class
+    {
+        public IReadOnlyList<T> Items;
+        public Action<IControl, T> BindCard;
+        public string Title;
+        public IReadOnlyList<(string label, string key)> Buttons;   // facade 保证非空
+        public string XmlSrcOverride;
+
+        public override string XmlSrc => XmlSrcOverride ?? CenteredSlideBox.XmlSrc;
+
+        public override bool TryEscape(out SlideSelection<T> result) { result = default; return true; }
+
+        public override void Bind(IScreen screen, Action<SlideSelection<T>> close)
+            => CenteredSlideBoxBinder.Bind(screen, Items, BindCard, Title, Buttons, XmlSrc,
+                   onConfirm: (item, key) => close(new SlideSelection<T>(item, key)),
+                   onCancel: () => close(default));
+    }
+```
+
+并在 `public static class CenteredSlideBox` 内（单按钮 `Open` 之后）追加 facade ② 重载：
+
+```csharp
+        // 多按钮 → 返回 (选中对象, 按钮 key)。buttons 必填且非空。
+        public static UnityEngine.Awaitable<SlideSelection<T>> Open<T>(
+            IReadOnlyList<T> items,
+            Action<IControl, T> bind,
+            IEnumerable<(string label, string key)> buttons,
+            string title = null,
+            ModalMode mode = ModalMode.Popup,
+            Action<IScreen> configure = null,
+            System.Threading.CancellationToken ct = default
+        ) where T : class
+        {
+            var list = new List<(string label, string key)>(
+                buttons ?? throw new ArgumentNullException(nameof(buttons)));
+            if (list.Count == 0)
+                throw new ArgumentException("buttons must be non-empty", nameof(buttons));
+            return UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<T>
+            {
+                Items = items,
+                BindCard = bind,
+                Title = title,
+                Buttons = list,
+                Configure = configure,
+            }, mode, ct);
+        }
+```
+
+- [ ] **Step 4: 跑确认全绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["CenteredSlideBoxTests"])
+mcp__UnityMCP__get_test_job(job_id="<id>")
+```
+Expected: `CenteredSlideBoxTests` 全 PASS（13 旧 + 7 新 = 20）。
+
+> 若 `Multi_Button_Over_Count_Throws` 报「未抛 InvalidOperationException」：检查 `UI.Modal` 是否把 RunBind 异常包了一层（spec §7 说应为 faulted awaitable）。若实际是被包成别的异常类型，把断言改成 `Assert.Throws<System.Exception>` 并 `StringAssert.Contains("button slot", ex.Message)`。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Application/Modals/CenteredSlideBoxRequest.cs Tests/EditMode/Modals/CenteredSlideBoxTests.cs
+git commit -m "feat: CenteredSlideBox 多按钮重载 + CenteredSlideBoxMultiRequest (CSB-D12..D17)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: PlayMode 烟雾（单按钮 id 改 + 多按钮）
+
+**Files:**
+- Modify: `Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs`
+
+- [ ] **Step 1: 改 XML const + 现有单按钮 id，加多按钮烟雾**
+
+In `Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs`：
+
+(a) `Xml` const 里把
+```xml
+      <Btn  id='confirm' anchor='bottom-center' size='140x40'>OK</Btn>
+```
+换成
+```xml
+      <HStack id='buttons' anchor='bottom-center' height='40' spacing='8'>
+        <Btn id='button0' size='140x40'>OK</Btn>
+        <Btn id='button1' size='140x40'/>
+        <Btn id='button2' size='140x40'/>
+      </HStack>
+```
+
+(b) `Open_GoTo_Confirm_Returns_Item_NoCrash` 里 `Get<PBtn>("confirm")` → `Get<PBtn>("button0")`。
+
+(c) 追加多按钮烟雾：
+```csharp
+        [Test]
+        public void Multi_Button_GoTo_Click_Returns_Item_And_Key_NoCrash()
+        {
+            var items = new List<Lv> { new Lv { Id = "a" }, new Lv { Id = "b" }, new Lv { Id = "c" } };
+            var task = UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
+            {
+                Items = items, BindCard = (c, l) => { },
+                Buttons = new[] { ("Go", "go"), ("Hard", "hard") },
+            });
+            UI.Modal.TopScreen.Get<Carousel>("cards").GoTo(2, animated: false);
+            UI.Modal.TopScreen.Get<PBtn>("button1").SimulateClick();
+            var sel = task.GetAwaiter().GetResult();
+            Assert.AreSame(items[2], sel.Item);
+            Assert.AreEqual("hard", sel.Button);
+        }
+```
+
+- [ ] **Step 2: 跑 PlayMode 确认绿**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], group_names=["CenteredSlideBoxPlayTests"])
+mcp__UnityMCP__get_test_job(job_id="<id>")
+```
+Expected: 2/2 PASS。
+> PlayMode runner 在本机偶有退化（见 memory `project_unity_mcp_test_gotchas`）；若 runner 卡死/初始化失败，记录现象、让用户重启 Unity 后重跑，不要当作代码失败。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs
+git commit -m "test: CenteredSlideBox 多按钮 PlayMode 烟雾 + button0 id
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: 更新 C# SKILL（公开 API 变更，CLAUDE.md 强制）
+
+**Files:**
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md`
+
+- [ ] **Step 1: 找到模态小节里的 `CenteredSlideBox.Open` 说明**
+
+```bash
+grep -n "CenteredSlideBox" .claude/skills/scripting-promptugui-csharp/SKILL.md
+```
+
+- [ ] **Step 2: 在现有 `CenteredSlideBox.Open<T>` 说明旁补多按钮重载**
+
+补充以下要点（贴合该文件既有风格，英文）：
+- 多按钮重载签名：`CenteredSlideBox.Open<T>(items, bind, IEnumerable<(string label,string key)> buttons, title=null, …) → Awaitable<SlideSelection<T>>`。
+- `SlideSelection<T>`：`.Item`（选中对象，取消=null）/ `.Button`（按钮 key，取消=null）/ `.Cancelled` / 支持解构 `var (item, key) = await …`。
+- `label` 走 i18n、`key` 稳定用于分支（别拿 label 当 key）。
+- 行为：按钮 ≥2 时**点居中卡=无操作**（去掉单按钮的自动确认捷径）；点侧卡仍居中；取消三通道（×/背景/ESC）→ `Cancelled`。
+- 按钮槽契约：默认皮肤提供 `button0..button4`（5 槽）；传超过皮肤槽数 → `InvalidOperationException`，换 `XmlSrc` 加 `button{i}` 槽可扩展；空 `buttons` → `ArgumentException`。
+- 换皮 id 契约从 `confirm` 改为 `button0..`（迁移说明）。
+- 示例：
+  ```csharp
+  var (level, action) = await CenteredSlideBox.Open(
+      levels, BindCard,
+      buttons: new[] { ("立即进入游戏", "play"), ("进入更高难度", "hard") },
+      title: "选择关卡");
+  if (action == null) return;            // 取消
+  if (action == "play") StartLevel(level);
+  ```
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add .claude/skills/scripting-promptugui-csharp/SKILL.md
+git commit -m "docs(skill): CenteredSlideBox 多按钮重载 + SlideSelection + 按钮槽契约
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: 全量验证 + lint + format
+
+**Files:** 无（仅验证）
+
+- [ ] **Step 1: 全量 EditMode（不只 group，跑整个 assembly 防漏）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__get_test_job(job_id="<id>")
+```
+Expected: 全 PASS（基线 1841 + 本特性新增；无回归）。
+
+- [ ] **Step 2: EditorOnly + PlayMode**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+mcp__UnityMCP__get_test_job(job_id="<id>")
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])
+mcp__UnityMCP__get_test_job(job_id="<id>")
+```
+Expected: EditorOnly 全 PASS；PlayMode 全 PASS（runner 退化时按 Task 4 Step 2 注记处理）。
+
+- [ ] **Step 3: UIXmlLint 全目录 + dotnet format 校验**
+
+```bash
+dotnet run --project .lint/UIXmlLint -- Runtime/Resources/
+cd .lint && dotnet restore PromptUGUI.Lint.slnx && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+Expected: UIXmlLint exit 0；`dotnet format --verify-no-changes` 无改动（如有，跑 `dotnet format whitespace/style PromptUGUI.Lint.slnx` 修后重验、并把修动作并入相关 commit）。
+
+- [ ] **Step 4: 自检 spec 覆盖**
+
+对照 spec §8 测试清单，确认每条都有对应通过的测试；§7 边界表每行都有覆盖（空 buttons / 超量 / 隐藏槽 / 空 items / 多按钮点居中卡 / 取消）。无缺口即完成。
+
+- [ ] **Step 5: 收尾**
+
+按 `superpowers:finishing-a-development-branch` 决定合并/PR 方式（**不要直接合 main**；按仓库惯例走 PR）。视觉 QA（默认皮肤多按钮行布局、单按钮退化视觉）留用户在宿主工程确认。
+
+---
+
+## 自检（writing-plans self-review）
+
+- **Spec 覆盖**：CSB-D12（Task 1）/ D13（Task 3 facade 签名）/ D14（Task 3 必填+非空两测试）/ D15（Task 2 binder + 两 request）/ D16（Task 3 `Multi_Button_Tap_Centered_Card_Is_NoOp` + 单按钮 autoConfirm 回归）/ D17（Task 3 超量 + 隐藏槽）/ D18（Task 2 皮肤）。全覆盖。
+- **类型一致**：`SlideSelection<T>`（`.Item`/`.Button`/`.Cancelled`/`Deconstruct`）、`CenteredSlideBoxBinder.Bind<T>(…, onConfirm, onCancel)`、`CenteredSlideBoxRequest<T> : ModalRequest<T>`（含 `ConfirmLabel`）、`CenteredSlideBoxMultiRequest<T> : ModalRequest<SlideSelection<T>>`（含 `Buttons`）跨任务签名一致。
+- **无占位符**：每个代码步骤含完整代码；每个测试步骤含完整断言；MCP/shell 命令具体可跑。
+- **id 契约**：默认皮肤 5 槽（button0..4）、测试 XML 3 槽（button0..2）——超量测试传 4 个对 3 槽，断言一致。

--- a/docs~/superpowers/specs/2026-06-16-centered-slide-box-multi-button-design.md
+++ b/docs~/superpowers/specs/2026-06-16-centered-slide-box-multi-button-design.md
@@ -4,15 +4,17 @@
 **状态**: 设计阶段（待 review，未进入实施）
 **建立在**: [`2026-06-15-centered-slide-box-design.md`](2026-06-15-centered-slide-box-design.md)（CSB-D1..D11，已合并入 main `fc00b26`）。本文是它的扩展，决策编号续到 `CSB-D12+`，沿用同一套模态机制（`ModalRequest<TResult>` / `UI.Modal.OpenAsync` / `Configure` / `TryEscape`）。
 
-**一句话**: 给 `CenteredSlideBox` 加**多个自定义动作按钮**——例如关卡选择窗里「立即进入游戏」/「进入更高难度」。返回值从「选中的对象」升级为「选中的对象 **+** 点了哪个按钮」（具名 `SlideSelection<T>`）；按钮 ≥2 时自动关闭「点居中卡=确认」这个捷径。现有单按钮 `Open<T> → Awaitable<T>` 保持不变。
+**一句话**: 给 `CenteredSlideBox` 加**多个自定义动作按钮**——例如关卡选择窗里「立即进入游戏」/「进入更高难度」。多按钮返回「选中的对象 **+** 点了哪个按钮」（具名 `SlideSelection<T>`）；按钮 ≥2 时自动关闭「点居中卡=确认」这个捷径。现有单按钮 `Open<T> → Awaitable<T>` 保持不变。
 
 **动机**: 当前只有一个确认按钮，确认语义单一（"选好了"）。现实选择器常需要在同一个选中项上分出多条动作路径（进入 / 高难度进入 / 预览…）。这要求返回值能同时携带「选了哪张卡」和「触发了哪个动作」，单个值装不下——这是整个设计的支点。
 
 **作用域**:
 1. 新增 `Runtime/Application/Modals/SlideSelection.cs`：`public readonly struct SlideSelection<T>`（多按钮返回类型；对标 `MsgBtn` 是个独立具名类型）。
 2. 改 `Runtime/Application/Modals/CenteredSlideBoxRequest.cs`：
-   - `CenteredSlideBoxRequest<T>` 基类 `ModalRequest<T>` → `ModalRequest<SlideSelection<T>>`，`Buttons` 列表驱动；
-   - facade 加多按钮重载；单按钮重载改 `async` 取 `.Item`（契约不变）。
+   - **新增**共享静态 `CenteredSlideBoxBinder`（把现有 Bind 逻辑搬进去，回调化）；
+   - `CenteredSlideBoxRequest<T> : ModalRequest<T>` **基类不变**、改为委托 binder；
+   - **新增** `CenteredSlideBoxMultiRequest<T> : ModalRequest<SlideSelection<T>>`；
+   - facade 加多按钮重载（单按钮重载签名/实现不变）。
 3. 改 `Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml`：单个 `<Btn id="confirm">` → `<HStack id="buttons">` + 5 个槽 `button0..button4`。
 4. 改 `.claude/skills/scripting-promptugui-csharp/SKILL.md`：补多按钮重载用法 + `SlideSelection<T>` + 按钮槽契约（公开 C# API 变更）。
 5. 改测试：`CenteredSlideBoxTests` / `CenteredSlideBoxDefaultSkinTests` / `CenteredSlideBoxPlayTests`（`confirm`→`button0`，新增多按钮用例）。
@@ -28,9 +30,9 @@
 | CSB-D12 | 多按钮返回类型 | 具名 `public readonly struct SlideSelection<T> { T Item; string Button; bool Cancelled; Deconstruct(…); }`，**不用匿名元组** | 对齐 `MsgBtn`「为返回值定义具名类型」的惯例；耐扩展（以后加字段不像元组那样改 arity 撞坏解构点）；自带 `Cancelled` 语义；`Deconstruct` 让 `var (lv, act) = await …` 解构写法不损失 |
 | CSB-D13 | 按钮规格 | `IEnumerable<(string label, string key)>`，**`key` 用 `string`**。对齐 MessageBox 的 `CustomLabels` | `label` 走 i18n 会被翻译、`key` 稳定用于分支判断（不能拿 label 当 key）；`string` key 零仪式、和库「不强加类型、JSON 自己反序列化」一致。备选「泛型 `Open<T,TKey>` 用 enum」更类型安全但多一个泛型参数，YAGNI |
 | CSB-D14 | 重载 / 向后兼容 | 保留单按钮 `Open<T>(…) → Awaitable<T>`；新增多按钮重载，`buttons` **必填**（消除 `Open(items,bind)` 两重载全可选参的歧义）+ **非空**（空列表 → facade 抛 `ArgumentException`） | 不破坏宿主已用的单按钮 API；`buttons` 必填让 C# 重载解析靠第三参类型（`string title` vs `IEnumerable<…>`）区分；选择器没有任何动作按钮 + 又无自动确认 = 不可用，fail-fast |
-| CSB-D15 | 内部统一 | 一个 `CenteredSlideBoxRequest<T> : ModalRequest<SlideSelection<T>>`，`Buttons` 列表驱动 Bind（单按钮 = 1 元素列表）；单按钮 facade `async` await 后 `return sel.Item` | Bind 只写一份；单/多按钮共用取消三通道、carousel 绑定、卡点击装配。单按钮 facade 的 `Awaitable<T>` 契约不变（内部多一层 await/解包） |
+| CSB-D15 | 内部因式分解 | **两个瘦 request + 一个共享静态 `CenteredSlideBoxBinder`**：`CenteredSlideBoxRequest<T> : ModalRequest<T>`（单按钮，**基类原样不变**、返回 `T`）＋ 新 `CenteredSlideBoxMultiRequest<T> : ModalRequest<SlideSelection<T>>`（多按钮）。两者 `Bind` 都委托 `CenteredSlideBoxBinder.Bind(…, onConfirm:(item,key)=>…, onCancel:()=>…)`，用回调抽掉结果类型差异 | DRY（共用取消三通道/carousel/卡点击/槽探测），又保单按钮 facade **非 async 直传、返回 `T`**——避开「统一成 `ModalRequest<SlideSelection<T>>` + 单按钮 facade async 解包」在 EditMode 下 awaitable 续体不同步恢复（`GetResult()` 挂起）的风险，且现有单按钮 request 测试**零结果形状改动**（只改 `confirm`→`button0` id） |
 | CSB-D16 | 自动确认条件化 | `autoConfirm = (buttons.Count == 1)`。单按钮：点居中卡 = 确认（≈现状）；多按钮：点居中卡 = **无操作**，点侧卡照旧居中，必须点某个按钮才关 | 用户明确要求：多按钮时「点居中卡=确认」语义歧义（确认哪条动作？），自动去掉；单按钮保留这个捷径 |
-| CSB-D17 | 按钮槽探测 + 超量硬报错 | Bind 从 `button0` 起 `Get<Btn>` 探到 `KeyNotFoundException`，数出皮肤槽数 N（**不在代码写死 cap**）。`buttons.Count > N` → 抛 `InvalidOperationException`（消息含 N + `XmlSrcOverride` 提示）；`< N` → 多余槽 `SetActive(false)` 隐藏 | 传超量是开发期写错，fail-fast 比静默丢弃强；槽数由皮肤决定 → 换皮放 `button0..button9` 自动支持 10 个，代码零改。同 `MessageBoxRequest` 探测可选 `icon` 槽的 `try/catch KeyNotFoundException` 套路 |
+| CSB-D17 | 按钮槽探测 + 超量硬报错 | binder 从 `button0` 起 `Get<Btn>` 探到 `KeyNotFoundException`，数出皮肤槽数 N（**不在代码写死 cap**）。`buttons.Count > N` → 抛 `InvalidOperationException`（消息含 N + `XmlSrcOverride` 提示）；`< N` → 多余槽 `SetActive(false)` 隐藏 | 传超量是开发期写错，fail-fast 比静默丢弃强；槽数由皮肤决定 → 换皮放 `button0..button9` 自动支持 10 个，代码零改。同 `MessageBoxRequest` 探测可选 `icon` 槽的 `try/catch KeyNotFoundException` 套路 |
 | CSB-D18 | 默认皮肤按钮行 | 单个 `<Btn id="confirm">` → 底部 `<HStack id="buttons">` + 5 个槽 `button0..button4`（对齐 MessageBox 的 5 槽慷慨度）。单按钮退化：只显 `button0`、居中、文案默认 `OK`，视觉 ≈现状 | 一个选择器动作行现实 2~3 个按钮，5 槽绰绰有余；要更多换皮。**迁移**：内置皮肤 id `confirm`→`button0`（见 §6 兼容性） |
 
 ---
@@ -64,21 +66,17 @@ public static class CenteredSlideBox
 {
     public static string XmlSrc { get; set; } = "PromptUGUI/Modals/CenteredSlideBox.ui";
 
-    // ① 单按钮（向后兼容，CSB-D14/D15）→ 返回选中对象 / null。签名不变，仅内部改 async 解包。
-    public static async UnityEngine.Awaitable<T> Open<T>(
+    // ① 单按钮（向后兼容，CSB-D14/D15）→ 返回选中对象 / null。签名 + 实现都不变（非 async 直传）。
+    public static UnityEngine.Awaitable<T> Open<T>(
         IReadOnlyList<T> items, Action<IControl, T> bind,
         string title = null, string confirmLabel = null,
         ModalMode mode = ModalMode.Popup, Action<IScreen> configure = null,
         CancellationToken ct = default) where T : class
-    {
-        var sel = await UI.Modal.OpenAsync(new CenteredSlideBoxRequest<T>
+        => UI.Modal.OpenAsync(new CenteredSlideBoxRequest<T>
         {
             Items = items, BindCard = bind, Title = title,
-            Buttons = new[] { (confirmLabel, (string)null) },   // 1 个隐式按钮；key 在单按钮路径里被忽略
-            Configure = configure,
+            ConfirmLabel = confirmLabel, Configure = configure,
         }, mode, ct);
-        return sel.Item;
-    }
 
     // ② 多按钮（CSB-D12/D13/D14）→ 返回 (选中对象, 按钮 key)。buttons 必填且非空。
     public static UnityEngine.Awaitable<SlideSelection<T>> Open<T>(
@@ -90,7 +88,7 @@ public static class CenteredSlideBox
     {
         var list = new List<(string label, string key)>(buttons ?? throw new ArgumentNullException(nameof(buttons)));
         if (list.Count == 0) throw new ArgumentException("buttons must be non-empty", nameof(buttons));
-        return UI.Modal.OpenAsync(new CenteredSlideBoxRequest<T>
+        return UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<T>
         {
             Items = items, BindCard = bind, Title = title,
             Buttons = list, Configure = configure,
@@ -116,7 +114,7 @@ if (action == "play")      StartLevel(level);
 else if (action == "hard") StartLevel(level, hard: true);
 ```
 
-单按钮老用法**完全不变**：
+单按钮老用法**完全不变**（仍返回 `T`）：
 
 ```csharp
 var picked = await CenteredSlideBox.Open(levels, BindCard, title: "选择关卡");
@@ -125,52 +123,40 @@ if (picked != null) StartLevel(picked);
 
 ---
 
-## 3. 内部：`CenteredSlideBoxRequest<T>`（统一 Bind）
+## 3. 内部：共享 binder + 两个瘦 request（CSB-D15）
+
+所有 Bind 逻辑（title / 取消三通道 / carousel 绑定 / 卡点击装配 / 按钮槽探测 / 超量报错）只写一份在静态 `CenteredSlideBoxBinder` 里，用 `onConfirm(item, key)` / `onCancel()` 回调抽掉「返回 `T` 还是 `SlideSelection<T>`」的差异：
 
 ```csharp
-public sealed class CenteredSlideBoxRequest<T> : ModalRequest<SlideSelection<T>> where T : class
+internal static class CenteredSlideBoxBinder
 {
-    public IReadOnlyList<T> Items;
-    public Action<IControl, T> BindCard;
-    public string Title;
-    public IReadOnlyList<(string label, string key)> Buttons;   // 1..N；单按钮 facade 传 1 个
-    public string XmlSrcOverride;
-
-    public override string XmlSrc => XmlSrcOverride ?? CenteredSlideBox.XmlSrc;
-
-    // 取消三通道 → default = (null, null) = Cancelled
-    public override bool TryEscape(out SlideSelection<T> result) { result = default; return true; }
-
-    public override void Bind(IScreen screen, Action<SlideSelection<T>> close)
+    // buttons 至少 1 个（两个 request 各自保证）。onConfirm/onCancel 由 request 注入以适配其 TResult。
+    public static void Bind<T>(
+        IScreen screen, IReadOnlyList<T> items, Action<IControl, T> bindCard, string title,
+        IReadOnlyList<(string label, string key)> buttons, string xmlSrcForError,
+        Action<T, string> onConfirm, Action onCancel) where T : class
     {
-        // —— title ——
         var titleCtl = screen.Get<Text>("title");
-        if (string.IsNullOrEmpty(Title)) titleCtl.GameObject.SetActive(false);
-        else titleCtl.TextValue = Title;
+        if (string.IsNullOrEmpty(title)) titleCtl.GameObject.SetActive(false);
+        else titleCtl.TextValue = title;
 
-        // —— 取消三通道（CSB-D9）——
-        screen.Get<Btn>("close").OnClick.Subscribe(_ => close(default)).AddTo(screen);
-        screen.Get<Image>("backdrop").OnPointerDown.Subscribe(_ => close(default)).AddTo(screen);
+        screen.Get<Btn>("close").OnClick.Subscribe(_ => onCancel()).AddTo(screen);          // 取消三通道（CSB-D9）
+        screen.Get<Image>("backdrop").OnPointerDown.Subscribe(_ => onCancel()).AddTo(screen);
 
-        Items ??= System.Array.Empty<T>();
-        var buttons = Buttons ?? System.Array.Empty<(string label, string key)>();
-        bool autoConfirm = buttons.Count == 1;                  // CSB-D16
+        items ??= System.Array.Empty<T>();
+        bool autoConfirm = buttons.Count == 1;                       // CSB-D16
         string soleKey = autoConfirm ? buttons[0].key : null;
 
-        // —— carousel + 卡 ——
         var car = screen.Get<Carousel>("cards");
         int idx = 0;
-        car.BindItems(
-            Observable.Return((IReadOnlyList<T>)Items),
-            (IControl card, T item) =>
-            {
-                int i = idx++;
-                BindCard?.Invoke(card, item);
-                AttachCardClick(card, i, car, close, autoConfirm, soleKey);   // CSB-D7/D8/D16
-            }).AddTo(screen);
+        car.BindItems(Observable.Return(items), (card, item) =>
+        {
+            int i = idx++;
+            bindCard?.Invoke(card, item);
+            AttachCardClick(card, i, car, items, onConfirm, autoConfirm, soleKey);          // CSB-D7/D8/D16
+        }).AddTo(screen);
 
-        // —— 探测皮肤按钮槽（CSB-D17）——
-        var slots = new List<Btn>();
+        var slots = new List<Btn>();                                 // 探测皮肤槽（CSB-D17）
         for (int i = 0; ; i++)
         {
             try { slots.Add(screen.Get<Btn>($"button{i}")); }
@@ -178,45 +164,80 @@ public sealed class CenteredSlideBoxRequest<T> : ModalRequest<SlideSelection<T>>
         }
         if (buttons.Count > slots.Count)
             throw new InvalidOperationException(
-                $"CenteredSlideBox skin '{XmlSrc}' provides {slots.Count} button slot(s) but " +
+                $"CenteredSlideBox skin '{xmlSrcForError}' provides {slots.Count} button slot(s) but " +
                 $"{buttons.Count} buttons were passed; override XmlSrc with more 'button{{i}}' slots.");
 
-        // —— 映射 buttons[i] → slot i，隐藏多余槽 ——
         for (int i = 0; i < slots.Count; i++)
         {
             var slot = slots[i];
-            if (i >= buttons.Count) { slot.GameObject.SetActive(false); continue; }
+            if (i >= buttons.Count) { slot.GameObject.SetActive(false); continue; }         // 隐藏多余槽
             var (label, key) = buttons[i];
-            if (!string.IsNullOrEmpty(label)) slot.Text = label;   // null/空 → 保留皮肤默认文案（如 button0 的 "OK"）
-            if (Items.Count == 0) slot.Interactable = false;       // CSB-D11：空列表禁确认
+            if (!string.IsNullOrEmpty(label)) slot.Text = label;     // null/空 → 保留皮肤默认（button0 的 "OK"）
+            if (items.Count == 0) slot.Interactable = false;         // CSB-D11
             slot.OnClick.Subscribe(_ =>
             {
                 int cur = car.Current;
-                if (cur >= 0 && cur < Items.Count) close(new SlideSelection<T>(Items[cur], key));
+                if (cur >= 0 && cur < items.Count) onConfirm(items[cur], key);
             }).AddTo(screen);
         }
     }
 
-    // 每张卡：透明 raycast catcher + PuiButton。click（非拖动）→ 居中导航或（仅单按钮）确认。
-    private void AttachCardClick(IControl card, int i, Carousel car,
-                                 Action<SlideSelection<T>> close, bool autoConfirm, string soleKey)
+    static void AttachCardClick<T>(IControl card, int i, Carousel car, IReadOnlyList<T> items,
+        Action<T, string> onConfirm, bool autoConfirm, string soleKey) where T : class
     {
         var go = card.GameObject;
         var img = go.GetComponent<UnityImage>() ?? go.AddComponent<UnityImage>();
-        img.color = new UnityEngine.Color(0f, 0f, 0f, 0f);   // 透明，仅 raycast
+        img.color = new UnityEngine.Color(0f, 0f, 0f, 0f);          // 透明，仅 raycast
         img.raycastTarget = true;
         var btn = go.AddComponent<PuiButton>();
         btn.targetGraphic = img;
         btn.onClick.AddListener(() =>
         {
-            if (car.Current == i)
-            {
-                if (autoConfirm) close(new SlideSelection<T>(Items[i], soleKey));   // 单按钮：点居中卡=确认
-                // 多按钮：无操作（必须点动作按钮）
-            }
-            else car.GoTo(i, animated: true);   // 点侧卡=居中
+            if (car.Current == i) { if (autoConfirm) onConfirm(items[i], soleKey); }   // 单按钮：点居中卡=确认；多按钮：无操作
+            else car.GoTo(i, animated: true);                                          // 点侧卡=居中
         });
     }
+}
+```
+
+两个 request 是薄适配层，只把各自的 `close` 映射成 `onConfirm`/`onCancel`：
+
+```csharp
+// 单按钮：原样保留 ModalRequest<T>，返回 T（现有测试零结果形状改动）
+public sealed class CenteredSlideBoxRequest<T> : ModalRequest<T> where T : class
+{
+    public IReadOnlyList<T> Items;
+    public Action<IControl, T> BindCard;
+    public string Title;
+    public string ConfirmLabel;                 // 单个按钮的 label（空→皮肤默认 "OK"）
+    public string XmlSrcOverride;
+
+    public override string XmlSrc => XmlSrcOverride ?? CenteredSlideBox.XmlSrc;
+    public override bool TryEscape(out T result) { result = null; return true; }
+
+    public override void Bind(IScreen screen, Action<T> close)
+        => CenteredSlideBoxBinder.Bind(screen, Items, BindCard, Title,
+               new[] { (ConfirmLabel, (string)null) }, XmlSrc,        // 1 个隐式按钮；key 忽略
+               onConfirm: (item, _) => close(item),
+               onCancel: () => close(null));
+}
+
+// 多按钮：ModalRequest<SlideSelection<T>>
+public sealed class CenteredSlideBoxMultiRequest<T> : ModalRequest<SlideSelection<T>> where T : class
+{
+    public IReadOnlyList<T> Items;
+    public Action<IControl, T> BindCard;
+    public string Title;
+    public IReadOnlyList<(string label, string key)> Buttons;     // facade 保证非空
+    public string XmlSrcOverride;
+
+    public override string XmlSrc => XmlSrcOverride ?? CenteredSlideBox.XmlSrc;
+    public override bool TryEscape(out SlideSelection<T> result) { result = default; return true; }  // (null,null)=Cancelled
+
+    public override void Bind(IScreen screen, Action<SlideSelection<T>> close)
+        => CenteredSlideBoxBinder.Bind(screen, Items, BindCard, Title, Buttons, XmlSrc,
+               onConfirm: (item, key) => close(new SlideSelection<T>(item, key)),
+               onCancel: () => close(default));
 }
 ```
 
@@ -255,13 +276,14 @@ public sealed class CenteredSlideBoxRequest<T> : ModalRequest<SlideSelection<T>>
 拖动 / 点 dots → 翻页，焦点卡放大不淡（peek）
 点侧卡   → car.GoTo(i) 居中它（动画），不关窗
 
-单按钮(autoConfirm)：点居中卡 → close((Items[i], soleKey)) ；button0 → close((居中项, key))
-多按钮             ：点居中卡 → 无操作          ；button{i} → close((居中项, buttons[i].key))
+单按钮(autoConfirm)：点居中卡 → onConfirm(Items[i], soleKey) ；button0 → onConfirm(居中项, key)
+多按钮             ：点居中卡 → 无操作              ；button{i} → onConfirm(居中项, buttons[i].key)
 
-× / 点背景 / ESC → close(default) → await 返回 Cancelled（Item=null, Button=null）
+× / 点背景 / ESC → onCancel() → await 返回取消
 ```
 
-单按钮 facade 把 `SlideSelection<T>` 解包成 `.Item`：选中→对象，取消→null（契约同 CSB-D3）。
+- **单按钮 request**：`onConfirm:(item,_)=>close(item)` / `onCancel:()=>close(null)` → 返回 `T`，取消 = `null`（契约同 CSB-D3，零变化）。
+- **多按钮 request**：`onConfirm:(item,key)=>close(new SlideSelection<T>(item,key))` / `onCancel:()=>close(default)` → 返回 `SlideSelection<T>`，取消 = `Cancelled`。
 
 ---
 
@@ -269,9 +291,10 @@ public sealed class CenteredSlideBoxRequest<T> : ModalRequest<SlideSelection<T>>
 
 | 面 | 影响 |
 |---|---|
-| 公开 facade `Open<T>(…) → Awaitable<T>`（单按钮） | **签名不变、契约不变**。仅内部从 expression-bodied 直传改为 `async` await 解包；返回值/取消语义一致 |
+| 公开 facade `Open<T>(…) → Awaitable<T>`（单按钮） | **签名 + 实现都不变**（仍非 async 直传）；返回值/取消语义一致 |
 | 公开 facade 多按钮 | **新增重载**，不影响旧调用 |
-| `public CenteredSlideBoxRequest<T>` 基类 | `ModalRequest<T>` → `ModalRequest<SlideSelection<T>>`：直接 `new` 该 request 并读其 `TResult` 的代码会受影响。实际用法是走 facade（同 `MessageBoxRequest`），认定为 de-facto internal 的可接受变更 |
+| `public CenteredSlideBoxRequest<T>`（单按钮 request） | **基类不变**（仍 `ModalRequest<T>`、仍返回 `T`）；唯一内部变化是 Bind 改为委托 binder + 字段从「直接逻辑」变成传 binder。直接 `new` 它的代码（测试/命名变体）**零结果形状改动** |
+| `public CenteredSlideBoxMultiRequest<T>`（新增） | 全新类型，多按钮 facade / 命名变体用 |
 | 内置皮肤 id `confirm` → `button0` | **皮肤契约变更**。用默认皮肤者无感；自定义 `XmlSrcOverride` 皮肤需把 `id="confirm"` 改成 `id="button0"`（要多按钮再加 `button1..`）。SKILL 文档同步更新槽位契约 |
 
 > `confirm` 不保留别名兜底——保持探测逻辑单一（纯 `button{i}` 序列）。若宿主已有自定义皮肤依赖 `confirm`，在 plan 阶段确认后可加一行 `button0` 缺失时回退 `confirm` 的兼容垫片；默认不加。
@@ -282,8 +305,8 @@ public sealed class CenteredSlideBoxRequest<T> : ModalRequest<SlideSelection<T>>
 
 | 场景 | 处理 |
 |---|---|
-| 多按钮 `buttons` 空 | facade 抛 `ArgumentException`（CSB-D14） |
-| `buttons.Count` > 皮肤槽数 | Bind 抛 `InvalidOperationException`，消息含槽数 + 换皮提示（CSB-D17） |
+| 多按钮 `buttons` 空 | facade 抛 `ArgumentException`（CSB-D14），开窗前 |
+| `buttons.Count` > 皮肤槽数 | binder 抛 `InvalidOperationException`（CSB-D17）。注意：抛在 `RunBind` 内 → `UI.Modal` 的 `MaterializePump` `try/catch` 把它转成 **faulted awaitable**（不是同步冒泡）；`task.GetAwaiter().GetResult()` 时重抛 |
 | `buttons.Count` < 皮肤槽数 | 多余槽隐藏（`SetActive(false)`） |
 | `items` 空 | carousel 空；**所有可见按钮** `Interactable=false`（灰）；只能取消 |
 | `items` 1 张 | 居中、无邻卡；点按钮/点居中卡（单按钮）返回该项 |
@@ -297,14 +320,15 @@ public sealed class CenteredSlideBoxRequest<T> : ModalRequest<SlideSelection<T>>
 
 EditMode（沿用现有 `CenteredSlideBoxTests` 套路 + `UI.ResetForTests`；按钮文案读 `GameObject.GetComponentInChildren<TMP_Text>().text`，`Btn.Text` 是 set-only）:
 
-- **现有单按钮用例**：`confirm`→`button0` 改 id 后全绿（确认返回居中项 / 点居中卡返回 / 取消三通道 / 空列表禁用 / confirmLabel 改文案）。
-- **多按钮 → 按钮 key 进返回**：`Open(items, bind, buttons:[("A","a"),("B","b")])`；`GoTo(k)`；点 `button1`；await == `SlideSelection(items[k], "b")`。
-- **多按钮 → 点居中卡无操作**：点 current 卡 PuiButton；Awaitable **未完成**、`car.Current` 不变（区别单按钮的确认）。
+- **现有单按钮用例**：**只改 `confirm`→`button0` id**（结果形状/`ConfirmLabel`/`TryEscape(out T)` 全不变）后全绿（确认返回居中项 / 点居中卡返回 / 取消三通道 / 空列表禁用 / confirmLabel 改文案 / 单项确认）。
+- **多按钮 → 按钮 key 进返回**：`new CenteredSlideBoxMultiRequest<Lv>{ Buttons=[("A","a"),("B","b")] }`；`GoTo(k)`；点 `button1` SimulateClick；await == `Item==items[k] && Button=="b"`。
+- **多按钮 → 点居中卡无操作**：2 按钮；`CardButton(0).onClick.Invoke()`；`UI.Modal.IsAnyOpen` 仍 true、`car.Current` 不变（区别单按钮的确认）。
 - **多按钮取消**：×/背景/ESC → `result.Cancelled == true`（`Item==null && Button==null`）。
-- **超量报错**：默认皮肤（5 槽）传 6 个按钮 → `Open` 内 Bind 抛 `InvalidOperationException`（用 `Assert.ThrowsAsync` 或对 OpenAsync 的异常路径断言）。
-- **空 buttons 列表**：多按钮重载传 `[]` → `ArgumentException`。
-- **隐藏槽**：传 2 个按钮 → `button2..button4` `activeSelf==false`、`button0/1` 可见且文案正确。
-- **单按钮自动确认仍在**：单按钮重载点居中卡 → 返回对象（autoConfirm 未被多按钮逻辑误关）。
+- **超量报错**：测试 XML 给 3 槽，传 4 个按钮 → `Assert.Throws<InvalidOperationException>(() => task.GetAwaiter().GetResult())`（faulted awaitable，见 §7）。
+- **空 buttons 列表**：多按钮 facade 传 `Array.Empty<(string,string)>()` → `Assert.Throws<ArgumentException>(…)`（facade 同步抛）。
+- **隐藏槽**：传 2 个按钮（3 槽测试 XML）→ `button2` `activeSelf==false`、`button0/button1` 可见且文案正确。
+- **单按钮自动确认仍在**：单按钮 request 点居中卡 → 返回对象（autoConfirm 未被多按钮逻辑误关）。
+- **多按钮 facade happy-path**：`CenteredSlideBox.Open(items, bind, buttons:[("A","a"),("B","b")])` → 点 button0 → `Button=="a"`（验证 facade 非 async 直传、`GetResult` 可同步取）。
 
 PlayMode：烟雾——多按钮开窗、拖一格、点第二个按钮，`SlideSelection.Button` 命中、不崩。
 
@@ -315,10 +339,10 @@ PlayMode：烟雾——多按钮开窗、拖一格、点第二个按钮，`Slide
 | 文件 | 动作 |
 |---|---|
 | `Runtime/Application/Modals/SlideSelection.cs`(+.meta) | 新建（`SlideSelection<T>` struct） |
-| `Runtime/Application/Modals/CenteredSlideBoxRequest.cs` | 改（基类→`ModalRequest<SlideSelection<T>>`、`Buttons` 驱动、探测槽、双 facade 重载、autoConfirm 条件化） |
+| `Runtime/Application/Modals/CenteredSlideBoxRequest.cs` | 改：新增 `CenteredSlideBoxBinder`（搬入 Bind 逻辑 + 探测槽 + autoConfirm 条件化）；`CenteredSlideBoxRequest<T>` 改委托 binder（基类不变）；新增 `CenteredSlideBoxMultiRequest<T>`；facade 加多按钮重载 |
 | `Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml` | 改（`confirm` → `<HStack id="buttons">` + `button0..button4`） |
-| `Tests/EditMode/Modals/CenteredSlideBoxTests.cs` | 改（`confirm`→`button0`，加多按钮/超量/隐藏槽用例） |
-| `Tests/EditMode/Modals/CenteredSlideBoxDefaultSkinTests.cs` | 改（`confirm`→`button0`） |
+| `Tests/EditMode/Modals/CenteredSlideBoxTests.cs` | 改：XML const `confirm`→`button0`（HStack+button0..button2，3 槽）、4 处 `Get<Btn>("confirm")`→`"button0"`；加多按钮/超量/隐藏槽/无操作用例 |
+| `Tests/EditMode/Modals/CenteredSlideBoxDefaultSkinTests.cs` | 改（3 处 `Get<Btn>("confirm")`→`"button0"`） |
 | `Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs` | 改（多按钮烟雾） |
 | `.claude/skills/scripting-promptugui-csharp/SKILL.md` | 改（多按钮重载 + `SlideSelection<T>` + 按钮槽契约） |
 

--- a/docs~/superpowers/specs/2026-06-16-centered-slide-box-multi-button-design.md
+++ b/docs~/superpowers/specs/2026-06-16-centered-slide-box-multi-button-design.md
@@ -1,0 +1,342 @@
+# `CenteredSlideBox` 多按钮设计
+
+**日期**: 2026-06-16
+**状态**: 设计阶段（待 review，未进入实施）
+**建立在**: [`2026-06-15-centered-slide-box-design.md`](2026-06-15-centered-slide-box-design.md)（CSB-D1..D11，已合并入 main `fc00b26`）。本文是它的扩展，决策编号续到 `CSB-D12+`，沿用同一套模态机制（`ModalRequest<TResult>` / `UI.Modal.OpenAsync` / `Configure` / `TryEscape`）。
+
+**一句话**: 给 `CenteredSlideBox` 加**多个自定义动作按钮**——例如关卡选择窗里「立即进入游戏」/「进入更高难度」。返回值从「选中的对象」升级为「选中的对象 **+** 点了哪个按钮」（具名 `SlideSelection<T>`）；按钮 ≥2 时自动关闭「点居中卡=确认」这个捷径。现有单按钮 `Open<T> → Awaitable<T>` 保持不变。
+
+**动机**: 当前只有一个确认按钮，确认语义单一（"选好了"）。现实选择器常需要在同一个选中项上分出多条动作路径（进入 / 高难度进入 / 预览…）。这要求返回值能同时携带「选了哪张卡」和「触发了哪个动作」，单个值装不下——这是整个设计的支点。
+
+**作用域**:
+1. 新增 `Runtime/Application/Modals/SlideSelection.cs`：`public readonly struct SlideSelection<T>`（多按钮返回类型；对标 `MsgBtn` 是个独立具名类型）。
+2. 改 `Runtime/Application/Modals/CenteredSlideBoxRequest.cs`：
+   - `CenteredSlideBoxRequest<T>` 基类 `ModalRequest<T>` → `ModalRequest<SlideSelection<T>>`，`Buttons` 列表驱动；
+   - facade 加多按钮重载；单按钮重载改 `async` 取 `.Item`（契约不变）。
+3. 改 `Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml`：单个 `<Btn id="confirm">` → `<HStack id="buttons">` + 5 个槽 `button0..button4`。
+4. 改 `.claude/skills/scripting-promptugui-csharp/SKILL.md`：补多按钮重载用法 + `SlideSelection<T>` + 按钮槽契约（公开 C# API 变更）。
+5. 改测试：`CenteredSlideBoxTests` / `CenteredSlideBoxDefaultSkinTests` / `CenteredSlideBoxPlayTests`（`confirm`→`button0`，新增多按钮用例）。
+
+**Carousel / BuiltinTags / lint / XSD：零改动**——仍是 C# 模态 API，不是新 XML 标签；按钮行用现有 `<HStack>`/`<Btn>`。
+
+---
+
+## 1. 决策一览（续 CSB-D11）
+
+| # | 决策 | 选择 | 理由 |
+|---|---|---|---|
+| CSB-D12 | 多按钮返回类型 | 具名 `public readonly struct SlideSelection<T> { T Item; string Button; bool Cancelled; Deconstruct(…); }`，**不用匿名元组** | 对齐 `MsgBtn`「为返回值定义具名类型」的惯例；耐扩展（以后加字段不像元组那样改 arity 撞坏解构点）；自带 `Cancelled` 语义；`Deconstruct` 让 `var (lv, act) = await …` 解构写法不损失 |
+| CSB-D13 | 按钮规格 | `IEnumerable<(string label, string key)>`，**`key` 用 `string`**。对齐 MessageBox 的 `CustomLabels` | `label` 走 i18n 会被翻译、`key` 稳定用于分支判断（不能拿 label 当 key）；`string` key 零仪式、和库「不强加类型、JSON 自己反序列化」一致。备选「泛型 `Open<T,TKey>` 用 enum」更类型安全但多一个泛型参数，YAGNI |
+| CSB-D14 | 重载 / 向后兼容 | 保留单按钮 `Open<T>(…) → Awaitable<T>`；新增多按钮重载，`buttons` **必填**（消除 `Open(items,bind)` 两重载全可选参的歧义）+ **非空**（空列表 → facade 抛 `ArgumentException`） | 不破坏宿主已用的单按钮 API；`buttons` 必填让 C# 重载解析靠第三参类型（`string title` vs `IEnumerable<…>`）区分；选择器没有任何动作按钮 + 又无自动确认 = 不可用，fail-fast |
+| CSB-D15 | 内部统一 | 一个 `CenteredSlideBoxRequest<T> : ModalRequest<SlideSelection<T>>`，`Buttons` 列表驱动 Bind（单按钮 = 1 元素列表）；单按钮 facade `async` await 后 `return sel.Item` | Bind 只写一份；单/多按钮共用取消三通道、carousel 绑定、卡点击装配。单按钮 facade 的 `Awaitable<T>` 契约不变（内部多一层 await/解包） |
+| CSB-D16 | 自动确认条件化 | `autoConfirm = (buttons.Count == 1)`。单按钮：点居中卡 = 确认（≈现状）；多按钮：点居中卡 = **无操作**，点侧卡照旧居中，必须点某个按钮才关 | 用户明确要求：多按钮时「点居中卡=确认」语义歧义（确认哪条动作？），自动去掉；单按钮保留这个捷径 |
+| CSB-D17 | 按钮槽探测 + 超量硬报错 | Bind 从 `button0` 起 `Get<Btn>` 探到 `KeyNotFoundException`，数出皮肤槽数 N（**不在代码写死 cap**）。`buttons.Count > N` → 抛 `InvalidOperationException`（消息含 N + `XmlSrcOverride` 提示）；`< N` → 多余槽 `SetActive(false)` 隐藏 | 传超量是开发期写错，fail-fast 比静默丢弃强；槽数由皮肤决定 → 换皮放 `button0..button9` 自动支持 10 个，代码零改。同 `MessageBoxRequest` 探测可选 `icon` 槽的 `try/catch KeyNotFoundException` 套路 |
+| CSB-D18 | 默认皮肤按钮行 | 单个 `<Btn id="confirm">` → 底部 `<HStack id="buttons">` + 5 个槽 `button0..button4`（对齐 MessageBox 的 5 槽慷慨度）。单按钮退化：只显 `button0`、居中、文案默认 `OK`，视觉 ≈现状 | 一个选择器动作行现实 2~3 个按钮，5 槽绰绰有余；要更多换皮。**迁移**：内置皮肤 id `confirm`→`button0`（见 §6 兼容性） |
+
+---
+
+## 2. 公开 API
+
+### 2.1 返回类型 `SlideSelection<T>`（新文件）
+
+```csharp
+namespace PromptUGUI.Application.Modals
+{
+    /// 多按钮 CenteredSlideBox 的返回值：选中的卡 + 点击的按钮 key。
+    /// 取消（×/背景/ESC）→ default(SlideSelection&lt;T&gt;)：Item=null, Button=null, Cancelled=true。
+    public readonly struct SlideSelection<T> where T : class
+    {
+        public readonly T Item;        // 选中的对象；取消时 null
+        public readonly string Button; // 点的按钮 key；取消时 null
+
+        public SlideSelection(T item, string button) { Item = item; Button = button; }
+
+        public bool Cancelled => Button == null;
+        public void Deconstruct(out T item, out string button) { item = Item; button = Button; }
+    }
+}
+```
+
+### 2.2 facade（两个重载）
+
+```csharp
+public static class CenteredSlideBox
+{
+    public static string XmlSrc { get; set; } = "PromptUGUI/Modals/CenteredSlideBox.ui";
+
+    // ① 单按钮（向后兼容，CSB-D14/D15）→ 返回选中对象 / null。签名不变，仅内部改 async 解包。
+    public static async UnityEngine.Awaitable<T> Open<T>(
+        IReadOnlyList<T> items, Action<IControl, T> bind,
+        string title = null, string confirmLabel = null,
+        ModalMode mode = ModalMode.Popup, Action<IScreen> configure = null,
+        CancellationToken ct = default) where T : class
+    {
+        var sel = await UI.Modal.OpenAsync(new CenteredSlideBoxRequest<T>
+        {
+            Items = items, BindCard = bind, Title = title,
+            Buttons = new[] { (confirmLabel, (string)null) },   // 1 个隐式按钮；key 在单按钮路径里被忽略
+            Configure = configure,
+        }, mode, ct);
+        return sel.Item;
+    }
+
+    // ② 多按钮（CSB-D12/D13/D14）→ 返回 (选中对象, 按钮 key)。buttons 必填且非空。
+    public static UnityEngine.Awaitable<SlideSelection<T>> Open<T>(
+        IReadOnlyList<T> items, Action<IControl, T> bind,
+        IEnumerable<(string label, string key)> buttons,
+        string title = null,
+        ModalMode mode = ModalMode.Popup, Action<IScreen> configure = null,
+        CancellationToken ct = default) where T : class
+    {
+        var list = new List<(string label, string key)>(buttons ?? throw new ArgumentNullException(nameof(buttons)));
+        if (list.Count == 0) throw new ArgumentException("buttons must be non-empty", nameof(buttons));
+        return UI.Modal.OpenAsync(new CenteredSlideBoxRequest<T>
+        {
+            Items = items, BindCard = bind, Title = title,
+            Buttons = list, Configure = configure,
+        }, mode, ct);
+    }
+}
+```
+
+### 2.3 调用（用户的关卡选择例子）
+
+```csharp
+record Level(string Id, string Name, Sprite Cover);
+
+var (level, action) = await CenteredSlideBox.Open(
+    levels,
+    bind: (card, lv) => { card.Get<Text>("name").TextValue = lv.Name;
+                          card.Get<Image>("cover").Sprite   = lv.Cover; },
+    buttons: new[] { ("立即进入游戏", "play"), ("进入更高难度", "hard") },
+    title: "选择关卡");
+
+if (action == null)        return;               // 取消（或用 result.Cancelled）
+if (action == "play")      StartLevel(level);
+else if (action == "hard") StartLevel(level, hard: true);
+```
+
+单按钮老用法**完全不变**：
+
+```csharp
+var picked = await CenteredSlideBox.Open(levels, BindCard, title: "选择关卡");
+if (picked != null) StartLevel(picked);
+```
+
+---
+
+## 3. 内部：`CenteredSlideBoxRequest<T>`（统一 Bind）
+
+```csharp
+public sealed class CenteredSlideBoxRequest<T> : ModalRequest<SlideSelection<T>> where T : class
+{
+    public IReadOnlyList<T> Items;
+    public Action<IControl, T> BindCard;
+    public string Title;
+    public IReadOnlyList<(string label, string key)> Buttons;   // 1..N；单按钮 facade 传 1 个
+    public string XmlSrcOverride;
+
+    public override string XmlSrc => XmlSrcOverride ?? CenteredSlideBox.XmlSrc;
+
+    // 取消三通道 → default = (null, null) = Cancelled
+    public override bool TryEscape(out SlideSelection<T> result) { result = default; return true; }
+
+    public override void Bind(IScreen screen, Action<SlideSelection<T>> close)
+    {
+        // —— title ——
+        var titleCtl = screen.Get<Text>("title");
+        if (string.IsNullOrEmpty(Title)) titleCtl.GameObject.SetActive(false);
+        else titleCtl.TextValue = Title;
+
+        // —— 取消三通道（CSB-D9）——
+        screen.Get<Btn>("close").OnClick.Subscribe(_ => close(default)).AddTo(screen);
+        screen.Get<Image>("backdrop").OnPointerDown.Subscribe(_ => close(default)).AddTo(screen);
+
+        Items ??= System.Array.Empty<T>();
+        var buttons = Buttons ?? System.Array.Empty<(string label, string key)>();
+        bool autoConfirm = buttons.Count == 1;                  // CSB-D16
+        string soleKey = autoConfirm ? buttons[0].key : null;
+
+        // —— carousel + 卡 ——
+        var car = screen.Get<Carousel>("cards");
+        int idx = 0;
+        car.BindItems(
+            Observable.Return((IReadOnlyList<T>)Items),
+            (IControl card, T item) =>
+            {
+                int i = idx++;
+                BindCard?.Invoke(card, item);
+                AttachCardClick(card, i, car, close, autoConfirm, soleKey);   // CSB-D7/D8/D16
+            }).AddTo(screen);
+
+        // —— 探测皮肤按钮槽（CSB-D17）——
+        var slots = new List<Btn>();
+        for (int i = 0; ; i++)
+        {
+            try { slots.Add(screen.Get<Btn>($"button{i}")); }
+            catch (System.Collections.Generic.KeyNotFoundException) { break; }
+        }
+        if (buttons.Count > slots.Count)
+            throw new InvalidOperationException(
+                $"CenteredSlideBox skin '{XmlSrc}' provides {slots.Count} button slot(s) but " +
+                $"{buttons.Count} buttons were passed; override XmlSrc with more 'button{{i}}' slots.");
+
+        // —— 映射 buttons[i] → slot i，隐藏多余槽 ——
+        for (int i = 0; i < slots.Count; i++)
+        {
+            var slot = slots[i];
+            if (i >= buttons.Count) { slot.GameObject.SetActive(false); continue; }
+            var (label, key) = buttons[i];
+            if (!string.IsNullOrEmpty(label)) slot.Text = label;   // null/空 → 保留皮肤默认文案（如 button0 的 "OK"）
+            if (Items.Count == 0) slot.Interactable = false;       // CSB-D11：空列表禁确认
+            slot.OnClick.Subscribe(_ =>
+            {
+                int cur = car.Current;
+                if (cur >= 0 && cur < Items.Count) close(new SlideSelection<T>(Items[cur], key));
+            }).AddTo(screen);
+        }
+    }
+
+    // 每张卡：透明 raycast catcher + PuiButton。click（非拖动）→ 居中导航或（仅单按钮）确认。
+    private void AttachCardClick(IControl card, int i, Carousel car,
+                                 Action<SlideSelection<T>> close, bool autoConfirm, string soleKey)
+    {
+        var go = card.GameObject;
+        var img = go.GetComponent<UnityImage>() ?? go.AddComponent<UnityImage>();
+        img.color = new UnityEngine.Color(0f, 0f, 0f, 0f);   // 透明，仅 raycast
+        img.raycastTarget = true;
+        var btn = go.AddComponent<PuiButton>();
+        btn.targetGraphic = img;
+        btn.onClick.AddListener(() =>
+        {
+            if (car.Current == i)
+            {
+                if (autoConfirm) close(new SlideSelection<T>(Items[i], soleKey));   // 单按钮：点居中卡=确认
+                // 多按钮：无操作（必须点动作按钮）
+            }
+            else car.GoTo(i, animated: true);   // 点侧卡=居中
+        });
+    }
+}
+```
+
+> 与 CSB-D8 一致：卡根（默认 `<Frame>`）本无 Graphic，`AttachCardClick` 补一层透明 raycast `Image`；换皮卡根须是无 Graphic 容器。
+
+---
+
+## 4. 内置 `CenteredSlideBox.ui.xml`（仅按钮行变更）
+
+`backdrop` / `panel` / `title` / `close` / `cards` 不变；底部单个 `<Btn id="confirm">` 换成按钮行：
+
+```xml
+<!-- 旧：<Btn id="confirm" anchor="bottom-center" size="160x48" margin="_,_,12,_">OK</Btn> -->
+<HStack id="buttons" anchor="bottom-center" height="48" margin="_,_,16,_" spacing="16">
+  <Btn id="button0" size="160x48">OK</Btn>
+  <Btn id="button1" size="160x48"/>
+  <Btn id="button2" size="160x48"/>
+  <Btn id="button3" size="160x48"/>
+  <Btn id="button4" size="160x48"/>
+</HStack>
+```
+
+- **居中、hug 内容宽**：`anchor="bottom-center"`（X 非 stretch → 宽由内容定），HStack 抱紧子按钮、隐藏槽 `SetActive(false)` 后在布局里折叠，整行随可见按钮数自动重新居中。
+- **固定 `size="160x48"`**：HStack 子节点固定尺寸经 LayoutElement min/preferred 固定（同 fixed-size stack child 既有行为），视觉一致。
+- 单按钮：只 `button0` 可见 → 居中的单个 160×48 按钮，≈旧 `confirm` 视觉。
+- > ⚠️ 精确 hug/居中行为（HStack 在 `bottom-center` 下是否需要额外尺寸属性）在 TDD 里以 live uGUI 矩形断言验证；设计意图固定为「底部居中、内容 hug、隐藏折叠」。
+
+**id 契约更新**：原 `confirm` → `button0..button4`（连续，从 0 起）。换皮 XML 想要 K 个动作按钮就提供 `button0..button{K-1}`。
+
+---
+
+## 5. 交互流（CSB-D7/D8/D9/D16）
+
+```
+开窗 → BindItems 建卡（每卡挂透明 raycast + PuiButton）→ 居中默认页(current=0)
+拖动 / 点 dots → 翻页，焦点卡放大不淡（peek）
+点侧卡   → car.GoTo(i) 居中它（动画），不关窗
+
+单按钮(autoConfirm)：点居中卡 → close((Items[i], soleKey)) ；button0 → close((居中项, key))
+多按钮             ：点居中卡 → 无操作          ；button{i} → close((居中项, buttons[i].key))
+
+× / 点背景 / ESC → close(default) → await 返回 Cancelled（Item=null, Button=null）
+```
+
+单按钮 facade 把 `SlideSelection<T>` 解包成 `.Item`：选中→对象，取消→null（契约同 CSB-D3）。
+
+---
+
+## 6. 兼容性 / 迁移
+
+| 面 | 影响 |
+|---|---|
+| 公开 facade `Open<T>(…) → Awaitable<T>`（单按钮） | **签名不变、契约不变**。仅内部从 expression-bodied 直传改为 `async` await 解包；返回值/取消语义一致 |
+| 公开 facade 多按钮 | **新增重载**，不影响旧调用 |
+| `public CenteredSlideBoxRequest<T>` 基类 | `ModalRequest<T>` → `ModalRequest<SlideSelection<T>>`：直接 `new` 该 request 并读其 `TResult` 的代码会受影响。实际用法是走 facade（同 `MessageBoxRequest`），认定为 de-facto internal 的可接受变更 |
+| 内置皮肤 id `confirm` → `button0` | **皮肤契约变更**。用默认皮肤者无感；自定义 `XmlSrcOverride` 皮肤需把 `id="confirm"` 改成 `id="button0"`（要多按钮再加 `button1..`）。SKILL 文档同步更新槽位契约 |
+
+> `confirm` 不保留别名兜底——保持探测逻辑单一（纯 `button{i}` 序列）。若宿主已有自定义皮肤依赖 `confirm`，在 plan 阶段确认后可加一行 `button0` 缺失时回退 `confirm` 的兼容垫片；默认不加。
+
+---
+
+## 7. 边界 / 错误处理
+
+| 场景 | 处理 |
+|---|---|
+| 多按钮 `buttons` 空 | facade 抛 `ArgumentException`（CSB-D14） |
+| `buttons.Count` > 皮肤槽数 | Bind 抛 `InvalidOperationException`，消息含槽数 + 换皮提示（CSB-D17） |
+| `buttons.Count` < 皮肤槽数 | 多余槽隐藏（`SetActive(false)`） |
+| `items` 空 | carousel 空；**所有可见按钮** `Interactable=false`（灰）；只能取消 |
+| `items` 1 张 | 居中、无邻卡；点按钮/点居中卡（单按钮）返回该项 |
+| 多按钮 + 点居中卡 | 无操作（CSB-D16） |
+| 换皮缺 `button0` | 探测得 0 槽；若传了按钮 → 抛 `InvalidOperationException`（槽数 0）。无 `button0` 的皮肤即「无动作按钮」皮肤（仅取消）|
+| `ct` 取消 | `UI.Modal.OpenAsync` 关窗 + Awaitable 取消（同其它模态） |
+
+---
+
+## 8. 测试
+
+EditMode（沿用现有 `CenteredSlideBoxTests` 套路 + `UI.ResetForTests`；按钮文案读 `GameObject.GetComponentInChildren<TMP_Text>().text`，`Btn.Text` 是 set-only）:
+
+- **现有单按钮用例**：`confirm`→`button0` 改 id 后全绿（确认返回居中项 / 点居中卡返回 / 取消三通道 / 空列表禁用 / confirmLabel 改文案）。
+- **多按钮 → 按钮 key 进返回**：`Open(items, bind, buttons:[("A","a"),("B","b")])`；`GoTo(k)`；点 `button1`；await == `SlideSelection(items[k], "b")`。
+- **多按钮 → 点居中卡无操作**：点 current 卡 PuiButton；Awaitable **未完成**、`car.Current` 不变（区别单按钮的确认）。
+- **多按钮取消**：×/背景/ESC → `result.Cancelled == true`（`Item==null && Button==null`）。
+- **超量报错**：默认皮肤（5 槽）传 6 个按钮 → `Open` 内 Bind 抛 `InvalidOperationException`（用 `Assert.ThrowsAsync` 或对 OpenAsync 的异常路径断言）。
+- **空 buttons 列表**：多按钮重载传 `[]` → `ArgumentException`。
+- **隐藏槽**：传 2 个按钮 → `button2..button4` `activeSelf==false`、`button0/1` 可见且文案正确。
+- **单按钮自动确认仍在**：单按钮重载点居中卡 → 返回对象（autoConfirm 未被多按钮逻辑误关）。
+
+PlayMode：烟雾——多按钮开窗、拖一格、点第二个按钮，`SlideSelection.Button` 命中、不崩。
+
+---
+
+## 9. 文件结构
+
+| 文件 | 动作 |
+|---|---|
+| `Runtime/Application/Modals/SlideSelection.cs`(+.meta) | 新建（`SlideSelection<T>` struct） |
+| `Runtime/Application/Modals/CenteredSlideBoxRequest.cs` | 改（基类→`ModalRequest<SlideSelection<T>>`、`Buttons` 驱动、探测槽、双 facade 重载、autoConfirm 条件化） |
+| `Runtime/Resources/PromptUGUI/Modals/CenteredSlideBox.ui.xml` | 改（`confirm` → `<HStack id="buttons">` + `button0..button4`） |
+| `Tests/EditMode/Modals/CenteredSlideBoxTests.cs` | 改（`confirm`→`button0`，加多按钮/超量/隐藏槽用例） |
+| `Tests/EditMode/Modals/CenteredSlideBoxDefaultSkinTests.cs` | 改（`confirm`→`button0`） |
+| `Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs` | 改（多按钮烟雾） |
+| `.claude/skills/scripting-promptugui-csharp/SKILL.md` | 改（多按钮重载 + `SlideSelection<T>` + 按钮槽契约） |
+
+---
+
+## 10. Out of Scope
+
+- **per-按钮 启用/禁用 / 样式**（如「高难度」仅满足条件才可点）：v1 所有按钮统一可点（空列表全禁）；细粒度走 `configure` 钩子自取 `screen.Get<Btn>("button1").Interactable=…`。
+- **per-按钮 不绑选中项**（如「随机一关」忽略居中卡）：v1 所有按钮都带居中项；这类需求自定逻辑。
+- **泛型 `TKey`**：v1 用 `string` key（CSB-D13）；要 enum 自己 `nameof`/`ToString`。
+- **运行时动态实例化按钮（真·无上限）**：固定槽 + 探测 + 超量报错已覆盖现实场景（CSB-D17）。
+- **按钮区位置/方向自定义**（底部固定）：换皮 XML 自理。
+
+---
+
+## 11. 整合点
+
+- `scripting-promptugui-csharp/SKILL.md` 模态小节：现有 `CenteredSlideBox.Open<T>` 旁补多按钮重载（`buttons:[(label,key),…]` → `SlideSelection<T>`：`Item`+`Button`+`Cancelled`+解构；多按钮自动去掉点居中卡确认；按钮槽契约 `button0..`；超量报错）。
+- XML / Addressables skill：无关（无新标签/属性）。
+- 主 spec / XSD / lint：无新 XML 标签或属性，不动。
+- 建立在 CSB-D1..D11（同特性），本文只增量。

--- a/install_for_claude.md
+++ b/install_for_claude.md
@@ -1,54 +1,54 @@
-# PromptUGUI 安装指南（写给 AI 助手）
+# PromptUGUI Installation Guide (for AI Assistants)
 
-> 本文档写给 AI 编程助手（Claude Code / Copilot / Cursor 等）。
-> 当用户说"帮我装一下 PromptUGUI"或把这份文件给你时，按以下步骤**顺序**执行，每步做完对应验证再进下一步。
+> This document is written for AI coding assistants (Claude Code / Copilot / Cursor, etc.).
+> When the user says "help me install PromptUGUI" or hands you this file, follow the steps below **in order**, verifying each step before moving on to the next.
 
-所有路径以**用户的 Unity 项目根目录**（`<project root>`，即 `Packages/`、`Assets/` 所在层）为基准。
+All paths are relative to the **user's Unity project root** (`<project root>`, i.e. the level where `Packages/` and `Assets/` live).
 
-## 前置条件
+## Prerequisites
 
-1. Unity 6000.0+ 项目
-2. `<project root>/Packages/manifest.json` 存在
-3. R3（Cysharp）已装好——PromptUGUI 运行时依赖。通常通过 NuGetForUnity 安装 `R3` 包；如未装，先告诉用户装好再继续
-4. .Net SDK 10，这是很重要的，脱离Unity检查lint需要。如未装，先告诉用户装好再继续：
+1. A Unity 6000.0+ project
+2. `<project root>/Packages/manifest.json` exists
+3. R3 (Cysharp) is installed — the PromptUGUI runtime depends on it. It is usually installed as the `R3` package via NuGetForUnity; if it isn't installed, tell the user to install it before continuing.
+4. .NET SDK 10 — this is important; it is needed to check lint outside of Unity. If it isn't installed, tell the user to install it before continuing:
     Windows: winget install Microsoft.DotNet.SDK.10
     macOS: brew install --cask dotnet-sdk
     linux: sudo apt-get update && sudo apt-get install -y dotnet-sdk-10.0
-5. (可选) 确认系统可以执行`xmllint`，如果不行，最后总结时提醒用户安装。
+5. (Optional) Confirm that `xmllint` can be run on the system; if not, remind the user to install it in the final summary.
 
-## 步骤 1：把包加到 manifest
+## Step 1: Add the package to the manifest
 
-读 `<project root>/Packages/manifest.json`，在 `dependencies` 对象里加2行（任一如已存在则跳过）：
+Read `<project root>/Packages/manifest.json` and add 2 lines to the `dependencies` object (skip either line if it already exists):
 
 ```json
 "com.promptugui.core": "https://github.com/heerozh/PromptUGUI.git"
 "com.annulusgames.lit-motion": "https://github.com/annulusgames/LitMotion.git?path=src/LitMotion/Assets/LitMotion"
 ```
 
-也可以让用户走 Unity → Window → Package Manager → "+" → "Add package from git URL"，URL 同上。
+Alternatively, have the user go to Unity → Window → Package Manager → "+" → "Add package from git URL", using the same URLs.
 
-**验证**：等 Unity 完成 import（可调 `mcp__UnityMCP__refresh_unity(compile="request", mode="standard", wait_for_ready=true)`），确认 `<project root>/Library/PackageCache/com.promptugui.core@<hash>/` 目录存在(hash为随机值)，含 `Runtime/`、`Editor/`、`package.json`。
+**Verification**: Wait for Unity to finish importing (you can call `mcp__UnityMCP__refresh_unity(compile="request", mode="standard", wait_for_ready=true)`), then confirm that the `<project root>/Library/PackageCache/com.promptugui.core@<hash>/` directory exists (the hash is a random value) and contains `Runtime/`, `Editor/`, and `package.json`.
 
-## 步骤 2：复制 LLM Skills 到用户项目
+## Step 2: Copy the LLM Skills into the user's project
 
-包内自带四个给 LLM 读的 skill，路径：
+The package ships four skills for LLMs to read, at these paths:
 
 ```
-<project root>/Library/PackageCache/com.promptugui.core@<hash>/.claude/skills/authoring-promptugui-xml/SKILL.md      # XML 编写
-<project root>/Library/PackageCache/com.promptugui.core@<hash>/.claude/skills/authoring-promptugui-pxl/SKILL.md      # .pxl 像素图（9-slice 边框 / 按钮皮肤 / 图标的网格文本格式）
-<project root>/Library/PackageCache/com.promptugui.core@<hash>/.claude/skills/scripting-promptugui-csharp/SKILL.md   # C# bridge（UI.Open / Get<T> / R3 / BindItems / 自定义 Control）
-<project root>/Library/PackageCache/com.promptugui.core@<hash>/.claude/skills/using-promptugui-addressables/SKILL.md # Addressables 集成（.ui.xml / .po / IconSet）
+<project root>/Library/PackageCache/com.promptugui.core@<hash>/.claude/skills/authoring-promptugui-xml/SKILL.md      # XML authoring
+<project root>/Library/PackageCache/com.promptugui.core@<hash>/.claude/skills/authoring-promptugui-pxl/SKILL.md      # .pxl pixel art (grid-text format for 9-slice borders / button skins / icons)
+<project root>/Library/PackageCache/com.promptugui.core@<hash>/.claude/skills/scripting-promptugui-csharp/SKILL.md   # C# bridge (UI.Open / Get<T> / R3 / BindItems / custom Control)
+<project root>/Library/PackageCache/com.promptugui.core@<hash>/.claude/skills/using-promptugui-addressables/SKILL.md # Addressables integration (.ui.xml / .po / IconSet)
 ```
 
-把整个 skills 目录复制到用户项目的 `.claude/skills/` 下（**项目作用域**，跟仓库走，团队共享）：
+Copy the entire skills directory into the user's project under `.claude/skills/` (**project scope**, tracked with the repo, shared by the team):
 
-**Unix / macOS / WSL：**
+**Unix / macOS / WSL:**
 ```bash
 mkdir -p .claude/skills
 cp -r Library/PackageCache/com.promptugui.core@<hash>/.claude/skills/* .claude/skills/
 ```
 
-**Windows PowerShell：**
+**Windows PowerShell:**
 ```powershell
 New-Item -ItemType Directory -Force -Path .claude/skills | Out-Null
 Copy-Item -Recurse -Force `
@@ -56,61 +56,63 @@ Copy-Item -Recurse -Force `
   .claude/skills/
 ```
 
-如目标已存在，覆盖即可（**幂等**——包升级时 skill 也要跟着升级，重新跑这一步）。
+If the target already exists, just overwrite it (**idempotent** — when the package is upgraded the skills must be upgraded too, so re-run this step).
 
-> 备选：如果用户希望这些 skill 跨所有项目可用，复制到 `~/.claude/skills/` 而不是项目内 `.claude/skills/`。默认推荐项目作用域。
+> Alternative: if the user wants these skills available across all projects, copy them to `~/.claude/skills/` instead of the project-local `.claude/skills/`. Project scope is the recommended default.
 
-**验证**：确认 `.claude/skills/` 下 `authoring-promptugui-xml/`、`authoring-promptugui-pxl/`、`scripting-promptugui-csharp/`、`using-promptugui-addressables/` 四个目录都存在，每个目录里的 `SKILL.md` 第 1 行都是 `---`（YAML frontmatter 起始）。
+**Verification**: Confirm that the four directories `authoring-promptugui-xml/`, `authoring-promptugui-pxl/`, `scripting-promptugui-csharp/`, and `using-promptugui-addressables/` all exist under `.claude/skills/`, and that line 1 of each directory's `SKILL.md` is `---` (the start of the YAML frontmatter).
 
-## 步骤 3：注入项目级 CLAUDE.md 约定
+## Step 3: Inject project-level CLAUDE.md conventions
 
-使用 PromptUGUI 的项目里，所有面向玩家的文本都应走 `Tr(...)` 包裹（i18n 约定，由项目自己接入翻译表，包本身不强制）。这个约定要让**所有 AI 会话默认知道**——写到项目根的 `CLAUDE.md`。
+In a project that uses PromptUGUI, all player-facing text should be wrapped with `Tr(...)` (an i18n convention; the project wires up its own translation table — the package itself does not enforce it). This convention should be known **by default in all AI sessions**, so write it into the project root's `CLAUDE.md`.
 
-**操作**：
-- 如果 `<project root>/CLAUDE.md` 不存在 → 创建，写入下面整段
-- 如果存在 → 先 grep `Tr() 包裹约定`，已存在跳过此步（**幂等**）；不存在则**追加**到文件末尾，**不要覆盖**既有内容
+**Actions**:
+- If `<project root>/CLAUDE.md` does not exist → create it and write the entire block below.
+- If it exists → first grep for `Tr() Wrapping Convention`; if it's already present, skip this step (**idempotent**); if not, **append** it to the end of the file — **do not overwrite** existing content.
 
-要追加（或写入）的内容：
+Content to append (or write):
 
 ```markdown
-## i18n: Tr() 包裹约定
+## i18n: Tr() Wrapping Convention
 
-项目里凡是会出现在 UI 上、玩家能读到的C#代码中的字符串，都用 `UI.Tr(...)` 包裹(`PromptUGUI.Application` namespace下)。
+In this project, every string in C# code that appears on the UI and can be read by the player is wrapped with `UI.Tr(...)` (in the `PromptUGUI.Application` namespace).
 
-**要包裹**：
-- C# 给 UI 控件赋值的字符串：`label.Text = Tr("Start Game")`
-- 错误提示弹窗、tooltip 文案
+**Wrap these**:
+- Strings assigned to UI controls in C#: `label.Text = Tr("Start Game")`
+- Error dialog messages, tooltip text
 
-**不要包裹**：
-- `.ui.xml` 里无须包裹
-- `Debug.Log`、异常消息、内部日志
-- 文件路径、URL、asset 键、format specifier、JSON / SQL 片段
-- `nameof(...)`、反射 identifier
-- 单字符 / 纯标点 / 纯数字字符串
+**Do not wrap these**:
+- No wrapping needed in `.ui.xml`
+- `Debug.Log`, exception messages, internal logs
+- File paths, URLs, asset keys, format specifiers, JSON / SQL fragments
+- `nameof(...)`, reflection identifiers
+- Single-character / punctuation-only / numeric-only strings
 
-**判断标准**：玩家能在屏幕上看到 → 包；工程内部用 → 不包。
+**Rule of thumb**: if the player can see it on screen → wrap it; if it's only used internally by the engineering → don't wrap it.
+
+We don't need to modify the i18n `po` files; translation is handled automatically by an LLM in CI later.
 ```
 
-**验证**：再读 `CLAUDE.md`，确认含 `Tr() 包裹约定` 字样且原有内容未丢失。
+**Verification**: Read `CLAUDE.md` again and confirm it contains the text `Tr() Wrapping Convention` and that the existing content was not lost.
 
-## 步骤 4：整体验收
+## Step 4: Final acceptance check
 
-依次确认：
+Confirm in order:
 
-1. ✓ `Library/PackageCache/com.promptugui.core@<hash>/Runtime/` 存在
-2. ✓ `.claude/skills/` 下 `authoring-promptugui-xml/`、`authoring-promptugui-pxl/`、`scripting-promptugui-csharp/`、`using-promptugui-addressables/` 四个 SKILL.md 都存在，frontmatter 完整
-3. ✓ `CLAUDE.md` 含 Tr() 包裹约定章节，原内容保留
-4. ✓ 检查 `dotnet --list-sdks` 是否安装了 10 版本。
-5. ✓ （可选）`mcp__UnityMCP__refresh_unity(compile="request", mode="standard")` 后 `mcp__UnityMCP__read_console(action="get", types=["error"])` 无编译错误
-6. ✓ （可选）检查`xmllint`是否可执行，提醒用户安装
+1. ✓ `Library/PackageCache/com.promptugui.core@<hash>/Runtime/` exists
+2. ✓ The four SKILL.md files under `.claude/skills/` — `authoring-promptugui-xml/`, `authoring-promptugui-pxl/`, `scripting-promptugui-csharp/`, `using-promptugui-addressables/` — all exist, with complete frontmatter
+3. ✓ `CLAUDE.md` contains the Tr() wrapping convention section, with the original content preserved
+4. ✓ Check whether `dotnet --list-sdks` shows a version 10 installed.
+5. ✓ (Optional) After `mcp__UnityMCP__refresh_unity(compile="request", mode="standard")`, `mcp__UnityMCP__read_console(action="get", types=["error"])` reports no compile errors
+6. ✓ (Optional) Check whether `xmllint` is runnable, and remind the user to install it
 
-全部通过即安装完成。下次会话 Claude Code 会自动加载 `CLAUDE.md`；用户编辑 `.ui.xml` 时 `authoring-promptugui-xml` 触发，创建/编辑 `.pxl` 像素图（9-slice 边框、按钮皮肤、图标）时 `authoring-promptugui-pxl` 触发，写 C# 调用 `UI.*` 时 `scripting-promptugui-csharp` 触发，集成 Unity Addressables 时 `using-promptugui-addressables` 触发。
+Once all pass, installation is complete. In the next session Claude Code will load `CLAUDE.md` automatically; when the user edits `.ui.xml` the `authoring-promptugui-xml` skill triggers, when creating/editing `.pxl` pixel art (9-slice borders, button skins, icons) the `authoring-promptugui-pxl` skill triggers, when writing C# that calls `UI.*` the `scripting-promptugui-csharp` skill triggers, and when integrating Unity Addressables the `using-promptugui-addressables` skill triggers.
 
-## 升级 / 卸载
+## Upgrade / Uninstall
 
-**升级包**（`git pull` 等价于 manifest 里 commit 推进）：重跑**步骤 2**——把包内最新 skill 覆盖到 `.claude/skills/`。CLAUDE.md 章节通常无需变动，除非 release notes 提到约定变更。
+**Upgrade the package** (equivalent to a `git pull` advancing the commit referenced in the manifest): re-run **Step 2** — overwrite `.claude/skills/` with the latest skills from the package. The CLAUDE.md section usually doesn't need to change, unless the release notes mention a convention change.
 
-**卸载**：
-1. 从 `manifest.json` 删除 `com.promptugui.core`
-2. 删除 `.claude/skills/authoring-promptugui-xml/`、`.claude/skills/authoring-promptugui-pxl/`、`.claude/skills/scripting-promptugui-csharp/`、`.claude/skills/using-promptugui-addressables/`
-3. 从 `CLAUDE.md` 删除 `## i18n: Tr() 包裹约定` 章节（如果项目里别的库也共用同名约定，保留）
+**Uninstall**:
+1. Remove `com.promptugui.core` from `manifest.json`
+2. Delete `.claude/skills/authoring-promptugui-xml/`, `.claude/skills/authoring-promptugui-pxl/`, `.claude/skills/scripting-promptugui-csharp/`, and `.claude/skills/using-promptugui-addressables/`
+3. Remove the `## i18n: Tr() Wrapping Convention` section from `CLAUDE.md` (if another library in the project shares the same-named convention, keep it)


### PR DESCRIPTION
## Summary
给第 4 个内置模态 `CenteredSlideBox`（居中卡片选择器）加**多个自定义动作按钮**——例如关卡选择窗里「立即进入游戏」/「进入更高难度」。

- **新增多按钮重载** `CenteredSlideBox.Open<T>(items, bind, IEnumerable<(string label,string key)> buttons, …) → Awaitable<SlideSelection<T>>`。返回具名 `SlideSelection<T>`（`.Item` 选中卡 + `.Button` 按钮 key + `.Cancelled` + 解构 `var (item,key)=await …`），对齐 `MsgBtn` 的「具名返回类型」惯例。
- **`label` 走 i18n（作者自己 `UI.Tr`）、`key` 稳定用于分支判断**（同 `MessageBox.CustomLabels`）。
- **按钮 ≥2 时自动去掉「点居中卡=确认」捷径**（语义歧义），必须点动作按钮；点侧卡仍居中；取消三通道（×/背景/ESC）→ `Cancelled`。
- **单按钮 `Open<T> → Awaitable<T>` 签名/行为一字未变**（向后兼容）。
- 内部：抽共享 `CenteredSlideBoxBinder`（回调化），单/多两个瘦 request 委托它；DRY 且单按钮保持非 async 直传（避开 EditMode awaitable 续体挂起风险）。
- 默认皮肤底部单 `<Btn id="confirm">` → `<HStack id="buttons">` + `button0..button4`（5 槽）；传超过皮肤槽数 → `InvalidOperationException`（换 `XmlSrc` 加 `button{i}` 槽），空 `buttons` → `ArgumentException`。

设计/计划：`docs~/superpowers/specs|plans/2026-06-16-centered-slide-box-multi-button*`（决策 CSB-D12..D18，建立在 #78 的 CSB-D1..D11 之上）。C# SKILL 已同步。

> 本分支还含一个先行修复 `899f604 fix: 默认xml写错了`（默认皮肤 `<Screen>` 补 `reference=` —— pixel 模式下缺它会兜底 factor=1）。

## ⚠️ Breaking（仅自定义皮肤）
内置皮肤按钮 id 从 `confirm` 改为 `button0..`。用默认皮肤者无感；自定义 `XmlSrcOverride` 皮肤需把 `id="confirm"` → `id="button0"`。

## Test Plan
- [x] EditMode 全量 **1858/1858**（+4 SlideSelection +9 多按钮，含 2 个评审驱动的兜底/边界测试）
- [x] EditorOnly **268/268**、PlayMode **146/146**
- [x] UIXmlLint（7 文件）+ `dotnet format --verify-no-changes` 干净
- [x] subagent-driven 双段评审（每 task spec+quality）+ opus 最终整体评审「Ready to merge」
- [ ] **视觉 QA（待 @Heerozh）**：宿主像素游戏里默认皮肤多按钮行（HStack 居中/hug、隐藏槽折叠）、单按钮退化视觉、超量报错文案

🤖 Generated with [Claude Code](https://claude.com/claude-code)