### PR TITLE
feat: Pixel 模式自动吸附 TMP 文本到像素网格 (pixel position snap)

### DIFF
--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -82,6 +82,12 @@ The callback fires once per `Open()` (so also re-fires on hot-reload, since relo
 
 **Power-of-two-only scaling `UI.PixelScalePowerOfTwo`** (`bool`, default `false`): when `true`, the Pixel-mode `scaleFactor` is constrained to a power-of-two ladder `…0.25, 0.5, 1, 2, 4, 8…`. The magnify segment snaps **down** to the largest power of two ≤ the fit-inside ratio, so a 3×-capable screen renders at 2×, 5× at 4× — content still fits inside (rounds down, never overflows; the slack is absorbed by `anchor="stretch"` / letterboxing). The sub-1× fallback is already `1/2^n`, so it is unchanged; only the integer magnify steps `3, 5, 6, 7, …` are removed. Applied **before** `MinPixelScale`, which still floors the snapped result — pair it with a power-of-two `MinPixelScale` to stay on-ladder. Pixel-mode only; Auto mode ignores it.
 
+> In Pixel mode (`scale-mode="pixel"`) the library auto-attaches a `PixelSnap` to
+> every TMP text so glyph origins land on whole device pixels (Canvas.pixelPerfect
+> does not pixel-adjust TMP). To opt out for a screen that needs smooth tweens,
+> disable `pixelPerfect` on that Canvas inside `UI.CanvasConfigurator` — that also
+> disables the text snap.
+
 ## Sprite resolver (Resources-backed)
 
 Needed if your XML uses `<Icon>` or any `sprite="ns:name"` form:

--- a/Runtime/Application/Screen.cs
+++ b/Runtime/Application/Screen.cs
@@ -667,6 +667,7 @@ namespace PromptUGUI.Application
             RecomputeFactorScale();
             ApplyCanvasScaler(RootGameObject.GetComponent<UnityEngine.UI.CanvasScaler>());
             ApplyScales();
+            AttachPixelSnaps(RootGameObject);
         }
 
         // deferApplyTo 非 null（Screen.Open 首次构建）：Add 子树属性 Apply 延迟收进该列表，

--- a/Runtime/Application/Screen.cs
+++ b/Runtime/Application/Screen.cs
@@ -391,6 +391,7 @@ namespace PromptUGUI.Application
         // 无 scale 声明的子树不登记（绝大多数列表卡片），零额外开销。
         internal void RegisterDynamicSubtree(Control root, Dictionary<ElementNode, Control> nodes)
         {
+            AttachPixelSnaps(root.GameObject);
             PruneDeadDynamicSubtrees();
             var hasScale = false;
             foreach (var node in nodes.Keys)

--- a/Runtime/Application/Screen.cs
+++ b/Runtime/Application/Screen.cs
@@ -27,6 +27,7 @@ namespace PromptUGUI.Application
         private IDisposable _variantSub;
         private System.Action<string> _themeHandler;
         private bool _isReapplyingScaler;
+        private bool _isPixelMode;
         // The pixel/auto factor that ApplyCanvasScaler last applied; 'Nx' scale divides by it.
         private float _canvasFactor = 1f;
         // True if any node declares a factor-dependent scale — scale="Nx" or scale="<r>r"
@@ -166,6 +167,7 @@ namespace PromptUGUI.Application
             // (so it doesn't fight ApplyCommon writes).
             RecomputeFactorScale();
             ApplyScales();
+            AttachPixelSnaps(root);
             // Measuring is done (apply pass + ApplyScales). Run the deferred initial hides
             // now, then close the window so all later (runtime) toggles hide immediately.
             var deferredHides = _deferredOpenActions;
@@ -189,6 +191,7 @@ namespace PromptUGUI.Application
         private void ApplyCanvasScaler(UnityEngine.UI.CanvasScaler scaler)
         {
             var mode = ResolveScaleMode();
+            _isPixelMode = mode == ScaleMode.Pixel;
             // scale-mode=pixel naturally pairs with Canvas.pixelPerfect — scale-mode
             // handles the integer outer scale, pixelPerfect snaps each UI vertex inside
             // to integer pixels (anchor/margin math can otherwise leave sub-pixel
@@ -286,6 +289,18 @@ namespace PromptUGUI.Application
             PruneDeadDynamicSubtrees();
             foreach (var subtree in _dynamicSubtrees)
                 ApplyScalesTo(subtree.Nodes);
+        }
+
+        // Pixel 模式下给子树里每个 TMP 文本挂 PixelSnap——Canvas.pixelPerfect 不吸 TMP 字形，
+        // 这里把文本渲染原点吸到设备整数像素。幂等（已挂则跳过）；Auto 模式 no-op。
+        // 见 spec 2026-06-17-pixel-position-snap (PPS-D1/D2)。
+        private void AttachPixelSnaps(UnityEngine.GameObject subtreeRoot)
+        {
+            if (!_isPixelMode || subtreeRoot == null) return;
+            var texts = subtreeRoot.GetComponentsInChildren<TMPro.TMP_Text>(includeInactive: true);
+            foreach (var t in texts)
+                if (t.GetComponent<Controls.Internal.PixelSnap>() == null)
+                    t.gameObject.AddComponent<Controls.Internal.PixelSnap>();
         }
 
         private void ApplyScalesTo(Dictionary<ElementNode, Control> nodes)

--- a/Runtime/Controls/Internal/PixelSnap.cs
+++ b/Runtime/Controls/Internal/PixelSnap.cs
@@ -1,0 +1,25 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace PromptUGUI.Controls.Internal
+{
+    // 把 TMP 文本的「对齐感知参考点」吸到整数设备像素网格——补 Canvas.pixelPerfect
+    // 漏掉的 TMP 字形对齐。见 spec 2026-06-17-pixel-position-snap (PPS-D1…D7)。
+    [DisallowMultipleComponent]
+    internal sealed class PixelSnap : UIBehaviour
+    {
+        // 参考点 = TMP 把文本块相对 rect 摆放所依据的边/中心（PPS-D4）。
+        internal static Vector2 ReferencePoint(
+            Rect rect, HorizontalAlignmentOptions h, VerticalAlignmentOptions v)
+        {
+            float x = h == HorizontalAlignmentOptions.Center ? rect.center.x
+                    : h == HorizontalAlignmentOptions.Right ? rect.xMax
+                    : rect.xMin;   // Left / Justified / Flush / Geometry
+            float y = v == VerticalAlignmentOptions.Middle ? rect.center.y
+                    : v == VerticalAlignmentOptions.Bottom ? rect.yMin
+                    : rect.yMax;   // Top / Baseline / Capline / Geometry
+            return new Vector2(x, y);
+        }
+    }
+}

--- a/Runtime/Controls/Internal/PixelSnap.cs
+++ b/Runtime/Controls/Internal/PixelSnap.cs
@@ -12,6 +12,9 @@ namespace PromptUGUI.Controls.Internal
         private RectTransform _rt;
         private TMP_Text _text;
         private Canvas _canvas;
+        private Vector3 _baseLocalPos;
+        private Vector3 _lastOffset;
+        private bool _hasBase;
 
         protected override void Awake()
         {
@@ -36,9 +39,23 @@ namespace PromptUGUI.Controls.Internal
                 || _canvas.renderMode == RenderMode.WorldSpace)
                 return;
 
-            var localRef = ReferencePoint(
-                _rt.rect, _text.horizontalAlignment, _text.verticalAlignment);
+            // 非累积：吸附偏移是"瞬时视觉修正"，不属于元素的逻辑位置。每帧先还原逻辑
+            // localPosition（layout/scroll 设定、不含上一帧偏移的值）再重新 fresh 吸附。
+            // 滚动改的是父级 content.anchoredPosition、不动本子节点的 localPosition——故外部
+            // 未改动时 localPosition 仍 == base+lastOffset，base 保持不变，逐帧修正不叠加，
+            // 不会把文字从滚动内容上"钉住"剥离（慢速滚动卡死 bug）。外部（layout/resize/
+            // ReSolve）改了 localPosition 时等式被打破 → 重新取基线（无陈旧残差）。
+            if (!_hasBase
+                || (_rt.localPosition - (_baseLocalPos + _lastOffset)).sqrMagnitude > 1e-6f)
+            {
+                _baseLocalPos = _rt.localPosition;
+                _hasBase = true;
+            }
+            _rt.localPosition = _baseLocalPos;
+
+            var localRef = ReferencePoint(_rt.rect, _text.horizontalAlignment, _text.verticalAlignment);
             SnapToPixelGrid(_rt, _canvas, localRef);
+            _lastOffset = _rt.localPosition - _baseLocalPos;
         }
 
         // 参考点 = TMP 把文本块相对 rect 摆放所依据的边/中心（PPS-D4）。

--- a/Runtime/Controls/Internal/PixelSnap.cs
+++ b/Runtime/Controls/Internal/PixelSnap.cs
@@ -26,6 +26,10 @@ namespace PromptUGUI.Controls.Internal
         protected override void OnCanvasHierarchyChanged() => _canvas = null;
         protected override void OnTransformParentChanged() => _canvas = null;
 
+        // 重新激活（Tab 页切换、对象池复用）后强制重取基线——隐藏期间 layout 可能已改 localPosition，
+        // 避免用陈旧 _baseLocalPos 吸附。
+        protected override void OnEnable() => _hasBase = false;
+
         private void LateUpdate() => Snap();
 
         // 运行期自门控于 canvas.pixelPerfect（关掉它 = 同时关吸附，复用既有 opt-out，PPS-D7）。

--- a/Runtime/Controls/Internal/PixelSnap.cs
+++ b/Runtime/Controls/Internal/PixelSnap.cs
@@ -28,9 +28,20 @@ namespace PromptUGUI.Controls.Internal
 
         // 重新激活（Tab 页切换、对象池复用）后强制重取基线——隐藏期间 layout 可能已改 localPosition，
         // 避免用陈旧 _baseLocalPos 吸附。
-        protected override void OnEnable() => _hasBase = false;
+        protected override void OnEnable()
+        {
+            _hasBase = false;
+            // 在 willRenderCanvases（PostLateUpdate，晚于所有 LateUpdate）里吸附，确保跑在
+            // ScrollRect 惯性移动 content（其自身 LateUpdate）与布局重建之后——否则吸附会用
+            // 移动前的陈旧位置，惯性滚动时文字逐帧渲染偏离整数像素而发糊/斜（LateUpdate 间
+            // 执行顺序不确定）。
+            Canvas.willRenderCanvases += Snap;
+        }
 
-        private void LateUpdate() => Snap();
+        protected override void OnDisable()
+        {
+            Canvas.willRenderCanvases -= Snap;
+        }
 
         // 运行期自门控于 canvas.pixelPerfect（关掉它 = 同时关吸附，复用既有 opt-out，PPS-D7）。
         internal void Snap()

--- a/Runtime/Controls/Internal/PixelSnap.cs
+++ b/Runtime/Controls/Internal/PixelSnap.cs
@@ -9,6 +9,38 @@ namespace PromptUGUI.Controls.Internal
     [DisallowMultipleComponent]
     internal sealed class PixelSnap : UIBehaviour
     {
+        private RectTransform _rt;
+        private TMP_Text _text;
+        private Canvas _canvas;
+
+        protected override void Awake()
+        {
+            _rt = (RectTransform)transform;
+            _text = GetComponent<TMP_Text>();
+        }
+
+        // 父链变化 → 下次 Snap 重新解析所属 Canvas。
+        protected override void OnCanvasHierarchyChanged() => _canvas = null;
+        protected override void OnTransformParentChanged() => _canvas = null;
+
+        private void LateUpdate() => Snap();
+
+        // 运行期自门控于 canvas.pixelPerfect（关掉它 = 同时关吸附，复用既有 opt-out，PPS-D7）。
+        internal void Snap()
+        {
+            if (_rt == null) _rt = (RectTransform)transform;
+            if (_text == null) _text = GetComponent<TMP_Text>();
+            if (_canvas == null) _canvas = GetComponentInParent<Canvas>(true);
+            if (_text == null || _canvas == null
+                || !_canvas.pixelPerfect
+                || _canvas.renderMode == RenderMode.WorldSpace)
+                return;
+
+            var localRef = ReferencePoint(
+                _rt.rect, _text.horizontalAlignment, _text.verticalAlignment);
+            SnapToPixelGrid(_rt, _canvas, localRef);
+        }
+
         // 参考点 = TMP 把文本块相对 rect 摆放所依据的边/中心（PPS-D4）。
         internal static Vector2 ReferencePoint(
             Rect rect, HorizontalAlignmentOptions h, VerticalAlignmentOptions v)

--- a/Runtime/Controls/Internal/PixelSnap.cs
+++ b/Runtime/Controls/Internal/PixelSnap.cs
@@ -21,5 +21,21 @@ namespace PromptUGUI.Controls.Internal
                     : rect.yMax;   // Top / Baseline / Capline / Geometry
             return new Vector2(x, y);
         }
+
+        // 把 rt 平移，使 localRef（局部空间）落在整数设备像素上。模式无关：overlay 用
+        // null 相机、camera 模式用 worldCamera。已实测幂等（PPS-D3）。
+        internal static void SnapToPixelGrid(RectTransform rt, Canvas canvas, Vector2 localRef)
+        {
+            var cam = canvas.renderMode == RenderMode.ScreenSpaceOverlay
+                ? null : canvas.worldCamera;
+            var refWorld = rt.TransformPoint((Vector3)localRef);
+            var before = RectTransformUtility.WorldToScreenPoint(cam, refWorld);
+            var snap = new Vector2(Mathf.Round(before.x), Mathf.Round(before.y));
+            if ((before - snap).sqrMagnitude < 1e-4f) return;          // 已对齐
+            var canvasRect = (RectTransform)canvas.transform;
+            if (RectTransformUtility.ScreenPointToWorldPointInRectangle(
+                    canvasRect, snap, cam, out var snapWorld))
+                rt.position += (snapWorld - refWorld);
+        }
     }
 }

--- a/Runtime/Controls/Internal/PixelSnap.cs.meta
+++ b/Runtime/Controls/Internal/PixelSnap.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8e898e66349196244b7a175d2a7d24bf

--- a/Tests/EditMode/Application/PixelSnapTests.cs
+++ b/Tests/EditMode/Application/PixelSnapTests.cs
@@ -39,5 +39,50 @@ namespace PromptUGUI.Tests.Application
                 HorizontalAlignmentOptions.Justified, VerticalAlignmentOptions.Top);
             Assert.AreEqual(0f, p.x);
         }
