### PR TITLE
feat: CenteredSlideBox 反应式 items + .AddTo(card) 卡片级订阅生命周期

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/reference/controls-carousel.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/controls-carousel.md
@@ -37,6 +37,23 @@ screen.Get<Carousel>("banner")
       }).AddTo(screen);
 ```
 
+`BindItems` 的第三个可选参 `Func<T,object> key`（如 `key: x => x.Id`）：源 Observable
+重新 emit（成员增删/换序）时，重建后按 key 把"上一帧居中的那张卡"重新居中；命中不到
+（被删/无 key 引用对不上）则就近夹位。一次 emit 至多触发一次 `OnCurrentChanged`。
+卡内实时字段在 `bind` 里订阅并 `.AddTo(card)`（重建/关窗自动退订）。
+
+```csharp
+screen.Get<Carousel>("sel")
+      .BindItems(
+          liveItems,                           // Observable<IReadOnlyList<T>>
+          (IControl card, MyItem item) => {
+              var lbl = card.Get<Text>("label");
+              item.Name.Subscribe(n => lbl.TextValue = n).AddTo(card);  // .AddTo(card), not screen
+          },
+          key: x => x.Id)                      // re-centre by identity across membership changes
+      .AddTo(screen);
+```
+
 ## 静态卡（§3.2）
 
 ```xml

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -203,6 +203,27 @@ State is driven by the Selectable machine and is disabled-aware (a disabled cont
 
 `screen.Track(disposable)` (or the `.AddTo(screen)` extension) ties a subscription to Screen lifetime. **Always do this** — leaked R3 subscriptions hold the GameObject alive after Close, and the next Open will produce phantom callbacks against the old (destroyed) GameObject.
 
+### Per-control subscription lifetime (`.AddTo(control)`)
+
+`.AddTo(screen)` ties a subscription to **Screen** lifetime. For per-item live
+data inside a `BindItems` / modal-card binder, tie it to the **card** instead so
+it's disposed when that card is rebuilt (list membership change) or the screen
+closes — whichever comes first:
+
+```csharp
+list.BindItems(items, (slot, item) => {
+    var label = slot.Get<Text>("label");                 // cache the handle
+    item.Count.Subscribe(n => label.TextValue = $"x{n}") // R3 field on the item VM
+        .AddTo(slot);                                    // ← card lifetime, NOT screen
+});
+```
+
+`.AddTo(control)` works on any `IControl` (mirrors `.AddTo(screen)`). Disposing a
+control disposes its tracked subscriptions, recursively including child controls.
+Using `.AddTo(screen)` for per-card subscriptions leaks across list rebuilds
+(old cards are destroyed but their subscriptions keep firing into dead controls
+until the screen closes).
+
 ## Screen-level hooks
 
 `screen.RectTransformDimensionsChanged` is the same as the Canvas's `screen.RootGameObject.RectTransformDimensionsChanged` — useful for re-layout reactions that span multiple controls.
@@ -550,13 +571,14 @@ EVENTS (R3)    .OnClick                Btn
                .OnCurrentChanged       Carousel:int (any-source page change, deduped)
                .OnEndEdit / .OnSubmit  InputField:string
                .Subscribe(...).AddTo(screen)   tie lifetime — ALWAYS
+               .Subscribe(...).AddTo(control)  per-card/per-control lifetime (BindItems 内订阅用它)
                Progress                display-only; .Value = 0.42f (Clamp01); no event
 
 DATA PUSH      Dropdown.BindOptions(Observable<IEnumerable<string>>)
                ScrollList.BindItems(Observable<IReadOnlyList<T>>, (slot,t)=>...)
                TabBar.BindItems(Observable<IReadOnlyList<T>>, (Tab tab,t)=>...)
                                        or BindItems<T,TSlot>(...) for wrapped templates
-               Carousel.BindItems(Observable<IReadOnlyList<T>>, (IControl card,t)=>...)
+               Carousel.BindItems(Observable<IReadOnlyList<T>>, (IControl card,t)=>..., key: o=>o.Id (反应式身份保持))
                                        or BindItems<T,TSlot>(...) for typed card template
                .AddTo(screen)
                TabBar query: .Count / .SelectedIndex (-1 if empty) / .SelectedTab / .GetAt(i)
@@ -607,6 +629,7 @@ MODAL          var r = await MessageBox.Open(text, MsgBtn.OK|MsgBtn.Cancel, icon
                               // 居中卡片选择器(关卡/角色弹窗,内含 fill=false peek Carousel);T:class
                               // 返回选中对象(取消 ×/背景/ESC → null);bind 填内置卡槽 cover/name(同 BindItems)
                               // 点侧卡居中,点居中卡 or 确认按钮 = 确认;换皮 CenteredSlideBox.XmlSrc 指自己 XML
+                              // items 可传 Observable<IReadOnlyList<T>> (反应式) + key: o=>o.Id 身份保持居中
                var (item,key) = await CenteredSlideBox.Open(items, bind, buttons, title, mode, configure, ct)
                               // multi-button overload → SlideSelection<T>(.Item/.Button/.Cancelled)
                               // ≥2 buttons: tap-centred-card shortcut disabled (must click a button); side-tap still centres
@@ -748,6 +771,23 @@ if (action == null) return;            // cancelled
 if (action == "play") StartLevel(level);
 // else action == "hard" → StartLevel(level, hard: true)
 
+// Reactive items: the card set changes live (orders appear/disappear) AND each
+// card's fields tick. Pass Observable<IReadOnlyList<T>> for membership; subscribe
+// per-card fields inside `bind` with .AddTo(card). `key` keeps the centred card
+// by identity across membership changes (so confirm submits the object the user sees).
+var picked = await CenteredSlideBox.Open(
+    items: liveOrders,                       // Observable<IReadOnlyList<OrderVM>>
+    bind: (card, vm) => {
+        var price = card.Get<Text>("price"); // cache; don't Get every tick
+        vm.Price.Subscribe(p => price.TextValue = p.ToString("C")).AddTo(card);
+    },
+    title: UI.Tr("Select order"),
+    key: o => o.Id);                         // identity for centred-card preservation
+// Membership change (add/remove/reorder) triggers a full card rebuild (NOT keyed diff).
+// For high-frequency lists, use ScrollList instead.
+// Per-card live fields: subscribe in bind + .AddTo(card); card is disposed on rebuild or close.
+// Cache card.Get<T>(...) handles outside the per-tick callback.
+
 // Different card style? point CenteredSlideBox.XmlSrc at your own .ui, keeping the id
 // contract: backdrop / panel / title / close / button0..buttonN / cards (Carousel fill="false")
 // + your card template's slots.
@@ -821,7 +861,7 @@ public static class MarkdownBox {
 public static class CenteredSlideBox {
     public static string XmlSrc { get; set; } = "PromptUGUI/Modals/CenteredSlideBox.ui";
 
-    // Single-button overload: returns the selected item, or null on cancel.
+    // Static single-button overload: returns the selected item, or null on cancel.
     // Tap a side card to centre it; tap the centred card OR the confirm button to pick.
     public static Awaitable<T> Open<T>(
         IReadOnlyList<T> items, Action<IControl, T> bind,
@@ -831,7 +871,7 @@ public static class CenteredSlideBox {
         Action<IScreen> configure = null,
         CancellationToken ct = default) where T : class;
 
-    // Multi-button overload: returns SlideSelection<T>.
+    // Static multi-button overload: returns SlideSelection<T>.
     // ≥2 buttons disables the "tap centred card" shortcut — user must click a button.
     // label is shown as-is (wrap in UI.Tr for i18n); key is the stable branch discriminator.
     // Default skin exposes button0..button4 (5 slots).
@@ -843,6 +883,31 @@ public static class CenteredSlideBox {
         string title         = null,
         ModalMode mode       = ModalMode.Popup,
         Action<IScreen> configure = null,
+        CancellationToken ct = default) where T : class;
+
+    // Reactive single-button overload: items is Observable<IReadOnlyList<T>>.
+    // On each re-emit the card set is fully rebuilt; `key` re-centres the previously-centred
+    // card by identity (Func<T,object>; e.g. key: o => o.Id). Key not found → clamp to nearest.
+    // ≤1 OnCurrentChanged per emit. Subscribe per-card live fields inside `bind` with .AddTo(card).
+    // Membership change = full rebuild (NOT keyed diff); for high-frequency lists use ScrollList.
+    // Static overloads are unchanged; `key` exists only on reactive overloads (static lists never rebuild).
+    public static Awaitable<T> Open<T>(
+        Observable<IReadOnlyList<T>> items, Action<IControl, T> bind,
+        string title         = null,
+        string confirmLabel  = null,
+        ModalMode mode       = ModalMode.Popup,
+        Action<IScreen> configure = null,
+        Func<T, object> key  = null,
+        CancellationToken ct = default) where T : class;
+
+    // Reactive multi-button overload: same reactive semantics + `key` as the single-button form.
+    public static Awaitable<SlideSelection<T>> Open<T>(
+        Observable<IReadOnlyList<T>> items, Action<IControl, T> bind,
+        IEnumerable<(string label, string key)> buttons,
+        string title         = null,
+        ModalMode mode       = ModalMode.Popup,
+        Action<IScreen> configure = null,
+        Func<T, object> key  = null,
         CancellationToken ct = default) where T : class;
 }
 

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -571,14 +571,15 @@ EVENTS (R3)    .OnClick                Btn
                .OnCurrentChanged       Carousel:int (any-source page change, deduped)
                .OnEndEdit / .OnSubmit  InputField:string
                .Subscribe(...).AddTo(screen)   tie lifetime — ALWAYS
-               .Subscribe(...).AddTo(control)  per-card/per-control lifetime (BindItems 内订阅用它)
+               .Subscribe(...).AddTo(control)  per-card/per-control lifetime (use inside BindItems)
                Progress                display-only; .Value = 0.42f (Clamp01); no event
 
 DATA PUSH      Dropdown.BindOptions(Observable<IEnumerable<string>>)
                ScrollList.BindItems(Observable<IReadOnlyList<T>>, (slot,t)=>...)
                TabBar.BindItems(Observable<IReadOnlyList<T>>, (Tab tab,t)=>...)
                                        or BindItems<T,TSlot>(...) for wrapped templates
-               Carousel.BindItems(Observable<IReadOnlyList<T>>, (IControl card,t)=>..., key: o=>o.Id (反应式身份保持))
+               Carousel.BindItems(Observable<IReadOnlyList<T>>, (IControl card,t)=>...[, key: o=>o.Id])
+                                                              // key optional: re-centre the centred card by identity on re-emit
                                        or BindItems<T,TSlot>(...) for typed card template
                .AddTo(screen)
                TabBar query: .Count / .SelectedIndex (-1 if empty) / .SelectedTab / .GetAt(i)

--- a/Runtime/Application/Disposables.cs
+++ b/Runtime/Application/Disposables.cs
@@ -15,5 +15,11 @@ namespace PromptUGUI.Application
             ((Screen)screen).Track(disposable);
             return disposable;
         }
+
+        public static T AddTo<T>(this T disposable, Controls.IControl control) where T : IDisposable
+        {
+            ((Controls.Control)control).Track(disposable);
+            return disposable;
+        }
     }
 }

--- a/Runtime/Application/Modals/CenteredSlideBoxRequest.cs
+++ b/Runtime/Application/Modals/CenteredSlideBoxRequest.cs
@@ -10,14 +10,16 @@ namespace PromptUGUI.Application.Modals
     // 共享 Bind 逻辑：单/多按钮 request 都委托这里。onConfirm/onCancel 抽掉结果类型差异。
     internal static class CenteredSlideBoxBinder
     {
-        // buttons 至少 1 个（两个 request 各自保证）。
+        // buttons 至少 1 个（两个 request 各自保证）；itemsSource 由 request 归一化为非空 Observable。
         public static void Bind<T>(
-            IScreen screen, IReadOnlyList<T> items, Action<IControl, T> bindCard, string title,
-            IReadOnlyList<(string label, string key)> buttons, string xmlSrcForError,
-            Action<T, string> onConfirm, Action onCancel) where T : class
+            IScreen screen, Observable<IReadOnlyList<T>> itemsSource, Action<IControl, T> bindCard,
+            string title, IReadOnlyList<(string label, string key)> buttons, Func<T, object> key,
+            string xmlSrcForError, Action<T, string> onConfirm, Action onCancel) where T : class
         {
-            if (buttons == null || buttons.Count == 0)        // facade 已挡空；这是直接 new request 的兜底（CSB-D14）
+            if (buttons == null || buttons.Count == 0)        // facade 已挡空；直接 new request 的兜底（CSB-D14）
                 throw new ArgumentException("CenteredSlideBox requires at least one button.", nameof(buttons));
+            if (itemsSource == null)
+                throw new ArgumentNullException(nameof(itemsSource));
 
             // —— title ——
             var titleCtl = screen.Get<Text>("title");
@@ -29,23 +31,14 @@ namespace PromptUGUI.Application.Modals
             screen.Get<PromptUGUI.Controls.Image>("backdrop")
                 .OnPointerDown.Subscribe(_ => onCancel()).AddTo(screen);
 
-            items ??= Array.Empty<T>();
             bool autoConfirm = buttons.Count == 1;                  // CSB-D16
             string soleKey = autoConfirm ? buttons[0].key : null;
 
-            // —— carousel + 卡 ——
-            var car = screen.Get<Carousel>("cards");
+            IReadOnlyList<T> latest = Array.Empty<T>();
             int idx = 0;
-            car.BindItems(
-                Observable.Return(items),
-                (IControl card, T item) =>
-                {
-                    int i = idx++;
-                    bindCard?.Invoke(card, item);
-                    AttachCardClick(card, i, car, items, onConfirm, autoConfirm, soleKey);
-                }).AddTo(screen);
+            var car = screen.Get<Carousel>("cards");
 
-            // —— 探测皮肤按钮槽（CSB-D17）——
+            // —— 探测皮肤按钮槽（CSB-D17）：必须在 BindItems 之前，.Do 首发会同步刷新按钮禁用态 ——
             var slots = new List<Btn>();
             for (int i = 0; ; i++)
             {
@@ -58,43 +51,68 @@ namespace PromptUGUI.Application.Modals
                     $"{buttons.Count} buttons were passed; override XmlSrc with more 'button{{i}}' slots.");
 
             // —— 映射 buttons[i] → slot i，隐藏多余槽 ——
+            var visibleButtons = new List<Btn>();
             for (int i = 0; i < slots.Count; i++)
             {
                 var slot = slots[i];
                 if (i >= buttons.Count) { slot.GameObject.SetActive(false); continue; }
-                var (label, key) = buttons[i];
+                var (label, btnKey) = buttons[i];
                 if (!string.IsNullOrEmpty(label)) slot.Text = label;   // null/空 → 保留皮肤默认（button0 的 "OK"）
-                if (items.Count == 0) slot.Interactable = false;       // CSB-D11
+                visibleButtons.Add(slot);
                 slot.OnClick.Subscribe(_ =>
                 {
                     int cur = car.Current;
-                    if (cur >= 0 && cur < items.Count) onConfirm(items[cur], key);
+                    if (cur >= 0 && cur < latest.Count) onConfirm(latest[cur], btnKey);
                 }).AddTo(screen);
             }
+            void RefreshButtonsEnabled(bool on) { foreach (var b in visibleButtons) b.Interactable = on; }
+
+            // —— carousel + 卡：.Do（上游先于下游 Rebuild）维护 latest / 重置 idx / 刷新按钮态（RI-D12/D13）；
+            //    BindItems 带 key 做身份保持（RI-D9~D11）——
+            var src = itemsSource.Do(list =>
+            {
+                latest = list ?? Array.Empty<T>();
+                idx = 0;                                            // ★ 每 emit 归零，否则跨重建累加致索引错乱
+                RefreshButtonsEnabled(latest.Count > 0);            // 空→disable，非空→enable（CSB-D11 反应式版）
+            });
+            car.BindItems(src, (IControl card, T item) =>
+            {
+                int i = idx++;
+                bindCard?.Invoke(card, item);
+                AttachCardClick(card, i, car, () => latest, onConfirm, autoConfirm, soleKey);
+            }, key).AddTo(screen);
         }
 
         // 每张卡：透明 raycast catcher + PuiButton。click（非拖动）→ 居中导航或（仅单按钮）确认。
-        private static void AttachCardClick<T>(IControl card, int i, Carousel car, IReadOnlyList<T> items,
+        private static void AttachCardClick<T>(IControl card, int i, Carousel car,
+            Func<IReadOnlyList<T>> getLatest,
             Action<T, string> onConfirm, bool autoConfirm, string soleKey) where T : class
         {
             var go = card.GameObject;
             var img = go.GetComponent<UnityImage>() ?? go.AddComponent<UnityImage>();
             img.color = new UnityEngine.Color(0f, 0f, 0f, 0f);   // 透明，仅 raycast
             img.raycastTarget = true;
-            // 卡 GO 每次 BindItems 重建都是全新的（旧的由 ClearCards 销毁），故无条件 AddComponent 安全、不重复挂。
+            // 卡 GO 每次 BindItems 重建都是全新的（旧的由 ClearCards 销毁），故无条件 AddComponent 安全。
             var btn = go.AddComponent<PuiButton>();
             btn.targetGraphic = img;
             btn.onClick.AddListener(() =>
             {
-                if (car.Current == i) { if (autoConfirm) onConfirm(items[i], soleKey); }   // 单按钮：点居中卡=确认；多按钮：无操作
-                else car.GoTo(i, animated: true);                                          // 点侧卡=居中
+                var items = getLatest();
+                if (car.Current == i)
+                {
+                    // 单按钮：点居中卡=确认；多按钮：无操作（CSB-D16）。
+                    if (autoConfirm && i >= 0 && i < items.Count) onConfirm(items[i], soleKey);
+                }
+                else car.GoTo(i, animated: true);                // 点侧卡=居中
             });
         }
     }
 
     public sealed class CenteredSlideBoxRequest<T> : ModalRequest<T> where T : class
     {
-        public IReadOnlyList<T> Items;
+        public IReadOnlyList<T> Items;                       // 静态（保留，向后兼容）
+        public Observable<IReadOnlyList<T>> ItemsSource;     // 反应式（优先）
+        public Func<T, object> Key;
         public Action<IControl, T> BindCard;
         public string Title;
         public string ConfirmLabel;                 // 单个按钮的 label（空→皮肤默认 "OK"）
@@ -105,8 +123,9 @@ namespace PromptUGUI.Application.Modals
         public override bool TryEscape(out T result) { result = null; return true; }
 
         public override void Bind(IScreen screen, Action<T> close)
-            => CenteredSlideBoxBinder.Bind(screen, Items, BindCard, Title,
-                   new[] { (ConfirmLabel, (string)null) }, XmlSrc,     // 1 个隐式按钮；key 忽略
+            => CenteredSlideBoxBinder.Bind(screen,
+                   ItemsSource ?? Observable.Return<IReadOnlyList<T>>(Items ?? Array.Empty<T>()),
+                   BindCard, Title, new[] { (ConfirmLabel, (string)null) }, Key, XmlSrc,   // 1 个隐式按钮；key 忽略
                    onConfirm: (item, _) => close(item),
                    onCancel: () => close(null));
     }
@@ -115,6 +134,8 @@ namespace PromptUGUI.Application.Modals
     public sealed class CenteredSlideBoxMultiRequest<T> : ModalRequest<SlideSelection<T>> where T : class
     {
         public IReadOnlyList<T> Items;
+        public Observable<IReadOnlyList<T>> ItemsSource;
+        public Func<T, object> Key;
         public Action<IControl, T> BindCard;
         public string Title;
         public IReadOnlyList<(string label, string key)> Buttons;   // facade 保证非空
@@ -125,7 +146,9 @@ namespace PromptUGUI.Application.Modals
         public override bool TryEscape(out SlideSelection<T> result) { result = default; return true; }
 
         public override void Bind(IScreen screen, Action<SlideSelection<T>> close)
-            => CenteredSlideBoxBinder.Bind(screen, Items, BindCard, Title, Buttons, XmlSrc,
+            => CenteredSlideBoxBinder.Bind(screen,
+                   ItemsSource ?? Observable.Return<IReadOnlyList<T>>(Items ?? Array.Empty<T>()),
+                   BindCard, Title, Buttons, Key, XmlSrc,
                    onConfirm: (item, key) => close(new SlideSelection<T>(item, key)),
                    onCancel: () => close(default));
     }
@@ -135,7 +158,7 @@ namespace PromptUGUI.Application.Modals
         // 必须带 .ui 后缀（Unity 只剥 .ui.xml 的最后 .xml）。可写 = 换皮入口。
         public static string XmlSrc { get; set; } = "PromptUGUI/Modals/CenteredSlideBox.ui";
 
-        // 单按钮 → 返回选中对象 / null（向后兼容，非 async 直传）。
+        // 单按钮 · 静态 → 返回选中对象 / null（向后兼容）。
         public static UnityEngine.Awaitable<T> Open<T>(
             IReadOnlyList<T> items,
             Action<IControl, T> bind,
@@ -154,7 +177,31 @@ namespace PromptUGUI.Application.Modals
                 Configure = configure,
             }, mode, ct);
 
-        // 多按钮 → 返回 (选中对象, 按钮 key)。buttons 必填且非空。
+        // 单按钮 · 反应式。
+        public static UnityEngine.Awaitable<T> Open<T>(
+            Observable<IReadOnlyList<T>> items,
+            Action<IControl, T> bind,
+            string title = null,
+            string confirmLabel = null,
+            ModalMode mode = ModalMode.Popup,
+            Action<IScreen> configure = null,
+            Func<T, object> key = null,
+            System.Threading.CancellationToken ct = default
+        ) where T : class
+        {
+            if (items == null) throw new ArgumentNullException(nameof(items));
+            return UI.Modal.OpenAsync(new CenteredSlideBoxRequest<T>
+            {
+                ItemsSource = items,
+                Key = key,
+                BindCard = bind,
+                Title = title,
+                ConfirmLabel = confirmLabel,
+                Configure = configure,
+            }, mode, ct);
+        }
+
+        // 多按钮 · 静态 → 返回 (选中对象, 按钮 key)。buttons 必填且非空。
         public static UnityEngine.Awaitable<SlideSelection<T>> Open<T>(
             IReadOnlyList<T> items,
             Action<IControl, T> bind,
@@ -172,6 +219,34 @@ namespace PromptUGUI.Application.Modals
             return UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<T>
             {
                 Items = items,
+                BindCard = bind,
+                Title = title,
+                Buttons = list,
+                Configure = configure,
+            }, mode, ct);
+        }
+
+        // 多按钮 · 反应式。
+        public static UnityEngine.Awaitable<SlideSelection<T>> Open<T>(
+            Observable<IReadOnlyList<T>> items,
+            Action<IControl, T> bind,
+            IEnumerable<(string label, string key)> buttons,
+            string title = null,
+            ModalMode mode = ModalMode.Popup,
+            Action<IScreen> configure = null,
+            Func<T, object> key = null,
+            System.Threading.CancellationToken ct = default
+        ) where T : class
+        {
+            if (items == null) throw new ArgumentNullException(nameof(items));
+            var list = new List<(string label, string key)>(
+                buttons ?? throw new ArgumentNullException(nameof(buttons)));
+            if (list.Count == 0)
+                throw new ArgumentException("buttons must be non-empty", nameof(buttons));
+            return UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<T>
+            {
+                ItemsSource = items,
+                Key = key,
                 BindCard = bind,
                 Title = title,
                 Buttons = list,

--- a/Runtime/Controls/Carousel.cs
+++ b/Runtime/Controls/Carousel.cs
@@ -158,19 +158,51 @@ namespace PromptUGUI.Controls
 
         public IDisposable BindItems<T>(
             Observable<IReadOnlyList<T>> source,
-            Action<IControl, T> bind)
-            => BindItems<T, IControl>(source, bind);
+            Action<IControl, T> bind,
+            Func<T, object> key = null)
+            => BindItems<T, IControl>(source, bind, key);
 
         public IDisposable BindItems<T, TSlot>(
             Observable<IReadOnlyList<T>> source,
-            Action<TSlot, T> bind) where TSlot : class, IControl
+            Action<TSlot, T> bind,
+            Func<T, object> key = null) where TSlot : class, IControl
         {
             _itemsSub?.Dispose();
-            _itemsSub = source.Subscribe(items => Rebuild(items, bind));
+            IReadOnlyList<T> prev = null;
+            _itemsSub = source.Subscribe(items =>
+            {
+                items ??= System.Array.Empty<T>();
+                int? desired = ComputeDesiredIndex(prev, items, key);
+                Rebuild(items, bind, desired);
+                prev = items;
+            });
             return _itemsSub;
         }
 
-        private void Rebuild<T, TSlot>(IReadOnlyList<T> items, Action<TSlot, T> bind)
+        // 重建前：按 key（无 key 则按默认相等/引用）在新列表找回"上一帧的居中项"。命中 → 其新 index；
+        // 不命中（被删 / 引用对不上 / key 返回 null）→ null，由 OnItemsRebuilt 走就近夹位。
+        private int? ComputeDesiredIndex<T>(IReadOnlyList<T> prev, IReadOnlyList<T> next, Func<T, object> key)
+        {
+            if (prev == null) return null;
+            int cur = _view.CurrentIndex;
+            if (cur < 0 || cur >= prev.Count) return null;
+            var centered = prev[cur];
+            if (key != null)
+            {
+                var ck = key(centered);
+                if (ck == null) return null;                          // null key → 不做身份保持（避免 null==null 误命中）
+                for (int i = 0; i < next.Count; i++)
+                    if (Equals(ck, key(next[i]))) return i;
+            }
+            else
+            {
+                for (int i = 0; i < next.Count; i++)
+                    if (EqualityComparer<T>.Default.Equals(centered, next[i])) return i;
+            }
+            return null;
+        }
+
+        private void Rebuild<T, TSlot>(IReadOnlyList<T> items, Action<TSlot, T> bind, int? desiredIndex)
             where TSlot : class, IControl
         {
             if (_factory == null) _factory = ResolveFactory(_itemTemplate);
@@ -184,7 +216,7 @@ namespace PromptUGUI.Controls
                     $"but BindItems expected {typeof(TSlot).Name}");
                 _view.AddCard(node);
             }
