### PR TITLE
fix: 模态实例化/绑定失败时 Debug.LogError（之前静默吞掉）

### DIFF
--- a/Runtime/Application/UI.Modal.cs
+++ b/Runtime/Application/UI.Modal.cs
@@ -131,6 +131,13 @@ namespace PromptUGUI.Application
                         }
                         catch (Exception ex)
                         {
+                            // The Open(...) awaitable is faulted below (entry.Cancel), but callers commonly
+                            // await fire-and-forget (or in an async void), and an unobserved Awaitable drops
+                            // its exception silently — so the modal just "never opens" with no diagnostic.
+                            // Surface it. Cancellation is normal control flow, not a failure, so skip it.
+                            if (ex is not OperationCanceledException)
+                                Debug.LogError($"[PromptUGUI] Modal '{entry.XmlSrc}' failed to open; its " +
+                                               $"Open(...) awaitable is faulted with this exception:\n{ex}");
                             entry.Cancel(ex);
                             if (slot != null) RemoveSlot(slot);
                         }

--- a/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
+++ b/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
@@ -1,11 +1,14 @@
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using PromptUGUI.Application;
 using PromptUGUI.Application.Modals;
 using PromptUGUI.Controls;
 using PromptUGUI.Controls.Internal;
 using TMPro;
+using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.TestTools;
 using PBtn = PromptUGUI.Controls.Btn;
 using PImage = PromptUGUI.Controls.Image;
 using PText = PromptUGUI.Controls.Text;
@@ -300,6 +303,8 @@ namespace PromptUGUI.Tests.Modals
         {
             // 测试 XML 只有 3 槽；传 4 个 → binder 抛 InvalidOperationException。
             // 整个 OpenAsync 放进 lambda：无论同步抛还是 faulted awaitable 都被捕获。
+            // pump 现在也会 Debug.LogError 这个 open 失败（faulted awaitable 常被 fire-and-forget 吞掉）。
+            LogAssert.Expect(LogType.Error, new Regex("failed to open"));
             Assert.Throws<System.InvalidOperationException>(() =>
             {
                 var task = UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>
@@ -324,6 +329,7 @@ namespace PromptUGUI.Tests.Modals
         public void Multi_Request_Empty_Buttons_Throws_From_Binder()
         {
             // 绕过 facade 直接 new request、Buttons 空 → binder 兜底抛 ArgumentException（faulted awaitable）。
+            LogAssert.Expect(LogType.Error, new Regex("failed to open"));
             Assert.Throws<System.ArgumentException>(() =>
             {
                 var task = UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<Lv>

--- a/Tests/EditMode/Modals/ModalInstantiationErrorTests.cs
+++ b/Tests/EditMode/Modals/ModalInstantiationErrorTests.cs
@@ -1,0 +1,40 @@
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.Modals
+{
+    // A modal whose XML throws during instantiation must surface the error to the console.
+    // The Open(...) awaitable is faulted (entry.Cancel(ex)), but callers commonly await
+    // fire-and-forget, so without an explicit log the modal "just doesn't open" with zero
+    // diagnostic. The materialize catch in UI.Modal must Debug.LogError such failures.
+    public class ModalInstantiationErrorTests : ModalTestFixture
+    {
+        // `anchor="right"` is an invalid anchor token (bare side words aren't allowed; only
+        // 'center' / 'stretch' or '<vertical>-<horizontal>'), so AnchorPreset.Parse throws
+        // while the close Btn is instantiated.
+        private const string BadAnchorXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='test/BadAnchor'>
+    <Image id='backdrop' anchor='stretch' color='#0000007F'/>
+    <Frame anchor='center' size='100x100'>
+      <Btn id='close' anchor='right' size='18x18'>x</Btn>
+    </Frame>
+  </Screen>
+</PromptUGUI>";
+
+        [Test]
+        public void Instantiation_failure_is_logged_with_src()
+        {
+            Files["test/BadAnchor"] = BadAnchorXml;
+            MessageBox.XmlSrc = "test/BadAnchor";
+
+            // The error message must name the failing modal src so authors can find it.
+            LogAssert.Expect(LogType.Error, new Regex("test/BadAnchor"));
+            UI.Modal.OpenAsync(new MessageBoxRequest { Text = "x", Buttons = MsgBtn.OK });
+        }
+    }
+}

--- a/Tests/EditMode/Modals/ModalInstantiationErrorTests.cs.meta
+++ b/Tests/EditMode/Modals/ModalInstantiationErrorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 259d309599d04b64fb109010b1b2af44

--- a/Tests/EditMode/Modals/ModalStackTests.cs
+++ b/Tests/EditMode/Modals/ModalStackTests.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using PromptUGUI.Application;
 using PromptUGUI.Application.Modals;
+using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace PromptUGUI.Tests.Modals
 {
@@ -83,6 +86,8 @@ namespace PromptUGUI.Tests.Modals
         [Test]
         public void Bind_exception_cancels_that_modal_and_pumps_next()
         {
+            // pump 现在 Debug.LogError 这个 open 失败（boom 来自 Bind）。
+            LogAssert.Expect(LogType.Error, new Regex("failed to open"));
             var t1 = UI.Modal.OpenAsync(new FakeRequest
             {
                 OnBind = (_, __) => throw new InvalidOperationException("boom"),


### PR DESCRIPTION
## 问题

自定义模态 skin 里写错 XML（例如 `<Btn anchor="right">` —— 非法 anchor 值，须写 `top-right` / `center-right`）时，模态**静默打不开、Console 无任何报错**，很难定位。

## 根因

`UI.Modal` 的 materialize `catch` 把实例化 / `Bind` 异常塞进 `entry.Cancel(ex)`（faulted awaitable）但**不打 Console**。模态大多通过 `await` fire-and-forget 使用，而未观察的 Unity `Awaitable`（不像 `Task`）会静默丢弃异常 → 失败时无任何诊断。

## 改动

- 在该 `catch` 里 `Debug.LogError` 失败模态的 `XmlSrc` + 完整异常。
- 排除 `OperationCanceledException`（取消是正常控制流，非错误）。
- 覆盖实例化（`OpenModalScreen`）与绑定（`RunBind`）两类失败（同一 `try` 内）。
- `entry.Cancel(ex)` 原行为不变（awaitable 照旧 faulted），只是顺手吼一声。

## 测试（TDD）

- 新增 `ModalInstantiationErrorTests`：喂一段 `anchor="right"` 的坏 XML → 断言 error log（先红 "Expected log did not appear" → 加 log 后绿）。
- 3 个故意触发模态失败的现存测试（`CenteredSlideBox` 按钮越界/空、`ModalStack` 的 `boom`）补 `LogAssert.Expect`（新 log 行为是期望的）。
- **EditMode 1859/1859 + PlayMode 146/146 + lint 绿**。
- 内部诊断日志，不碰 XML / 公共 API，无需更 SKILL。

🤖 Generated with [Claude Code](https://claude.com/claude-code)