### PR TITLE
feat: Markdown boldStyle 粗体渲染样式（关键字 + 颜色，可组合）

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/reference/controls-markdown.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/controls-markdown.md
@@ -76,6 +76,7 @@ Frequently-used style items can be set on the tag itself; full styling lives in 
 | `spacing` | float | `MarkdownStyle` default | Vertical spacing between top-level blocks (pixels). |
 | `padding` | int (px) | `2` | Inner inset of the rendered content within the built-in scroll viewport (applied as the document-root `<VStack>`'s `padding`). The default `2` gives **outlined / stroked fonts** room so the viewport `RectMask2D` doesn't clip the first/last glyph outlines at the edges. Maps to `MarkdownStyle.Padding`. Set `0` for flush content. |
 | `wrap` | bool | `true` | Whether paragraph text wraps. `false` makes long paragraphs clip horizontally (the internal `ScrollRect` is vertical-only). |
+| `boldStyle` | space-separated tokens | `bold` | How **bold** renders — governs inline `**bold**`, **headings**, and **table headers** (the three places that otherwise emit TMP `<b>`). Tokens combine: style keywords `bold` / `underline` / `italic` / `strikethrough` (and `none` = strip), plus at most one color value (theme token / hex / CSS name / `/alpha` suffix). E.g. `boldStyle="underline #ffcc00"` → underline + gold; `boldStyle="none"` → plain (headings still magnify via `scale`). Default `bold` = TMP `<b>` (faux-bold — looks poor on pixel fonts, hence this attribute). Maps to `MarkdownStyle.BoldStyle`. |
 
 > Complete styling (heading **scale** ladder `HeadingScales`, quote bar color, code block background, list indent, bullet glyph, task-list glyphs, HR color / thickness) is controlled via C# `MarkdownStyle`. See **scripting-promptugui-csharp → Markdown** for the full API.
 
@@ -119,7 +120,7 @@ Frequently-used style items can be set on the tag itself; full styling lives in 
 | Markdown block | Generated ElementNode | Notes |
 |---|---|---|
 | Document root | `<VStack spacing=BlockSpacing padding=Padding>` (the `ScrollRect.content`) | Anchor `top-stretch`, pivot top, `ContentSizeFitter` vertical; width tracks viewport, height tracks content. `padding` insets content off the viewport `RectMask2D` so outlined-font glyph edges aren't clipped (default 2) |
-| Heading h1–h6 | `<Text fontSize=BodySize scale=HeadingScales[n-1]>` + `<b>` inline wrap | Magnified via RectTransform `localScale` (the V/HStack scale-wrapper + `ScaledTextLayoutBridge` reserve the visual size), **not** a larger font size → pixel fonts stay crisp. `scale 1` (h6 default) emits no `scale=`/wrapper. font=BodyFont |
+| Heading h1–h6 | `<Text fontSize=BodySize scale=HeadingScales[n-1]>` + `<b>` inline wrap | Magnified via RectTransform `localScale` (the V/HStack scale-wrapper + `ScaledTextLayoutBridge` reserve the visual size), **not** a larger font size → pixel fonts stay crisp. `scale 1` (h6 default) emits no `scale=`/wrapper. font=BodyFont. Bold wrap governed by `boldStyle` (default `<b>`). |
 | Paragraph | `<Text wrap>` with inline rich-text string | See inline mapping below |
 | Unordered list | `<VStack>` — each item is `<HStack>` (bullet `<Text>`) + (content `<Text>`) | Nested lists: content cell contains another `<VStack>`; indent = `ListIndent × depth` |
 | Ordered list | Same as unordered; bullet is `"1."`, `"2."`, … (start offset from Markdig) | |
@@ -128,7 +129,7 @@ Frequently-used style items can be set on the tag itself; full styling lives in 
 | Fenced code block | `<Text font=CodeFont wrap=false>` with code background applied via inline TMP `<mark=…>` tag (no separate container) | Language tag ignored; no syntax highlighting |
 | Horizontal rule `---` | `<Image width=stretch height=HrThickness color=HrColor>` | |
 | Block-level image `![alt](url)` | `<RawImage type="contain">` + generated id → `ImageRequest` | Texture loaded async; alt text shown as placeholder until texture arrives |
-| GFM table | `<VStack>` → each row `<HStack>` → each cell `<Text width="stretch" wrap>` | Header row is bold; equal-width columns (`width="stretch"`); no cell border lines (v1) |
+| GFM table | `<VStack>` → each row `<HStack>` → each cell `<Text width="stretch" wrap>` | Header row uses the `boldStyle` wrap (default bold); equal-width columns (`width="stretch"`); no cell border lines (v1) |
 | HTML block | Plain text (tags stripped) or discarded | MD-D17 |
 
 ### Inline → TMP rich-text mapping
@@ -138,7 +139,7 @@ Inline content within a single paragraph or heading is compiled into one TMP ric
 | Markdown inline | TMP output |
 |---|---|
 | Literal text | Escaped: `&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;` (prevents TMP from consuming raw `<` as a tag) |
-| `**bold**` | `<b>…</b>` |
+| `**bold**` | `boldStyle` wrap (default `<b>…</b>`; e.g. `<u>…</u>` / `<color=…>…</color>` / combined) |
 | `*italic*` | `<i>…</i>` |
 | `~~strike~~` | `<s>…</s>` |
 | `` `code` `` | `<mark=CodeBackground><font="CodeFont">…</font></mark>` |

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -313,6 +313,7 @@ md.Style = MarkdownStyle.CreateDefault();
 md.Style.BodySize = 18;                          // base font size for ALL text (body + headings). XML attr: fontSize=
 md.Style.HeadingScales = new float[] { 2.5f, 2f, 1.75f, 1.5f, 1.25f, 1f };  // per-level h1..h6 transform scale over BodySize — headings magnify via localScale (font stays native size → pixel-font-crisp). Integer scales = pixel-perfect.
 md.Style.BodyColor = "primary";                 // base text color for all body text (paragraphs/headings/lists/…); "" = default ink. Links keep LinkColor
+md.Style.BoldStyle = "underline accent";        // how **bold** + headings + table headers render (XML: boldStyle=). Space-separated: keywords bold/underline/italic/strikethrough/none + one color (token/hex/CSS/alpha). Default "bold" → TMP <b> (faux-bold; ugly on pixel fonts). "none" → strip
 md.Style.Padding = 2;                            // px inset of content within the scroll viewport (XML: padding=); default 2 keeps outlined fonts from clipping. 0 = flush
 
 // Per-control image resolver (null falls back to UI.Markdown.ImageResolver)

--- a/Runtime/Controls/Markdown.cs
+++ b/Runtime/Controls/Markdown.cs
@@ -105,6 +105,17 @@ namespace PromptUGUI.Controls
         }
 
         [UIAttr, Preserve]