-            _view.OnItemsRebuilt();
+            _view.OnItemsRebuilt(desiredIndex);
         }
 
         private Func<RectTransform, IControl> ResolveFactory(string tag)

--- a/Runtime/Controls/Control.cs
+++ b/Runtime/Controls/Control.cs
@@ -45,6 +45,7 @@ namespace PromptUGUI.Controls
         public bool StateReact { get; set; } = true;
 
         private readonly List<IControl> _children = new();
+        private System.Collections.Generic.List<System.IDisposable> _subscriptions;
 
         public bool Hidden
         {
@@ -519,12 +520,30 @@ namespace PromptUGUI.Controls
             }
         }
 
+        /// <summary>把 R3 订阅绑到本 Control 生命周期（卡片重建 / 关窗时随 Dispose 释放）。对称 Screen.Track。</summary>
+        public void Track(System.IDisposable d)
+            => (_subscriptions ??= new System.Collections.Generic.List<System.IDisposable>()).Add(d);
+
+        // 释放自身订阅袋 + 递归子树兜底：动态卡子树的内层 Control 不会被单独 Dispose（只销毁根 GO 级联），
+        // 故 .AddTo(innerControl) 必须靠这条递归，否则泄漏。只碰订阅袋，不额外销毁 GO（GO 由根 Destroy 级联）。
+        private void DisposeSubscriptionsRecursive()
+        {
+            if (_subscriptions != null)
+            {
+                for (int i = _subscriptions.Count - 1; i >= 0; i--) _subscriptions[i]?.Dispose();
+                _subscriptions.Clear();
+                _subscriptions = null;
+            }
+            foreach (var c in _children)
+                if (c is Control cc) cc.DisposeSubscriptionsRecursive();
+        }
+
         public virtual void Dispose()
         {
+            // 先退订（自身 + 子树）——teardown 可能读 GO；避免往半销毁 GO fire。
+            DisposeSubscriptionsRecursive();
             if (HostGameObject == null) return;
-            // 与 Screen.Close 一致：EditMode 下用 DestroyImmediate，避免 "Destroy may not be called" 警告。
-            // 销毁宿主 GO（wrapper 存在时即 wrapper，内层随子级联销毁）——BindItems 重建
-            // 经 Dispose 走这里，不会把 wrapper 留在 LayoutGroup 里占行高。
+            // 与 Screen.Close 一致：EditMode 用 DestroyImmediate。
             if (UnityEngine.Application.isPlaying) Object.Destroy(HostGameObject);
             else Object.DestroyImmediate(HostGameObject);
         }

--- a/Runtime/Controls/Internal/CarouselView.cs
+++ b/Runtime/Controls/Internal/CarouselView.cs
@@ -139,17 +139,19 @@ namespace PromptUGUI.Controls.Internal
             _cards.Clear();
         }
 