+
+        // ---- Task 2: SnapToPixelGrid ----
+        private static (GameObject root, RectTransform rt, Canvas canvas) MakeRT(
+            Vector2 anchoredPos, Vector2 size)
+        {
+            var go = new GameObject("c");
+            var canvas = go.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvas.scaleFactor = 3f;
+            var child = new GameObject("ch");
+            child.transform.SetParent(go.transform, false);
+            var rt = child.AddComponent<RectTransform>();
+            rt.anchorMin = rt.anchorMax = Vector2.zero;
+            rt.pivot = Vector2.zero;
+            rt.sizeDelta = size;
+            rt.anchoredPosition = anchoredPos;
+            Canvas.ForceUpdateCanvases();
+            return (go, rt, canvas);
+        }
+
+        [Test]
+        public void SnapToPixelGrid_FractionalScreenPos_SnapsToIntegerScreen()
+        {
+            var (root, rt, canvas) = MakeRT(new Vector2(7.3f, 4.1f), new Vector2(10f, 16f));
+            PixelSnap.SnapToPixelGrid(rt, canvas, rt.rect.min);
+            Canvas.ForceUpdateCanvases();
+            var after = RectTransformUtility.WorldToScreenPoint(
+                null, rt.TransformPoint((Vector3)rt.rect.min));
+            Assert.AreEqual(22f, after.x, 0.01f);
+            Assert.AreEqual(12f, after.y, 0.01f);
+            Object.DestroyImmediate(root);
+        }
+
+        [Test]
+        public void SnapToPixelGrid_AlreadyAligned_Idempotent()
+        {
+            var (root, rt, canvas) = MakeRT(new Vector2(7.3f, 4.1f), new Vector2(10f, 16f));
+            PixelSnap.SnapToPixelGrid(rt, canvas, rt.rect.min);
+            Canvas.ForceUpdateCanvases();
+            var pos1 = rt.position;
+            PixelSnap.SnapToPixelGrid(rt, canvas, rt.rect.min);
+            Assert.AreEqual(pos1.x, rt.position.x, 1e-4f);
+            Assert.AreEqual(pos1.y, rt.position.y, 1e-4f);
+            Object.DestroyImmediate(root);
+        }
     }
 }

--- a/Tests/EditMode/Application/PixelSnapTests.cs
+++ b/Tests/EditMode/Application/PixelSnapTests.cs
@@ -220,5 +220,52 @@ namespace PromptUGUI.Tests.Application
                 "翻到 pixel 变体后 ReSolve 应补挂 PixelSnap");
             UI.ResetForTests();
         }
+
+        // ---- Task 9: slow scroll must not detach text from scroll content ----
+        [Test]
+        public void Snap_SlowScrollInParent_TextFollowsScroll_NoDetach()
+        {
+            var go = new GameObject("c");
+            var canvas = go.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvas.scaleFactor = 3f;
+            canvas.pixelPerfect = true;
+            var content = new GameObject("content").AddComponent<RectTransform>();
+            content.SetParent(go.transform, false);
+            content.anchorMin = content.anchorMax = Vector2.zero;
+            content.pivot = Vector2.zero;
+            var t = new GameObject("txt");
+            t.transform.SetParent(content, false);
+            var tmp = t.AddComponent<TextMeshProUGUI>();
+            var rt = tmp.rectTransform;
+            rt.anchorMin = rt.anchorMax = Vector2.zero;
+            rt.pivot = Vector2.zero;
+            rt.sizeDelta = new Vector2(10f, 16f);
+            rt.anchoredPosition = new Vector2(5f, 5f);
+            var snap = t.AddComponent<PixelSnap>();
+            Canvas.ForceUpdateCanvases();
+
+            snap.Snap();
+            Canvas.ForceUpdateCanvases();
+            var localStartY = rt.localPosition.y;
+            var screenStartY = RectTransformUtility.WorldToScreenPoint(null, rt.TransformPoint(Vector3.zero)).y;
+
+            // slow scroll: parent content moves +0.1 design units (=0.3 screen px @sf3) per frame, 30 frames = 9px
+            for (int i = 0; i < 30; i++)
+            {
+                content.anchoredPosition += new Vector2(0f, 0.1f);
+                Canvas.ForceUpdateCanvases();
+                snap.Snap();
+                Canvas.ForceUpdateCanvases();
+            }
+
+            var localEndY = rt.localPosition.y;
+            var screenEndY = RectTransformUtility.WorldToScreenPoint(null, rt.TransformPoint(Vector3.zero)).y;
+            // text must FOLLOW the scroll (~+9px), not stay pinned (~0); and its local offset within
+            // content must NOT drift (no detach).
+            Assert.AreEqual(9f, screenEndY - screenStartY, 1.5f, "text should follow scroll, not stay pinned");
+            Assert.AreEqual(localStartY, localEndY, 1f, "text local position must not drift off the scroll content");
+            Object.DestroyImmediate(go);
+        }
     }
 }

--- a/Tests/EditMode/Application/PixelSnapTests.cs
+++ b/Tests/EditMode/Application/PixelSnapTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using PromptUGUI.Application;
 using PromptUGUI.Controls.Internal;
 using TMPro;
 using UnityEngine;
@@ -130,6 +131,45 @@ namespace PromptUGUI.Tests.Application
             snap.Snap();
             Assert.AreEqual(before, tmp.rectTransform.position);   // 门控：不动
             Object.DestroyImmediate(root);
+        }
+
+        // ---- Task 4: Screen 静态挂载 ----
+        private static PromptUGUI.Application.Screen OpenPixel(string body)
+        {
+            UI.CanvasSizeOverride = () => new Vector2(5760f, 3240f); // /1920x1080 → factor 3
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>" + body + @"</Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            return (PromptUGUI.Application.Screen)UI.Open("S");
+        }
+
+        [Test]
+        public void Open_PixelMode_AttachesPixelSnapToText()
+        {
+            UI.ResetForTests();
+            var screen = OpenPixel("<Text id='t'>hi</Text>");
+            var tmp = screen.RootGameObject.GetComponentInChildren<TMP_Text>(true);
+            Assert.IsNotNull(tmp);
+            Assert.IsNotNull(tmp.GetComponent<PixelSnap>(), "pixel 模式应挂 PixelSnap");
+            UI.ResetForTests();
+        }
+
+        [Test]
+        public void Open_AutoMode_DoesNotAttachPixelSnap()
+        {
+            UI.ResetForTests();
+            UI.CanvasSizeOverride = () => new Vector2(1920f, 1080f);
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='auto' reference='1920x1080'><Text id='t'>hi</Text></Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = (PromptUGUI.Application.Screen)UI.Open("S");
+            var tmp = screen.RootGameObject.GetComponentInChildren<TMP_Text>(true);
+            Assert.IsNull(tmp.GetComponent<PixelSnap>(), "auto 模式不应挂");
+            UI.ResetForTests();
         }
     }
 }

--- a/Tests/EditMode/Application/PixelSnapTests.cs
+++ b/Tests/EditMode/Application/PixelSnapTests.cs
@@ -197,5 +197,28 @@ namespace PromptUGUI.Tests.Application
             Assert.IsNull(tmp.GetComponent<PixelSnap>(), "auto 模式不应挂");
             UI.ResetForTests();
         }
+
+        // ---- Task 8: ReSolve re-attaches (runtime scale-mode flip / Add-block activation) ----
+        [Test]
+        public void ReSolve_ScaleModeFlipsToPixel_AttachesPixelSnap()
+        {
+            UI.ResetForTests();
+            UI.CanvasSizeOverride = () => new Vector2(5760f, 3240f); // factor 3 in pixel mode
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='auto' scale-mode.portrait='pixel' reference='1920x1080'>
+    <Text id='t'>hi</Text>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = (PromptUGUI.Application.Screen)UI.Open("S");
+            var tmp = screen.RootGameObject.GetComponentInChildren<TMP_Text>(true);
+            Assert.IsNull(tmp.GetComponent<PixelSnap>(), "auto 模式开屏时不应有 PixelSnap");
+
+            UI.Variants.Set("portrait", true);   // scale-mode.portrait='pixel' → ReSolve, _isPixelMode=true
+            Assert.IsNotNull(tmp.GetComponent<PixelSnap>(),
+                "翻到 pixel 变体后 ReSolve 应补挂 PixelSnap");
+            UI.ResetForTests();
+        }
     }
 }

--- a/Tests/EditMode/Application/PixelSnapTests.cs
+++ b/Tests/EditMode/Application/PixelSnapTests.cs
@@ -1,0 +1,43 @@
+using NUnit.Framework;
+using PromptUGUI.Controls.Internal;
+using TMPro;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Application
+{
+    public class PixelSnapTests
+    {
+        // ---- Task 1: ReferencePoint ----
+        [Test]
+        public void ReferencePoint_LeftTop_ReturnsMinXMaxY()
+        {
+            var p = PixelSnap.ReferencePoint(new Rect(0, 0, 10, 16),
+                HorizontalAlignmentOptions.Left, VerticalAlignmentOptions.Top);
+            Assert.AreEqual(new Vector2(0f, 16f), p);
+        }
+
+        [Test]
+        public void ReferencePoint_CenterMiddle_ReturnsCenter()
+        {
+            var p = PixelSnap.ReferencePoint(new Rect(0, 0, 10, 16),
+                HorizontalAlignmentOptions.Center, VerticalAlignmentOptions.Middle);
+            Assert.AreEqual(new Vector2(5f, 8f), p);
+        }
+
+        [Test]
+        public void ReferencePoint_RightBottom_ReturnsMaxXMinY()
+        {
+            var p = PixelSnap.ReferencePoint(new Rect(0, 0, 10, 16),
+                HorizontalAlignmentOptions.Right, VerticalAlignmentOptions.Bottom);
+            Assert.AreEqual(new Vector2(10f, 0f), p);
+        }
+
+        [Test]
+        public void ReferencePoint_Justified_TreatedAsLeft()
+        {
+            var p = PixelSnap.ReferencePoint(new Rect(0, 0, 10, 16),
+                HorizontalAlignmentOptions.Justified, VerticalAlignmentOptions.Top);
+            Assert.AreEqual(0f, p.x);
+        }
+    }
+}

--- a/Tests/EditMode/Application/PixelSnapTests.cs
+++ b/Tests/EditMode/Application/PixelSnapTests.cs
@@ -84,5 +84,52 @@ namespace PromptUGUI.Tests.Application
             Assert.AreEqual(pos1.y, rt.position.y, 1e-4f);
             Object.DestroyImmediate(root);
         }
+
+        // ---- Task 3: 组件 Snap() ----
+        private static (GameObject root, TextMeshProUGUI tmp, PixelSnap snap) MakeText(
+            Vector2 anchoredPos, bool pixelPerfect)
+        {
+            var go = new GameObject("c");
+            var canvas = go.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvas.scaleFactor = 3f;
+            canvas.pixelPerfect = pixelPerfect;
+            var t = new GameObject("txt");
+            t.transform.SetParent(go.transform, false);
+            var tmp = t.AddComponent<TextMeshProUGUI>();   // 默认 TopLeft 对齐
+            var rt = tmp.rectTransform;
+            rt.anchorMin = rt.anchorMax = Vector2.zero;
+            rt.pivot = Vector2.zero;
+            rt.sizeDelta = new Vector2(10f, 16f);
+            rt.anchoredPosition = anchoredPos;
+            var snap = t.AddComponent<PixelSnap>();
+            Canvas.ForceUpdateCanvases();
+            return (go, tmp, snap);
+        }
+
+        [Test]
+        public void Snap_PixelPerfectOn_SnapsLeftTopReferenceToInteger()
+        {
+            var (root, tmp, snap) = MakeText(new Vector2(7.3f, 4.1f), pixelPerfect: true);
+            snap.Snap();
+            Canvas.ForceUpdateCanvases();
+            // TopLeft → 参考点 (xMin, yMax) = (0,16) → 屏幕 (21.9, (4.1+16)*3=60.3) → (22,60)
+            var after = RectTransformUtility.WorldToScreenPoint(
+                null, tmp.rectTransform.TransformPoint((Vector3)tmp.rectTransform.rect.min
+                       + Vector3.up * tmp.rectTransform.rect.height));
+            Assert.AreEqual(22f, after.x, 0.01f);
+            Assert.AreEqual(60f, after.y, 0.01f);
+            Object.DestroyImmediate(root);
+        }
+
+        [Test]
+        public void Snap_PixelPerfectOff_NoOp()
+        {
+            var (root, tmp, snap) = MakeText(new Vector2(7.3f, 4.1f), pixelPerfect: false);
+            var before = tmp.rectTransform.position;
+            snap.Snap();
+            Assert.AreEqual(before, tmp.rectTransform.position);   // 门控：不动
+            Object.DestroyImmediate(root);
+        }
     }
 }

--- a/Tests/EditMode/Application/PixelSnapTests.cs
+++ b/Tests/EditMode/Application/PixelSnapTests.cs
@@ -133,6 +133,32 @@ namespace PromptUGUI.Tests.Application
             Object.DestroyImmediate(root);
         }
 
+        // ---- Task 5: 动态子树挂载 ----
+        [Test]
+        public void BindItems_PixelMode_DynamicTextGetsPixelSnap()
+        {
+            UI.ResetForTests();
+            UI.CanvasSizeOverride = () => new Vector2(5760f, 3240f); // factor 3
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Row'><Frame width='200' height='50'><Text id='label'>x</Text></Frame></Template>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <ScrollList id='list' itemTemplate='Row'/>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var list = screen.Get<PromptUGUI.Controls.ScrollList>("list");
+            PromptUGUI.Controls.IControl captured = null;
+            list.BindItems(
+                R3.Observable.Return<System.Collections.Generic.IReadOnlyList<string>>(new[] { "a" }),
+                (PromptUGUI.Controls.IControl slot, string s) => captured = slot);
+            var label = captured.Get<PromptUGUI.Controls.Text>("label");
+            Assert.IsNotNull(label.GameObject.GetComponent<PixelSnap>(),
+                "动态实例化的文本也应挂 PixelSnap");
+            UI.ResetForTests();
+        }
+
         // ---- Task 4: Screen 静态挂载 ----
         private static PromptUGUI.Application.Screen OpenPixel(string body)
         {

--- a/Tests/EditMode/Application/PixelSnapTests.cs.meta
+++ b/Tests/EditMode/Application/PixelSnapTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 39ce2e7a1ee6bb64aaa927d54b9c6fcb

--- a/Tests/PlayMode/PixelSnapPlayTests.cs
+++ b/Tests/PlayMode/PixelSnapPlayTests.cs
@@ -40,5 +40,43 @@ namespace PromptUGUI.Tests.PlayMode
             Assert.AreEqual(Mathf.Round(screenPt.x), screenPt.x, 0.02f, "x 应落整数设备像素");
             Assert.AreEqual(Mathf.Round(screenPt.y), screenPt.y, 0.02f, "y 应落整数设备像素");
         }