+        public string BoldStyle
+        {
+            set
+            {
+                if (string.IsNullOrEmpty(value) || value == Style.BoldStyle) return;
+                Style.BoldStyle = value;
+                MarkDirty();
+            }
+        }
+
+        [UIAttr, Preserve]
         public float FontSize
         {
             set

--- a/Runtime/MarkdigBackend/MarkdigRenderer.cs
+++ b/Runtime/MarkdigBackend/MarkdigRenderer.cs
@@ -20,12 +20,16 @@ namespace PromptUGUI.MarkdigBackend
         private List<ImageRequest> _images;
         // Sequence counter for generated block-image node ids; consumed when image blocks are rendered.
         private int _imageSeq;
+        // Bold wrapper open/close tags, recomputed once per Render from _style.BoldStyle.
+        private string _boldOpen = "<b>";
+        private string _boldClose = "</b>";
 
         public MarkdownRenderResult Render(string markdown, MarkdownStyle style)
         {
             _style = style ?? MarkdownStyle.CreateDefault();
             _images = new List<ImageRequest>();
             _imageSeq = 0;
+            ComputeBoldWrap();
 
             var root = NewVStack(_style.BlockSpacing);
             root.Attributes["anchor"] = "top-stretch";
@@ -103,10 +107,20 @@ namespace PromptUGUI.MarkdigBackend
                     break;
                 case EmphasisInline em:
                     {
-                        string tag = em.DelimiterChar == '~' ? "s" : (em.DelimiterCount >= 2 ? "b" : "i");
-                        sb.Append('<').Append(tag).Append('>');
-                        foreach (var child in em) AppendInline(sb, child);
-                        sb.Append("</").Append(tag).Append('>');
+                        bool isBold = em.DelimiterChar != '~' && em.DelimiterCount >= 2;
+                        if (isBold)
+                        {
+                            sb.Append(_boldOpen);
+                            foreach (var child in em) AppendInline(sb, child);
+                            sb.Append(_boldClose);
+                        }
+                        else
+                        {
+                            string tag = em.DelimiterChar == '~' ? "s" : "i";
+                            sb.Append('<').Append(tag).Append('>');
+                            foreach (var child in em) AppendInline(sb, child);
+                            sb.Append("</").Append(tag).Append('>');
+                        }
                         break;
                     }
                 case LineBreakInline _:
@@ -155,9 +169,44 @@ namespace PromptUGUI.MarkdigBackend
             // Inline <color=LinkColor> spans still override it per-link. Empty -> no color= -> the node
             // inherits ProceduralBuilders.DefaultLabelColor (the library-wide default ink color).
             if (!string.IsNullOrEmpty(_style.BodyColor)) n.Attributes["color"] = _style.BodyColor;
-            n.TextContent = bold ? $"<b>{richText}</b>" : richText;
+            n.TextContent = bold ? WrapBold(richText) : richText;
             return n;
         }
+
+        // Parse _style.BoldStyle (space-separated keyword/color tokens) into an open/close tag pair.
+        private void ComputeBoldWrap()
+        {
+            var spec = string.IsNullOrWhiteSpace(_style.BoldStyle) ? "bold" : _style.BoldStyle;
+            var open = new StringBuilder();
+            var close = new StringBuilder();
+            foreach (var tok in spec.Split(new[] { ' ', '\t', '\n', '\r' },
+                                           System.StringSplitOptions.RemoveEmptyEntries))
+            {
+                switch (tok.ToLowerInvariant())
+                {
+                    case "none":
+                        _boldOpen = ""; _boldClose = "";
+                        return;
+                    case "bold":
+                        open.Append("<b>"); close.Insert(0, "</b>"); break;
+                    case "italic":
+                        open.Append("<i>"); close.Insert(0, "</i>"); break;
+                    case "underline":
+                        open.Append("<u>"); close.Insert(0, "</u>"); break;
+                    case "strikethrough":
+                    case "strike":
+                        open.Append("<s>"); close.Insert(0, "</s>"); break;
+                    default:
+                        // Unknown token: ignored here. Color-token handling added in Task 3.
+                        break;
+                }
+            }
+            _boldOpen = open.ToString();
+            _boldClose = close.ToString();
+        }
+
+        private string WrapBold(string inner) =>
+            _boldOpen.Length == 0 ? inner : _boldOpen + inner + _boldClose;
 
         private ElementNode RenderList(ListBlock list, int depth)
         {

--- a/Runtime/MarkdigBackend/MarkdigRenderer.cs
+++ b/Runtime/MarkdigBackend/MarkdigRenderer.cs
@@ -197,7 +197,20 @@ namespace PromptUGUI.MarkdigBackend
                     case "strike":
                         open.Append("<s>"); close.Insert(0, "</s>"); break;
                     default:
-                        // Unknown token: ignored here. Color-token handling added in Task 3.
+                        // Treat as a single solid color via the standard pipeline (theme token /
+                        // hex / CSS name / "/alpha"). try/catch so a typo'd token warns + is skipped
+                        // rather than throwing out of Render (UI.Theme.Resolve throws on unknown/gradient).
+                        try
+                        {
+                            var hex = ToHex(tok);
+                            open.Append("<color=").Append(hex).Append('>');
+                            close.Insert(0, "</color>");
+                        }
+                        catch (System.Exception e)
+                        {
+                            Debug.LogWarning($"<Markdown> boldStyle token '{tok}' is not a known keyword " +
+                                $"or resolvable color; ignored. ({e.Message})");
+                        }
                         break;
                 }
             }

--- a/Runtime/Markdown/MarkdownStyle.cs
+++ b/Runtime/Markdown/MarkdownStyle.cs
@@ -13,6 +13,11 @@ namespace PromptUGUI
         public string CodeFont = "default";
         public string LinkColor = "#4EA1FF";
         public string BodyColor = "";   // empty = inherit ProceduralBuilders.DefaultLabelColor (body text gets no color=)
+        // How **bold** (and headings / table headers) render. Space-separated tokens: style keywords
+        // {bold, underline, italic, strikethrough, none} + at most one color value (theme token / hex /
+        // CSS name / "/alpha" suffix). Combinable, e.g. "underline #ffcc00". Default "bold" → TMP <b>
+        // (unchanged). "none" → strip. A color token → <color=…>. Parsed by MarkdigRenderer.ComputeBoldWrap.
+        public string BoldStyle = "bold";
         public string CodeBackground = "#00000020";
         public string QuoteBarColor = "#888888";
         public float BlockSpacing = 8f;

--- a/Tests/EditMode/Controls/MarkdownControlTests.cs
+++ b/Tests/EditMode/Controls/MarkdownControlTests.cs
@@ -98,6 +98,17 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.IsTrue(scroll.vertical);
             Assert.IsNotNull(md.GameObject.transform.Find("Viewport"));
         }
+
+        [Test]
+        public void BoldStyle_attribute_flows_to_style()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='B'><Markdown id='md' anchor='stretch' boldStyle='underline #ffcc00'/></Screen></PromptUGUI>";
+            UI.LoadDocument("b", xml);
+            var screen = UI.Open("B");
+            var md = screen.Get<Markdown>("md");
+            Assert.AreEqual("underline #ffcc00", md.Style.BoldStyle);
+        }
     }
 
     // Shared fake renderer + tree builders for Phase A control tests.

--- a/Tests/EditMode/Controls/MarkdownControlTests.cs
+++ b/Tests/EditMode/Controls/MarkdownControlTests.cs
@@ -36,6 +36,12 @@ namespace PromptUGUI.Tests.EditMode.Controls
             b.HeadingScales[0] = 999f;
             Assert.AreNotEqual(999f, a.HeadingScales[0]);
         }
+
+        [Test]
+        public void CreateDefault_boldStyle_is_bold()
+        {
+            Assert.AreEqual("bold", MarkdownStyle.CreateDefault().BoldStyle);
+        }
     }
 
     public class UIMarkdownFacadeTests

--- a/Tests/EditMode/Markdown/MarkdigRendererTests.cs
+++ b/Tests/EditMode/Markdown/MarkdigRendererTests.cs
@@ -10,6 +10,13 @@ namespace PromptUGUI.Tests.Markdown
         private static ElementNode Render(string md)
             => new MarkdigRenderer().Render(md, MarkdownStyle.CreateDefault()).Root;
 