-        // BindItems 重建完：钳当前页进新范围，重建指示点，重排，重启自动播放计时。
-        public void OnItemsRebuilt()
+        // BindItems 重建完：定位当前页（给定 desiredIndex 用它、否则保旧页夹位），重建指示点，重排，重启自动播放计时。
+        public void OnItemsRebuilt(int? desiredIndex = null)
         {
             int prev = _current;
             if (_cards.Count == 0) { _current = -1; _scroll = 0f; }
-            else _current = Mathf.Clamp(_current < 0 ? 0 : _current, 0, _cards.Count - 1);
+            else if (desiredIndex.HasValue)
+                _current = Mathf.Clamp(desiredIndex.Value, 0, _cards.Count - 1);
+            else
+                _current = Mathf.Clamp(_current < 0 ? 0 : _current, 0, _cards.Count - 1);
             RebuildIndicator();
             RelayoutNow();
             StartAutoplayIfNeeded();
-            // Emit when the committed page changed (empty -> -1, or clamped into a smaller deck),
-            // mirroring GoTo's change-guarded emission so OnCurrentChanged stays in sync after a rebuild.
+            // 仅当提交页真正变化时 fire（空→-1 / 夹位 / 身份跟随），与 GoTo 的 change-guarded 一致 → 一次 emit ≤ 一次。
             if (_current != prev) OnCurrent?.Invoke(_current);
         }
 

--- a/Tests/EditMode/Controls/CarouselBindItemsTests.cs
+++ b/Tests/EditMode/Controls/CarouselBindItemsTests.cs
@@ -100,5 +100,78 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.AreEqual(0, car.Current, "current clamps into the 1-item deck");
             Assert.AreEqual(0, fired, "a rebuild that changes the committed page emits OnCurrentChanged");
         }
+
+        // —— 身份保持 / 卡片级订阅（Task 2）——
+        private sealed class Item { public string Id; }
+        private sealed class Flag : System.IDisposable { public bool Disposed; public void Dispose() => Disposed = true; }
+
+        [Test]
+        public void Rebuild_Preserves_Centered_Item_By_Key()
+        {
+            var car = Open("<Carousel id='car' size='200x100'/>");
+            var a = new Item { Id = "a" }; var b = new Item { Id = "b" }; var c = new Item { Id = "c" };
+            var subject = new Subject<IReadOnlyList<Item>>();
+            using var sub = car.BindItems(subject, (IControl card, Item it) => { }, key: x => x.Id);
+            subject.OnNext(new[] { a, b, c });
+            car.GoTo(1, animated: false);                 // 居中 b（index 1）
+            Assert.AreEqual(1, car.Current);
+            subject.OnNext(new[] { a, c, b });            // b 移到 index 2
+            Assert.AreEqual(2, car.Current, "居中项按 key 跟随到新 index");
+        }
+
+        [Test]
+        public void Rebuild_Preserves_Centered_Item_By_Reference_When_No_Key()
+        {
+            var car = Open("<Carousel id='car' size='200x100'/>");
+            var a = new Item { Id = "a" }; var b = new Item { Id = "b" }; var c = new Item { Id = "c" };
+            var subject = new Subject<IReadOnlyList<Item>>();
+            using var sub = car.BindItems(subject, (IControl card, Item it) => { });   // 无 key
+            subject.OnNext(new[] { a, b, c });
+            car.GoTo(2, animated: false);                 // 居中 c
+            subject.OnNext(new[] { c, a, b });            // c 移到 index 0
+            Assert.AreEqual(0, car.Current, "无 key 时按引用相等跟随");
+        }
+
+        [Test]
+        public void Rebuild_Removed_Centered_Item_Clamps()
+        {
+            var car = Open("<Carousel id='car' size='200x100'/>");
+            var a = new Item { Id = "a" }; var b = new Item { Id = "b" }; var c = new Item { Id = "c" };
+            var subject = new Subject<IReadOnlyList<Item>>();
+            using var sub = car.BindItems(subject, (IControl card, Item it) => { }, key: x => x.Id);
+            subject.OnNext(new[] { a, b, c });
+            car.GoTo(2, animated: false);                 // 居中 c（index 2）
+            subject.OnNext(new[] { a, b });               // c 被删；剩 2 张
+            Assert.AreEqual(1, car.Current, "被删的居中项就近夹到末位");
+        }
+
+        [Test]
+        public void Rebuild_Emits_OnCurrentChanged_At_Most_Once()
+        {
+            var car = Open("<Carousel id='car' size='200x100'/>");
+            var a = new Item { Id = "a" }; var b = new Item { Id = "b" }; var c = new Item { Id = "c" };
+            var subject = new Subject<IReadOnlyList<Item>>();
+            using var sub0 = car.BindItems(subject, (IControl card, Item it) => { }, key: x => x.Id);
+            subject.OnNext(new[] { a, b, c });
+            car.GoTo(1, animated: false);                 // 居中 b
+            int count = 0;
+            using var sub = car.OnCurrentChanged.Subscribe(_ => count++);
+            subject.OnNext(new[] { a, c, b });            // b → index 2：应恰好 fire 一次
+            Assert.AreEqual(1, count, "一次 emit 至多一次 OnCurrentChanged");
+        }
+
+        [Test]
+        public void Card_Subscription_Disposed_On_Rebuild()
+        {
+            var car = Open("<Carousel id='car' size='200x100'/>");
+            var subject = new Subject<IReadOnlyList<string>>();
+            Flag flag = null;
+            using var sub = car.BindItems(subject,
+                (IControl card, string s) => { if (flag == null) flag = new Flag().AddTo(card); });
+            subject.OnNext(new[] { "a" });                // 建 1 卡，flag 绑首卡
+            Assert.IsFalse(flag.Disposed);
+            subject.OnNext(new[] { "x", "y" });           // 重建 → 旧卡 Dispose → flag 释放
+            Assert.IsTrue(flag.Disposed, "重建释放旧卡跟踪的订阅（无泄漏）");
+        }
     }
 }

--- a/Tests/EditMode/Controls/ControlSubscriptionTests.cs
+++ b/Tests/EditMode/Controls/ControlSubscriptionTests.cs
@@ -1,0 +1,59 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class ControlSubscriptionTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        // 极简追踪 disposable：被 Dispose 时翻 flag。
+        private sealed class Flag : System.IDisposable
+        {
+            public bool Disposed;
+            public void Dispose() => Disposed = true;
+        }
+
+        private static IScreen Open(string innerXml)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{innerXml}</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S");
+        }
+
+        [Test]
+        public void AddTo_Control_Disposes_On_Control_Dispose()
+        {
+            var screen = Open("<Frame id='f'/>");
+            var f = screen.Get<Frame>("f");
+            var flag = new Flag().AddTo(f);
+            Assert.IsFalse(flag.Disposed);
+            f.Dispose();
+            Assert.IsTrue(flag.Disposed, "control 的订阅袋在 Dispose 时释放被跟踪的订阅");
+        }
+
+        [Test]
+        public void Control_Dispose_Recursively_Disposes_Child_Subscriptions()
+        {
+            var screen = Open("<Frame id='outer'><Text id='inner'/></Frame>");
+            var outer = screen.Get<Frame>("outer");
+            var inner = screen.Get<Text>("inner");
+            var flag = new Flag().AddTo(inner);
+            outer.Dispose();
+            Assert.IsTrue(flag.Disposed, "销毁父节点递归释放子节点的订阅袋");
+        }
+
+        [Test]
+        public void Control_Double_Dispose_Is_Idempotent()
+        {
+            var screen = Open("<Frame id='f'/>");
+            var f = screen.Get<Frame>("f");
+            new Flag().AddTo(f);
+            f.Dispose();
+            Assert.DoesNotThrow(() => f.Dispose(), "二次 Dispose 不抛");
+        }
+    }
+}

--- a/Tests/EditMode/Controls/ControlSubscriptionTests.cs.meta
+++ b/Tests/EditMode/Controls/ControlSubscriptionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c43c890509bd47fe58cdf5fb879bf1f8

--- a/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
+++ b/Tests/EditMode/Modals/CenteredSlideBoxTests.cs
@@ -353,5 +353,75 @@ namespace PromptUGUI.Tests.Modals
             Assert.AreSame(items[0], sel.Item);
             Assert.AreEqual("a", sel.Button);
         }
+
+        // —— 反应式 items（Task 3）——
+        [Test]
+        public void Reactive_Open_Renders_On_First_Emit()
+        {
+            var subject = new R3.Subject<IReadOnlyList<Lv>>();
+            CenteredSlideBox.Open(subject, (c, l) => { });
+            Assert.AreEqual(0, Cards().Count, "首发前无卡");
+            subject.OnNext(ThreeLevels());
+            Assert.AreEqual(3, Cards().Count, "首 emit 渲染卡片");
+        }
+
+        [Test]
+        public void Reactive_Membership_Change_Rebuilds_Cards()
+        {
+            var subject = new R3.Subject<IReadOnlyList<Lv>>();
+            CenteredSlideBox.Open(subject, (c, l) => { });
+            subject.OnNext(ThreeLevels());
+            Assert.AreEqual(3, Cards().Count);
+            subject.OnNext(new List<Lv> { new Lv { Id = "x", Name = "X" } });
+            Assert.AreEqual(1, Cards().Count, "成员变化触发重建");
+        }
+
+        [Test]
+        public void Reactive_Confirm_Returns_Centered_Item_After_Reorder()
+        {
+            var subject = new R3.Subject<IReadOnlyList<Lv>>();
+            var task = CenteredSlideBox.Open(subject, (c, l) => { }, key: o => o.Id);
+            var first = ThreeLevels();                       // a,b,c
+            subject.OnNext(first);
+            Cards().GoTo(1, animated: false);               // 居中 b
+            var reordered = new List<Lv> { first[0], first[2], first[1] };  // a,c,b → b 到 index 2
+            subject.OnNext(reordered);
+            Assert.AreEqual(2, Cards().Current, "身份保持：b 跟随到新 index");
+            UI.Modal.TopScreen.Get<PBtn>("button0").SimulateClick();
+            Assert.AreSame(first[1], task.GetAwaiter().GetResult(), "确认返回最新列表里的居中项 b");
+        }
+
+        [Test]
+        public void Reactive_Empty_Emit_Disables_Then_NonEmpty_Enables()
+        {
+            var subject = new R3.Subject<IReadOnlyList<Lv>>();
+            CenteredSlideBox.Open(subject, (c, l) => { });
+            subject.OnNext(new List<Lv>());                 // 空 → 禁用
+            Assert.IsFalse(UI.Modal.TopScreen.Get<PBtn>("button0").Interactable);
+            subject.OnNext(ThreeLevels());                  // 非空 → 启用
+            Assert.IsTrue(UI.Modal.TopScreen.Get<PBtn>("button0").Interactable);
+        }
+
+        [Test]
+        public void Reactive_Multi_Button_Returns_Item_And_Key()
+        {
+            var subject = new R3.Subject<IReadOnlyList<Lv>>();
+            var task = CenteredSlideBox.Open(subject, (c, l) => { },
+                buttons: new[] { ("A", "a"), ("B", "b") }, key: o => o.Id);
+            var items = ThreeLevels();
+            subject.OnNext(items);
+            Cards().GoTo(1, animated: false);
+            UI.Modal.TopScreen.Get<PBtn>("button1").SimulateClick();
+            var sel = task.GetAwaiter().GetResult();
+            Assert.AreSame(items[1], sel.Item);
+            Assert.AreEqual("b", sel.Button);
+        }
+
+        [Test]
+        public void Reactive_Null_Items_Throws_ArgumentNullException()
+        {
+            Assert.Throws<System.ArgumentNullException>(() =>
+                CenteredSlideBox.Open((R3.Observable<IReadOnlyList<Lv>>)null, (c, l) => { }));
+        }
     }
 }

--- a/Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs
+++ b/Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs
@@ -73,5 +73,18 @@ namespace PromptUGUI.Tests.PlayMode.Modals
             Assert.AreSame(items[2], sel.Item);
             Assert.AreEqual("hard", sel.Button);
         }
+
+        [Test]
+        public void Reactive_Rebuild_Then_Confirm_NoCrash()
+        {
+            var subject = new R3.Subject<IReadOnlyList<Lv>>();
+            var task = CenteredSlideBox.Open(subject, (c, l) => { }, key: o => o.Id);
+            subject.OnNext(new List<Lv> { new Lv { Id = "a" }, new Lv { Id = "b" } });
+            subject.OnNext(new List<Lv> { new Lv { Id = "a" }, new Lv { Id = "b" }, new Lv { Id = "c" } });
+            UI.Modal.TopScreen.Get<Carousel>("cards").GoTo(2, animated: false);
+            UI.Modal.TopScreen.Get<PBtn>("button0").SimulateClick();
+            var picked = task.GetAwaiter().GetResult();
+            Assert.AreEqual("c", picked.Id);
+        }
     }
 }