+
+        [UnityTest]
+        public IEnumerator LayoutGroupChildText_SnapsAndStaysStable()
+        {
+            UI.CanvasSizeOverride = () => new Vector2(5760f, 3240f); // factor 3
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <VStack width='200' anchor='center'>
+      <Text id='a' height='20'>aaa</Text>
+      <Text id='b' height='20'>bbb</Text>
+    </VStack>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var tmp = screen.Get<Text>("a").TmpComponent;
+            var rt = tmp.rectTransform;
+            yield return null; yield return null; yield return null; // layout + snap settle
+
+            System.Func<Vector2> refScreen = () =>
+            {
+                var localRef = PromptUGUI.Controls.Internal.PixelSnap.ReferencePoint(
+                    rt.rect, tmp.horizontalAlignment, tmp.verticalAlignment);
+                return RectTransformUtility.WorldToScreenPoint(null, rt.TransformPoint((Vector3)localRef));
+            };
+
+            var p1 = refScreen();
+            Assert.AreEqual(Mathf.Round(p1.x), p1.x, 0.02f, "layout-child text x should be pixel-snapped");
+            Assert.AreEqual(Mathf.Round(p1.y), p1.y, 0.02f, "layout-child text y should be pixel-snapped");
+
+            // PixelSnap writes localPosition every frame; it must NOT fight the LayoutGroup
+            // (no oscillation / drift) — position stays put over several frames.
+            for (int i = 0; i < 5; i++) yield return null;
+            var p2 = refScreen();
+            Assert.AreEqual(p1.x, p2.x, 0.5f, "layout-child text must stay stable (no fight/drift)");
+            Assert.AreEqual(p1.y, p2.y, 0.5f, "layout-child text must stay stable (no fight/drift)");
+        }
     }
 }

--- a/Tests/PlayMode/PixelSnapPlayTests.cs
+++ b/Tests/PlayMode/PixelSnapPlayTests.cs
@@ -42,6 +42,71 @@ namespace PromptUGUI.Tests.PlayMode
         }
 
         [UnityTest]
+        public IEnumerator Snap_DuringInertialScroll_TextStaysOnGrid()
+        {
+            var go = new GameObject("canvas");
+            var canvas = go.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvas.scaleFactor = 3f;
+            canvas.pixelPerfect = true;
+            var canvasRT = (RectTransform)go.transform;
+            canvasRT.sizeDelta = new Vector2(300f, 300f);
+
+            var viewport = new GameObject("viewport").AddComponent<RectTransform>();
+            viewport.SetParent(go.transform, false);
+            viewport.anchorMin = Vector2.zero; viewport.anchorMax = Vector2.one;
+            viewport.sizeDelta = Vector2.zero;
+            viewport.gameObject.AddComponent<UnityEngine.UI.RectMask2D>();
+
+            var content = new GameObject("content").AddComponent<RectTransform>();
+            content.SetParent(viewport, false);
+            content.anchorMin = new Vector2(0f, 1f); content.anchorMax = new Vector2(0f, 1f);
+            content.pivot = new Vector2(0f, 1f);
+            content.sizeDelta = new Vector2(100f, 2000f);
+            content.anchoredPosition = Vector2.zero;
+
+            var t = new GameObject("txt"); t.transform.SetParent(content, false);
+            var tmp = t.AddComponent<TextMeshProUGUI>();
+            var rt = tmp.rectTransform;
+            rt.anchorMin = new Vector2(0f, 1f); rt.anchorMax = new Vector2(0f, 1f);
+            rt.pivot = new Vector2(0f, 1f);
+            rt.sizeDelta = new Vector2(80f, 20f);
+            rt.anchoredPosition = new Vector2(5.3f, -5.3f); // fractional so snapping is non-trivial
+            t.AddComponent<PromptUGUI.Controls.Internal.PixelSnap>();
+
+            var sr = go.AddComponent<UnityEngine.UI.ScrollRect>();
+            sr.viewport = viewport; sr.content = content;
+            sr.horizontal = false; sr.vertical = true;
+            sr.movementType = UnityEngine.UI.ScrollRect.MovementType.Unrestricted;
+            sr.inertia = true;
+            Canvas.ForceUpdateCanvases();
+            yield return null;
+
+            System.Func<float> contentY = () => content.anchoredPosition.y;
+            System.Func<Vector2> refScreen = () =>
+            {
+                var localRef = PromptUGUI.Controls.Internal.PixelSnap.ReferencePoint(
+                    rt.rect, tmp.horizontalAlignment, tmp.verticalAlignment);
+                return RectTransformUtility.WorldToScreenPoint(null, rt.TransformPoint((Vector3)localRef));
+            };
+
+            var y0 = contentY();
+            sr.velocity = new Vector2(0f, 900f);   // launch inertial scroll
+            bool moved = false;
+            int offGridFrames = 0;
+            for (int i = 0; i < 30; i++)
+            {
+                yield return null;                  // frame end: ScrollRect.LateUpdate moved, willRenderCanvases snapped
+                if (Mathf.Abs(contentY() - y0) > 1f) moved = true;
+                var p = refScreen();
+                if (Mathf.Abs(p.x - Mathf.Round(p.x)) > 0.05f || Mathf.Abs(p.y - Mathf.Round(p.y)) > 0.05f)
+                    offGridFrames++;
+            }
+            Assert.IsTrue(moved, "ScrollRect inertia should have moved the content (test not vacuous)");
+            Assert.AreEqual(0, offGridFrames, "text reference must stay on the integer device-pixel grid during inertial scroll");
+        }
+
+        [UnityTest]
         public IEnumerator LayoutGroupChildText_SnapsAndStaysStable()
         {
             UI.CanvasSizeOverride = () => new Vector2(5760f, 3240f); // factor 3

--- a/Tests/PlayMode/PixelSnapPlayTests.cs
+++ b/Tests/PlayMode/PixelSnapPlayTests.cs
@@ -1,0 +1,44 @@
+using System.Collections;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using TMPro;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.PlayMode
+{
+    public class PixelSnapPlayTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [UnityTest]
+        public IEnumerator CenterAnchoredText_SnapsToIntegerDevicePixel_InPlayLoop()
+        {
+            UI.CanvasSizeOverride = () => new Vector2(5760f, 3240f); // factor 3
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Text id='t' anchor='center' width='100' height='20'>hi</Text>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var tmp = screen.Get<Text>("t").TmpComponent;
+            var rt = tmp.rectTransform;
+
+            // 强制一个分数设备位置
+            rt.anchoredPosition = new Vector2(7.5f / 3f, 0f);
+            yield return null;   // LateUpdate 跑 Snap
+            yield return null;
+
+            var localRef = PromptUGUI.Controls.Internal.PixelSnap.ReferencePoint(
+                rt.rect, tmp.horizontalAlignment, tmp.verticalAlignment);
+            var screenPt = RectTransformUtility.WorldToScreenPoint(
+                null, rt.TransformPoint((Vector3)localRef));
+            Assert.AreEqual(Mathf.Round(screenPt.x), screenPt.x, 0.02f, "x 应落整数设备像素");
+            Assert.AreEqual(Mathf.Round(screenPt.y), screenPt.y, 0.02f, "y 应落整数设备像素");
+        }
+    }
+}

--- a/Tests/PlayMode/PixelSnapPlayTests.cs.meta
+++ b/Tests/PlayMode/PixelSnapPlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b7266e3f241f9ea41a77ada0432a8967