+        private static ElementNode Render(string md, string boldStyle)
+        {
+            var style = MarkdownStyle.CreateDefault();
+            style.BoldStyle = boldStyle;
+            return new MarkdigRenderer().Render(md, style).Root;
+        }
+
         // depth-first find first node with tag whose TextContent contains `needle`
         private static ElementNode Find(ElementNode n, string tag, string needle)
         {
@@ -180,6 +187,54 @@ namespace PromptUGUI.Tests.Markdown
             style.Padding = 8;
             var root = new MarkdigRenderer().Render("hi", style).Root;
             Assert.AreEqual("8", root.Attributes["padding"]);
+        }
+
+        [Test]
+        public void BoldStyle_default_still_wraps_bold()
+        {
+            var root = Render("**x**", "bold");
+            Assert.GreaterOrEqual(Count(root, n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<b>")), 1);
+        }
+
+        [Test]
+        public void BoldStyle_underline_uses_u_not_b()
+        {
+            var root = Render("**x**", "underline");
+            Assert.GreaterOrEqual(Count(root, n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<u>")), 1);
+            Assert.AreEqual(0, Count(root, n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<b>")));
+        }
+
+        [Test]
+        public void BoldStyle_none_strips_bold()
+        {
+            var root = Render("**x**", "none");
+            Assert.AreEqual(0, Count(root, n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<b>")));
+            Assert.AreEqual(0, Count(root, n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<u>")));
+        }
+
+        [Test]
+        public void BoldStyle_two_keywords_nest_in_order()
+        {
+            var t = Find(Render("**x**", "bold underline"), "Text", "<b>");
+            Assert.IsNotNull(t);
+            StringAssert.Contains("<b><u>x</u></b>", t.TextContent);   // open in order, close reversed
+        }
+
+        [Test]
+        public void BoldStyle_applies_to_headings()
+        {
+            var root = Render("# Title", "underline");
+            Assert.GreaterOrEqual(Count(root, n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<u>")), 1);
+            Assert.AreEqual(0, Count(root, n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<b>")));
+        }
+
+        [Test]
+        public void BoldStyle_applies_to_table_headers()
+        {
+            // header row is bold by default; "none" must strip it
+            const string md = "| a | b |\n|---|---|\n| 1 | 2 |";
+            Assert.GreaterOrEqual(Count(Render(md, "bold"), n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<b>")), 1);
+            Assert.AreEqual(0, Count(Render(md, "none"), n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<b>")));
         }
     }
 

--- a/Tests/EditMode/Markdown/MarkdigRendererTests.cs
+++ b/Tests/EditMode/Markdown/MarkdigRendererTests.cs
@@ -236,6 +236,42 @@ namespace PromptUGUI.Tests.Markdown
             Assert.GreaterOrEqual(Count(Render(md, "bold"), n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<b>")), 1);
             Assert.AreEqual(0, Count(Render(md, "none"), n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<b>")));
         }
+
+        [Test]
+        public void BoldStyle_color_hex_emits_color_tag()
+        {
+            var t = Find(Render("**x**", "#ffcc00"), "Text", "<color=");
+            Assert.IsNotNull(t);
+            StringAssert.Contains("<color=#FFCC00FF>", t.TextContent);   // ToHex uppercases, appends FF alpha
+            StringAssert.DoesNotContain("<b>", t.TextContent);
+        }
+
+        [Test]
+        public void BoldStyle_color_alpha_suffix_replaces_alpha()
+        {
+            var t = Find(Render("**x**", "#ff0000/0.4"), "Text", "<color=");
+            Assert.IsNotNull(t);
+            StringAssert.Contains("<color=#FF000066>", t.TextContent);   // 0.4*255 = 102 = 0x66
+        }
+
+        [Test]
+        public void BoldStyle_underline_plus_color_nests()
+        {
+            var t = Find(Render("**x**", "underline #ffcc00"), "Text", "<u>");
+            Assert.IsNotNull(t);
+            StringAssert.Contains("<u><color=#FFCC00FF>x</color></u>", t.TextContent);
+        }
+
+        [Test]
+        public void BoldStyle_invalid_token_does_not_throw_and_renders_plain()
+        {
+            // 'bogus' is neither a keyword nor a resolvable color. Render must NOT throw (the try/catch
+            // in the color branch swallows UI.Theme.Resolve's exception) and must still emit the text.
+            Assert.DoesNotThrow(() => Render("**x**", "bogus"));
+            var t = Find(Render("**x**", "bogus"), "Text", "x");
+            Assert.IsNotNull(t);
+            StringAssert.DoesNotContain("<b>", t.TextContent);
+        }
     }
 
     public class MarkdigRendererBlockTests

--- a/docs~/superpowers/plans/2026-06-16-markdown-bold-style.md
+++ b/docs~/superpowers/plans/2026-06-16-markdown-bold-style.md
@@ -1,0 +1,589 @@
+# Markdown `boldStyle` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `boldStyle` attribute to `<Markdown>` that redirects how "bold" (inline `**bold**`, headings, and table headers) renders — replacing the hardcoded TMP `<b>` with a configurable, combinable mix of style keywords + a color (so pixel fonts can use underline / a color instead of ugly faux-bold).
+
+**Architecture:** One new string field `MarkdownStyle.BoldStyle` (default `"bold"`, backward-compatible). `MarkdigRenderer` parses it once per `Render` into an open/close tag pair (`ComputeBoldWrap`) and wraps the three faux-bold sites through a `WrapBold` helper. The XML `boldStyle` attribute maps to the field via a `[UIAttr]` setter on the `Markdown` control. Color tokens resolve through the existing `UI.Theme.Resolve` chokepoint (theme token / hex / CSS name / `/alpha` suffix), wrapped in try/catch so a bad token never breaks rendering.
+
+**Tech Stack:** Unity 6 / C# 9, Markdig (gated behind `PROMPTUGUI_HAS_MARKDIG`), R3, NUnit (UnityMCP test runner), `dotnet format` lint.
+
+**Spec:** [`docs~/superpowers/specs/2026-06-16-markdown-bold-style-design.md`](../specs/2026-06-16-markdown-bold-style-design.md)
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `Runtime/Markdown/MarkdownStyle.cs` | Modify | Add `public string BoldStyle = "bold";` field |
+| `Runtime/MarkdigBackend/MarkdigRenderer.cs` | Modify | `ComputeBoldWrap()` + `WrapBold()`; route the 3 faux-bold sites through it (gated `PROMPTUGUI_HAS_MARKDIG` asmdef) |
+| `Runtime/Controls/Markdown.cs` | Modify | `[UIAttr] BoldStyle` setter → `Style.BoldStyle` + `MarkDirty()` |
+| `Tests/EditMode/Controls/MarkdownControlTests.cs` | Modify | Field default test (`MarkdownStyleTests`) + attribute-flow test (`MarkdownControlScaffoldTests`) — regular EditMode asmdef, no Markdig needed |
+| `Tests/EditMode/Markdown/MarkdigRendererTests.cs` | Modify | Renderer behavior tests — gated `PromptUGUI.Tests.EditMode.Markdown` asmdef |
+| `.claude/skills/authoring-promptugui-xml/reference/controls-markdown.md` | Modify | `boldStyle` attribute row + inline/block mapping notes |
+| `.claude/skills/scripting-promptugui-csharp/SKILL.md` | Modify | `MarkdownStyle.BoldStyle` in the style example block |
+
+**Test-runner note (every "Run" step):** Tests run through UnityMCP, not a shell. The canonical sequence after a source edit:
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])           # confirm 0 compile errors first
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=[...], group_names=[...])   # returns job_id
+mcp__UnityMCP__get_test_job(job_id=...)                              # poll until done; read pass/fail
+```
+
+`group_names` filters to a test class. The two relevant assemblies: `PromptUGUI.Tests.EditMode` (field + control tests) and `PromptUGUI.Tests.EditMode.Markdown` (renderer tests, requires `PROMPTUGUI_HAS_MARKDIG`).
+
+---
+
+## Task 1: `MarkdownStyle.BoldStyle` field
+
+**Files:**
+- Modify: `Runtime/Markdown/MarkdownStyle.cs`
+- Test: `Tests/EditMode/Controls/MarkdownControlTests.cs` (class `MarkdownStyleTests`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `MarkdownStyleTests` class in `Tests/EditMode/Controls/MarkdownControlTests.cs`:
+
+```csharp
+[Test]
+public void CreateDefault_boldStyle_is_bold()
+{
+    Assert.AreEqual("bold", MarkdownStyle.CreateDefault().BoldStyle);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: compile error `CS1061: 'MarkdownStyle' does not contain a definition for 'BoldStyle'` (field doesn't exist yet).
+
+- [ ] **Step 3: Add the field**
+
+In `Runtime/Markdown/MarkdownStyle.cs`, add the field next to the other string style fields (after `BodyColor`, around line 15):
+
+```csharp
+        public string BodyColor = "";   // empty = inherit ProceduralBuilders.DefaultLabelColor (body text gets no color=)
+        // How **bold** (and headings / table headers) render. Space-separated tokens: style keywords
+        // {bold, underline, italic, strikethrough, none} + at most one color value (theme token / hex /
+        // CSS name / "/alpha" suffix). Combinable, e.g. "underline #ffcc00". Default "bold" → TMP <b>
+        // (unchanged). "none" → strip. A color token → <color=…>. Parsed by MarkdigRenderer.ComputeBoldWrap.
+        public string BoldStyle = "bold";
+```
+
+`Clone()` uses `MemberwiseClone()`, which copies the string reference — strings are immutable, so no extra clone handling is needed.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["MarkdownStyleTests"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: PASS (all `MarkdownStyleTests`, including the existing 3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Markdown/MarkdownStyle.cs Tests/EditMode/Controls/MarkdownControlTests.cs
+git commit -m "feat: add MarkdownStyle.BoldStyle field (default bold)"
+```
+
+---
+
+## Task 2: Renderer keyword wrapping (`ComputeBoldWrap` / `WrapBold` + 3 sites)
+
+Implements the style-keyword tokens (`bold`/`underline`/`italic`/`strikethrough`/`none`) and routes all three faux-bold sites through `WrapBold`. Color tokens are **not** handled yet (unknown tokens are ignored here; Task 3 adds color).
+
+**Files:**
+- Modify: `Runtime/MarkdigBackend/MarkdigRenderer.cs`
+- Test: `Tests/EditMode/Markdown/MarkdigRendererTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `MarkdigRendererTests` in `Tests/EditMode/Markdown/MarkdigRendererTests.cs`. First add a style-aware render helper next to the existing `Render(string md)` (around line 11):
+
+```csharp
+        private static ElementNode Render(string md, string boldStyle)
+        {
+            var style = MarkdownStyle.CreateDefault();
+            style.BoldStyle = boldStyle;
+            return new MarkdigRenderer().Render(md, style).Root;
+        }
+```
+
+Then add the tests (the `Count` helper already exists in this file):
+
+```csharp
+        [Test]
+        public void BoldStyle_default_still_wraps_bold()
+        {
+            var root = Render("**x**", "bold");
+            Assert.GreaterOrEqual(Count(root, n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<b>")), 1);
+        }
+
+        [Test]
+        public void BoldStyle_underline_uses_u_not_b()
+        {
+            var root = Render("**x**", "underline");
+            Assert.GreaterOrEqual(Count(root, n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<u>")), 1);
+            Assert.AreEqual(0, Count(root, n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<b>")));
+        }
+
+        [Test]
+        public void BoldStyle_none_strips_bold()
+        {
+            var root = Render("**x**", "none");
+            Assert.AreEqual(0, Count(root, n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<b>")));
+            Assert.AreEqual(0, Count(root, n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<u>")));
+        }
+
+        [Test]
+        public void BoldStyle_two_keywords_nest_in_order()
+        {
+            var t = Find(Render("**x**", "bold underline"), "Text", "<b>");
+            Assert.IsNotNull(t);
+            StringAssert.Contains("<b><u>x</u></b>", t.TextContent);   // open in order, close reversed
+        }
+
+        [Test]
+        public void BoldStyle_applies_to_headings()
+        {
+            var root = Render("# Title", "underline");
+            Assert.GreaterOrEqual(Count(root, n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<u>")), 1);
+            Assert.AreEqual(0, Count(root, n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<b>")));
+        }
+
+        [Test]
+        public void BoldStyle_applies_to_table_headers()
+        {
+            // header row is bold by default; "none" must strip it
+            const string md = "| a | b |\n|---|---|\n| 1 | 2 |";
+            Assert.GreaterOrEqual(Count(Render(md, "bold"), n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<b>")), 1);
+            Assert.AreEqual(0, Count(Render(md, "none"), n => n.Tag == "Text" && n.TextContent != null && n.TextContent.Contains("<b>")));
+        }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode.Markdown"], group_names=["MarkdigRendererTests"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: the new keyword tests FAIL (current renderer always emits `<b>`; `underline`/`none` produce no `<u>` / still `<b>`). `BoldStyle_default_still_wraps_bold` passes already.
+
+- [ ] **Step 3: Add `ComputeBoldWrap` + `WrapBold` and the per-render fields**
+
+In `Runtime/MarkdigBackend/MarkdigRenderer.cs`, add two fields next to `_imageSeq` (after line 22):
+
+```csharp
+        // Bold wrapper open/close tags, recomputed once per Render from _style.BoldStyle.
+        private string _boldOpen = "<b>";
+        private string _boldClose = "</b>";
+```
+
+Add these two methods (e.g. just after `NewText`, around line 160):
+
+```csharp
+        // Parse _style.BoldStyle (space-separated keyword/color tokens) into an open/close tag pair.
+        private void ComputeBoldWrap()
+        {
+            var spec = string.IsNullOrWhiteSpace(_style.BoldStyle) ? "bold" : _style.BoldStyle;
+            var open = new StringBuilder();
+            var close = new StringBuilder();
+            foreach (var tok in spec.Split(new[] { ' ', '\t', '\n', '\r' },
+                                           System.StringSplitOptions.RemoveEmptyEntries))
+            {
+                switch (tok.ToLowerInvariant())
+                {
+                    case "none":
+                        _boldOpen = ""; _boldClose = "";
+                        return;
+                    case "bold":
+                        open.Append("<b>"); close.Insert(0, "</b>"); break;
+                    case "italic":
+                        open.Append("<i>"); close.Insert(0, "</i>"); break;
+                    case "underline":
+                        open.Append("<u>"); close.Insert(0, "</u>"); break;
+                    case "strikethrough":
+                    case "strike":
+                        open.Append("<s>"); close.Insert(0, "</s>"); break;
+                    default:
+                        // Unknown token: ignored here. Color-token handling added in Task 3.
+                        break;
+                }
+            }
+            _boldOpen = open.ToString();
+            _boldClose = close.ToString();
+        }
+
+        private string WrapBold(string inner) =>
+            _boldOpen.Length == 0 ? inner : _boldOpen + inner + _boldClose;
+```
+
+- [ ] **Step 4: Call `ComputeBoldWrap` in `Render` and route the 3 sites**
+
+In `Render(...)`, after `_imageSeq = 0;` (line 28), add:
+
+```csharp
+            ComputeBoldWrap();
+```
+
+In `NewText` (line 158), change:
+
+```csharp
+            n.TextContent = bold ? $"<b>{richText}</b>" : richText;
+```
+to:
+```csharp
+            n.TextContent = bold ? WrapBold(richText) : richText;
+```
+(this covers **both** headings and table headers — both build their `<Text>` via `NewText`.)
+
+In `AppendInline`, replace the `EmphasisInline` case (lines 104–111) with:
+
+```csharp
+                case EmphasisInline em:
+                    {
+                        bool isBold = em.DelimiterChar != '~' && em.DelimiterCount >= 2;
+                        if (isBold)
+                        {
+                            sb.Append(_boldOpen);
+                            foreach (var child in em) AppendInline(sb, child);
+                            sb.Append(_boldClose);
+                        }
+                        else
+                        {
+                            string tag = em.DelimiterChar == '~' ? "s" : "i";
+                            sb.Append('<').Append(tag).Append('>');
+                            foreach (var child in em) AppendInline(sb, child);
+                            sb.Append("</").Append(tag).Append('>');
+                        }
+                        break;
+                    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode.Markdown"], group_names=["MarkdigRendererTests"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: PASS — all new keyword tests **and** the pre-existing ones (`Heading_becomes_bold_text`, `Paragraph_inline_maps_to_tmp_tags_and_escapes` stay green because default `BoldStyle="bold"` still yields `<b>`, and italic `<i>` / strike `<s>` are untouched).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Runtime/MarkdigBackend/MarkdigRenderer.cs Tests/EditMode/Markdown/MarkdigRendererTests.cs
+git commit -m "feat: Markdown boldStyle keyword wrapping (bold/underline/italic/strike/none)"
+```
+
+---
+
+## Task 3: Color token + alpha in `boldStyle`
+
+Fills in the `default:` branch of `ComputeBoldWrap` so a non-keyword token resolves as a single solid color via the standard pipeline, wrapped in try/catch so an invalid token warns-and-skips instead of throwing.
+
+**Files:**
+- Modify: `Runtime/MarkdigBackend/MarkdigRenderer.cs`
+- Test: `Tests/EditMode/Markdown/MarkdigRendererTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `MarkdigRendererTests`:
+
+```csharp
+        [Test]
+        public void BoldStyle_color_hex_emits_color_tag()
+        {
+            var t = Find(Render("**x**", "#ffcc00"), "Text", "<color=");
+            Assert.IsNotNull(t);
+            StringAssert.Contains("<color=#FFCC00FF>", t.TextContent);   // ToHex uppercases, appends FF alpha
+            StringAssert.DoesNotContain("<b>", t.TextContent);
+        }
+
+        [Test]
+        public void BoldStyle_color_alpha_suffix_replaces_alpha()
+        {
+            var t = Find(Render("**x**", "#ff0000/0.4"), "Text", "<color=");
+            Assert.IsNotNull(t);
+            StringAssert.Contains("<color=#FF000066>", t.TextContent);   // 0.4*255 = 102 = 0x66
+        }
+
+        [Test]
+        public void BoldStyle_underline_plus_color_nests()
+        {
+            var t = Find(Render("**x**", "underline #ffcc00"), "Text", "<u>");
+            Assert.IsNotNull(t);
+            StringAssert.Contains("<u><color=#FFCC00FF>x</color></u>", t.TextContent);
+        }
+
+        [Test]
+        public void BoldStyle_invalid_token_does_not_throw_and_renders_plain()
+        {
+            // 'bogus' is neither a keyword nor a resolvable color. Render must NOT throw (the try/catch
+            // in the color branch swallows UI.Theme.Resolve's exception) and must still emit the text.
+            Assert.DoesNotThrow(() => Render("**x**", "bogus"));
+            var t = Find(Render("**x**", "bogus"), "Text", "x");
+            Assert.IsNotNull(t);
+            StringAssert.DoesNotContain("<b>", t.TextContent);
+        }
+```
+
+(No new `using` needed — these tests use only NUnit + the existing `Render`/`Find`/`Count` helpers.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode.Markdown"], group_names=["MarkdigRendererTests"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: the 3 color tests (`..._color_hex_...`, `..._color_alpha_...`, `..._underline_plus_color_...`) FAIL — Task 2's `default:` branch ignores color tokens, so no `<color=>` is emitted. The invalid-token guard already passes (Task 2 ignores unknown → plain text, no throw) and stays green; it guards the try/catch you add in Step 3 (without it, the color code below would throw on `'bogus'`).
+
+- [ ] **Step 3: Implement color resolution in the `default:` branch**
+
+In `ComputeBoldWrap`, replace the `default:` branch:
+
+```csharp
+                    default:
+                        // Unknown token: ignored here. Color-token handling added in Task 3.
+                        break;
+```
+with:
+```csharp
+                    default:
+                        // Treat as a single solid color via the standard pipeline (theme token /
+                        // hex / CSS name / "/alpha"). try/catch so a typo'd token warns + is skipped
+                        // rather than throwing out of Render (UI.Theme.Resolve throws on unknown/gradient).
+                        try
+                        {
+                            var hex = ToHex(tok);
+                            open.Append("<color=").Append(hex).Append('>');
+                            close.Insert(0, "</color>");
+                        }
+                        catch (System.Exception e)
+                        {
+                            Debug.LogWarning($"<Markdown> boldStyle token '{tok}' is not a known keyword " +
+                                $"or resolvable color; ignored. ({e.Message})");
+                        }
+                        break;
+```
+
+`ToHex` already exists in this file (`"#" + ColorUtility.ToHtmlStringRGBA(UI.Theme.Resolve(token))`) and handles the full token/hex/CSS/alpha pipeline.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode.Markdown"], group_names=["MarkdigRendererTests"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: PASS — all color tests plus everything from Task 2.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/MarkdigBackend/MarkdigRenderer.cs Tests/EditMode/Markdown/MarkdigRendererTests.cs
+git commit -m "feat: Markdown boldStyle color tokens (+alpha, invalid-token tolerant)"
+```
+
+---
+
+## Task 4: XML `boldStyle` attribute on the `Markdown` control
+
+**Files:**
+- Modify: `Runtime/Controls/Markdown.cs`
+- Test: `Tests/EditMode/Controls/MarkdownControlTests.cs` (class `MarkdownControlScaffoldTests`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `MarkdownControlScaffoldTests` in `Tests/EditMode/Controls/MarkdownControlTests.cs` (this class has `UI.ResetForTests()` in SetUp/TearDown already; the test exercises only attribute application, so it does **not** need Markdig):
+
+```csharp
+        [Test]
+        public void BoldStyle_attribute_flows_to_style()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='B'><Markdown id='md' anchor='stretch' boldStyle='underline #ffcc00'/></Screen></PromptUGUI>";
+            UI.LoadDocument("b", xml);
+            var screen = UI.Open("B");
+            var md = screen.Get<Markdown>("md");
+            Assert.AreEqual("underline #ffcc00", md.Style.BoldStyle);
+        }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["MarkdownControlScaffoldTests"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: FAIL — `boldStyle` is an unknown attribute, so it's never applied; `md.Style.BoldStyle` stays `"bold"`, assert mismatch (`Expected "underline #ffcc00" but was "bold"`).
+
+- [ ] **Step 3: Add the `[UIAttr]` setter**
+
+In `Runtime/Controls/Markdown.cs`, add after the `BodyColor` property (after line 105), mirroring the existing string setters (empty string → skip, same as `BodyFont`/`LinkColor`):
+
+```csharp
+        [UIAttr, Preserve]
+        public string BoldStyle
+        {
+            set
+            {
+                if (string.IsNullOrEmpty(value) || value == Style.BoldStyle) return;
+                Style.BoldStyle = value;
+                MarkDirty();
+            }
+        }
+```
+
+`[UIAttr]` with no explicit name derives the attribute name from the property → `boldStyle`. It is **not** `IsColor` — the value is a keyword+color combination string, not a pure color.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["MarkdownControlScaffoldTests"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Runtime/Controls/Markdown.cs Tests/EditMode/Controls/MarkdownControlTests.cs
+git commit -m "feat: <Markdown boldStyle> XML attribute"
+```
+
+---
+
+## Task 5: Documentation (XML reference + C# SKILL)
+
+Per CLAUDE.md, a new XML attribute + public C# field requires SKILL updates in the same PR.
+
+**Files:**
+- Modify: `.claude/skills/authoring-promptugui-xml/reference/controls-markdown.md`
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md`
+
+- [ ] **Step 1: Add the `boldStyle` row to the XML attribute table**
+
+In `controls-markdown.md`, in the `## Attributes` table (after the `wrap` row, line 78), add:
+
+```markdown
+| `boldStyle` | space-separated tokens | `bold` | How **bold** renders — governs inline `**bold**`, **headings**, and **table headers** (the three places that otherwise emit TMP `<b>`). Tokens combine: style keywords `bold` / `underline` / `italic` / `strikethrough` (and `none` = strip), plus at most one color value (theme token / hex / CSS name / `/alpha` suffix). E.g. `boldStyle="underline #ffcc00"` → underline + gold; `boldStyle="none"` → plain (headings still magnify via `scale`). Default `bold` = TMP `<b>` (faux-bold — looks poor on pixel fonts, hence this attribute). Maps to `MarkdownStyle.BoldStyle`. |
+```
+
+- [ ] **Step 2: Update the inline + block mapping notes**
+
+In the "Inline → TMP rich-text mapping" table, change the `**bold**` row (line 141) from:
+
+```markdown
+| `**bold**` | `<b>…</b>` |
+```
+to:
+```markdown
+| `**bold**` | `boldStyle` wrap (default `<b>…</b>`; e.g. `<u>…</u>` / `<color=…>…</color>` / combined) |
+```
+
+In the "Block → control mapping" table, update the Heading row (line 122) — append to its Notes cell: ` Bold wrap governed by \`boldStyle\` (default \`<b>\`).` And the GFM table row (line 131) — change `Header row is bold;` to `Header row uses the \`boldStyle\` wrap (default bold);`.
+
+- [ ] **Step 3: Add `BoldStyle` to the C# SKILL style example**
+
+In `scripting-promptugui-csharp/SKILL.md`, in the per-control style block, after the `md.Style.BodyColor` line (line 315), add:
+
+```csharp
+md.Style.BoldStyle = "underline accent";        // how **bold** + headings + table headers render (XML: boldStyle=). Space-separated: keywords bold/underline/italic/strikethrough/none + one color (token/hex/CSS/alpha). Default "bold" → TMP <b> (faux-bold; ugly on pixel fonts). "none" → strip
+```
+
+- [ ] **Step 4: Verify the docs (no test; visual read)**
+
+Re-read the edited table rows to confirm no broken Markdown table syntax (pipe counts match the header) and the wording matches the implemented behavior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/skills/authoring-promptugui-xml/reference/controls-markdown.md .claude/skills/scripting-promptugui-csharp/SKILL.md
+git commit -m "docs: document <Markdown boldStyle> in XML + C# skills"
+```
+
+---
+
+## Task 6: Full verification & finalize
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Lint**
+
+From the repo root:
+
+```bash
+cd .lint && dotnet restore PromptUGUI.Lint.slnx
+dotnet format whitespace PromptUGUI.Lint.slnx
+dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+Expected: no changes / no warnings. (Do **not** run `dotnet format analyzers --severity info` — see CLAUDE.md.) If `dotnet format whitespace` reports object-initializer or trailing-whitespace fixes, re-stage and amend the relevant commit.
+
+- [ ] **Step 2: Full EditMode suite (both assemblies)**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__get_test_job(job_id=...)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode.Markdown"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: 0 failures in both. (Don't trust per-group runs alone — run the whole assemblies. Pre-existing renderer tests `Heading_becomes_bold_text` / `Paragraph_inline_maps_to_tmp_tags_and_escapes` must remain green.)
+
+- [ ] **Step 3: PlayMode suite (Markdown touch-point)**
+
+```
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: 0 failures. (`MarkdownWebImageTests` etc. unaffected — sanity check only.)
+
+- [ ] **Step 4: Confirm clean tree & branch**
+
+```bash
+git status --short          # expect clean
+git log --oneline -7        # the 5 feature commits + spec, all on feat/markdown-bold-style
+git branch --show-current   # feat/markdown-bold-style (NOT main)
+```
+
+- [ ] **Step 5: Hand back for visual QA**
+
+Report the green test counts and lint status. Do not merge to `main` (CLAUDE.md: never commit to main). Surface the branch for the user's visual QA / PR decision.
+
+---
+
+## Self-Review
+
+**1. Spec coverage** — every spec section maps to a task:
+- §2 接口 (XML attr + C# field) → Task 1 (field), Task 4 (XML attr).
+- §3 取值语法 (keywords, color, combination, default, `none`, separator) → Task 2 (keywords + default + combo + none), Task 3 (color + alpha + invalid).
+- §4 作用范围 (inline + heading + table-header) → Task 2 (all 3 sites routed via `WrapBold`/`NewText`; heading + table tests).
+- §5 实现 (ComputeBoldWrap/WrapBold, per-render parse, 3 sites, try/catch) → Task 2 + Task 3.
+- §6 测试 → Tasks 2–4 (default, underline, combo, none, color, alpha, heading, table, invalid, attr-flow).
+- §7 文档 → Task 5.
+- §8 决策 — D1/D3 (default bold) Task 1+2; D2 (3 sites) Task 2; D4 (space sep, single color) Task 3 split logic; D5 (`none` independent → early return) Task 2; D6 (italic untouched) verified by keeping the `else` branch in Task 2's `EmphasisInline`.
+
+**2. Placeholder scan** — no TBD/TODO; every code step shows full code; run steps give exact MCP calls + expected result. The one `job_id=...` is a runtime value the executor fills from the prior `run_tests` return, not a plan placeholder.
+
+**3. Type/name consistency** — `MarkdownStyle.BoldStyle` (Task 1) used identically in renderer (Task 2/3), control setter (Task 4), tests, docs. `ComputeBoldWrap()` / `WrapBold(string)` / fields `_boldOpen` / `_boldClose` named consistently across Task 2 (declare) and Task 3 (edit `default:` only). `Render(string, string)` test helper added once in Task 2, reused in Task 3. `Count` / `Find` helpers pre-exist in the renderer test file. The `default:`-branch `Debug.LogWarning` is fire-and-forget (no test asserts its text — the invalid-token test only asserts no-throw + plain output, so it stays robust to UI theme state).

--- a/docs~/superpowers/specs/2026-06-16-markdown-bold-style-design.md
+++ b/docs~/superpowers/specs/2026-06-16-markdown-bold-style-design.md
@@ -1,0 +1,139 @@
+# Markdown `boldStyle`:粗体渲染样式（关键字 + 颜色，可组合）
+
+**日期**:2026-06-16
+**状态**:设计阶段(待 review,未进入实施)
+**作用域**:给 `<Markdown>` 控件新增一个 `boldStyle` 属性,让作者控制"粗体"如何渲染 —— 把硬编码的 TMP `<b>` 替换成可配置的标签组合。新增一个作者可写的 XML 属性 + 一个公开 C# 字段(`MarkdownStyle.BoldStyle`);`authoring-promptugui-xml`(reference/controls-markdown.md)与 `scripting-promptugui-csharp` 都必须更新。
+**关联**:建立在 [`2026-06-09-markdown-control-design.md`](2026-06-09-markdown-control-design.md) 的 `<Markdown>` 控件之上;粗体走 scale-放大的标题渲染见该 spec。不改其它控件、不改模态。
+
+---
+
+## 1. 背景与目标
+
+`<Markdown>` 当前在三处把内容包进 TMP 的 `<b>…</b>`:
+
+1. 行内 `**bold**` / `__bold__`（`MarkdigRenderer.AppendInline` 的 `EmphasisInline` 分支,`DelimiterCount >= 2`）;
+2. 标题 h1–h6（`RenderBlock` 的 `HeadingBlock` 分支 → `NewText(..., bold: true)`）;
+3. GFM 表头单元格（`RenderTable` → `NewText(..., bold: row.IsHeader)`）。
+
+TMP 的 `<b>` 对**没有真粗体字重的字体**（尤其位图/像素字体）只能做**合成描粗**(faux-bold):把字形外扩一圈,像素字体下边缘糊、发虚,非常难看。标题虽然已经靠 `RectTransform.localScale`（`HeadingScales`）放大、字号本身不变(像素清晰),但额外的 `<b>` 仍会把放大后的标题描粗。
+
+**目标**:增加一个属性,让作者把"粗体"重定向成像素字体下更好看的表现 —— 例如下划线、换一个强调色,或者干脆去掉描粗只靠字号/scale 区分。要求**关键字与颜色可任意组合**(下划线 + 颜色同时生效)。
+
+**非目标**:
+- 不动斜体 `*italic*`(仍 `<i>`)与删除线 `~~~~`(仍 `<s>`)。本次只重定向粗体。将来若需要,可对称加 `italicStyle`,实现成本几乎为零(见 MDBS-D6)。
+- 不支持渐变色作为粗体色(行内 `<color>` 标签本就只能单色;且逗号已被渐变语法占用,见 MDBS-D4)。
+
+## 2. 接口
+
+**XML**(`reference/controls-markdown.md` 属性表新增一行):
+
+```xml
+<Markdown id="md" text="..."
+          boldStyle="underline #ffcc00"/>   <!-- 下划线 + 金色 -->
+```
+
+**C#**(`MarkdownStyle` 新增字段):
+
+```csharp
+public sealed class MarkdownStyle
+{
+    // ...
+    /// <summary>How **bold** (and headings / table headers) render. Space-separated tokens:
+    /// style keywords {bold, underline, italic, strikethrough, none} + at most one color value
+    /// (theme token / hex / CSS name / "/alpha" suffix). Combinable, e.g. "underline #ffcc00".
+    /// Default "bold" → TMP &lt;b&gt; (unchanged). "none" → strip. Color → &lt;color=…&gt;.</summary>
+    public string BoldStyle = "bold";
+    // ...
+}
+```
+
+`Markdown` 控件新增 `[UIAttr] BoldStyle` setter（**非** `IsColor` —— 值不只是颜色,而是关键字+颜色的组合串）,设进 `Style.BoldStyle` 后 `MarkDirty()`,与现有 `BodyFont` / `LinkColor` 等 setter 同构。属性名由 `[UIAttr]` 自动从属性名派生为 `boldStyle`。
+
+## 3. 取值语法
+
+值 = 以**空格**分隔的若干 token,逐个识别后**组合嵌套**:
+
+| token（大小写不敏感） | 含义 | 产出标签 |
+|---|---|---|
+| `bold` | 描粗(当前默认行为) | `<b>` |
+| `underline` | 下划线 | `<u>` |
+| `italic` | 斜体 | `<i>` |
+| `strikethrough`（别名 `strike`） | 删除线 | `<s>` |
+| `none` | 去掉一切样式,纯文字 | （无包裹,且忽略其它 token） |
+| 其它任意值 | 当作颜色,走标准颜色管线解析 | `<color=#RRGGBBAA>` |
+
+**颜色解析**复用既有管线（与 `linkColor` / `bodyColor` 同：`UI.Theme.Resolve` → 主题 token 基链 → hex 字面量 → CSS 命名色 → `/alpha` 后缀替换 alpha 分量）。一个 `boldStyle` 串里**至多一个**颜色 token（多写时后者覆盖前者,不报错）。
+
+**组合示例**:
+
+```
+boldStyle 未写 / "bold"     → <b>…</b>                         （默认,向后兼容）
+boldStyle="underline #ffcc00" → <u><color=#ffcc00ff>…</color></u>   （下划线+金色）
+boldStyle="bold accent"      → <b><color=…>…</color></b>          （保留粗体再加主题色）
+boldStyle="#ffcc00"          → <color=#ffcc00ff>…</color>          （只换色,不描粗）
+boldStyle="accent/0.8"       → <color=…>…</color>                 （主题色 + 0.8 alpha）
+boldStyle="none"             → …                                  （纯文字）
+```
+
+**嵌套顺序**:按 token 出现顺序"先开先在外、后开后在内"地嵌套（开标签按序追加,闭标签逆序）。这些 TMP 标签互相独立,嵌套顺序不影响渲染结果,但产出确定、可测。
+
+**边界**:
+- 未写 / 空白串 → 视为 `"bold"`(默认)。控件 setter 对空字符串走"跳过"语义(同其它 setter),`MarkdownStyle.BoldStyle` 字段默认即 `"bold"`。
+- `none` 一旦出现即清空全部包裹并忽略同串其它 token（`none` 与别的 token 混写无意义,以 `none` 为准）。
+- 无法识别又无法解析成颜色的 token：交给颜色管线兜底(与现有 `bodyColor` 行为一致,不额外报错;后续如需要可加 lint,本次不做)。
+
+## 4. 作用范围（MDBS-D2）
+
+`boldStyle` 统一治理上述三处 faux-bold:行内 `**bold**`、标题、表头单元格。标题仍走 `HeadingScales` 的 scale 放大(字号不变),`boldStyle` 只替换它额外的 `<b>` 包裹 —— 即"标题 = scale 放大 + boldStyle 修饰"。
+
+斜体 `*italic*`、删除线 `~~~~`、行内 `[link]`、代码 `` `code` `` 不受影响。注意:若 `boldStyle` 含颜色而粗体片段内又嵌了链接,链接自带的 `<color=LinkColor>` 在内层、TMP 内层颜色胜出,链接颜色不被粗体色覆盖(符合预期)。
+
+## 5. 实现
+
+仅改 `Runtime/MarkdigBackend/MarkdigRenderer.cs`(在 `PROMPTUGUI_HAS_MARKDIG` 门控的 `PromptUGUI.Markdown` asmdef 内)+ `Runtime/Markdown/MarkdownStyle.cs` + `Runtime/Controls/Markdown.cs`。
+
+**MarkdownStyle.cs**:加 `public string BoldStyle = "bold";` 字段(`Clone()` 走 `MemberwiseClone`,string 自动复制,无需额外处理)。
+
+**Markdown.cs**:加 `[UIAttr, Preserve] public string BoldStyle { set { ...; Style.BoldStyle = v; MarkDirty(); } }`,空串跳过,与 `BodyFont` 同构。
+
+**MarkdigRenderer.cs**:
+- 新增两个 per-render 字段 `_boldOpen` / `_boldClose`,在 `Render(...)` 开头(`_style` 赋值后)调用 `ComputeBoldWrap()` 解析一次。
+- `ComputeBoldWrap()`:按空格切 `_style.BoldStyle`,逐 token 追加开标签 / 逆序拼闭标签;遇 `none` 清空两段并返回;非关键字 token 走 `ToHex(tok)`(已存在的颜色 helper)拼 `<color=…>`。
+- 新增 `private string WrapBold(string inner) => _boldOpen.Length == 0 ? inner : _boldOpen + inner + _boldClose;`。
+- 三处替换:
+  - `NewText` 的 `bold ? $"<b>{richText}</b>" : richText` → `bold ? WrapBold(richText) : richText`（标题 + 表头自动覆盖,二者都走 `NewText`）。
+  - `EmphasisInline` 的粗体分支(`DelimiterChar != '~' && DelimiterCount >= 2`)用 `_boldOpen` / `_boldClose` 包裹子内容,替换原 `<b>` / `</b>`;斜体/删除线分支不变。
+
+约 30 行净增。运行时无新分配热路径(每次 Render 只解析一次)。
+
+## 6. 测试（TDD,先红后绿）
+
+测试加在 Markdown 测试程序集(`PROMPTUGUI_HAS_MARKDIG` 门控,与现有 Markdig 渲染测试同处)。直接断言 `MarkdigRenderer.Render(md, style)` 产出 IR 里 `<Text>` 节点的 `TextContent` 子串:
+
+1. `BoldStyle` 默认 → 行内 `**x**` 产出含 `<b>x</b>`(回归,保持现状)。
+2. `BoldStyle="underline"` → 含 `<u>`、不含 `<b>`。
+3. `BoldStyle="underline #ffcc00"` → 同时含 `<u>` 与 `<color=#FFCC00FF>`(组合)。
+4. `BoldStyle="none"` → 既不含 `<b>` 也不含 `<u>`/`<color>`(纯文字)。
+5. 颜色单独：`BoldStyle="#ff0000"` → 含 `<color=#FF0000FF>`、不含 `<b>`。
+6. 主题 token：`BoldStyle="<已注册的主题色名>"` → 解析成对应 hex 的 `<color=…>`。
+7. 标题：`# H` 在 `BoldStyle="underline"` 下,标题 `<Text>` 的 `TextContent` 含 `<u>`、不含 `<b>`。
+8. 表头：GFM 表的表头单元格在 `BoldStyle="none"` 下不含 `<b>`。
+
+(XML→属性的打通路径已由现有 `[UIAttr]` 反射 + `MarkdownStyle` setter 测试模式覆盖;如 Markdown 控件已有 EditMode 属性测试则补一条 `boldStyle` 设值断言。)
+
+## 7. 文档更新（同 PR）
+
+- `reference/controls-markdown.md`:
+  - 属性表新增 `boldStyle` 行(取值/默认/效果)。
+  - "Inline → TMP rich-text mapping" 表的 `**bold**` 行:从写死 `<b>…</b>` 改为说明"受 `boldStyle` 控制(默认 `<b>`)"。
+  - "Block → control mapping" 的 Heading 行与 GFM table 行:标注粗体包裹受 `boldStyle` 控制。
+- `scripting-promptugui-csharp/SKILL.md` 的 `MarkdownStyle` 段:新增 `BoldStyle` 字段说明。
+
+## 8. 决策记录
+
+- **MDBS-D1 单属性、关键字+颜色组合串(空格分隔)**。备选"任意裸 TMP 标签(闭标签按名推导)"被否:对 LLM 作者不友好、颜色用不上主题 token/alpha 后缀、难 lint。关键字集覆盖像素字体的真实诉求(下划线/换色/去描粗),颜色复用全库一致的 token 管线。
+- **MDBS-D2 治理全部三处 faux-bold(行内+标题+表头)**,而非只行内。动机本就是"像素字体下粗体难看",标题/表头同样是粗体重灾区;用户明确点名标题。
+- **MDBS-D3 默认 `"bold"`,向后兼容**。不写属性 = 现状 `<b>`。去描粗用显式 `none`,不让空串承担"去掉"语义(空串=未设,同其它 setter)。
+- **MDBS-D4 分隔符用空格、颜色仅单色**。逗号已被渐变色语法 `#fff,#000` 占用;且行内 `<color>` 标签只能单色,渐变无法表达。颜色 token 内部不含空格(主题名/hex/CSS 名/`/alpha` 后缀皆然),空格切分安全。
+- **MDBS-D5 `none` 独占**。出现即清空、忽略其它 token,语义最不易误解。
+- **MDBS-D6 斜体本次不动**。只重定向粗体;`italicStyle` 留作将来对称扩展(同一 `ComputeWrap` 机制),本次 YAGNI。


### PR DESCRIPTION
## Summary
- 给 `<Markdown>` 新增 `boldStyle` 属性（↔ `MarkdownStyle.BoldStyle`，默认 `bold`），把硬编码的 TMP `<b>` 换成**可配置、可组合**的标签：关键字 `bold`/`underline`/`italic`/`strikethrough`/`none` + 至多一个颜色（主题 token / hex / CSS 名 / `/alpha` 后缀）。空格分隔、自由组合，例 `boldStyle="underline #ffcc00"`。**动机**：像素字体下 TMP 合成描粗（faux-bold）很难看。
- 统一治理三处粗体来源：行内 `**bold**`、标题 h1–h6、GFM 表头单元格。标题仍走 `scale` 放大（字号不变、像素清晰），`boldStyle` 只替换额外的 `<b>`；`none` = 纯文字。
- 颜色走既有 `UI.Theme.Resolve` 管线；非法 / 渐变 token 用 try/catch 兜底（`Debug.LogWarning` + 跳过），渲染**绝不抛异常**。默认 `bold` 与旧 `<b>` 输出**字节级等价**（向后兼容，结构性保证）。
- 设计见 spec [`docs~/superpowers/specs/2026-06-16-markdown-bold-style-design.md`](docs~/superpowers/specs/2026-06-16-markdown-bold-style-design.md)（§3 取值语法、§4 作用范围、§8 决策 MDBS-D1..D6）。SKILL 文档（XML `reference/controls-markdown.md` + C# `scripting-promptugui-csharp`）同步更新。

## Test Plan
- [x] EditMode 1870/1870
- [x] EditMode.Markdown 40/40（新增 10 条渲染器测试 + 既有 `<b>` 回归全绿）
- [x] PlayMode 146/146
- [x] lint clean（`dotnet format --verify-no-changes --severity warn`）
- [ ] 视觉 QA（待 @heerozh）：像素字体下 `boldStyle="underline"` / `"#ffcc00"` / `"underline #ffcc00"` / `"none"` 在标题 / 行内 / 表头的实际观感

🤖 Generated with [Claude Code](https://claude.com/claude-code)