--- a/docs~/superpowers/plans/2026-06-23-centered-slidebox-reactive-items.md
+++ b/docs~/superpowers/plans/2026-06-23-centered-slidebox-reactive-items.md
@@ -1,0 +1,916 @@
+# CenteredSlideBox 实时数据 / 反应式 items Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 `CenteredSlideBox.Open` 能承载长期、实时变化的卡片界面——卡片集合可反应式增删（`Observable<IReadOnlyList<T>>`），卡内字段可在 `bind` 里订阅实时流并 `.AddTo(card)` 绑卡片生命周期。
+
+**Architecture:** 三块解耦改动：(1) 给 `Control` 加按卡片的订阅袋 + R3 扩展 `.AddTo(IControl)`（对称 `.AddTo(screen)`）；(2) `Carousel.BindItems` 增 `key` 选择器，成员变化全量重建后按身份保住居中卡，一次 emit ≤ 一次 `OnCurrentChanged`；(3) `CenteredSlideBox.Open` 新增 `Observable<IReadOnlyList<T>>` 反应式重载，binder 维护"最新列表"供确认/点击读取、每 emit 刷新按钮禁用态。静态重载与请求对象 `Items` 字段全部保留 → 零破坏。
+
+**Tech Stack:** Unity 6 / C# 9.0、R3（Cysharp Observable/Subject/Do/AddTo）、Unity `Awaitable`（禁 `System.Threading.Task`）、NUnit + Unity MCP 跑测。
+
+## Global Constraints
+
+- **禁用 .NET Threading**（WebGL）：不用 `Task` 返回值，用 `Awaitable`；TCS 用 `AwaitableCompletionSource`。本计划只用 R3 `Observable`/`Subject`，合规。
+- **C# 9.0**：不用 primary constructor、collection expression `[]`、`[field: SerializeField]`。local function、tuple 解构可用。
+- **无新增 `[UIAttr]`**：`key` 是 C# 形参，不是 XML 属性 → 不需 `[Preserve]`、不需 regenerate XSD、不改任何 `.ui.xml`（故无需跑 UIXmlLint）。
+- **测试经 Unity MCP**，非 batch 模式。EditMode/PlayMode 测试类触碰 `UI` 必须在 `[SetUp]`/`[TearDown]` 调 `UI.ResetForTests()`。
+- **每次写代码后 lint**：仓库根 `cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx`（whitespace 安全、不需 Unity 引用）。**禁** `dotnet format analyzers --severity info`。
+- **不提交 main**：已在 `feat/centered-slidebox-reactive-items` 分支。每任务一次 commit。
+- **MCP 跑测节奏**：每次源码改动后先 `refresh_unity(compile="request", mode="force")`，再 `read_console(types=["error"])` 确认无编译错，再 `run_tests`（异步返回 `job_id`，轮询 `get_test_job` 读通过数）。**禁** `execute_menu_item("Assets/Reimport All")`。
+- 关联 spec：`docs~/superpowers/specs/2026-06-23-centered-slidebox-reactive-items-design.md`（决策码 RI-D1~D13）。
+
+---
+
+## Task 1: Control 订阅袋 + `.AddTo(IControl)`
+
+补上唯一缺失的卡片级生命周期原语。对所有 Control 通用（RI-D2/D5/D6）。
+
+**Files:**
+- Modify: `Runtime/Controls/Control.cs`（加 `_subscriptions` 字段、`Track`、`DisposeSubscriptionsRecursive`、改 `Dispose`）
+- Modify: `Runtime/Application/Disposables.cs`（加 `AddTo(this T, IControl)`）
+- Test: `Tests/EditMode/Controls/ControlSubscriptionTests.cs`（新建）
+
+**Interfaces:**
+- Produces:
+  - `void PromptUGUI.Controls.Control.Track(System.IDisposable d)` — 把 disposable 加入该 Control 的订阅袋
+  - `T PromptUGUI.Application.DisposableExtensions.AddTo<T>(this T disposable, PromptUGUI.Controls.IControl control) where T : IDisposable` — 返回原 disposable
+  - `Control.Dispose()` 现在先释放订阅袋（自身 + 递归 `_children` 兜底）再销毁 GameObject，幂等
+
+- [ ] **Step 1: 写失败测试** —— 新建 `Tests/EditMode/Controls/ControlSubscriptionTests.cs`
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class ControlSubscriptionTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        // 极简追踪 disposable：被 Dispose 时翻 flag。
+        private sealed class Flag : System.IDisposable
+        {
+            public bool Disposed;
+            public void Dispose() => Disposed = true;
+        }
+
+        private static IScreen Open(string innerXml)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{innerXml}</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S");
+        }
+
+        [Test]
+        public void AddTo_Control_Disposes_On_Control_Dispose()
+        {
+            var screen = Open("<Frame id='f'/>");
+            var f = screen.Get<Frame>("f");
+            var flag = new Flag().AddTo(f);
+            Assert.IsFalse(flag.Disposed);
+            f.Dispose();
+            Assert.IsTrue(flag.Disposed, "control 的订阅袋在 Dispose 时释放被跟踪的订阅");
+        }
+
+        [Test]
+        public void Control_Dispose_Recursively_Disposes_Child_Subscriptions()
+        {
+            var screen = Open("<Frame id='outer'><Text id='inner'/></Frame>");
+            var outer = screen.Get<Frame>("outer");
+            var inner = screen.Get<Text>("inner");
+            var flag = new Flag().AddTo(inner);
+            outer.Dispose();
+            Assert.IsTrue(flag.Disposed, "销毁父节点递归释放子节点的订阅袋");
+        }
+
+        [Test]
+        public void Control_Double_Dispose_Is_Idempotent()
+        {
+            var screen = Open("<Frame id='f'/>");
+            var f = screen.Get<Frame>("f");
+            new Flag().AddTo(f);
+            f.Dispose();
+            Assert.DoesNotThrow(() => f.Dispose(), "二次 Dispose 不抛");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 跑测确认失败（编译失败：`AddTo(IControl)` 不存在）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force")
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: 编译错误 `'Flag' does not contain ... AddTo` / `no overload for method 'AddTo' takes ... Frame`（即 `AddTo(IControl)` 未定义）。
+
+- [ ] **Step 3: 实现** —— `Runtime/Application/Disposables.cs` 追加 `AddTo(IControl)` 重载（紧挨现有两个 `AddTo`）
+
+```csharp
+        public static T AddTo<T>(this T disposable, Controls.IControl control) where T : IDisposable
+        {
+            ((Controls.Control)control).Track(disposable);
+            return disposable;
+        }
+```
+
+- [ ] **Step 4: 实现** —— `Runtime/Controls/Control.cs`：加订阅袋字段（放在 `private readonly List<IControl> _children = new();` 那一行附近），并新增 `Track` / `DisposeSubscriptionsRecursive`，最后**替换** `Dispose()`。
+
+加字段（与 `_children` 同区）：
+```csharp
+        private System.Collections.Generic.List<System.IDisposable> _subscriptions;
+```
+
+新增方法（放在文件末尾 `Dispose` 之前）：
+```csharp
+        /// <summary>把 R3 订阅绑到本 Control 生命周期（卡片重建 / 关窗时随 Dispose 释放）。对称 Screen.Track。</summary>
+        public void Track(System.IDisposable d)
+            => (_subscriptions ??= new System.Collections.Generic.List<System.IDisposable>()).Add(d);
+
+        // 释放自身订阅袋 + 递归子树兜底：动态卡子树的内层 Control 不会被单独 Dispose（只销毁根 GO 级联），
+        // 故 .AddTo(innerControl) 必须靠这条递归，否则泄漏。只碰订阅袋，不额外销毁 GO（GO 由根 Destroy 级联）。
+        private void DisposeSubscriptionsRecursive()
+        {
+            if (_subscriptions != null)
+            {
+                for (int i = _subscriptions.Count - 1; i >= 0; i--) _subscriptions[i]?.Dispose();
+                _subscriptions.Clear();
+                _subscriptions = null;
+            }
+            foreach (var c in _children)
+                if (c is Control cc) cc.DisposeSubscriptionsRecursive();
+        }
+```
+
+替换 `Dispose()`（原方法只销毁 GO；先退订再销毁，幂等守卫保留）：
+```csharp
+        public virtual void Dispose()
+        {
+            // 先退订（自身 + 子树）——teardown 可能读 GO；避免往半销毁 GO fire。
+            DisposeSubscriptionsRecursive();
+            if (HostGameObject == null) return;
+            // 与 Screen.Close 一致：EditMode 用 DestroyImmediate。
+            if (UnityEngine.Application.isPlaying) Object.Destroy(HostGameObject);
+            else Object.DestroyImmediate(HostGameObject);
+        }
+```
+
+- [ ] **Step 5: 跑测确认通过**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force")
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["ControlSubscriptionTests"])
+# 轮询 get_test_job(job_id) 直到完成
+```
+Expected: 3 个测试 PASS，0 fail。
+
+- [ ] **Step 6: 回归 + lint**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+# 轮询；确认无回归（尤其 Carousel/ScrollList/TabBar 既有测试）
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx
+```
+Expected: 全绿；lint 无残留改动（或只做了空白规整）。
+
+- [ ] **Step 7: 提交**
+
+```bash
+git add Runtime/Controls/Control.cs Runtime/Application/Disposables.cs \
+        Tests/EditMode/Controls/ControlSubscriptionTests.cs Tests/EditMode/Controls/ControlSubscriptionTests.cs.meta
+git commit -m "feat: Control 订阅袋 + .AddTo(IControl) 卡片级生命周期原语
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Carousel.BindItems `key` + 身份保持
+
+成员变化全量重建后按身份保住居中卡；一次 emit ≤ 一次 `OnCurrentChanged`（RI-D9/D10/D11）。
+
+**Files:**
+- Modify: `Runtime/Controls/Carousel.cs`（`BindItems` 加 `key` 形参、`Rebuild` 加 `desiredIndex`、新增 `ComputeDesiredIndex`）
+- Modify: `Runtime/Controls/Internal/CarouselView.cs`（`OnItemsRebuilt` 加可选 `int? desiredIndex`）
+- Test: `Tests/EditMode/Controls/CarouselBindItemsTests.cs`（追加测试）
+
+**Interfaces:**
+- Consumes: `T.AddTo(IControl)`（Task 1）
+- Produces:
+  - `IDisposable Carousel.BindItems<T>(Observable<IReadOnlyList<T>> source, Action<IControl, T> bind, Func<T, object> key = null)`
+  - `IDisposable Carousel.BindItems<T, TSlot>(Observable<IReadOnlyList<T>> source, Action<TSlot, T> bind, Func<T, object> key = null) where TSlot : class, IControl`
+  - `void CarouselView.OnItemsRebuilt(int? desiredIndex = null)`
+
+- [ ] **Step 1: 写失败测试** —— 在 `Tests/EditMode/Controls/CarouselBindItemsTests.cs` 的类**内部**追加（沿用文件已有的 `Open(innerXml)` 帮手）：
+
+```csharp
+        // —— 身份保持 / 卡片级订阅（Task 2）——
+        private sealed class Item { public string Id; }
+        private sealed class Flag : System.IDisposable { public bool Disposed; public void Dispose() => Disposed = true; }
+
+        [Test]
+        public void Rebuild_Preserves_Centered_Item_By_Key()
+        {
+            var car = Open("<Carousel id='car' size='200x100'/>");
+            var a = new Item { Id = "a" }; var b = new Item { Id = "b" }; var c = new Item { Id = "c" };
+            var subject = new Subject<IReadOnlyList<Item>>();
+            using var sub = car.BindItems(subject, (IControl card, Item it) => { }, key: x => x.Id);
+            subject.OnNext(new[] { a, b, c });
+            car.GoTo(1, animated: false);                 // 居中 b（index 1）
+            Assert.AreEqual(1, car.Current);
+            subject.OnNext(new[] { a, c, b });            // b 移到 index 2
+            Assert.AreEqual(2, car.Current, "居中项按 key 跟随到新 index");
+        }
+
+        [Test]
+        public void Rebuild_Preserves_Centered_Item_By_Reference_When_No_Key()
+        {
+            var car = Open("<Carousel id='car' size='200x100'/>");
+            var a = new Item { Id = "a" }; var b = new Item { Id = "b" }; var c = new Item { Id = "c" };
+            var subject = new Subject<IReadOnlyList<Item>>();
+            using var sub = car.BindItems(subject, (IControl card, Item it) => { });   // 无 key
+            subject.OnNext(new[] { a, b, c });
+            car.GoTo(2, animated: false);                 // 居中 c
+            subject.OnNext(new[] { c, a, b });            // c 移到 index 0
+            Assert.AreEqual(0, car.Current, "无 key 时按引用相等跟随");
+        }
+
+        [Test]
+        public void Rebuild_Removed_Centered_Item_Clamps()
+        {
+            var car = Open("<Carousel id='car' size='200x100'/>");
+            var a = new Item { Id = "a" }; var b = new Item { Id = "b" }; var c = new Item { Id = "c" };
+            var subject = new Subject<IReadOnlyList<Item>>();
+            using var sub = car.BindItems(subject, (IControl card, Item it) => { }, key: x => x.Id);
+            subject.OnNext(new[] { a, b, c });
+            car.GoTo(2, animated: false);                 // 居中 c（index 2）
+            subject.OnNext(new[] { a, b });               // c 被删；剩 2 张
+            Assert.AreEqual(1, car.Current, "被删的居中项就近夹到末位");
+        }
+
+        [Test]
+        public void Rebuild_Emits_OnCurrentChanged_At_Most_Once()
+        {
+            var car = Open("<Carousel id='car' size='200x100'/>");
+            var a = new Item { Id = "a" }; var b = new Item { Id = "b" }; var c = new Item { Id = "c" };
+            var subject = new Subject<IReadOnlyList<Item>>();
+            using var sub0 = car.BindItems(subject, (IControl card, Item it) => { }, key: x => x.Id);
+            subject.OnNext(new[] { a, b, c });
+            car.GoTo(1, animated: false);                 // 居中 b
+            int count = 0;
+            using var sub = car.OnCurrentChanged.Subscribe(_ => count++);
+            subject.OnNext(new[] { a, c, b });            // b → index 2：应恰好 fire 一次
+            Assert.AreEqual(1, count, "一次 emit 至多一次 OnCurrentChanged");
+        }
+
+        [Test]
+        public void Card_Subscription_Disposed_On_Rebuild()
+        {
+            var car = Open("<Carousel id='car' size='200x100'/>");
+            var subject = new Subject<IReadOnlyList<string>>();
+            Flag flag = null;
+            using var sub = car.BindItems(subject,
+                (IControl card, string s) => { if (flag == null) flag = new Flag().AddTo(card); });
+            subject.OnNext(new[] { "a" });                // 建 1 卡，flag 绑首卡
+            Assert.IsFalse(flag.Disposed);
+            subject.OnNext(new[] { "x", "y" });           // 重建 → 旧卡 Dispose → flag 释放
+            Assert.IsTrue(flag.Disposed, "重建释放旧卡跟踪的订阅（无泄漏）");
+        }
+```
+
+- [ ] **Step 2: 跑测确认失败（编译失败：`BindItems` 无 `key` 形参）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force")
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: 编译错 `BindItems ... no parameter named 'key'`（前 4 个测试），`Card_Subscription_Disposed_On_Rebuild` 逻辑依赖 Task 1（已就绪）。
+
+- [ ] **Step 3: 实现** —— `Runtime/Controls/Carousel.cs`：**替换** `BindItems`/`Rebuild` 两段（原文件 159-188 行），并加 `ComputeDesiredIndex`。
+
+```csharp
+        public IDisposable BindItems<T>(
+            Observable<IReadOnlyList<T>> source,
+            Action<IControl, T> bind,
+            Func<T, object> key = null)
+            => BindItems<T, IControl>(source, bind, key);
+
+        public IDisposable BindItems<T, TSlot>(
+            Observable<IReadOnlyList<T>> source,
+            Action<TSlot, T> bind,
+            Func<T, object> key = null) where TSlot : class, IControl
+        {
+            _itemsSub?.Dispose();
+            IReadOnlyList<T> prev = null;
+            _itemsSub = source.Subscribe(items =>
+            {
+                items ??= System.Array.Empty<T>();
+                int? desired = ComputeDesiredIndex(prev, items, key);
+                Rebuild(items, bind, desired);
+                prev = items;
+            });
+            return _itemsSub;
+        }
+
+        // 重建前：按 key（无 key 则按默认相等/引用）在新列表找回"上一帧的居中项"。命中 → 其新 index；
+        // 不命中（被删 / 引用对不上 / key 返回 null）→ null，由 OnItemsRebuilt 走就近夹位。
+        private int? ComputeDesiredIndex<T>(IReadOnlyList<T> prev, IReadOnlyList<T> next, Func<T, object> key)
+        {
+            if (prev == null) return null;
+            int cur = _view.CurrentIndex;
+            if (cur < 0 || cur >= prev.Count) return null;
+            var centered = prev[cur];
+            if (key != null)
+            {
+                var ck = key(centered);
+                if (ck == null) return null;                          // null key → 不做身份保持（避免 null==null 误命中）
+                for (int i = 0; i < next.Count; i++)
+                    if (Equals(ck, key(next[i]))) return i;
+            }
+            else
+            {
+                for (int i = 0; i < next.Count; i++)
+                    if (EqualityComparer<T>.Default.Equals(centered, next[i])) return i;
+            }
+            return null;
+        }
+
+        private void Rebuild<T, TSlot>(IReadOnlyList<T> items, Action<TSlot, T> bind, int? desiredIndex)
+            where TSlot : class, IControl
+        {
+            if (_factory == null) _factory = ResolveFactory(_itemTemplate);
+            _view.ClearCards();
+            for (int i = 0; i < items.Count; i++)
+            {
+                var node = _factory(_strip);
+                if (node is TSlot typed) bind(typed, items[i]);
+                else throw new InvalidCastException(
+                    $"itemTemplate='{_itemTemplate}' instantiated {node.GetType().Name}, " +
+                    $"but BindItems expected {typeof(TSlot).Name}");
+                _view.AddCard(node);
+            }
+            _view.OnItemsRebuilt(desiredIndex);
+        }
+```
+
+- [ ] **Step 4: 实现** —— `Runtime/Controls/Internal/CarouselView.cs`：**替换** `OnItemsRebuilt`（原文件 143-154 行），加可选 `desiredIndex` 分支。
+
+```csharp
+        // BindItems 重建完：定位当前页（给定 desiredIndex 用它、否则保旧页夹位），重建指示点，重排，重启自动播放计时。
+        public void OnItemsRebuilt(int? desiredIndex = null)
+        {
+            int prev = _current;
+            if (_cards.Count == 0) { _current = -1; _scroll = 0f; }
+            else if (desiredIndex.HasValue)
+                _current = Mathf.Clamp(desiredIndex.Value, 0, _cards.Count - 1);
+            else
+                _current = Mathf.Clamp(_current < 0 ? 0 : _current, 0, _cards.Count - 1);
+            RebuildIndicator();
+            RelayoutNow();
+            StartAutoplayIfNeeded();
+            // 仅当提交页真正变化时 fire（空→-1 / 夹位 / 身份跟随），与 GoTo 的 change-guarded 一致 → 一次 emit ≤ 一次。
+            if (_current != prev) OnCurrent?.Invoke(_current);
+        }
+```
+
+> 注：`Carousel.OnAfterApply` 调的是 `_view.RelayoutNow()`，不是 `OnItemsRebuilt`；`Rebuild` 是唯一调用方。可选默认参数 `= null` 保旧行为。
+
+- [ ] **Step 5: 跑测确认通过**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force")
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["CarouselBindItemsTests"])
+# 轮询 get_test_job
+```
+Expected: 全部 PASS（含原有 `BindItems_Rebuild_That_Clamps_Current_Fires_OnCurrentChanged` —— 首次 emit `prev==null` → desiredIndex 为 null → 走夹位，行为不变）。
+
+- [ ] **Step 6: 回归 + lint**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx
+```
+Expected: 全绿。
+
+- [ ] **Step 7: 提交**
+
+```bash
+git add Runtime/Controls/Carousel.cs Runtime/Controls/Internal/CarouselView.cs \
+        Tests/EditMode/Controls/CarouselBindItemsTests.cs
+git commit -m "feat: Carousel.BindItems 增 key 选择器 + 成员变化按身份保持居中卡
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: CenteredSlideBox 反应式 Open + binder 改造
+
+`Observable<IReadOnlyList<T>>` 重载 + `key`；binder 维护最新列表、确认/点击读最新项、每 emit 刷新按钮禁用态（RI-D7/D12/D13）。
+
+**Files:**
+- Modify: `Runtime/Application/Modals/CenteredSlideBoxRequest.cs`（整文件替换：binder 改签名 + 重排、请求加 `ItemsSource`/`Key`、facade 加反应式重载）
+- Test: `Tests/EditMode/Modals/CenteredSlideBoxTests.cs`（追加反应式测试）
+- Test: `Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs`（追加 1 个反应式 play 测试）
+
+**Interfaces:**
+- Consumes: `Carousel.BindItems(..., key)`（Task 2）、`.AddTo(IControl)`（Task 1）
+- Produces:
+  - `Awaitable<T> CenteredSlideBox.Open<T>(Observable<IReadOnlyList<T>> items, Action<IControl,T> bind, string title=null, string confirmLabel=null, ModalMode mode=Popup, Action<IScreen> configure=null, Func<T,object> key=null, CancellationToken ct=default) where T:class`
+  - `Awaitable<SlideSelection<T>> CenteredSlideBox.Open<T>(Observable<IReadOnlyList<T>> items, Action<IControl,T> bind, IEnumerable<(string,string)> buttons, string title=null, ModalMode mode=Popup, Action<IScreen> configure=null, Func<T,object> key=null, CancellationToken ct=default) where T:class`
+  - 请求类新增字段 `Observable<IReadOnlyList<T>> ItemsSource` + `Func<T,object> Key`（保留 `Items`）
+
+- [ ] **Step 1: 写失败测试** —— 在 `Tests/EditMode/Modals/CenteredSlideBoxTests.cs` 类内追加（沿用文件已有的 `ThreeLevels()` / `Cards()` / `CardButton(i)` / `Lv`）：
+
+```csharp
+        // —— 反应式 items（Task 3）——
+        [Test]
+        public void Reactive_Open_Renders_On_First_Emit()
+        {
+            var subject = new R3.Subject<IReadOnlyList<Lv>>();
+            CenteredSlideBox.Open(subject, (c, l) => { });
+            Assert.AreEqual(0, Cards().Count, "首发前无卡");
+            subject.OnNext(ThreeLevels());
+            Assert.AreEqual(3, Cards().Count, "首 emit 渲染卡片");
+        }
+
+        [Test]
+        public void Reactive_Membership_Change_Rebuilds_Cards()
+        {
+            var subject = new R3.Subject<IReadOnlyList<Lv>>();
+            CenteredSlideBox.Open(subject, (c, l) => { });
+            subject.OnNext(ThreeLevels());
+            Assert.AreEqual(3, Cards().Count);
+            subject.OnNext(new List<Lv> { new Lv { Id = "x", Name = "X" } });
+            Assert.AreEqual(1, Cards().Count, "成员变化触发重建");
+        }
+
+        [Test]
+        public void Reactive_Confirm_Returns_Centered_Item_After_Reorder()
+        {
+            var subject = new R3.Subject<IReadOnlyList<Lv>>();
+            var task = CenteredSlideBox.Open(subject, (c, l) => { }, key: o => o.Id);
+            var first = ThreeLevels();                       // a,b,c
+            subject.OnNext(first);
+            Cards().GoTo(1, animated: false);               // 居中 b
+            var reordered = new List<Lv> { first[0], first[2], first[1] };  // a,c,b → b 到 index 2
+            subject.OnNext(reordered);
+            Assert.AreEqual(2, Cards().Current, "身份保持：b 跟随到新 index");
+            UI.Modal.TopScreen.Get<PBtn>("button0").SimulateClick();
+            Assert.AreSame(first[1], task.GetAwaiter().GetResult(), "确认返回最新列表里的居中项 b");
+        }
+
+        [Test]
+        public void Reactive_Empty_Emit_Disables_Then_NonEmpty_Enables()
+        {
+            var subject = new R3.Subject<IReadOnlyList<Lv>>();
+            CenteredSlideBox.Open(subject, (c, l) => { });
+            subject.OnNext(new List<Lv>());                 // 空 → 禁用
+            Assert.IsFalse(UI.Modal.TopScreen.Get<PBtn>("button0").Interactable);
+            subject.OnNext(ThreeLevels());                  // 非空 → 启用
+            Assert.IsTrue(UI.Modal.TopScreen.Get<PBtn>("button0").Interactable);
+        }
+
+        [Test]
+        public void Reactive_Multi_Button_Returns_Item_And_Key()
+        {
+            var subject = new R3.Subject<IReadOnlyList<Lv>>();
+            var task = CenteredSlideBox.Open(subject, (c, l) => { },
+                buttons: new[] { ("A", "a"), ("B", "b") }, key: o => o.Id);
+            var items = ThreeLevels();
+            subject.OnNext(items);
+            Cards().GoTo(1, animated: false);
+            UI.Modal.TopScreen.Get<PBtn>("button1").SimulateClick();
+            var sel = task.GetAwaiter().GetResult();
+            Assert.AreSame(items[1], sel.Item);
+            Assert.AreEqual("b", sel.Button);
+        }
+
+        [Test]
+        public void Reactive_Null_Items_Throws_ArgumentNullException()
+        {
+            Assert.Throws<System.ArgumentNullException>(() =>
+                CenteredSlideBox.Open((R3.Observable<IReadOnlyList<Lv>>)null, (c, l) => { }));
+        }
+```
+
+并在 `Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs` 类内追加 1 个 play 测试（验证运行时多轮重建不残留、确认正常）：
+
+```csharp
+        [Test]
+        public void Reactive_Rebuild_Then_Confirm_NoCrash()
+        {
+            var subject = new R3.Subject<IReadOnlyList<Lv>>();
+            var task = CenteredSlideBox.Open(subject, (c, l) => { }, key: o => o.Id);
+            subject.OnNext(new List<Lv> { new Lv { Id = "a" }, new Lv { Id = "b" } });
+            subject.OnNext(new List<Lv> { new Lv { Id = "a" }, new Lv { Id = "b" }, new Lv { Id = "c" } });
+            UI.Modal.TopScreen.Get<Carousel>("cards").GoTo(2, animated: false);
+            UI.Modal.TopScreen.Get<PBtn>("button0").SimulateClick();
+            var picked = task.GetAwaiter().GetResult();
+            Assert.AreEqual("c", picked.Id);
+        }
+```
+
+- [ ] **Step 2: 跑测确认失败（编译失败：`Open(Observable, ...)` 重载不存在）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force")
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: 编译错 `no overload for 'Open' ... Subject<...>`。
+
+- [ ] **Step 3: 实现** —— **整文件替换** `Runtime/Application/Modals/CenteredSlideBoxRequest.cs` 为：
+
+```csharp
+using System;
+using System.Collections.Generic;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using R3;
+using UnityImage = UnityEngine.UI.Image;
+
+namespace PromptUGUI.Application.Modals
+{
+    // 共享 Bind 逻辑：单/多按钮 request 都委托这里。onConfirm/onCancel 抽掉结果类型差异。
+    internal static class CenteredSlideBoxBinder
+    {
+        // buttons 至少 1 个（两个 request 各自保证）；itemsSource 由 request 归一化为非空 Observable。
+        public static void Bind<T>(
+            IScreen screen, Observable<IReadOnlyList<T>> itemsSource, Action<IControl, T> bindCard,
+            string title, IReadOnlyList<(string label, string key)> buttons, Func<T, object> key,
+            string xmlSrcForError, Action<T, string> onConfirm, Action onCancel) where T : class
+        {
+            if (buttons == null || buttons.Count == 0)        // facade 已挡空；直接 new request 的兜底（CSB-D14）
+                throw new ArgumentException("CenteredSlideBox requires at least one button.", nameof(buttons));
+            if (itemsSource == null)
+                throw new ArgumentNullException(nameof(itemsSource));
+
+            // —— title ——
+            var titleCtl = screen.Get<Text>("title");
+            if (string.IsNullOrEmpty(title)) titleCtl.GameObject.SetActive(false);
+            else titleCtl.TextValue = title;
+
+            // —— 取消三通道（CSB-D9）——
+            screen.Get<Btn>("close").OnClick.Subscribe(_ => onCancel()).AddTo(screen);
+            screen.Get<PromptUGUI.Controls.Image>("backdrop")
+                .OnPointerDown.Subscribe(_ => onCancel()).AddTo(screen);
+
+            bool autoConfirm = buttons.Count == 1;                  // CSB-D16
+            string soleKey = autoConfirm ? buttons[0].key : null;
+
+            IReadOnlyList<T> latest = Array.Empty<T>();
+            int idx = 0;
+            var car = screen.Get<Carousel>("cards");
+
+            // —— 探测皮肤按钮槽（CSB-D17）：必须在 BindItems 之前，.Do 首发会同步刷新按钮禁用态 ——
+            var slots = new List<Btn>();
+            for (int i = 0; ; i++)
+            {
+                try { slots.Add(screen.Get<Btn>($"button{i}")); }
+                catch (KeyNotFoundException) { break; }
+            }
+            if (buttons.Count > slots.Count)
+                throw new InvalidOperationException(
+                    $"CenteredSlideBox skin '{xmlSrcForError}' provides {slots.Count} button slot(s) but " +
+                    $"{buttons.Count} buttons were passed; override XmlSrc with more 'button{{i}}' slots.");
+
+            // —— 映射 buttons[i] → slot i，隐藏多余槽 ——
+            var visibleButtons = new List<Btn>();
+            for (int i = 0; i < slots.Count; i++)
+            {
+                var slot = slots[i];
+                if (i >= buttons.Count) { slot.GameObject.SetActive(false); continue; }
+                var (label, btnKey) = buttons[i];
+                if (!string.IsNullOrEmpty(label)) slot.Text = label;   // null/空 → 保留皮肤默认（button0 的 "OK"）
+                visibleButtons.Add(slot);
+                slot.OnClick.Subscribe(_ =>
+                {
+                    int cur = car.Current;
+                    if (cur >= 0 && cur < latest.Count) onConfirm(latest[cur], btnKey);
+                }).AddTo(screen);
+            }
+            void RefreshButtonsEnabled(bool on) { foreach (var b in visibleButtons) b.Interactable = on; }
+
+            // —— carousel + 卡：.Do（上游先于下游 Rebuild）维护 latest / 重置 idx / 刷新按钮态（RI-D12/D13）；
+            //    BindItems 带 key 做身份保持（RI-D9~D11）——
+            var src = itemsSource.Do(list =>
+            {
+                latest = list ?? Array.Empty<T>();
+                idx = 0;                                            // ★ 每 emit 归零，否则跨重建累加致索引错乱
+                RefreshButtonsEnabled(latest.Count > 0);            // 空→disable，非空→enable（CSB-D11 反应式版）
+            });
+            car.BindItems(src, (IControl card, T item) =>
+            {
+                int i = idx++;
+                bindCard?.Invoke(card, item);
+                AttachCardClick(card, i, car, () => latest, onConfirm, autoConfirm, soleKey);
+            }, key).AddTo(screen);
+        }
+
+        // 每张卡：透明 raycast catcher + PuiButton。click（非拖动）→ 居中导航或（仅单按钮）确认。
+        private static void AttachCardClick<T>(IControl card, int i, Carousel car,
+            Func<IReadOnlyList<T>> getLatest,
+            Action<T, string> onConfirm, bool autoConfirm, string soleKey) where T : class
+        {
+            var go = card.GameObject;
+            var img = go.GetComponent<UnityImage>() ?? go.AddComponent<UnityImage>();
+            img.color = new UnityEngine.Color(0f, 0f, 0f, 0f);   // 透明，仅 raycast
+            img.raycastTarget = true;
+            // 卡 GO 每次 BindItems 重建都是全新的（旧的由 ClearCards 销毁），故无条件 AddComponent 安全。
+            var btn = go.AddComponent<PuiButton>();
+            btn.targetGraphic = img;
+            btn.onClick.AddListener(() =>
+            {
+                var items = getLatest();
+                if (car.Current == i)
+                {
+                    // 单按钮：点居中卡=确认；多按钮：无操作（CSB-D16）。
+                    if (autoConfirm && i >= 0 && i < items.Count) onConfirm(items[i], soleKey);
+                }
+                else car.GoTo(i, animated: true);                // 点侧卡=居中
+            });
+        }
+    }
+
+    public sealed class CenteredSlideBoxRequest<T> : ModalRequest<T> where T : class
+    {
+        public IReadOnlyList<T> Items;                       // 静态（保留，向后兼容）
+        public Observable<IReadOnlyList<T>> ItemsSource;     // 反应式（优先）
+        public Func<T, object> Key;
+        public Action<IControl, T> BindCard;
+        public string Title;
+        public string ConfirmLabel;                 // 单个按钮的 label（空→皮肤默认 "OK"）
+        public string XmlSrcOverride;               // 命名变体 facade 可传；null→静态默认
+
+        public override string XmlSrc => XmlSrcOverride ?? CenteredSlideBox.XmlSrc;
+
+        public override bool TryEscape(out T result) { result = null; return true; }
+
+        public override void Bind(IScreen screen, Action<T> close)
+            => CenteredSlideBoxBinder.Bind(screen,
+                   ItemsSource ?? Observable.Return<IReadOnlyList<T>>(Items ?? Array.Empty<T>()),
+                   BindCard, Title, new[] { (ConfirmLabel, (string)null) }, Key, XmlSrc,   // 1 个隐式按钮；key 忽略
+                   onConfirm: (item, _) => close(item),
+                   onCancel: () => close(null));
+    }
+
+    // 多按钮：返回 SlideSelection<T>（选中卡 + 按钮 key）。
+    public sealed class CenteredSlideBoxMultiRequest<T> : ModalRequest<SlideSelection<T>> where T : class
+    {
+        public IReadOnlyList<T> Items;
+        public Observable<IReadOnlyList<T>> ItemsSource;
+        public Func<T, object> Key;
+        public Action<IControl, T> BindCard;
+        public string Title;
+        public IReadOnlyList<(string label, string key)> Buttons;   // facade 保证非空
+        public string XmlSrcOverride;
+
+        public override string XmlSrc => XmlSrcOverride ?? CenteredSlideBox.XmlSrc;
+
+        public override bool TryEscape(out SlideSelection<T> result) { result = default; return true; }
+
+        public override void Bind(IScreen screen, Action<SlideSelection<T>> close)
+            => CenteredSlideBoxBinder.Bind(screen,
+                   ItemsSource ?? Observable.Return<IReadOnlyList<T>>(Items ?? Array.Empty<T>()),
+                   BindCard, Title, Buttons, Key, XmlSrc,
+                   onConfirm: (item, key) => close(new SlideSelection<T>(item, key)),
+                   onCancel: () => close(default));
+    }
+
+    public static class CenteredSlideBox
+    {
+        // 必须带 .ui 后缀（Unity 只剥 .ui.xml 的最后 .xml）。可写 = 换皮入口。
+        public static string XmlSrc { get; set; } = "PromptUGUI/Modals/CenteredSlideBox.ui";
+
+        // 单按钮 · 静态 → 返回选中对象 / null（向后兼容）。
+        public static UnityEngine.Awaitable<T> Open<T>(
+            IReadOnlyList<T> items,
+            Action<IControl, T> bind,
+            string title = null,
+            string confirmLabel = null,
+            ModalMode mode = ModalMode.Popup,
+            Action<IScreen> configure = null,
+            System.Threading.CancellationToken ct = default
+        ) where T : class
+            => UI.Modal.OpenAsync(new CenteredSlideBoxRequest<T>
+            {
+                Items = items,
+                BindCard = bind,
+                Title = title,
+                ConfirmLabel = confirmLabel,
+                Configure = configure,
+            }, mode, ct);
+
+        // 单按钮 · 反应式。
+        public static UnityEngine.Awaitable<T> Open<T>(
+            Observable<IReadOnlyList<T>> items,
+            Action<IControl, T> bind,
+            string title = null,
+            string confirmLabel = null,
+            ModalMode mode = ModalMode.Popup,
+            Action<IScreen> configure = null,
+            Func<T, object> key = null,
+            System.Threading.CancellationToken ct = default
+        ) where T : class
+        {
+            if (items == null) throw new ArgumentNullException(nameof(items));
+            return UI.Modal.OpenAsync(new CenteredSlideBoxRequest<T>
+            {
+                ItemsSource = items,
+                Key = key,
+                BindCard = bind,
+                Title = title,
+                ConfirmLabel = confirmLabel,
+                Configure = configure,
+            }, mode, ct);
+        }
+
+        // 多按钮 · 静态 → 返回 (选中对象, 按钮 key)。buttons 必填且非空。
+        public static UnityEngine.Awaitable<SlideSelection<T>> Open<T>(
+            IReadOnlyList<T> items,
+            Action<IControl, T> bind,
+            IEnumerable<(string label, string key)> buttons,
+            string title = null,
+            ModalMode mode = ModalMode.Popup,
+            Action<IScreen> configure = null,
+            System.Threading.CancellationToken ct = default
+        ) where T : class
+        {
+            var list = new List<(string label, string key)>(
+                buttons ?? throw new ArgumentNullException(nameof(buttons)));
+            if (list.Count == 0)
+                throw new ArgumentException("buttons must be non-empty", nameof(buttons));
+            return UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<T>
+            {
+                Items = items,
+                BindCard = bind,
+                Title = title,
+                Buttons = list,
+                Configure = configure,
+            }, mode, ct);
+        }
+
+        // 多按钮 · 反应式。
+        public static UnityEngine.Awaitable<SlideSelection<T>> Open<T>(
+            Observable<IReadOnlyList<T>> items,
+            Action<IControl, T> bind,
+            IEnumerable<(string label, string key)> buttons,
+            string title = null,
+            ModalMode mode = ModalMode.Popup,
+            Action<IScreen> configure = null,
+            Func<T, object> key = null,
+            System.Threading.CancellationToken ct = default
+        ) where T : class
+        {
+            if (items == null) throw new ArgumentNullException(nameof(items));
+            var list = new List<(string label, string key)>(
+                buttons ?? throw new ArgumentNullException(nameof(buttons)));
+            if (list.Count == 0)
+                throw new ArgumentException("buttons must be non-empty", nameof(buttons));
+            return UI.Modal.OpenAsync(new CenteredSlideBoxMultiRequest<T>
+            {
+                ItemsSource = items,
+                Key = key,
+                BindCard = bind,
+                Title = title,
+                Buttons = list,
+                Configure = configure,
+            }, mode, ct);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: 跑测确认通过（EditMode 模态 + PlayMode）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force")
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["CenteredSlideBoxTests"])
+# 轮询；再跑 play：
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], group_names=["CenteredSlideBoxPlayTests"])
+# 轮询 get_test_job
+```
+Expected: 新增反应式测试 + **所有原有 CenteredSlideBox 测试**（用 `Items=` 静态字段，经 `ItemsSource ?? Observable.Return(Items)` 归一化）全 PASS。
+
+- [ ] **Step 5: 全量回归 + lint**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])
+cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx
+```
+Expected: 全绿。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add Runtime/Application/Modals/CenteredSlideBoxRequest.cs \
+        Tests/EditMode/Modals/CenteredSlideBoxTests.cs Tests/PlayMode/Modals/CenteredSlideBoxPlayTests.cs
+git commit -m "feat: CenteredSlideBox.Open 反应式 items 重载 + 按身份保持确认
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: 文档 / SKILL 更新
+
+CLAUDE.md 强制：功能变更必须同 PR 更新对应 skill（英文）。
+
+**Files:**
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md`
+- Modify: `.claude/skills/authoring-promptugui-xml/reference/controls-carousel.md`
+
+**Interfaces:** Consumes 全部前序任务的最终 API 形态（文档化，无新代码）。
+
+- [ ] **Step 1: scripting skill —— 新增 `.AddTo(card)` 生命周期原语**
+
+在 "Events & subscriptions" 段（讲 `.AddTo(screen)` 处）后补一小节：
+
+```markdown
+### Per-control subscription lifetime (`.AddTo(control)`)
+
+`.AddTo(screen)` ties a subscription to **Screen** lifetime. For per-item live
+data inside a `BindItems` / modal-card binder, tie it to the **card** instead so
+it's disposed when that card is rebuilt (list membership change) or the screen
+closes — whichever comes first:
+
+\```csharp
+list.BindItems(items, (slot, item) => {
+    var label = slot.Get<Text>("label");                 // cache the handle
+    item.Count.Subscribe(n => label.TextValue = $"x{n}") // R3 field on the item VM
+        .AddTo(slot);                                    // ← card lifetime, NOT screen
+});
+\```
+
+`.AddTo(control)` works on any `IControl` (mirrors `.AddTo(screen)`). Disposing a
+control disposes its tracked subscriptions, recursively including child controls.
+Using `.AddTo(screen)` for per-card subscriptions leaks across list rebuilds
+(old cards are destroyed but their subscriptions keep firing into dead controls
+until the screen closes).
+```
+
+- [ ] **Step 2: scripting skill —— CenteredSlideBox 反应式 Open + key + 实时示例**
+
+在 CenteredSlideBox 段（`var lv = await CenteredSlideBox.Open(...)` 附近 + API surface）补充反应式重载与 `key`，并加实时下单示例：
+
+```markdown
+// Reactive items: the card set changes live (orders appear/disappear) AND each
+// card's fields tick. Pass Observable<IReadOnlyList<T>> for membership; subscribe
+// per-card fields inside `bind` with .AddTo(card). `key` keeps the centred card
+// by identity across membership changes (so confirm submits the object the user sees).
+var picked = await CenteredSlideBox.Open(
+    items: liveOrders,                       // Observable<IReadOnlyList<OrderVM>>
+    bind: (card, vm) => {
+        var price = card.Get<Text>("price"); // cache; don't Get every tick
+        vm.Price.Subscribe(p => price.TextValue = p.ToString("C")).AddTo(card);
+    },
+    title: UI.Tr("Select order"),
+    key: o => o.Id);                         // identity for centred-card preservation
+```
+
+并在 API surface 的 `CenteredSlideBox` 块补两个反应式重载签名（`Observable<IReadOnlyList<T>> items` + `Func<T,object> key = null`，单/多按钮各一），注明：静态重载保留；`key` 仅反应式重载有（静态永不重建）；成员变化全量重建（非 keyed diff，高频变化应改用 ScrollList）。
+
+- [ ] **Step 3: scripting skill —— cheatsheet**
+
+`DATA PUSH` 段在 `Carousel.BindItems(...)` 行后补 `, key: o=>o.Id (反应式身份保持)`；`EVENTS (R3)` 段 `.AddTo(screen)` 行后补一行 `.AddTo(control)  per-card/per-control lifetime (BindItems 内订阅用它)`；`MODAL` 段 CenteredSlideBox 注释补 "items 可传 Observable<IReadOnlyList<T>> + key 身份保持"。
+
+- [ ] **Step 4: carousel reference —— BindItems key 参数**
+
+在 `.claude/skills/authoring-promptugui-xml/reference/controls-carousel.md` 的 `BindItems` 说明处补：
+
+```markdown
+`BindItems` 第三个可选参 `Func<T,object> key`（如 `key: x => x.Id`）：源 Observable
+重新 emit（成员增删/换序）时，重建后按 key 把"上一帧居中的那张卡"重新居中；命中不到
+（被删/无 key 引用对不上）则就近夹位。一次 emit 至多触发一次 `OnCurrentChanged`。
+卡内实时字段在 `bind` 里订阅并 `.AddTo(card)`（重建/关窗自动退订）。
+```
+
+- [ ] **Step 5: 校对 + 提交**
+
+通读两份 skill 改动，确认与 Task 1-3 的最终签名一致（`AddTo(IControl)`、`Open(Observable<IReadOnlyList<T>>, ..., Func<T,object> key=null, ct)`、`BindItems(..., Func<T,object> key=null)`）。
+
+```bash
+git add .claude/skills/scripting-promptugui-csharp/SKILL.md \
+        .claude/skills/authoring-promptugui-xml/reference/controls-carousel.md
+git commit -m "docs: skill 更新 .AddTo(card) / CenteredSlideBox 反应式 items / Carousel key
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## 完成标准
+
+- EditMode `PromptUGUI.Tests.EditMode` + PlayMode `PromptUGUI.Tests.PlayMode` 全绿，含全部新增测试与零回归。
+- `cd .lint && dotnet format whitespace PromptUGUI.Lint.slnx` 无残留。
+- 两份 skill 已反映新 API。
+- 4 次 commit 均在 `feat/centered-slidebox-reactive-items`，main 无改动。
+- 静态 `Open(IReadOnlyList<T>, ...)` 与请求对象 `Items` 字段签名不变 → 现有调用方零影响。

--- a/docs~/superpowers/specs/2026-06-23-centered-slidebox-reactive-items-design.md
+++ b/docs~/superpowers/specs/2026-06-23-centered-slidebox-reactive-items-design.md
@@ -182,9 +182,11 @@ public static Awaitable<SlideSelection<T>> Open<T>(
 
 > 命名澄清：多按钮的 `buttons` 里每个元素的 `key` 是"按钮分支判别符"（既有语义），与本设计新增的 `Func<T,object> key`（身份选择器）是两个无关概念。代码中前者是 `(label, key)` 元组字段，后者是形参 `key`。
 
-请求对象 `CenteredSlideBoxRequest<T>` / `CenteredSlideBoxMultiRequest<T>` 字段调整：
-- `IReadOnlyList<T> Items` → `Observable<IReadOnlyList<T>> ItemsSource`（静态重载用 `Observable.Return(items)` 填）；
+请求对象 `CenteredSlideBoxRequest<T>` / `CenteredSlideBoxMultiRequest<T>` 字段调整（**保留** `Items`、**新增** `ItemsSource` + `Key`——这两个 request 类是 public 且被现有测试直接构造，重命名会破坏公共 API / 测试，故新增而非替换）：
+- 保留 `IReadOnlyList<T> Items`（静态调用方继续用）；
+- 新增 `Observable<IReadOnlyList<T>> ItemsSource`（反应式调用方用，优先）；
 - 新增 `Func<T, object> Key`。
+- `Bind` 归一化：`var source = ItemsSource ?? Observable.Return<IReadOnlyList<T>>(Items ?? Array.Empty<T>());`。
 
 ### 5.2 `CenteredSlideBoxBinder` 改造（RI-D12/D13）
 

--- a/docs~/superpowers/specs/2026-06-23-centered-slidebox-reactive-items-design.md
+++ b/docs~/superpowers/specs/2026-06-23-centered-slidebox-reactive-items-design.md
@@ -1,0 +1,307 @@
+# CenteredSlideBox 实时数据 / 反应式 items 设计
+
+**日期**: 2026-06-23
+**状态**: 设计阶段（待 review，未进入实施）
+**作用域**:
+1. `Runtime/Controls/Control.cs` —— 新增按 Control 的订阅生命周期：惰性 `_subscriptions` 袋 + `public void Track(IDisposable)`，`Dispose()` 释放它（先订阅、后销毁 GO，递归 `_children` 兜底，幂等）
+2. `Runtime/Application/Disposables.cs` —— 新增 R3 扩展 `AddTo(this T, IControl)`（对称现有 `AddTo(IScreen)`）
+3. `Runtime/Controls/Carousel.cs` —— `BindItems` 增加可选 `Func<T,object> key` 形参；emit 重建后按身份保持居中卡
+4. `Runtime/Controls/Internal/CarouselView.cs` —— `OnItemsRebuilt` 支持"重建后定位到指定 index"，避免一次 emit 内重复 fire `OnCurrentChanged`
+5. `Runtime/Application/Modals/CenteredSlideBoxRequest.cs` —— `Open` 新增 `Observable<IReadOnlyList<T>>` 反应式重载（单/多按钮各一）+ `key`；`CenteredSlideBoxBinder` 改为维护"最新列表"，确认/点击读最新项；空列表→按钮 disable 改为每 emit 更新；旧静态重载保留、委托反应式实现
+6. `scripting-promptugui-csharp/SKILL.md` —— 文档化 `.AddTo(card)` 原语、反应式 `Open` + `key`、"bind 内订阅实时字段"模式、cheatsheet、CenteredSlideBox API surface
+7. `authoring-promptugui-xml/reference/controls-carousel.md` —— `BindItems` 的 `key` 参数
+
+**依赖**: 无新增包。复用：R3（`Observable` / `Subject` / `.AddTo` / `.Do`）、现有 `Screen.Track` / `AddTo(IScreen)` 范式、`Carousel.BindItems` / `CarouselView` 翻页与重建机制、`CenteredSlideBoxBinder` 现有按钮探测 / 取消三通道逻辑。
+
+---
+
+## 1. 背景
+
+`CenteredSlideBox.Open` 现在是一次性快照型 API：
+
+```csharp
+// CenteredSlideBoxRequest.cs:39
+car.BindItems(Observable.Return(items), bindCard);   // emit 一次即 complete，永不重建
+```
+
+- `items` 是**静态** `IReadOnlyList<T>`；
+- `bind` 是 `Action<IControl, T>`，调用方在里面 `card.Get<Text>("name").TextValue = ...` 填卡槽。
+
+真实需求：用户用 CenteredSlideBox 打开一个**长期存在、数据实时变化**的复杂界面（典型如"实时下单"——几张可滑动的卡片，卡内价格/状态/库存不停跳，且卡片集合本身也会增删）。当前 API 无法承载，存在两个正交的更新粒度都没解：
+
+| 粒度 | 含义 | 现状 |
+|---|---|---|
+| **A. 列表成员变化** | 卡片增 / 删 / 换序 | ❌ `Open` 只收静态 `IReadOnlyList<T>`，传不进 `Observable` |
+| **B. 卡内字段更新** | 某张卡的价格 / 状态字段跳动，卡本身不增删 | ⚠️ 今天**碰巧能做**（卡片永不重建 → `bind` 内订阅 + `.AddTo(screen)` 可工作），但无文档、且一旦支持 A 就会泄漏 |
+
+**B 的关键现状**：因为底层是 `Observable.Return`，卡片建出来后永不重建，所以在 `bind` 里订阅实时流并 `.AddTo(screen)` **目前就能正常工作**。问题在于：
+
+1. **没有"按卡片"的生命周期**。`Control` 没有 disposable 袋，`Control.Dispose()` 只销毁 GameObject、不释放任何 R3 订阅。唯一能绑的生命周期是 `screen`（`.AddTo(screen)`）。一旦支持 A（列表会重建），旧卡被 `ClearCards` 销毁，但其 `.AddTo(screen)` 订阅会存活到关窗、继续往已销毁控件写值 → 泄漏 + 无效写。
+2. **模式无文档**。用户正是因为不确定才来问"bind 里订阅上就行了？"——答案基本是"对"，但要补一个干净的卡片级生命周期才安全。
+
+需要的不是一套声明式数据绑定层（那违背本库"XML 只描述结构、C# 显式接线"的核心哲学），而是：**补上唯一缺失的原语——按 Control 的订阅生命周期 `.AddTo(card)`（对称 `.AddTo(screen)`），再让 `items` 能反应式、并在成员变化时按身份保住居中卡。**
+
+---
+
+## 2. 决策一览
+
+| # | 决策 | 选择 | 理由 |
+|---|---|---|---|
+| RI-D1 | 更新粒度 | 拆成 A（成员，`Observable<IReadOnlyList<T>>`）+ B（字段，`bind` 内订阅 `T` 自带的 R3 字段）两条正交通道 | 二者生命周期、频率截然不同：成员低频、整列表重建；字段高频、原地更新。混在一起（如整列表重发来表达字段跳动）对高频字段是灾难 |
+| RI-D2 | 卡片级生命周期 | 给 `Control` 加订阅袋 + `Track`，新增 R3 扩展 `.AddTo(card)`，对称 `.AddTo(screen)` | 最贴合既有范式、最易发现；`bind` 签名 `Action<IControl,T>` **不变**（`card` 就是 `IControl`），调用方只是把 `.AddTo(screen)` 换成 `.AddTo(card)`；零破坏 |
+| RI-D3 | 备选：第三参 `Action<IControl,T,CompositeDisposable>` | **否决** | 要改签名 / 加重载、与 `.AddTo(screen)` 不对称；`.AddTo(card)` 同样达意且零签名churn |
+| RI-D4 | 备选：文档化 `.AddTo(card.GameObject)`（R3 自带 GameObject 触发器） | **否决** | 每卡多挂一个 `ObservableDestroyTrigger` MonoBehaviour、销毁时机随 Unity 帧末、与 `.AddTo(screen)` 不对称、不可发现 |
+| RI-D5 | `Control.Dispose()` 顺序 | **先**释放订阅袋（自身 + 递归 `_children` 兜底），**再**销毁 `HostGameObject`；幂等（释放后置 null） | 订阅 teardown 可能要读 GO；先退订避免往半销毁 GO fire；递归 `_children` 让 `.AddTo(innerControl)` 也安全（不止根卡），消除脚枪 |
+| RI-D6 | 通用性 | `.AddTo(card)` 原语做在 `Control` 上，对**所有** Control 通用，不止模态卡片 | 同一机制顺带让 `ScrollList`/`Carousel`/`TabBar` 的 `BindItems` per-row 订阅可安全 `.AddTo(slot)`，修复"列表重建时 `.AddTo(screen)` 订阅泄漏"这一既有潜在 bug |
+| RI-D7 | 反应式 API 形态 | `Open` **新增** `Observable<IReadOnlyList<T>>` 重载（单/多按钮各一），旧静态重载保留、内部包 `Observable.Return(items)` 委托过去 | 向后兼容零破坏；调用方按首参类型自然重载分派 |
+| RI-D8 | 数据形态 | `T`（视图模型）自带 R3 字段（如 `ReactiveProperty<decimal> Price`）；成员走 `Observable<IReadOnlyList<T>>`，字段走 `bind` 内订阅 | R3 惯用法；与本库"C# 显式接线"一致；列表流管成员、字段流管跳动，职责分离 |
+| RI-D9 | 成员变化时居中卡 | **按身份保持**：重建后重新居中"同一对象"；被删则就近夹位 | 防止静默重排/删除后点确认提交错对象（确认正确性，非纯 UI）；用户已排除"保留卡片全状态"（keyed diff），仅保居中身份足够 |
+| RI-D10 | 身份判定 | 可选 `Func<T,object> key`；不传 → 引用相等；都不命中 → 沿用就近夹位 | `key`（如 `o => o.Id`）覆盖"每 emit 重建视图模型"场景；引用相等覆盖"复用同实例"场景；夹位是安全兜底。`object` 会装箱值类型 key，但成员变化低频、可忽略 |
+| RI-D11 | 身份保持归属层 | 放 **Carousel.BindItems**（它拥有 `_current` 分页状态），而非 binder | 复用：任何反应式 Carousel 都受益；状态就在 `CarouselView` |
+| RI-D12 | 确认 / 点击读哪份列表 | binder 用 `source.Do(l => _latest = l)` 维护**最新列表**，确认读 `_latest[car.Current]`、每卡点击读 `_latest[i]` | 反应式下捕获的静态 `items` 会过期；单订阅 + `.Do` 副作用零额外开销 |
+| RI-D13 | 空列表 → 按钮 disable | 由现在一次性（CSB-D11）改为**每 emit 更新**：`_latest.Count==0` → 确认按钮 disable，非空 → enable | 反应式下列表可在首发前为空、或 emit 成空集 |
+
+---
+
+## 3. 核心机制：按 Control 的订阅生命周期 `.AddTo(card)`
+
+### 3.1 `Control` 的订阅袋（RI-D2 / RI-D5）
+
+```csharp
+// Runtime/Controls/Control.cs
+private List<IDisposable> _subscriptions;   // 惰性：未用过的 Control 恒为 null，零内存代价
+
+public void Track(IDisposable d) => (_subscriptions ??= new List<IDisposable>()).Add(d);
+
+public virtual void Dispose()
+{
+    // 先退订（自身 + 递归子树兜底）——teardown 可能读 GO；避免往半销毁 GO fire
+    DisposeSubscriptionsRecursive();
+    if (HostGameObject == null) return;     // 既有幂等守卫
+    if (UnityEngine.Application.isPlaying) Object.Destroy(HostGameObject);
+    else Object.DestroyImmediate(HostGameObject);
+}
+
+private void DisposeSubscriptionsRecursive()
+{
+    if (_subscriptions != null)
+    {
+        for (int i = _subscriptions.Count - 1; i >= 0; i--) _subscriptions[i]?.Dispose();
+        _subscriptions.Clear();
+        _subscriptions = null;
+    }
+    foreach (var c in _children)            // _children 已由 AddChild 维护
+        if (c is Control cc) cc.DisposeSubscriptionsRecursive();
+}
+```
+
+- **幸福路径**：`bind` 拿到的 `card`（卡片根 IControl）上 `.AddTo(card)`，根 `Dispose()` 释放整卡订阅。
+- **兜底**：`.AddTo(card.Get<Text>("price"))`（绑到内层控件）也安全——根 Dispose 递归释放 `_children` 的袋。注：动态卡子树的内层控件不会被单独 `Dispose()`（只销毁根 GO 级联），故必须靠这条递归，否则内层 AddTo 会泄漏。
+- **幂等**：`Dispose()` 二次调用——`_subscriptions` 已置 null、`HostGameObject==null` 守卫返回，安全（与现有 double-dispose 安全契约一致）。
+- 子类（`Carousel`/`ScrollList`/`TabBar`/...）的 `override Dispose()` 末尾都 `base.Dispose()` → 自动获得退订。
+
+### 3.2 R3 扩展 `.AddTo(IControl)`（RI-D2）
+
+```csharp
+// Runtime/Application/Disposables.cs —— 紧挨现有 AddTo(Screen)/AddTo(IScreen)
+public static T AddTo<T>(this T disposable, Controls.IControl control) where T : IDisposable
+{
+    ((Controls.Control)control).Track(disposable);
+    return disposable;
+}
+```
+
+- 与 `AddTo(IScreen)`（`((Screen)screen).Track(...)`）写法对称。
+- 是 `IControl` 上的全新重载，不与 R3 自带 `AddTo(GameObject/Component/ICollection/CancellationToken)` 冲突。
+
+### 3.3 生命周期语义
+
+| 订阅绑到 | 释放时机 |
+|---|---|
+| `.AddTo(screen)` | 关窗 / `UI.Close` / `UnloadAll`（既有） |
+| `.AddTo(card)` | **卡片重建（成员变化）或关窗**——以先到者为准 |
+
+---
+
+## 4. Carousel.BindItems：key 选择器 + 身份保持
+
+### 4.1 API（RI-D9/D10/D11）
+
+```csharp
+// Runtime/Controls/Carousel.cs —— 形参追加，旧调用点（key 默认 null）零改动
+public IDisposable BindItems<T>(
+    Observable<IReadOnlyList<T>> source, Action<IControl, T> bind,
+    Func<T, object> key = null);
+
+public IDisposable BindItems<T, TSlot>(
+    Observable<IReadOnlyList<T>> source, Action<TSlot, T> bind,
+    Func<T, object> key = null) where TSlot : class, IControl;
+```
+
+### 4.2 行为
+
+每次 `source` emit：
+
+1. **重建前**：若上一份列表非空且当前居中 index 合法，记下居中项 `prevCentered = prev[CurrentIndex]`。
+2. `Rebuild(items, bind)`：`ClearCards()`（销毁旧卡 → 触发各卡根 `Dispose()` → 释放 `.AddTo(card)` 订阅）→ 逐项建新卡 + 调 `bind`。
+3. **重建后定位**：在 `items` 中找回 `prevCentered`（有 `key` → 比 `key`；否则比引用相等）。命中 → 居中其新 index；不命中（被删/无 key 引用对不上）→ 沿用 `OnItemsRebuilt` 现有就近夹位。
+4. `prev = items`，供下次 emit 用。
+
+### 4.3 避免一次 emit 内重复 fire `OnCurrentChanged`（RI-D11）
+
+现状 `Rebuild → OnItemsRebuilt` 会先夹位 `_current` 并可能 fire 一次 `OnCurrent`，若随后再 `GoTo(target)` 定位则可能二次 fire。解决：把"目标 index"在重建时一次性传入定位。
+
+实现取向：`CarouselView.OnItemsRebuilt` 增可选 `int? desiredIndex` 形参——给定且合法则直接定位到它、只在与旧 `_current` 不同才 fire 一次；不给定走原夹位逻辑。`Carousel.BindItems` 把第 3 步算出的新 index 作为 `desiredIndex` 下传。**净效果：一次 emit 至多一次 `OnCurrentChanged`。**
+
+---
+
+## 5. CenteredSlideBox.Open：反应式重载
+
+### 5.1 新增 / 保留的重载（RI-D7）
+
+```csharp
+// === 反应式（新增） ===
+// 单按钮 → Awaitable<T>
+public static Awaitable<T> Open<T>(
+    Observable<IReadOnlyList<T>> items, Action<IControl, T> bind,
+    string title = null, string confirmLabel = null, ModalMode mode = ModalMode.Popup,
+    Action<IScreen> configure = null, Func<T, object> key = null,
+    CancellationToken ct = default) where T : class;
+
+// 多按钮 → Awaitable<SlideSelection<T>>
+public static Awaitable<SlideSelection<T>> Open<T>(
+    Observable<IReadOnlyList<T>> items, Action<IControl, T> bind,
+    IEnumerable<(string label, string key)> buttons,
+    string title = null, ModalMode mode = ModalMode.Popup,
+    Action<IScreen> configure = null, Func<T, object> key = null,
+    CancellationToken ct = default) where T : class;
+
+// === 静态（保留，向后兼容；内部 Observable.Return(items) 委托反应式） ===
+// 既有两个静态重载签名不变，无 key 形参（静态永不重建，key 无意义）
+```
+
+> 命名澄清：多按钮的 `buttons` 里每个元素的 `key` 是"按钮分支判别符"（既有语义），与本设计新增的 `Func<T,object> key`（身份选择器）是两个无关概念。代码中前者是 `(label, key)` 元组字段，后者是形参 `key`。
+
+请求对象 `CenteredSlideBoxRequest<T>` / `CenteredSlideBoxMultiRequest<T>` 字段调整：
+- `IReadOnlyList<T> Items` → `Observable<IReadOnlyList<T>> ItemsSource`（静态重载用 `Observable.Return(items)` 填）；
+- 新增 `Func<T, object> Key`。
+
+### 5.2 `CenteredSlideBoxBinder` 改造（RI-D12/D13）
+
+```csharp
+public static void Bind<T>(
+    IScreen screen, Observable<IReadOnlyList<T>> itemsSource, Action<IControl,T> bindCard,
+    string title, IReadOnlyList<(string label, string key)> buttons, Func<T,object> key,
+    string xmlSrcForError, Action<T,string> onConfirm, Action onCancel) where T : class
+{
+    // title / 取消三通道（close + backdrop）—— 不变
+
+    IReadOnlyList<T> latest = Array.Empty<T>();
+    int idx = 0;                                    // 每 emit 内的卡片构建序号
+    var car = screen.Get<Carousel>("cards");
+
+    // .Do 在下游 Rebuild 之前跑（同一 OnNext 上游先于下游）：维护最新列表、重置构建序号、
+    // 每 emit 刷新按钮 disable 态（RI-D12/D13）。
+    var src = itemsSource.Do(list =>
+    {
+        latest = list ?? Array.Empty<T>();
+        idx = 0;                                    // ★ 必须每 emit 归零——否则跨重建累加致索引错乱
+        RefreshButtonsEnabled(latest.Count > 0);    // 空 → disable，非空 → enable
+    });
+
+    car.BindItems(src, (IControl cardCtl, T item) =>
+    {
+        int i = idx++;                              // 该卡在本次 emit / latest 中的下标
+        bindCard?.Invoke(cardCtl, item);
+        AttachCardClick(cardCtl, i, car, () => latest, onConfirm, autoConfirm, soleKey);
+    }, key).AddTo(screen);
+
+    // 按钮槽探测 / 映射 buttons[i] → slot i —— 逻辑不变；
+    // 确认点击体改为读 latest：
+    //   int cur = car.Current; if (cur in range(latest)) onConfirm(latest[cur], btnKey);
+}
+```
+
+- **`AttachCardClick`** 由捕获静态 `items` 改为持构建下标 `i` + `Func<IReadOnlyList<T>> getLatest`；"点居中卡=确认（单按钮）/点侧卡=居中"判定用 `car.Current == i`（卡片随每 emit 重建、与 `latest` 一一对应，故构建下标 `i` 即该卡在 `latest` 的下标），确认体读 `getLatest()[i]`。
+- **空列表**：首发前 `latest` 为空 → 按钮 disable；emit 空集同理。非空 emit 自动 enable。
+- **确认正确性**：身份保持（§4）确保 `car.Current` 始终指向用户视觉上居中的那张卡在 `latest` 中的真实项 → `onConfirm(latest[car.Current], …)` 提交的就是用户看到的对象。
+
+---
+
+## 6. 用法（将写进 scripting skill）
+
+```csharp
+// 视图模型：成员身份用稳定 Id，字段用 R3
+sealed class OrderVM {
+    public string Id;
+    public ReactiveProperty<decimal> Price;
+    public ReactiveProperty<int>     Stock;
+}
+
+// liveOrders: Observable<IReadOnlyList<OrderVM>> —— 成员增删换序由它推
+var picked = await CenteredSlideBox.Open(
+    items: liveOrders,
+    bind: (card, vm) => {
+        var price = card.Get<Text>("price");          // 缓存句柄：别每 tick 走 Get 字典
+        var stock = card.Get<Text>("stock");
+        vm.Price.Subscribe(p => price.TextValue = p.ToString("C")).AddTo(card);  // 绑卡生命周期
+        vm.Stock.Subscribe(s => stock.TextValue = $"x{s}").AddTo(card);          // 重建/关窗自动退订
+    },
+    title: UI.Tr("选择订单"),
+    key: o => o.Id);                                  // 成员变化按 Id 保住居中卡
+if (picked != null) Trade.Place(picked);
+```
+
+要点（写进文档）：
+- 成员变化 → `Observable<IReadOnlyList<T>>`；字段跳动 → `T` 自带 R3 字段 + `bind` 内订阅 `.AddTo(card)`。
+- **永远 `.AddTo(card)` 而非 `.AddTo(screen)`** 给卡内订阅——否则列表重建时旧订阅泄漏。
+- 在 `bind` 入口缓存 `card.Get<T>(...)` 句柄，避免每次 tick 重复字典查找。
+
+---
+
+## 7. 测试（先红后绿，经 Unity MCP）
+
+**EditMode**（`PromptUGUI.Tests.EditMode`）：
+- `Control` 订阅袋：`Track` + `Dispose` 释放并退订；递归释放 `_children`（内层 `.AddTo` 也退订）；double-dispose 幂等。
+- `AddTo(IControl)` 扩展：返回原 disposable；Control Dispose 后已 disposed。
+- Carousel 身份保持：居中项被删 → 就近夹位；被移序 → 跟随到新 index；无 `key` 用引用相等命中；一次 emit 至多一次 `OnCurrentChanged`。
+- 反应式 `Open`：emit 新列表 → 卡更新；空列表 → 确认按钮 disable、非空 → enable；身份保持后确认读到正确项；静态重载向后兼容（仍工作、行为不变）。
+
+**PlayMode**（`PromptUGUI.Tests.PlayMode`，`Modals/CenteredSlideBoxPlayTests.cs` 同址）：
+- 多轮成员重建后，旧卡的字段订阅计数归零（无泄漏、无往已销毁控件写）。
+- 关窗 → 全部 `.AddTo(card)` / `.AddTo(screen)` 订阅释放。
+
+---
+
+## 8. 边界 / 错误处理
+
+- `itemsSource` 为 `null`：静态重载不会产生（总包 `Observable.Return`）；反应式重载传 `null` → `ArgumentNullException`（与多按钮 `buttons` 空校验同风格）。
+- 首发前（`Observable` 尚未 emit）：无卡片、确认按钮 disable；正常，等首 emit。
+- `key` 返回 `null` 或抛异常：`null` 视为不命中 → 夹位；抛异常按既有 binder 异常路径（取消该 modal 的 await，与 `configure` 抛错一致）。
+- emit 频率：成员变化预期低频。高频成员变化（每帧增删）超出本设计（用户已排除 keyed diff）——文档注明此时应换 `ScrollList` 或自管。
+
+---
+
+## 9. Out of Scope
+
+- **卡片复用 / keyed diff**（成员变化时复用未变卡、其订阅原地存活、不闪烁、不重置滚动）——用户已明确排除；成员变化走全量重建。
+- **声明式 XML 数据绑定**（`<Text text="{{vm.price}}">`）——违背本库哲学。
+- **`ScrollList` / `TabBar` 的身份保持 `key`**——本次只给 `Carousel`（CenteredSlideBox 依赖它）。但 `.AddTo(slot)` 因做在 `Control` 上，三者 per-row 订阅**自动**受益（修复潜在泄漏）。后续若需可同样给它们加 `key`。
+
+---
+
+## 10. 跟现有 spec / SKILL 的整合点
+
+- **主 spec** `2026-05-07-promptugui-description-language-design.md`：CenteredSlideBox / Carousel 章节追加反应式 `items` + `key` + `.AddTo(card)` 说明（沿用其 §编号引用惯例）。
+- **`scripting-promptugui-csharp/SKILL.md`**：`.AddTo(card)` 原语（生命周期表）、反应式 `Open` 重载 + `key`、"bind 内订阅实时字段"模式 + §6 示例、cheatsheet（`DATA PUSH` / `MODAL` 段）、CenteredSlideBox API surface。
+- **`authoring-promptugui-xml/reference/controls-carousel.md`**：`BindItems` 的 `key` 形参。
+- **addressables skill**：无关，不动。
+- **XSD**：无新增 `[UIAttr]`（`key` 是 C# 形参，非 XML 属性），不需 regenerate。
+
+---
+
+## 11. 风险与回滚
+
+- **风险：`Control.Dispose()` 递归释放 `_children` 改了销毁路径**。缓解：先释放订阅再销毁 GO、保留既有 `HostGameObject==null` 幂等守卫；递归只碰订阅袋、不额外销毁 GO（GO 仍由根 Destroy 级联）。EditMode 全量回归（尤其 ScrollList/Carousel/TabBar 重建、Variant ReSolve）。
+- **风险：身份保持引入的 `GoTo`/定位与 `OnItemsRebuilt` 既有夹位双触发**。缓解：用 `desiredIndex` 一次性定位（§4.3），单元测试钉死"一次 emit ≤ 一次 OnCurrentChanged"。
+- **回滚**：三块解耦——(1) Control 订阅袋 + `.AddTo(IControl)`、(2) Carousel `key` 身份保持、(3) CenteredSlideBox 反应式重载。可独立 revert：去掉 (3) 退回静态、去掉 (2) 退回夹位、去掉 (1) 仅失 `.AddTo(card)`（`.AddTo(screen)` 仍在）。静态重载签名不变 → 现有调用方零影响。


### PR DESCRIPTION
## 概要

让 `CenteredSlideBox.Open` 能承载**长期、数据实时变化**的卡片界面（典型如实时下单）。三块解耦改动 + 文档：

1. **按 Control 的订阅生命周期 `.AddTo(card)`** —— `Control` 加惰性订阅袋 + `Track`，新增 R3 扩展 `.AddTo(IControl)`（对称既有 `.AddTo(screen)`）。`Control.Dispose()` 先退订（递归覆盖 `_children` 子控件）再销毁 GameObject。卡片重建/关窗自动退订；顺带修复 ScrollList/Carousel/TabBar 重建时 per-row 订阅泄漏的潜在 bug。
2. **`Carousel.BindItems` 增 `key` 选择器** —— 成员变化全量重建后，按 `key`（或引用相等）把"上一帧居中的卡"重新居中（防止静默重排/删除后确认提交错对象）；命中不到则就近夹位；一次 emit ≤ 一次 `OnCurrentChanged`。
3. **`CenteredSlideBox.Open` 反应式重载** —— 新增 `Observable<IReadOnlyList<T>>` + `Func<T,object> key`（单/多按钮各一）。binder 维护"最新列表"供确认/点击读取，每 emit 刷新按钮禁用态。**静态重载与请求对象 `Items` 字段全部保留 → 零破坏**。
4. **skill 文档** —— `.AddTo(card)`、反应式 `Open`、Carousel `key`（含 cheatsheet）。

## 用法

```csharp
// T 自带 R3 字段；成员走 Observable，字段走 bind 内订阅 + .AddTo(card)
var picked = await CenteredSlideBox.Open(
    items: liveOrders,                       // Observable<IReadOnlyList<OrderVM>>
    bind: (card, vm) => {
        var price = card.Get<Text>("price"); // 缓存句柄，别每 tick 走字典
        vm.Price.Subscribe(p => price.TextValue = p.ToString("C")).AddTo(card);
    },
    title: UI.Tr("选择订单"),
    key: o => o.Id);                         // 成员变化按 Id 保持居中
```

## 测试（经 Unity MCP 验证）

- **EditMode `PromptUGUI.Tests.EditMode`：1928/1928 通过**，0 失败（本特性新增 14：Control 3 / Carousel 5 / CenteredSlideBox 6）
- **PlayMode `CenteredSlideBoxPlayTests`：3/3 通过**（含新增 `Reactive_Rebuild_Then_Confirm`）
- 全量回归零破坏；静态调用路径（`Items =`）经归一化 `ItemsSource ?? Observable.Return(Items)` 继续通过

## 设计

spec：`docs~/superpowers/specs/2026-06-23-centered-slidebox-reactive-items-design.md`（决策 RI-D1..D13）
plan：`docs~/superpowers/plans/2026-06-23-centered-slidebox-reactive-items.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