--- a/docs~/superpowers/plans/2026-06-17-pixel-position-snap.md
+++ b/docs~/superpowers/plans/2026-06-17-pixel-position-snap.md
@@ -1,0 +1,745 @@
+# 像素位置吸附 (Pixel Position Snap) 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pixel 模式下自动把 TMP 文本的渲染原点吸附到设备整数像素网格，补上 `Canvas.pixelPerfect` 漏掉的 TMP 字形对齐，修复像素字/中心锚点文字随屏幕尺寸时糊时清。
+
+**Architecture:** 新增内部组件 `PixelSnap : UIBehaviour`，由 `Screen` 在 Pixel 模式下挂到每个 `TMP_Text` 上；组件在 `LateUpdate` 用经实测验证的「屏幕空间往返」公式把**对齐感知参考点**吸到整数设备像素（幂等、运行期自门控于 `canvas.pixelPerfect`）。静态文本在 `Open` 挂载，动态文本（BindItems/Markdown）在 `RegisterDynamicSubtree` 挂载。
+
+**Tech Stack:** Unity 6 uGUI + TextMeshPro (`TMPro.TMP_Text`)；测试 NUnit（`PromptUGUI.Tests.EditMode` / `.PlayMode`）；经 UnityMCP 跑测试 + `dotnet format` lint。
+
+**关键已验证事实（宿主 Unity 实测）：**
+- `Canvas.pixelPerfect` 已把 Image/RawImage 的位置+尺寸吸到整数设备像素（`30.9→31`），但 **TMP 绕过该路径**，故只需补 TMP 文本（spec PPS-D1）。
+- Overlay 画布下 `canvas.transform.localScale = (sf,sf,sf)`，**世界坐标 == 屏幕设备像素**。
+- 吸附公式（已实测：`screen (21.90,12.30) → (22,12)`，二次 pass delta `=0` 幂等）：
+  `WorldToScreenPoint(ref) → round → ScreenPointToWorldPointInRectangle(canvasRect) → rt.position += (snapWorld - refWorld)`。
+
+---
+
+## 文件结构
+
+| 文件 | 职责 | 动作 |
+|---|---|---|
+| `Runtime/Controls/Internal/PixelSnap.cs` | 吸附组件 + 两个可测纯静态助手（`ReferencePoint` / `SnapToPixelGrid`） | 新建 |
+| `Runtime/Application/Screen.cs` | 缓存 `_isPixelMode`；`AttachPixelSnaps`；在 `Open` 与 `RegisterDynamicSubtree` 调用 | 改 |
+| `Tests/EditMode/Application/PixelSnapTests.cs` | 助手数学 + 组件 + Screen 挂载（静态/动态）EditMode 测试 | 新建 |
+| `Tests/PlayMode/PixelSnapPlayTests.cs` | 真实 play loop 下中心锚点文本落格回归 | 新建 |
+| `scripting-promptugui-csharp/SKILL.md` | CanvasConfigurator/Pixel 一节加一句（吸附 + opt-out） | 改 |
+| `docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md` | 补节引用本设计（PPS-D1…D7） | 改 |
+
+> `PixelSnap` 是内部组件，**不是 XML builtin tag → 不需要同步 `Runtime/Core/Lint/BuiltinTags.cs`**（spec §5.1）。
+> 新建 `.cs` 文件需先 `refresh_unity` 生成 `.meta`，提交时连 `.meta` 一起 `git add`。
+
+---
+
+## Task 1: `ReferencePoint` 对齐感知参考点（纯静态助手）
+
+**Files:**
+- Create: `Runtime/Controls/Internal/PixelSnap.cs`
+- Test: `Tests/EditMode/Application/PixelSnapTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `Tests/EditMode/Application/PixelSnapTests.cs`：
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Controls.Internal;
+using TMPro;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.Application
+{
+    public class PixelSnapTests
+    {
+        // ---- Task 1: ReferencePoint ----
+        [Test]
+        public void ReferencePoint_LeftTop_ReturnsMinXMaxY()
+        {
+            var p = PixelSnap.ReferencePoint(new Rect(0, 0, 10, 16),
+                HorizontalAlignmentOptions.Left, VerticalAlignmentOptions.Top);
+            Assert.AreEqual(new Vector2(0f, 16f), p);
+        }
+
+        [Test]
+        public void ReferencePoint_CenterMiddle_ReturnsCenter()
+        {
+            var p = PixelSnap.ReferencePoint(new Rect(0, 0, 10, 16),
+                HorizontalAlignmentOptions.Center, VerticalAlignmentOptions.Middle);
+            Assert.AreEqual(new Vector2(5f, 8f), p);
+        }
+
+        [Test]
+        public void ReferencePoint_RightBottom_ReturnsMaxXMinY()
+        {
+            var p = PixelSnap.ReferencePoint(new Rect(0, 0, 10, 16),
+                HorizontalAlignmentOptions.Right, VerticalAlignmentOptions.Bottom);
+            Assert.AreEqual(new Vector2(10f, 0f), p);
+        }
+
+        [Test]
+        public void ReferencePoint_Justified_TreatedAsLeft()
+        {
+            var p = PixelSnap.ReferencePoint(new Rect(0, 0, 10, 16),
+                HorizontalAlignmentOptions.Justified, VerticalAlignmentOptions.Top);
+            Assert.AreEqual(0f, p.x);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认编译失败（`PixelSnap` 不存在）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: 编译错误 `PixelSnap could not be found`。
+
+- [ ] **Step 3: 写最小实现**
+
+新建 `Runtime/Controls/Internal/PixelSnap.cs`（先只放 `ReferencePoint`，组件骨架下个 task 补全）：
+
+```csharp
+using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace PromptUGUI.Controls.Internal
+{
+    // 把 TMP 文本的「对齐感知参考点」吸到整数设备像素网格——补 Canvas.pixelPerfect
+    // 漏掉的 TMP 字形对齐。见 spec 2026-06-17-pixel-position-snap (PPS-D1…D7)。
+    [DisallowMultipleComponent]
+    internal sealed class PixelSnap : UIBehaviour
+    {
+        // 参考点 = TMP 把文本块相对 rect 摆放所依据的边/中心（PPS-D4）。
+        internal static Vector2 ReferencePoint(
+            Rect rect, HorizontalAlignmentOptions h, VerticalAlignmentOptions v)
+        {
+            float x = h == HorizontalAlignmentOptions.Center ? rect.center.x
+                    : h == HorizontalAlignmentOptions.Right ? rect.xMax
+                    : rect.xMin;   // Left / Justified / Flush / Geometry
+            float y = v == VerticalAlignmentOptions.Middle ? rect.center.y
+                    : v == VerticalAlignmentOptions.Bottom ? rect.yMin
+                    : rect.yMax;   // Top / Baseline / Capline / Geometry
+            return new Vector2(x, y);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["PixelSnapTests"])
+mcp__UnityMCP__get_test_job(job_id=...)   # 轮询到完成
+```
+Expected: 4 个 ReferencePoint 测试 PASS，0 fail。
+
+- [ ] **Step 5: 提交**
+
+```bash
+mcp__UnityMCP__refresh_unity   # 确保 .meta 已生成
+git add Runtime/Controls/Internal/PixelSnap.cs Runtime/Controls/Internal/PixelSnap.cs.meta Tests/EditMode/Application/PixelSnapTests.cs Tests/EditMode/Application/PixelSnapTests.cs.meta
+git commit -m "$(cat <<'EOF'
+feat: PixelSnap.ReferencePoint 对齐感知参考点助手
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `SnapToPixelGrid` 吸附公式（纯静态助手）
+
+**Files:**
+- Modify: `Runtime/Controls/Internal/PixelSnap.cs`
+- Test: `Tests/EditMode/Application/PixelSnapTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `PixelSnapTests` 类追加（锚点在屏幕左下角 → 屏幕坐标 = anchoredPos × scaleFactor，与编辑器视口尺寸无关，故断言确定）：
+
+```csharp
+        // ---- Task 2: SnapToPixelGrid ----
+        private static (GameObject root, RectTransform rt, Canvas canvas) MakeRT(
+            Vector2 anchoredPos, Vector2 size)
+        {
+            var go = new GameObject("c");
+            var canvas = go.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvas.scaleFactor = 3f;
+            var child = new GameObject("ch");
+            child.transform.SetParent(go.transform, false);
+            var rt = child.AddComponent<RectTransform>();
+            rt.anchorMin = rt.anchorMax = Vector2.zero;
+            rt.pivot = Vector2.zero;
+            rt.sizeDelta = size;
+            rt.anchoredPosition = anchoredPos;
+            Canvas.ForceUpdateCanvases();
+            return (go, rt, canvas);
+        }
+
+        [Test]
+        public void SnapToPixelGrid_FractionalScreenPos_SnapsToIntegerScreen()
+        {
+            var (root, rt, canvas) = MakeRT(new Vector2(7.3f, 4.1f), new Vector2(10f, 16f));
+            // localRef = rect 左下 (0,0) → 屏幕 (21.9,12.3) → 期望吸到 (22,12)
+            PixelSnap.SnapToPixelGrid(rt, canvas, rt.rect.min);
+            Canvas.ForceUpdateCanvases();
+            var after = RectTransformUtility.WorldToScreenPoint(
+                null, rt.TransformPoint((Vector3)rt.rect.min));
+            Assert.AreEqual(22f, after.x, 0.01f);
+            Assert.AreEqual(12f, after.y, 0.01f);
+            Object.DestroyImmediate(root);
+        }
+
+        [Test]
+        public void SnapToPixelGrid_AlreadyAligned_Idempotent()
+        {
+            var (root, rt, canvas) = MakeRT(new Vector2(7.3f, 4.1f), new Vector2(10f, 16f));
+            PixelSnap.SnapToPixelGrid(rt, canvas, rt.rect.min);
+            Canvas.ForceUpdateCanvases();
+            var pos1 = rt.position;
+            PixelSnap.SnapToPixelGrid(rt, canvas, rt.rect.min);   // 第二次
+            Assert.AreEqual(pos1.x, rt.position.x, 1e-4f);
+            Assert.AreEqual(pos1.y, rt.position.y, 1e-4f);
+            Object.DestroyImmediate(root);
+        }
+```
+
+- [ ] **Step 2: 跑测试确认失败（`SnapToPixelGrid` 不存在）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: 编译错误 `SnapToPixelGrid` 未定义。
+
+- [ ] **Step 3: 写最小实现**
+
+在 `PixelSnap` 类内追加（公式已实测验证）：
+
+```csharp
+        // 把 rt 平移，使 localRef（局部空间）落在整数设备像素上。模式无关：overlay 用
+        // null 相机、camera 模式用 worldCamera。已实测幂等（PPS-D3）。
+        internal static void SnapToPixelGrid(RectTransform rt, Canvas canvas, Vector2 localRef)
+        {
+            var cam = canvas.renderMode == RenderMode.ScreenSpaceOverlay
+                ? null : canvas.worldCamera;
+            var refWorld = rt.TransformPoint((Vector3)localRef);
+            var before = RectTransformUtility.WorldToScreenPoint(cam, refWorld);
+            var snap = new Vector2(Mathf.Round(before.x), Mathf.Round(before.y));
+            if ((before - snap).sqrMagnitude < 1e-4f) return;          // 已对齐
+            var canvasRect = (RectTransform)canvas.transform;
+            if (RectTransformUtility.ScreenPointToWorldPointInRectangle(
+                    canvasRect, snap, cam, out var snapWorld))
+                rt.position += (snapWorld - refWorld);
+        }
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["PixelSnapTests"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: Task1+Task2 全部 PASS（6 个）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Controls/Internal/PixelSnap.cs Tests/EditMode/Application/PixelSnapTests.cs
+git commit -m "$(cat <<'EOF'
+feat: PixelSnap.SnapToPixelGrid 屏幕空间往返吸附公式
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `PixelSnap` 组件（LateUpdate + 门控 + TMP 接线）
+
+**Files:**
+- Modify: `Runtime/Controls/Internal/PixelSnap.cs`
+- Test: `Tests/EditMode/Application/PixelSnapTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+追加（用真实 `TextMeshProUGUI`；无字体环境下 rect/对齐仍可用，吸附只读几何）：
+
+```csharp
+        // ---- Task 3: 组件 Snap() ----
+        private static (GameObject root, TextMeshProUGUI tmp, PixelSnap snap) MakeText(
+            Vector2 anchoredPos, bool pixelPerfect)
+        {
+            var go = new GameObject("c");
+            var canvas = go.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvas.scaleFactor = 3f;
+            canvas.pixelPerfect = pixelPerfect;
+            var t = new GameObject("txt");
+            t.transform.SetParent(go.transform, false);
+            var tmp = t.AddComponent<TextMeshProUGUI>();   // 默认 TopLeft 对齐
+            var rt = tmp.rectTransform;
+            rt.anchorMin = rt.anchorMax = Vector2.zero;
+            rt.pivot = Vector2.zero;
+            rt.sizeDelta = new Vector2(10f, 16f);
+            rt.anchoredPosition = anchoredPos;
+            var snap = t.AddComponent<PixelSnap>();
+            Canvas.ForceUpdateCanvases();
+            return (go, tmp, snap);
+        }
+
+        [Test]
+        public void Snap_PixelPerfectOn_SnapsLeftTopReferenceToInteger()
+        {
+            var (root, tmp, snap) = MakeText(new Vector2(7.3f, 4.1f), pixelPerfect: true);
+            snap.Snap();
+            Canvas.ForceUpdateCanvases();
+            // TopLeft → 参考点 (xMin, yMax) = (0,16) → 屏幕 (21.9, (4.1+16)*3=60.3) → (22,60)
+            var after = RectTransformUtility.WorldToScreenPoint(
+                null, tmp.rectTransform.TransformPoint((Vector3)tmp.rectTransform.rect.min
+                       + Vector3.up * tmp.rectTransform.rect.height));
+            Assert.AreEqual(22f, after.x, 0.01f);
+            Assert.AreEqual(60f, after.y, 0.01f);
+            Object.DestroyImmediate(root);
+        }
+
+        [Test]
+        public void Snap_PixelPerfectOff_NoOp()
+        {
+            var (root, tmp, snap) = MakeText(new Vector2(7.3f, 4.1f), pixelPerfect: false);
+            var before = tmp.rectTransform.position;
+            snap.Snap();
+            Assert.AreEqual(before, tmp.rectTransform.position);   // 门控：不动
+            Object.DestroyImmediate(root);
+        }
+```
+
+- [ ] **Step 2: 跑测试确认失败（`Snap()` 不存在）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: 编译错误 `Snap` 未定义。
+
+- [ ] **Step 3: 写最小实现**
+
+在 `PixelSnap` 类加字段、生命周期与 `Snap()`（放在静态助手之上）：
+
+```csharp
+        private RectTransform _rt;
+        private TMP_Text _text;
+        private Canvas _canvas;
+
+        protected override void Awake()
+        {
+            _rt = (RectTransform)transform;
+            _text = GetComponent<TMP_Text>();
+        }
+
+        // 父链变化 → 下次 Snap 重新解析所属 Canvas。
+        protected override void OnCanvasHierarchyChanged() => _canvas = null;
+        protected override void OnTransformParentChanged() => _canvas = null;
+
+        private void LateUpdate() => Snap();
+
+        // 运行期自门控于 canvas.pixelPerfect（关掉它 = 同时关吸附，复用既有 opt-out，PPS-D7）。
+        internal void Snap()
+        {
+            if (_rt == null) _rt = (RectTransform)transform;
+            if (_text == null) _text = GetComponent<TMP_Text>();
+            if (_canvas == null) _canvas = GetComponentInParent<Canvas>(true);
+            if (_text == null || _canvas == null
+                || !_canvas.pixelPerfect
+                || _canvas.renderMode == RenderMode.WorldSpace)
+                return;
+
+            var localRef = ReferencePoint(
+                _rt.rect, _text.horizontalAlignment, _text.verticalAlignment);
+            SnapToPixelGrid(_rt, _canvas, localRef);
+        }
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["PixelSnapTests"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: Task1-3 全 PASS（8 个）。若 `TextMeshProUGUI` 因测试环境缺 TMP Essentials 报 material 警告但测试仍 PASS 即可（吸附只读几何）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Controls/Internal/PixelSnap.cs Tests/EditMode/Application/PixelSnapTests.cs
+git commit -m "$(cat <<'EOF'
+feat: PixelSnap 组件 (LateUpdate + pixelPerfect 门控 + TMP 接线)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Screen 在 Pixel 模式下挂载静态文本
+
+**Files:**
+- Modify: `Runtime/Application/Screen.cs`（字段 ~30；`ApplyCanvasScaler` ~191；`Open` 168 后；新方法）
+- Test: `Tests/EditMode/Application/PixelSnapTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+追加（`OpenScreen` 风格；锚定全屏的 `<Text>`）：
+
+```csharp
+        // ---- Task 4: Screen 静态挂载 ----
+        private static PromptUGUI.Application.Screen OpenPixel(string body)
+        {
+            UI.CanvasSizeOverride = () => new Vector2(5760f, 3240f); // /1920x1080 → factor 3
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>" + body + @"</Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            return (PromptUGUI.Application.Screen)UI.Open("S");
+        }
+
+        [Test]
+        public void Open_PixelMode_AttachesPixelSnapToText()
+        {
+            var screen = OpenPixel("<Text id='t'>hi</Text>");
+            var tmp = screen.RootGameObject.GetComponentInChildren<TMP_Text>(true);
+            Assert.IsNotNull(tmp);
+            Assert.IsNotNull(tmp.GetComponent<PixelSnap>(), "pixel 模式应挂 PixelSnap");
+        }
+
+        [Test]
+        public void Open_AutoMode_DoesNotAttachPixelSnap()
+        {
+            UI.CanvasSizeOverride = () => new Vector2(1920f, 1080f);
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='auto' reference='1920x1080'><Text id='t'>hi</Text></Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = (PromptUGUI.Application.Screen)UI.Open("S");
+            var tmp = screen.RootGameObject.GetComponentInChildren<TMP_Text>(true);
+            Assert.IsNull(tmp.GetComponent<PixelSnap>(), "auto 模式不应挂");
+        }
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["PixelSnapTests"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: `Open_PixelMode_AttachesPixelSnapToText` FAIL（未挂载）。
+
+- [ ] **Step 3: 改 `Screen.cs`**
+
+(a) 在字段区（约 line 30，`_canvasFactor` 附近）加：
+```csharp
+        private bool _isPixelMode;
+```
+
+(b) 在 `ApplyCanvasScaler`，`var mode = ResolveScaleMode();`（约 line 191）下一行加：
+```csharp
+            _isPixelMode = mode == ScaleMode.Pixel;
+```
+
+(c) 在 `Open` 的 `ApplyScales();`（line 168）之后加：
+```csharp
+            AttachPixelSnaps(root);
+```
+
+(d) 在 `ApplyScales` 方法附近新增：
+```csharp
+        // Pixel 模式下给子树里每个 TMP 文本挂 PixelSnap——Canvas.pixelPerfect 不吸 TMP 字形，
+        // 这里把文本渲染原点吸到设备整数像素。幂等（已挂则跳过）；Auto 模式 no-op。
+        // 见 spec 2026-06-17-pixel-position-snap (PPS-D1/D2)。
+        private void AttachPixelSnaps(GameObject subtreeRoot)
+        {
+            if (!_isPixelMode || subtreeRoot == null) return;
+            var texts = subtreeRoot.GetComponentsInChildren<TMPro.TMP_Text>(includeInactive: true);
+            foreach (var t in texts)
+                if (t.GetComponent<Controls.Internal.PixelSnap>() == null)
+                    t.gameObject.AddComponent<Controls.Internal.PixelSnap>();
+        }
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["PixelSnapTests"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: Task1-4 全 PASS（10 个）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Application/Screen.cs Tests/EditMode/Application/PixelSnapTests.cs
+git commit -m "$(cat <<'EOF'
+feat: Screen 在 Pixel 模式下给静态 TMP 文本挂 PixelSnap
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: 动态子树（BindItems/Markdown）挂载
+
+**Files:**
+- Modify: `Runtime/Application/Screen.cs`（`RegisterDynamicSubtree` 顶部，约 line 377）
+- Test: `Tests/EditMode/Application/PixelSnapTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+追加（BindItems 模式，参照 `DynamicSubtreeScaleTests`）：
+
+```csharp
+        // ---- Task 5: 动态子树挂载 ----
+        [Test]
+        public void BindItems_PixelMode_DynamicTextGetsPixelSnap()
+        {
+            UI.CanvasSizeOverride = () => new Vector2(5760f, 3240f); // factor 3
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Row'><Frame width='200' height='50'><Text id='label'>x</Text></Frame></Template>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <ScrollList id='list' itemTemplate='Row'/>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var list = screen.Get<PromptUGUI.Controls.ScrollList>("list");
+            PromptUGUI.Controls.IControl captured = null;
+            list.BindItems(
+                R3.Observable.Return<System.Collections.Generic.IReadOnlyList<string>>(new[] { "a" }),
+                (PromptUGUI.Controls.IControl slot, string s) => captured = slot);
+            var label = captured.Get<PromptUGUI.Controls.Text>("label");
+            Assert.IsNotNull(label.GameObject.GetComponent<PixelSnap>(),
+                "动态实例化的文本也应挂 PixelSnap");
+        }
+```
+
+> 注：`IControl` / `Text` / `ScrollList` 在 `PromptUGUI.Controls`；`Observable` 在 `R3`。文件顶部已有 `using TMPro; using UnityEngine; using PromptUGUI.Controls.Internal;`——本测试用全限定名引用，避免改 using 块。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["PixelSnapTests"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: `BindItems_PixelMode_DynamicTextGetsPixelSnap` FAIL（动态子树未挂）。
+
+- [ ] **Step 3: 改 `Screen.cs`**
+
+在 `RegisterDynamicSubtree(Control root, ...)` 方法体**最开头**（`PruneDeadDynamicSubtrees();` 之前，约 line 379）加一行——必须在 `if (!hasScale) return;` 早返回之前，使无 scale 的动态文本也被挂：
+
+```csharp
+            AttachPixelSnaps(root.GameObject);
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["PixelSnapTests"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: Task1-5 全 PASS（11 个）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Application/Screen.cs Tests/EditMode/Application/PixelSnapTests.cs
+git commit -m "$(cat <<'EOF'
+feat: 动态子树 (BindItems/Markdown) 文本也挂 PixelSnap
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: PlayMode 回归——真实 loop 下中心锚点文本落格
+
+**Files:**
+- Create: `Tests/PlayMode/PixelSnapPlayTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `Tests/PlayMode/PixelSnapPlayTests.cs`（真实 play loop 自动跑 `LateUpdate`）：
+
+```csharp
+using System.Collections;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using TMPro;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.PlayMode
+{
+    public class PixelSnapPlayTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [UnityTest]
+        public IEnumerator CenterAnchoredText_SnapsToIntegerDevicePixel_InPlayLoop()
+        {
+            UI.CanvasSizeOverride = () => new Vector2(5760f, 3240f); // factor 3
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' scale-mode='pixel' reference='1920x1080'>
+    <Text id='t' anchor='center' width='100' height='20'>hi</Text>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("test", xml);
+            var screen = UI.Open("S");
+            var tmp = screen.Get<Text>("t").TmpComponent;
+            var rt = tmp.rectTransform;
+
+            // 强制一个分数设备位置：anchoredPosition x 落在半像素（×3 后 .5）
+            rt.anchoredPosition = new Vector2(7.5f / 3f, 0f); // 期望参考点 x 原 7.5 → 吸到 8 或 7
+            yield return null;   // LateUpdate 跑 Snap
+            yield return null;
+
+            var localRef = PromptUGUI.Controls.Internal.PixelSnap.ReferencePoint(
+                rt.rect, tmp.horizontalAlignment, tmp.verticalAlignment);
+            var screenPt = RectTransformUtility.WorldToScreenPoint(
+                null, rt.TransformPoint((Vector3)localRef));
+            Assert.AreEqual(Mathf.Round(screenPt.x), screenPt.x, 0.02f, "x 应落整数设备像素");
+            Assert.AreEqual(Mathf.Round(screenPt.y), screenPt.y, 0.02f, "y 应落整数设备像素");
+        }
+    }
+}
+```
+
+> `Text.TmpComponent`（internal `TMP_Text` getter）已存在（`Runtime/Controls/Text.cs:16`）。`anchor='center'` 让文本中心锚点对屏幕中心——与用户报告的失效场景同构。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], group_names=["PixelSnapPlayTests"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: 若 Task4 的挂载在 PlayMode 也生效，此测试可能直接 PASS（说明吸附在真实 loop 工作）。若 FAIL，按 systematic-debugging 排查（多为 `LateUpdate` 时序——`yield return null` 加一帧再断言）。
+
+- [ ] **Step 3: 无需新实现**（功能已由 Task 1-5 提供）。若 Step 2 因时序 FAIL：在断言前多 `yield return null` 一帧，或确认 PixelSnap 在 inactive GO 上不跑、显示后跑。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], group_names=["PixelSnapPlayTests"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+mcp__UnityMCP__refresh_unity
+git add Tests/PlayMode/PixelSnapPlayTests.cs Tests/PlayMode/PixelSnapPlayTests.cs.meta
+git commit -m "$(cat <<'EOF'
+test: PlayMode 回归——中心锚点文本在真实 loop 下落格
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: 文档同步 + 全量回归 + lint
+
+**Files:**
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md`
+- Modify: `docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md`
+
+- [ ] **Step 1: C# SKILL 加一句**
+
+在 `scripting-promptugui-csharp/SKILL.md` 的 `UI.CanvasConfigurator` / Pixel 模式相关段落，追加（英文，SKILL 用英文）：
+
+```markdown
+> In Pixel mode (`scale-mode="pixel"`) the library auto-attaches a `PixelSnap` to
+> every TMP text so glyph origins land on whole device pixels (Canvas.pixelPerfect
+> does not pixel-adjust TMP). To opt out for a screen that needs smooth tweens,
+> disable `pixelPerfect` on that Canvas inside `UI.CanvasConfigurator` — that also
+> disables the text snap.
+```
+
+- [ ] **Step 2: master spec 补引用**
+
+在 `2026-05-07-promptugui-description-language-design.md` 的 scale-mode 章节末尾加一句：
+
+```markdown
+Pixel-mode TMP text is additionally pixel-snapped at render time — see
+`2026-06-17-pixel-position-snap-design.md` (decisions PPS-D1…D7).
+```
+
+- [ ] **Step 3: 全量三套 + lint**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__get_test_job(job_id=...)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+mcp__UnityMCP__get_test_job(job_id=...)
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+然后 lint（从仓库根）：
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+Expected: 三套全绿（EditMode 基线 +11、PlayMode +1）、lint 零改动。**勿只看 group——按 [[feedback_verify_full_suites_not_groups]] 跑整套断言全绿。**
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add .claude/skills/scripting-promptugui-csharp/SKILL.md docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
+git commit -m "$(cat <<'EOF'
+docs: pixel position snap 同步 C# SKILL + master spec
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review（写完已检查）
+
+- **Spec 覆盖**：PPS-D1（只补 TMP，Task4 的 GetComponentsInChildren<TMP_Text>）、D2（Screen 挂载 Pixel 门控 Task4 + 动态 Task5）、D3（LateUpdate+公式 Task2/3）、D4（ReferencePoint Task1）、D5（与 scale 正交——`SnapToPixelGrid` 读最终 transform，无需专门 task，PlayMode 隐式覆盖）、D6（行为变更——文档 Task7）、D7（pixelPerfect 门控 Task3）。✅ 全覆盖。
+- **占位扫描**：无 TBD/TODO；每个代码步含完整代码。✅
+- **类型一致**：`ReferencePoint(Rect, HorizontalAlignmentOptions, VerticalAlignmentOptions)`、`SnapToPixelGrid(RectTransform, Canvas, Vector2)`、`Snap()`、`AttachPixelSnaps(GameObject)`、`_isPixelMode`——跨 task 命名一致。✅
+- **风险**：①PlayMode `LateUpdate` 时序（Task6 Step3 已给排查）；②`TextMeshProUGUI` 无字体环境警告（吸附只读几何，不影响断言）；③居中/右对齐 + 奇内容宽 ≤0.5px 残差（spec §3.3 已文档化，非 v1）。

--- a/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
+++ b/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
@@ -237,6 +237,10 @@ Template 同名（含 commons 与各 Import 的任意组合）→ 报错；`as="
 - `scale-mode="auto|pixel"`（可选，支持 `.variant`）：`pixel` 切 CanvasScaler 到 `ConstantPixelSize` + 整数倍 `scaleFactor`（用于像素艺术）。详见 [`2026-05-25-pixel-perfect-scaling-design.md`](2026-05-25-pixel-perfect-scaling-design.md)。
 - 元素级 `scale="Nx"`（N 正整数，支持 `.variant`）：设备像素密度形态，`localScale = N / canvasFactor`（每个设计单位渲染 N 个物理像素，canvas factor 变化时重算），用于 `scale-mode="pixel"` 下位图字的像素对齐。普通 `scale="N"`（正浮点）仍是 factor-independent 的 box-preserving 渲染密度乘数。详见 [`2026-05-31-scale-device-density-design.md`](2026-05-31-scale-device-density-design.md)。
 - 元素级 `scale="<r>r"`（r 正浮点，小写 `r`，支持 `.variant`）：画布相对吸附形态，`localScale = max(1, round(canvasFactor × r)) / canvasFactor`——缩放跟随 factor（随窗口长大），但净物理像素/设计单位吸附到整数保持像素对齐，填补 `scale="N"`（响应但奇数 factor 糊）与 `scale="Nx"`（恒定不长大）之间。详见 [`2026-06-01-scale-canvas-relative-snap-design.md`](2026-06-01-scale-canvas-relative-snap-design.md)。
+
+Pixel-mode TMP text is additionally pixel-snapped at render time — see
+`2026-06-17-pixel-position-snap-design.md` (decisions PPS-D1…D7).
+
 - V/HStack 直下声明了 scale 的 `<Text>` 自动桥接（实例化期 wrapper + `ILayoutElement` 报告 `TMP preferred × s`）：占位 = 视觉、按整行宽换行、行高随内容；三种形态（`N` / `Nx` / `<r>r`）一致，resize / Variant 重算。其余控件与 Grid 子节点维持 LayoutGroup-skip（footgun 文档化）。详见 [`2026-06-11-scaled-text-layout-bridge-design.md`](2026-06-11-scaled-text-layout-bridge-design.md)。
 
 ### 5.7 `<Trigger>` / `<Animation>`（事件订阅 + LitMotion 动画，since 2026-05-14）

--- a/docs~/superpowers/specs/2026-06-17-pixel-position-snap-design.md
+++ b/docs~/superpowers/specs/2026-06-17-pixel-position-snap-design.md
@@ -79,7 +79,7 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 
 **门控**：`canvas == null || !canvas.pixelPerfect || canvas.renderMode == WorldSpace` → 直接返回（PPS-D7）。
 
-**时序（`LateUpdate`，不碰共享 `transform.hasChanged` 标志）**：
+**時序（`LateUpdate`，不碰共享 `transform.hasChanged` 标志）**：
 - 每帧计算对齐感知参考点（局部坐标，见 §3.3）；
 - 用 `RectTransformUtility.WorldToScreenPoint(camera, refWorld)` 把参考点转成屏幕坐标（Overlay canvas 传 `null` camera，Camera-Space 传 `worldCamera`）；
 - 对屏幕坐标各分量 `Mathf.Round`，得目标整数屏幕像素；
@@ -87,6 +87,8 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 - `rt.position += (snapWorld - refWorld)`——平移整个 RT 使参考点落格；
 - 已落格保护：`(snapWorld - refWorld).sqrMagnitude < 1e-4f` 则提前返回，不写入。
 - **幂等**：落格后下一帧同样 `sqrMagnitude < 1e-4f`，提前返回（不累积）。
+
+**非累积基线追踪（防慢速滚动脱轨 bug）**：吸附偏移是瞬时视觉修正，不属于元素的逻辑位置。实现采用基线追踪策略：每帧记住"逻辑 `localPosition`（不含上一帧偏移）"作为 `_baseLocalPos`；若当前 `localPosition == _baseLocalPos + _lastOffset`（误差 < 1e-6），则外部未改动，直接恢复到 `_baseLocalPos` 再重新吸附——修正不叠加；若等式被打破（layout / resize / ReSolve 动了 `localPosition`），则重新取基线（无陈旧残差）。滚动改的是父级 content 的 `anchoredPosition`，不动子节点的 `localPosition`，因此慢速滚动（< 0.5px/帧，每帧修正量相同）不会让修正累积为漂移——文字跟随滚动移动，不被"钉"在初始屏幕像素上。
 
 **为何 `LateUpdate`、为何不用 `hasChanged`**：`LateUpdate` 在 Update 之后；`hasChanged` 是全进程共享的单一 bool（被别处读/重置会互相干扰），故不依赖它——每帧直接重算参考点屏幕坐标、已落格则提前返回（不写入），无额外缓存状态。布局重排相对 `LateUpdate` 的精确时序（uGUI 布局在 `willRenderCanvases` 阶段重建）可能让吸附滞后 1 帧 → 静态屏 1~2 帧内收敛、稳定后正确；resize 拖动中至多 1 帧延迟（不可见）。**确切时序由 PlayMode 测试（resize→清晰）钉死**，若出现可见滞后再改挂 `Canvas.willRenderCanvases` 回调。
 
@@ -126,6 +128,7 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 | 运行时改文本内容 | 块宽变 → 参考点签名变 → 下一帧重吸 |
 | ReSolve（Variant/theme/resize 重算） | ApplyCommon 重置、`AttachPixelSnaps(RootGameObject)` 幂等补挂新增文本、PixelSnap 下一帧重吸 |
 | 画布 resize（无 scale 的中心锚点文字） | Unity 锚点系统重定位 → transform 变 → PixelSnap 重吸（**本 bug 的修复点**，独立于 `_hasFactorScale` ReSolve 门控） |
+| ScrollRect 内文本 + 慢速滚动（< 0.5px/帧） | 非累积基线追踪：文字随滚动移动、不被钉在初始像素、localPosition 不漂移 |
 | 旋转/倾斜（`<Animation>` 旋转文字） | 只吸位置参考点；动画进行中 ≤1px 抖动不可见，静止时正确 |
 | hot reload | 整树重建 → Screen 重新扫描挂载 |
 | `Screen.Close` / Dispose | 组件随 GO 销毁 |

--- a/docs~/superpowers/specs/2026-06-17-pixel-position-snap-design.md
+++ b/docs~/superpowers/specs/2026-06-17-pixel-position-snap-design.md
@@ -44,7 +44,7 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 
 ## 2. 方案概览（PPS-D1：只补 TMP 文本，自包含组件）
 
-新增内部组件 `PixelSnap : UIBehaviour`，挂在库创建的每个 `TMP_Text` 上（仅 Pixel 模式，PPS-D2），在 `LateUpdate` 里把该文本的**对齐感知参考点**吸到设备整数像素网格（PPS-D3/D4），运行期自门控于 `canvas.pixelPerfect`（PPS-D7）。
+新增内部组件 `PixelSnap : UIBehaviour`，挂在库创建的每个 `TMP_Text` 上（仅 Pixel 模式，PPS-D2），在 `Canvas.willRenderCanvases`（PostLateUpdate）里把该文本的**对齐感知参考点**吸到设备整数像素网格（PPS-D3/D4），运行期自门控于 `canvas.pixelPerfect`（PPS-D7）。
 
 ```
 <Text>/label/Markdown 片段 (TMP_Text)
@@ -79,7 +79,7 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 
 **门控**：`canvas == null || !canvas.pixelPerfect || canvas.renderMode == WorldSpace` → 直接返回（PPS-D7）。
 
-**時序（`LateUpdate`，不碰共享 `transform.hasChanged` 标志）**：
+**時序（`Canvas.willRenderCanvases`，PostLateUpdate，不碰共享 `transform.hasChanged` 标志）**：
 - 每帧计算对齐感知参考点（局部坐标，见 §3.3）；
 - 用 `RectTransformUtility.WorldToScreenPoint(camera, refWorld)` 把参考点转成屏幕坐标（Overlay canvas 传 `null` camera，Camera-Space 传 `worldCamera`）；
 - 对屏幕坐标各分量 `Mathf.Round`，得目标整数屏幕像素；
@@ -90,7 +90,7 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 
 **非累积基线追踪（防慢速滚动脱轨 bug）**：吸附偏移是瞬时视觉修正，不属于元素的逻辑位置。实现采用基线追踪策略：每帧记住"逻辑 `localPosition`（不含上一帧偏移）"作为 `_baseLocalPos`；若当前 `localPosition == _baseLocalPos + _lastOffset`（误差 < 1e-6），则外部未改动，直接恢复到 `_baseLocalPos` 再重新吸附——修正不叠加；若等式被打破（layout / resize / ReSolve 动了 `localPosition`），则重新取基线（无陈旧残差）。滚动改的是父级 content 的 `anchoredPosition`，不动子节点的 `localPosition`，因此慢速滚动（< 0.5px/帧，每帧修正量相同）不会让修正累积为漂移——文字跟随滚动移动，不被"钉"在初始屏幕像素上。
 
-**为何 `LateUpdate`、为何不用 `hasChanged`**：`LateUpdate` 在 Update 之后；`hasChanged` 是全进程共享的单一 bool（被别处读/重置会互相干扰），故不依赖它——每帧直接重算参考点屏幕坐标、已落格则提前返回（不写入），无额外缓存状态。布局重排相对 `LateUpdate` 的精确时序（uGUI 布局在 `willRenderCanvases` 阶段重建）可能让吸附滞后 1 帧 → 静态屏 1~2 帧内收敛、稳定后正确；resize 拖动中至多 1 帧延迟（不可见）。**确切时序由 PlayMode 测试（resize→清晰）钉死**，若出现可见滞后再改挂 `Canvas.willRenderCanvases` 回调。
+**为何 `Canvas.willRenderCanvases`、为何不用 `hasChanged`**：`willRenderCanvases` 是 Unity 的 PostLateUpdate 阶段静态事件，在**所有**组件的 `LateUpdate` 和布局重建均完成后、canvas 实际渲染之前触发——设置 transform 在该帧渲染中即生效（网格坐标是局部空间，transform 矩阵在绘制时才应用）。使用 `LateUpdate` 有一个关键问题：`ScrollRect` 在自己的 `LateUpdate` 中通过惯性移动 content 的 `anchoredPosition`，而两个组件的 `LateUpdate` 执行顺序在 Unity 中是**未定义**的——若 `PixelSnap.LateUpdate` 先跑，吸附用的是 ScrollRect 移动前的陈旧位置，本帧渲染前 ScrollRect 再移动 content，吸附偏移不再正确 → 惯性滚动时文字每帧偏离整数像素网格而发糊/斜；静止时 ScrollRect 不移动，吸附永远用最终位置，故只有滚动时可见。改挂 `willRenderCanvases` 后，吸附必然跑在 ScrollRect 惯性移动之后，逐帧落格。`hasChanged` 是全进程共享的单一 bool（被别处读/重置会互相干扰），故不依赖它——每帧直接重算参考点屏幕坐标、已落格则提前返回（不写入），无额外缓存状态。UIBehaviour.`OnDisable`（含销毁前调用）中必须反订阅 `Canvas.willRenderCanvases -= Snap`，避免对禁用/已销毁对象调用。
 
 ### 3.3 对齐感知参考点（PPS-D4，取代 brainstorm 的"吸偶数宽"）
 
@@ -112,7 +112,7 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 ### 3.4 与 `scale` / scaled-text wrapper 的叠加（PPS-D5）
 
 - `scale` 管密度（`localScale`），`PixelSnap` 管位置，正交。吸附经目标 transform 的 `TransformPoint`/`WorldToScreenPoint` 计算，自动含 `localScale`。
-- ReSolve 时 `ApplyCommon` 把 RT 重置到 margin 基线、`ApplyScales` 再膨胀；`PixelSnap` 的 `localPosition` 微调随之被抹掉，下一帧 `LateUpdate` 重吸（不累积、收敛）。
+- ReSolve 时 `ApplyCommon` 把 RT 重置到 margin 基线、`ApplyScales` 再膨胀；`PixelSnap` 的 `localPosition` 微调随之被抹掉，下一帧 `willRenderCanvases` 重吸（不累积、收敛）。
 - scaled-text wrapper 模式（V/HStack 直下 scaled `<Text>`）：`PixelSnap` 挂在**内层 TMP** 上、吸内层原点；wrapper 的位置由布局驱动，内层在 wrapper 内 stretch，吸附是内层 `localPosition` 的亚像素微调，共存无冲突。
 
 ## 4. 边界情形
@@ -128,6 +128,7 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 | 运行时改文本内容 | 块宽变 → 参考点签名变 → 下一帧重吸 |
 | ReSolve（Variant/theme/resize 重算） | ApplyCommon 重置、`AttachPixelSnaps(RootGameObject)` 幂等补挂新增文本、PixelSnap 下一帧重吸 |
 | 画布 resize（无 scale 的中心锚点文字） | Unity 锚点系统重定位 → transform 变 → PixelSnap 重吸（**本 bug 的修复点**，独立于 `_hasFactorScale` ReSolve 门控） |
+| ScrollRect 惯性滚动（Y 持续变化） | 在 willRenderCanvases 吸附（晚于 ScrollRect 的 LateUpdate 内容移动）→ 逐帧落格、不发糊 |
 | ScrollRect 内文本 + 慢速滚动（< 0.5px/帧） | 非累积基线追踪：文字随滚动移动、不被钉在初始像素、localPosition 不漂移 |
 | 旋转/倾斜（`<Animation>` 旋转文字） | 只吸位置参考点；动画进行中 ≤1px 抖动不可见，静止时正确 |
 | hot reload | 整树重建 → Screen 重新扫描挂载 |
@@ -139,7 +140,7 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 
 仅影响 **Pixel 模式**屏幕：TMP 文本从"可能随尺寸亚像素发糊"变为"稳定落格清晰"——纯修复，方向只更符合意图。Auto 模式无变化。无新增 XML/API；唯一 opt-out 是关 `pixelPerfect`（既有杠杆）。非 XML builtin tag → **无需同步 `Runtime/Core/Lint/BuiltinTags.cs`**。
 
-**性能**：每个 TMP 文本一个 `LateUpdate`，每帧执行约 2 次廉价变换调用 + 一次 `localPosition` 写入。**静态屏的每帧写入无法跳过**——父级 ScrollRect 移动元素的世界坐标而不改变其 `localPosition`，故吸附必须每帧重算（"已对齐"保护的是 `rt.position` 写入，不能跳过 `localPosition` 恢复 + 参考点求值）；不触发 layout/canvas 重构，开销低但非零，属有意为之（正确性优先于微优化）。几十上百文本量级在 Profile 下可忽略；若将来成为热点可加签名缓存（需同时解决 ScrollRect 可见性问题）。
+**性能**：每个 TMP 文本订阅一个 `Canvas.willRenderCanvases` 回调，每帧执行约 2 次廉价变换调用 + 一次 `localPosition` 写入。**静态屏的每帧写入无法跳过**——父级 ScrollRect 移动元素的世界坐标而不改变其 `localPosition`，故吸附必须每帧重算（"已对齐"保护的是 `rt.position` 写入，不能跳过 `localPosition` 恢复 + 参考点求值）；不触发 layout/canvas 重构，开销低但非零，属有意为之（正确性优先于微优化）。几十上百文本量级在 Profile 下可忽略；若将来成为热点可加签名缓存（需同时解决 ScrollRect 可见性问题）。
 
 ### 5.2 文档同步
 

--- a/docs~/superpowers/specs/2026-06-17-pixel-position-snap-design.md
+++ b/docs~/superpowers/specs/2026-06-17-pixel-position-snap-design.md
@@ -86,7 +86,7 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 - 用 `RectTransformUtility.ScreenPointToWorldPointInRectangle(canvasRect, screenRounded, camera, out snapWorld)` 反算回世界坐标；
 - `rt.position += (snapWorld - refWorld)`——平移整个 RT 使参考点落格；
 - 已落格保护：`(snapWorld - refWorld).sqrMagnitude < 1e-4f` 则提前返回，不写入。
-- **幂等**：落格后下一帧同样 `sqrMagnitude < 1e-4f`，提前返回（不累积）。
+- 静态屏稳定：落格后下一帧仍 `sqrMagnitude < 1e-4f` → 提前返回、不重复写入。（注意：仅此"已落格"保护**不足以**防累积——慢速滚动时每帧亚像素位移使参考点反复"刚好偏离格"、每帧都写入，故必须配合下面的基线追踪。）
 
 **非累积基线追踪（防慢速滚动脱轨 bug）**：吸附偏移是瞬时视觉修正，不属于元素的逻辑位置。实现采用基线追踪策略：每帧记住"逻辑 `localPosition`（不含上一帧偏移）"作为 `_baseLocalPos`；若当前 `localPosition == _baseLocalPos + _lastOffset`（误差 < 1e-6），则外部未改动，直接恢复到 `_baseLocalPos` 再重新吸附——修正不叠加；若等式被打破（layout / resize / ReSolve 动了 `localPosition`），则重新取基线（无陈旧残差）。滚动改的是父级 content 的 `anchoredPosition`，不动子节点的 `localPosition`，因此慢速滚动（< 0.5px/帧，每帧修正量相同）不会让修正累积为漂移——文字跟随滚动移动，不被"钉"在初始屏幕像素上。
 

--- a/docs~/superpowers/specs/2026-06-17-pixel-position-snap-design.md
+++ b/docs~/superpowers/specs/2026-06-17-pixel-position-snap-design.md
@@ -68,6 +68,7 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 
 - **静态**：`Open` 构建完、`ApplyScales` 之后，若 `ResolveScaleMode() == Pixel`，对 `root.GetComponentsInChildren<TMP_Text>(includeInactive: true)` 每个**幂等**确保挂一个 `PixelSnap`（已有则跳过；注入该 TMP 引用）。控件类型无关——`<Text>`、Btn/Tab/Toggle/Dropdown 的 label、InputField 文本、`<Markdown>` 片段全覆盖。
 - **动态**：`RegisterDynamicSubtree`（`BindItems` / `<Markdown>` 的 `InstantiateNode` 后调用）在 Pixel 模式下扫描新子树的 `TMP_Text` 并补挂。
+- **ReSolve**：`ReSolve` 在 `ApplyScales` 之后也调用 `AttachPixelSnaps(RootGameObject)`（幂等重扫描），覆盖两类情形：运行时首次激活的 `<Add when="...">` 块（Strategy C：首次激活在 ReSolve 内通过 `InstantiateRecursive` 完成，绕开 `RegisterDynamicSubtree`）；以及运行时 `scale-mode` auto→pixel 变体翻转（`ApplyCanvasScaler` 将 `_isPixelMode` 设为 `true`，但 `Open` 时未扫描）。
 - **Auto 模式**：不扫描、不挂 → 零开销、零行为变化（满足目标 6）。
 
 > `includeInactive: true` 是必须的——初始隐藏的 Tab 页里的文本也要在显示时落格（镜像 common-controls-sample 抓到的 inactive-bound-page 坑）。
@@ -78,10 +79,14 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 
 **门控**：`canvas == null || !canvas.pixelPerfect || canvas.renderMode == WorldSpace` → 直接返回（PPS-D7）。
 
-**时序（`LateUpdate`，缓存比较，不碰共享 `transform.hasChanged` 标志）**：
-- 缓存 `_lastSnapKey`（参考点的世界坐标 + rect 尺寸的量化签名）；本帧重算参考点世界坐标，若与缓存一致则 return（绝大多数静态帧零原生调用）；
-- 否则用 **`RectTransformUtility.PixelAdjustPoint`**（与 `pixelPerfect` 同一套原生数学，版本一致、不自己重写设备像素公式）求参考点落格所需的修正量，叠加到 `RectTransform.localPosition`；写完更新缓存。
-- **幂等**：每帧的目标是"吸到最近的格点"，重复运行不累积（落格后下一帧签名不变即跳过 → 收敛、稳定）。
+**时序（`LateUpdate`，不碰共享 `transform.hasChanged` 标志）**：
+- 每帧计算对齐感知参考点（局部坐标，见 §3.3）；
+- 用 `RectTransformUtility.WorldToScreenPoint(camera, refWorld)` 把参考点转成屏幕坐标（Overlay canvas 传 `null` camera，Camera-Space 传 `worldCamera`）；
+- 对屏幕坐标各分量 `Mathf.Round`，得目标整数屏幕像素；
+- 用 `RectTransformUtility.ScreenPointToWorldPointInRectangle(canvasRect, screenRounded, camera, out snapWorld)` 反算回世界坐标；
+- `rt.position += (snapWorld - refWorld)`——平移整个 RT 使参考点落格；
+- 已落格保护：`(snapWorld - refWorld).sqrMagnitude < 1e-4f` 则提前返回，不写入。
+- **幂等**：落格后下一帧同样 `sqrMagnitude < 1e-4f`，提前返回（不累积）。
 
 **为何 `LateUpdate` + 缓存比较**：`LateUpdate` 在 Update 之后；`hasChanged` 是全进程共享的单一 bool（被别处读/重置会互相干扰），故用自有缓存判断"是否移动过"。布局重排相对 `LateUpdate` 的精确时序（uGUI 布局在 `willRenderCanvases` 阶段重建）可能让吸附滞后 1 帧 → 静态屏 1~2 帧内收敛、稳定后正确；resize 拖动中至多 1 帧延迟（不可见）。**确切时序由 PlayMode 测试（resize→清晰）钉死**，若出现可见滞后再改挂 `Canvas.willRenderCanvases` 回调。
 
@@ -119,7 +124,7 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 | `<Text scale=…>`（含 Nx/`<r>r`/wrapper） | 吸内层 TMP 原点，与密度正交叠加 |
 | 动态文本（BindItems/Markdown） | `RegisterDynamicSubtree` 在 Pixel 模式补扫描挂载 |
 | 运行时改文本内容 | 块宽变 → 参考点签名变 → 下一帧重吸 |
-| ReSolve（Variant/theme/resize 重算） | ApplyCommon 重置、PixelSnap 下一帧重吸 |
+| ReSolve（Variant/theme/resize 重算） | ApplyCommon 重置、`AttachPixelSnaps(RootGameObject)` 幂等补挂新增文本、PixelSnap 下一帧重吸 |
 | 画布 resize（无 scale 的中心锚点文字） | Unity 锚点系统重定位 → transform 变 → PixelSnap 重吸（**本 bug 的修复点**，独立于 `_hasFactorScale` ReSolve 门控） |
 | 旋转/倾斜（`<Animation>` 旋转文字） | 只吸位置参考点；动画进行中 ≤1px 抖动不可见，静止时正确 |
 | hot reload | 整树重建 → Screen 重新扫描挂载 |
@@ -131,7 +136,7 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 
 仅影响 **Pixel 模式**屏幕：TMP 文本从"可能随尺寸亚像素发糊"变为"稳定落格清晰"——纯修复，方向只更符合意图。Auto 模式无变化。无新增 XML/API；唯一 opt-out 是关 `pixelPerfect`（既有杠杆）。非 XML builtin tag → **无需同步 `Runtime/Core/Lint/BuiltinTags.cs`**。
 
-**性能**：每个 TMP 文本一个 `LateUpdate`，靠缓存签名比较短路；仅在位置真变化时调一次原生 `PixelAdjustPoint`。静态屏收敛后近零开销；几十上百文本量级可忽略。
+**性能**：每个 TMP 文本一个 `LateUpdate`；每帧计算参考点屏幕位置（2 次廉价变换调用），已对齐则提前返回（不写入）。静态屏开销低但非零——未做签名缓存，经判定收益有限、避免复杂度与风险。几十上百文本量级在 Profile 下可忽略；若将来成为热点可加 `sqrMagnitude` 签名缓存。
 
 ### 5.2 文档同步
 

--- a/docs~/superpowers/specs/2026-06-17-pixel-position-snap-design.md
+++ b/docs~/superpowers/specs/2026-06-17-pixel-position-snap-design.md
@@ -88,7 +88,7 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 - 已落格保护：`(snapWorld - refWorld).sqrMagnitude < 1e-4f` 则提前返回，不写入。
 - **幂等**：落格后下一帧同样 `sqrMagnitude < 1e-4f`，提前返回（不累积）。
 
-**为何 `LateUpdate` + 缓存比较**：`LateUpdate` 在 Update 之后；`hasChanged` 是全进程共享的单一 bool（被别处读/重置会互相干扰），故用自有缓存判断"是否移动过"。布局重排相对 `LateUpdate` 的精确时序（uGUI 布局在 `willRenderCanvases` 阶段重建）可能让吸附滞后 1 帧 → 静态屏 1~2 帧内收敛、稳定后正确；resize 拖动中至多 1 帧延迟（不可见）。**确切时序由 PlayMode 测试（resize→清晰）钉死**，若出现可见滞后再改挂 `Canvas.willRenderCanvases` 回调。
+**为何 `LateUpdate`、为何不用 `hasChanged`**：`LateUpdate` 在 Update 之后；`hasChanged` 是全进程共享的单一 bool（被别处读/重置会互相干扰），故不依赖它——每帧直接重算参考点屏幕坐标、已落格则提前返回（不写入），无额外缓存状态。布局重排相对 `LateUpdate` 的精确时序（uGUI 布局在 `willRenderCanvases` 阶段重建）可能让吸附滞后 1 帧 → 静态屏 1~2 帧内收敛、稳定后正确；resize 拖动中至多 1 帧延迟（不可见）。**确切时序由 PlayMode 测试（resize→清晰）钉死**，若出现可见滞后再改挂 `Canvas.willRenderCanvases` 回调。
 
 ### 3.3 对齐感知参考点（PPS-D4，取代 brainstorm 的"吸偶数宽"）
 
@@ -109,7 +109,7 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 
 ### 3.4 与 `scale` / scaled-text wrapper 的叠加（PPS-D5）
 
-- `scale` 管密度（`localScale`），`PixelSnap` 管位置，正交。`PixelAdjustPoint` 用目标 transform 计算，自动含 `localScale`。
+- `scale` 管密度（`localScale`），`PixelSnap` 管位置，正交。吸附经目标 transform 的 `TransformPoint`/`WorldToScreenPoint` 计算，自动含 `localScale`。
 - ReSolve 时 `ApplyCommon` 把 RT 重置到 margin 基线、`ApplyScales` 再膨胀；`PixelSnap` 的 `localPosition` 微调随之被抹掉，下一帧 `LateUpdate` 重吸（不累积、收敛）。
 - scaled-text wrapper 模式（V/HStack 直下 scaled `<Text>`）：`PixelSnap` 挂在**内层 TMP** 上、吸内层原点；wrapper 的位置由布局驱动，内层在 wrapper 内 stretch，吸附是内层 `localPosition` 的亚像素微调，共存无冲突。
 
@@ -119,7 +119,7 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 |---|---|
 | Auto 模式（非 pixel） | Screen 不挂 PixelSnap → 零开销、零变化 |
 | Pixel 模式 + CanvasConfigurator 关掉 `pixelPerfect`（求平滑 tween） | 组件在但门控返回 → inert（与既有 opt-out 杠杆一致，PPS-D7） |
-| World Space canvas | `PixelAdjustPoint` 本就 no-op，门控直接返回 |
+| World Space canvas | 门控 `renderMode == WorldSpace` 直接返回（pixelPerfect 在世界空间本就无意义） |
 | 居中/右对齐 + 奇内容宽像素字 | 按 rect 几何吸 → 可能 ≤0.5px 残差（文档化，后续增强） |
 | `<Text scale=…>`（含 Nx/`<r>r`/wrapper） | 吸内层 TMP 原点，与密度正交叠加 |
 | 动态文本（BindItems/Markdown） | `RegisterDynamicSubtree` 在 Pixel 模式补扫描挂载 |

--- a/docs~/superpowers/specs/2026-06-17-pixel-position-snap-design.md
+++ b/docs~/superpowers/specs/2026-06-17-pixel-position-snap-design.md
@@ -1,0 +1,157 @@
+# 像素位置吸附（pixel position snap）设计
+
+**日期**：2026-06-17
+**状态**：设计阶段（待 review，未进入实施）
+**作用域**：Pixel 模式（`scale-mode="pixel"`）下，让 **TMP 文本**的渲染原点自动吸附到设备整数像素网格，补上 `Canvas.pixelPerfect` 唯一漏掉的常见屏幕渲染器。修复"像素字体/中心锚点文字随屏幕尺寸时糊时清、看着像斜体"的问题。XML 零新增属性、C# 零新增 API（透明默认行为）。
+**依赖**：
+- [`2026-05-31-scale-device-density-design.md`](2026-05-31-scale-device-density-design.md)（`ScaleMode.Pixel`、整数 `scaleFactor`、`Canvas.pixelPerfect = (mode==Pixel)`、`_canvasFactor`、`OnCanvasDimensionsChanged` resize 门控、`ApplyScales`/box-preserving）
+- [`2026-06-11-scaled-text-layout-bridge-design.md`](2026-06-11-scaled-text-layout-bridge-design.md)（V/HStack 直下 scaled `<Text>` 的 wrapper + TMP 内层）
+- [`2026-05-07-promptugui-description-language-design.md`](2026-05-07-promptugui-description-language-design.md)（scale-mode 章节）
+
+---
+
+## 1. 背景与目标
+
+### 1.1 问题
+
+Pixel 模式下 `scaleFactor` 是整数（`PixelScaleSolver` 取 floor），`Canvas.pixelPerfect` 已打开。理论上一切清晰，但实测仍出现：中心锚点的像素字（Cubic 11）、自由定位的图标，在**某些屏幕尺寸**下半边偏移 1px、看着像斜体；改一下窗口尺寸有时修复、再改又歪；移动元素坐标能修。
+
+**已在宿主 Unity 实测定位根因**（`scaleFactor=3`、`pixelPerfect=true`、临时 canvas 探针）：
+
+- `Canvas.pixelPerfect` 是靠各个 uGUI `Graphic`（Image/RawImage/旧 Text）在生成网格时调 `GetPixelAdjustedRect` 实现的，**把矩形位置和尺寸都吸到整数设备像素**（实测：位置 `-5.00→-4.90`；尺寸 `30.9→31`、`49.2→49`）。
+- **TMP 完全绕过这条路径**——它自己接管字形网格生成，不调 `GetPixelAdjustedRect`。所以 TMP 文本的 rect 原点一旦落在半像素（中心锚点 + 屏幕尺寸奇偶性 → 画布中心落在 `.5`），字形位图就跨纹素采样 → 半边偏 1px。
+- **为何 resize 时好时坏**：纯中心锚点文字，resize 时本地 rect 不变、库的 `_hasFactorScale` ReSolve 门控也不触发，但 Unity 的锚点系统会自动把它重定位到新中心 → 世界坐标变成半像素，没有任何一方去重新吸附。屏幕尺寸的奇偶翻转 → 中心落格/落半像素翻转 → 时清时糊。
+
+> 一句话：**Pixel 模式承诺"清晰"，但只靠 `Canvas.pixelPerfect` 兑现不了——它管不到 TMP 文本。** 库的 C# 侧目前没有任何世界坐标吸附（`scale` 链路只动 `localScale` 管密度、box-preserving 只为保盒子动 anchor/sizeDelta，`anchoredPosition` 原样不动），位置对齐全托付给了 `pixelPerfect`。
+
+### 1.2 目标
+
+Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设备整数像素上，且在**布局重排 / 画布 resize / ReSolve / 父级移动**后保持落格。作者/调用方零改动。验收语义：
+
+1. 中心锚点 `<Text>`：任意屏幕尺寸（奇/偶宽）下渲染清晰，不再随尺寸时糊时清；
+2. resize 拖动后稳定落格（独立于库的 ReSolve 门控）；
+3. LayoutGroup 子节点文本（如 Tab label）落格；
+4. 与 `scale`（密度）正交叠加、与 scaled-text wrapper 共存；
+5. 动态文本（`BindItems` / `<Markdown>`）同样落格；
+6. Auto 模式零开销、零行为变化。
+
+### 1.3 非目标
+
+- **精灵的非整数倍缩放撕裂**（缩放轴，PPS-D1）：例如 16×16 源图被放大到 24×24（1.5×）→ 点采样不均撕裂。这是"屏上尺寸 ≠ 源图整数倍"，与位置无关，`pixelPerfect` 把尺寸吸到整数设备像素也救不了（救不到整数**倍**）。本次**明确搁置**——属作者侧规范（图标用原生/整数倍尺寸）+ 未来 lint 兜底。
+- **Image/RawImage 的位置吸附**：实测 `pixelPerfect` 已覆盖；再去吸是冗余，且会和它打架、或让相邻 LayoutGroup 子节点（如 TabBar tab 背景）出现 1px 缝。**不碰**（PPS-D1）。
+- **TabBar 分数宽**（`xx.75`）：tab 背景是 Image（边已被 `pixelPerfect` 吸），label 是 TMP（本方案管）。tab 的 `anchoredPosition` 值仍是分数——这是布局值，渲染由上述两条覆盖，不追求 Inspector 数值整数化。
+- 不提供 opt-in / 新属性；唯一 opt-out 复用既有的 `pixelPerfect` 开关（PPS-D7）。
+
+## 2. 方案概览（PPS-D1：只补 TMP 文本，自包含组件）
+
+新增内部组件 `PixelSnap : UIBehaviour`，挂在库创建的每个 `TMP_Text` 上（仅 Pixel 模式，PPS-D2），在 `LateUpdate` 里把该文本的**对齐感知参考点**吸到设备整数像素网格（PPS-D3/D4），运行期自门控于 `canvas.pixelPerfect`（PPS-D7）。
+
+```
+<Text>/label/Markdown 片段 (TMP_Text)
+   + PixelSnap        ← 新组件：每帧（仅当位置变化时）把渲染参考点吸到设备格
+```
+
+**为何只补 TMP 文本**：实测 `pixelPerfect` 已把所有 `Graphic` 派生组件（Image/RawImage/旧 Text）的位置+尺寸吸到整数设备像素；屏幕 UI 里唯一绕过这条路的就是 TMP。把吸附限定在 TMP 文本，是对"已实证的洞"的最小精确修复——更紧、更低风险（不和 `pixelPerfect` 的 Image 路径重叠/冲突）。
+
+**为何用 per-element 组件而非 Screen 集中 pass**：核心诉求是"resize 后落格"。纯中心锚点文字在 resize 时由 **Unity 的锚点系统**重定位，库的 `_hasFactorScale` ReSolve 门控**不触发** → Screen 集中 pass 不会重跑 → 文字 resize 后又歪（正是本 bug）。per-element 组件盯自己 transform 的变化，能在 Unity 重排后立即重吸，**不依赖库的 ReSolve**。这是组件方案相对集中 pass 的决定性优势。
+
+被否方案：
+- **Screen 集中后处理 pass**：resize 反应要么漏（门控不触发），要么得为所有 Pixel 屏在每次 resize 无条件重跑全树——比一个自反应组件更重且更易漏。
+- **改 Canvas.pixelPerfect 之外另设全局吸附**：无法触达 TMP 字形（同样得 per-text）。
+- **TMP Pixel-Snap 着色器**：per-material、对图文混排/描边材质组合脆弱，且不受库控制；组件吸 Rect 更可靠、版本无关。
+
+## 3. 组件设计
+
+### 3.1 挂载（PPS-D2，由 Screen 在 Pixel 模式下注入）
+
+挂载发生在 **Screen**（而非 ScreenInstantiator），因为 scale-mode 在 `Screen.Open` 的 `ResolveScaleMode()` 才确定：
+
+- **静态**：`Open` 构建完、`ApplyScales` 之后，若 `ResolveScaleMode() == Pixel`，对 `root.GetComponentsInChildren<TMP_Text>(includeInactive: true)` 每个**幂等**确保挂一个 `PixelSnap`（已有则跳过；注入该 TMP 引用）。控件类型无关——`<Text>`、Btn/Tab/Toggle/Dropdown 的 label、InputField 文本、`<Markdown>` 片段全覆盖。
+- **动态**：`RegisterDynamicSubtree`（`BindItems` / `<Markdown>` 的 `InstantiateNode` 后调用）在 Pixel 模式下扫描新子树的 `TMP_Text` 并补挂。
+- **Auto 模式**：不扫描、不挂 → 零开销、零行为变化（满足目标 6）。
+
+> `includeInactive: true` 是必须的——初始隐藏的 Tab 页里的文本也要在显示时落格（镜像 common-controls-sample 抓到的 inactive-bound-page 坑）。
+
+### 3.2 吸附数学与时序（PPS-D3）
+
+`internal sealed class PixelSnap : UIBehaviour`，持目标 `TMP_Text` + 其 `RectTransform` + `Canvas` 引用。
+
+**门控**：`canvas == null || !canvas.pixelPerfect || canvas.renderMode == WorldSpace` → 直接返回（PPS-D7）。
+
+**时序（`LateUpdate`，缓存比较，不碰共享 `transform.hasChanged` 标志）**：
+- 缓存 `_lastSnapKey`（参考点的世界坐标 + rect 尺寸的量化签名）；本帧重算参考点世界坐标，若与缓存一致则 return（绝大多数静态帧零原生调用）；
+- 否则用 **`RectTransformUtility.PixelAdjustPoint`**（与 `pixelPerfect` 同一套原生数学，版本一致、不自己重写设备像素公式）求参考点落格所需的修正量，叠加到 `RectTransform.localPosition`；写完更新缓存。
+- **幂等**：每帧的目标是"吸到最近的格点"，重复运行不累积（落格后下一帧签名不变即跳过 → 收敛、稳定）。
+
+**为何 `LateUpdate` + 缓存比较**：`LateUpdate` 在 Update 之后；`hasChanged` 是全进程共享的单一 bool（被别处读/重置会互相干扰），故用自有缓存判断"是否移动过"。布局重排相对 `LateUpdate` 的精确时序（uGUI 布局在 `willRenderCanvases` 阶段重建）可能让吸附滞后 1 帧 → 静态屏 1~2 帧内收敛、稳定后正确；resize 拖动中至多 1 帧延迟（不可见）。**确切时序由 PlayMode 测试（resize→清晰）钉死**，若出现可见滞后再改挂 `Canvas.willRenderCanvases` 回调。
+
+### 3.3 对齐感知参考点（PPS-D4，取代 brainstorm 的"吸偶数宽"）
+
+只吸 rect 原点对**居中/右对齐**文本不够：TMP 把文本块按对齐方式相对 rect 摆放，块的渲染边 = `rectEdge + 对齐偏移`，偏移随 rect 宽与块宽变化。故吸附的参考点要**随 TMP 对齐方式选取**：
+
+| `TMP_Text` 对齐 | 水平参考点 | 垂直参考点 |
+|---|---|---|
+| Left / Top | rect 左边 / 上边（= 原点） | |
+| Center | rect 水平中心 | rect 垂直中心 |
+| Right / Bottom | rect 右边 / 下边 | |
+| Justified | 同 Left（块左边对齐） | |
+
+对**像素字体**（字形步进为整数像素），参考点落格 + 整数步进 ⇒ 字形落格。
+
+> **改自 brainstorm 提案**：原提"把 rect 宽吸成偶数设备像素"——但 (a) LayoutGroup 子节点的宽由布局驱动（DrivenRectTransformTracker），外部改宽贴不住；(b) 即便偶数宽，块宽为奇时块左边仍落半像素。改吸**参考点**（只动 `localPosition`，不动 rect 尺寸）→ 既不和驱动宽打架，又对 stretch/驱动宽的居中文本同样有效。
+>
+> **已知残差**：居中/右对齐 + 文本**内容宽为奇**像素时，按 rect 几何吸参考点仍可能留 ≤0.5px 残差（块宽奇偶取决于内容）。完全消除需读 TMP 实际渲染块边（`textBounds`/`textInfo`，随 `TEXT_CHANGED` 重吸）——列为后续增强，非 v1 范围（像素字体多左对齐，居中为少数）。文档化。
+
+### 3.4 与 `scale` / scaled-text wrapper 的叠加（PPS-D5）
+
+- `scale` 管密度（`localScale`），`PixelSnap` 管位置，正交。`PixelAdjustPoint` 用目标 transform 计算，自动含 `localScale`。
+- ReSolve 时 `ApplyCommon` 把 RT 重置到 margin 基线、`ApplyScales` 再膨胀；`PixelSnap` 的 `localPosition` 微调随之被抹掉，下一帧 `LateUpdate` 重吸（不累积、收敛）。
+- scaled-text wrapper 模式（V/HStack 直下 scaled `<Text>`）：`PixelSnap` 挂在**内层 TMP** 上、吸内层原点；wrapper 的位置由布局驱动，内层在 wrapper 内 stretch，吸附是内层 `localPosition` 的亚像素微调，共存无冲突。
+
+## 4. 边界情形
+
+| 情形 | 行为 |
+|---|---|
+| Auto 模式（非 pixel） | Screen 不挂 PixelSnap → 零开销、零变化 |
+| Pixel 模式 + CanvasConfigurator 关掉 `pixelPerfect`（求平滑 tween） | 组件在但门控返回 → inert（与既有 opt-out 杠杆一致，PPS-D7） |
+| World Space canvas | `PixelAdjustPoint` 本就 no-op，门控直接返回 |
+| 居中/右对齐 + 奇内容宽像素字 | 按 rect 几何吸 → 可能 ≤0.5px 残差（文档化，后续增强） |
+| `<Text scale=…>`（含 Nx/`<r>r`/wrapper） | 吸内层 TMP 原点，与密度正交叠加 |
+| 动态文本（BindItems/Markdown） | `RegisterDynamicSubtree` 在 Pixel 模式补扫描挂载 |
+| 运行时改文本内容 | 块宽变 → 参考点签名变 → 下一帧重吸 |
+| ReSolve（Variant/theme/resize 重算） | ApplyCommon 重置、PixelSnap 下一帧重吸 |
+| 画布 resize（无 scale 的中心锚点文字） | Unity 锚点系统重定位 → transform 变 → PixelSnap 重吸（**本 bug 的修复点**，独立于 `_hasFactorScale` ReSolve 门控） |
+| 旋转/倾斜（`<Animation>` 旋转文字） | 只吸位置参考点；动画进行中 ≤1px 抖动不可见，静止时正确 |
+| hot reload | 整树重建 → Screen 重新扫描挂载 |
+| `Screen.Close` / Dispose | 组件随 GO 销毁 |
+
+## 5. 兼容性、性能与文档
+
+### 5.1 行为变更（PPS-D6）
+
+仅影响 **Pixel 模式**屏幕：TMP 文本从"可能随尺寸亚像素发糊"变为"稳定落格清晰"——纯修复，方向只更符合意图。Auto 模式无变化。无新增 XML/API；唯一 opt-out 是关 `pixelPerfect`（既有杠杆）。非 XML builtin tag → **无需同步 `Runtime/Core/Lint/BuiltinTags.cs`**。
+
+**性能**：每个 TMP 文本一个 `LateUpdate`，靠缓存签名比较短路；仅在位置真变化时调一次原生 `PixelAdjustPoint`。静态屏收敛后近零开销；几十上百文本量级可忽略。
+
+### 5.2 文档同步
+
+属"透明默认运行时行为"（无作者可写的 API/属性）——按既有惯例（pure default/fallback 运行时行为豁免 SKILL 详述），**不新增 XML SKILL 条目**。仅：
+- **C# SKILL**（`scripting-promptugui-csharp`）的 `UI.CanvasConfigurator` / Pixel 模式一节加一句：Pixel 模式下库会把 TMP 文本吸附到像素网格保持清晰；如需平滑 tween 可在 CanvasConfigurator 里关掉该 Canvas 的 `pixelPerfect`（同时关闭吸附）。
+- **master spec** 补节引用本设计（决策号 PPS-D1…D7）。
+
+## 6. 测试策略（Red 先行）
+
+**先写复现红测试**（systematic-debugging Phase 4）：Pixel 模式、受控 canvas 尺寸（奇宽）、中心锚点 TMP → 断言其设备原点为分数（无吸附时失败方向）→ 实现后转为"设备原点为整数"。
+
+**EditMode**（`PromptUGUI.Tests.EditMode`，`UI.ResetForTests()`）：
+1. 挂载矩阵：Pixel 模式 Open 后每个 TMP 文本有 PixelSnap（静态 + BindItems/Markdown 动态子树）；Auto 模式无。
+2. 门控：`pixelPerfect=false` 时组件 inert（不改 localPosition）。
+3. 吸附数学（受控 canvas + 已知 `scaleFactor`）：给定亚像素设备位置 → 吸后参考点设备坐标为整数；按对齐选参考点（left→左边、center→中心、right→右边）。
+4. 与 `scale` 叠加：scaled 文本（含 wrapper）吸后原点落格、密度不变。
+5. 幂等：连跑两帧 `LateUpdate` 结果稳定、不累积。
+
+**PlayMode**（真实布局 + Canvas，`PromptUGUI.Tests.PlayMode`）：
+6. 中心锚点文本在奇/偶画布尺寸下设备原点均为整数；模拟 resize（改 canvas 尺寸）后仍落格（**本 bug 回归**）。
+7. LayoutGroup 子节点文本（Tab label）落格；left vs center 对齐均落格（居中容差含 §3.3 残差说明）。
+
+**工具链**：UnityMCP 跑三套（EditMode / EditorOnly / PlayMode）+ `dotnet format --verify-no-changes --severity warn`。

--- a/docs~/superpowers/specs/2026-06-17-pixel-position-snap-design.md
+++ b/docs~/superpowers/specs/2026-06-17-pixel-position-snap-design.md
@@ -139,7 +139,7 @@ Pixel 模式下，库创建的每个 TMP 文本，其渲染原点自动落在设
 
 仅影响 **Pixel 模式**屏幕：TMP 文本从"可能随尺寸亚像素发糊"变为"稳定落格清晰"——纯修复，方向只更符合意图。Auto 模式无变化。无新增 XML/API；唯一 opt-out 是关 `pixelPerfect`（既有杠杆）。非 XML builtin tag → **无需同步 `Runtime/Core/Lint/BuiltinTags.cs`**。
 
-**性能**：每个 TMP 文本一个 `LateUpdate`；每帧计算参考点屏幕位置（2 次廉价变换调用），已对齐则提前返回（不写入）。静态屏开销低但非零——未做签名缓存，经判定收益有限、避免复杂度与风险。几十上百文本量级在 Profile 下可忽略；若将来成为热点可加 `sqrMagnitude` 签名缓存。
+**性能**：每个 TMP 文本一个 `LateUpdate`，每帧执行约 2 次廉价变换调用 + 一次 `localPosition` 写入。**静态屏的每帧写入无法跳过**——父级 ScrollRect 移动元素的世界坐标而不改变其 `localPosition`，故吸附必须每帧重算（"已对齐"保护的是 `rt.position` 写入，不能跳过 `localPosition` 恢复 + 参考点求值）；不触发 layout/canvas 重构，开销低但非零，属有意为之（正确性优先于微优化）。几十上百文本量级在 Profile 下可忽略；若将来成为热点可加签名缓存（需同时解决 ScrollRect 可见性问题）。
 
 ### 5.2 文档同步
 


### PR DESCRIPTION
## Summary
- Pixel 模式（`scale-mode="pixel"`）下，库自动给每个 TMP 文本挂内部组件 `PixelSnap`，把文本渲染原点吸附到**整数设备像素网格**——补上 `Canvas.pixelPerfect` 唯一漏掉的屏幕渲染器（TMP 绕过了 `GetPixelAdjustedRect`）。修复中心锚点 / 像素字（Cubic 11）随屏幕尺寸「时糊时清、看着像斜体」。
- 零新增 XML / C# API（透明默认行为）；唯一 opt-out = 在 `UI.CanvasConfigurator` 里关掉该 Canvas 的 `pixelPerfect`（同时关闭吸附）。
- 设计与决策 PPS-D1…D7：`docs~/superpowers/specs/2026-06-17-pixel-position-snap-design.md`。
- **非目标（搁置）**：精灵非整数倍缩放撕裂（如 16×16→24×24，与位置无关）、TabBar 分数宽（tab 背景是 Image 已被 pixelPerfect 覆盖）。

## 关键实现
- `PixelSnap : UIBehaviour`（`Runtime/Controls/Internal/PixelSnap.cs`）：在 **`Canvas.willRenderCanvases`**（PostLateUpdate，晚于所有 `LateUpdate`/ScrollRect 内容移动/布局重建）按**对齐感知参考点**吸附（左/中/右对齐取不同边）；**非累积基线追踪**，避免 ScrollRect 内文字脱轨。
- `Screen` 在 Pixel 模式下于 `Open` / `RegisterDynamicSubtree`（BindItems/Markdown）/ `ReSolve`（运行时 Add 块、scale-mode 变体翻转）幂等挂载；Auto 模式零开销。

## Test Plan
- [x] 全量绿：EditMode 1903 / EditorOnly 268 / PlayMode 152；`dotnet format` lint clean
- [x] 单元：`ReferencePoint`、`SnapToPixelGrid`（落格 + 幂等）、组件 `pixelPerfect` 门控
- [x] 集成：Pixel 静态/动态/ReSolve 挂载；中心锚点、LayoutGroup 子节点、慢速滚动不脱轨、**真实 ScrollRect 惯性滚动逐帧落格**
- [x] 用户实机视觉 QA：奇偶屏幕尺寸 / resize、慢速滚动、惯性滚动均清晰
- [ ] 已知 v1 残差：居中/右对齐 + 奇内容宽像素字 ≤0.5px（文档化，后续增强）

🤖 Generated with [Claude Code](https://claude.com/claude-code)