### PR TITLE
feat: Btn/Tab/Toggle 实体按钮按压位移（pressedOffset / selectedOffset）

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -223,7 +223,7 @@ Image + uGUI Toggle + 自动 label。R3 `OnValueChanged: bool`。`<Toggle>静音
 | `textColor` | hex / CSS / token | — | **label 文字色**（区别于 `color`=背景）；支持渐变 / `/alpha`；空=默认 ink |
 | `hoverColor` · `pressedColor` · `selectedColor` · `disabledColor` | hex / CSS / token | — | **绝对**单态 bg 色（仅 targetGraphic，不扩散）；`selectedColor`=勾选时 bg 基色（同 `<Tab>` 的 selection-aware base，hover/pressed/disabled 叠在上面）；见 states.md |
 | `hoverModulate` · `pressedModulate` · `selectedModulate` · `disabledModulate` | hex / CSS / token | white | **相对**乘子，扩散到 bg + 所有子 Graphic；子节点 `stateReact="false"` 退出；见 states.md |
-| `pressedOffset` · `selectedOffset` | `x,y` px | — | 子内容位移（content-holder 平移；**负 y=下**）；瞬移；`selectedOffset`=选中(`isOn`)保持按入；Pressed 优先；`""`/`none`=不动；见 states.md |
+| `pressedOffset` · `selectedOffset` | `x,y` px | — | 子内容位移（content-holder 平移；**Unity 符号 负 y=下**）；瞬移；`selectedOffset`=选中(`isOn`)保持按入；Pressed 优先；`""`/`none`=不动；见 states.md |
 | `tint` | `multiply` / `linear` | — | 见 **Tint blend modes** |
 
 ### `<Slider>`
@@ -342,7 +342,7 @@ Tab 容器；私有 `ToggleGroup`（`allowSwitchOff=false`）+ `Horizontal` / `V
 | `selectedSprite` | sprite key | — | 选中（`isOn`）时把 bg `overrideSprite` 换成它、取消选中还原——无独立 overlay；keyed on `isOn` 故 hover/press 不扰动；设了切 transition off ColorTint（同 `<Btn pressedSprite>`）；`""` / `none`=不换 |
 | `hoverColor` · `pressedColor` · `selectedColor` · `disabledColor` | hex / CSS / token | — | **绝对**单态 bg 色（仅 targetGraphic，不扩散）；`selectedColor`=**选中时** bg 基色（hover/pressed/disabled 叠在上面）；见 states.md |
 | `hoverModulate` · `pressedModulate` · `selectedModulate` · `disabledModulate` | hex / CSS / token | white | **相对**乘子，扩散到 bg + 所有子 Graphic；子节点 `stateReact="false"` 退出；见 states.md |
-| `pressedOffset` · `selectedOffset` | `x,y` px | — | 子内容位移（content-holder 平移；**负 y=下**）；瞬移；`selectedOffset`=选中(`isOn`)保持按入；Pressed 优先；`""`/`none`=不动；见 states.md |
+| `pressedOffset` · `selectedOffset` | `x,y` px | — | 子内容位移（content-holder 平移；**Unity 符号 负 y=下**）；瞬移；`selectedOffset`=选中(`isOn`)保持按入；Pressed 优先；`""`/`none`=不动；见 states.md |
 | `tint` | `multiply` / `linear` | — | 作用于 bg（`selectedSprite` 换的也是 bg sprite，故选中图也被 tint）；见 **Tint blend modes** |
 
 ### `<Carousel>`

--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -198,6 +198,7 @@ Image + Button + R3 `OnClick` / `OnState`。`<Btn>开始</Btn>` 简写生成内�
 | `sprite` | sprite key | — | 背景图 |
 | `pressedSprite` | sprite key | — | 按下换 bg `overrideSprite`、松开还原（不动 `sprite`）；自动切 Btn off uGUI ColorTint 避免双重变暗；`""` / `none`=不换；与 `pressedModulate` 叠加；见 states.md |
 | `disabledSprite` | sprite key | — | Disabled 态换 bg `overrideSprite`（`interactable="false"` 或运行时 `Btn.Interactable=false`）；同 `pressedSprite` 契约；与 `pressedSprite` 共存（Disabled 优先）；仅 `<Btn>`；见 states.md |
+| `pressedOffset` | `x,y` px | — | 按下时子内容整体位移（content-holder 平移；**Unity 符号 负 y=下**）；瞬移不补间；与 `<Animation>`/`*Color`/`*Sprite` 叠加；`""`/`none`=不动；见 states.md |
 | `hoverColor` · `pressedColor` · `disabledColor` | hex / CSS / token | — | **绝对**单态 bg 色（仅 targetGraphic，不扩散） |
 | `hoverModulate` · `pressedModulate` · `disabledModulate` | hex / CSS / token | white | **相对**乘子，扩散到 bg + 所有子 Graphic |
 | `fontSize` | int | — | 仅作用于自动 label；其它 Text 属性（`align` / `wrap`）需显式 `<Text>` 子节点 |
@@ -222,6 +223,7 @@ Image + uGUI Toggle + 自动 label。R3 `OnValueChanged: bool`。`<Toggle>静音
 | `textColor` | hex / CSS / token | — | **label 文字色**（区别于 `color`=背景）；支持渐变 / `/alpha`；空=默认 ink |
 | `hoverColor` · `pressedColor` · `selectedColor` · `disabledColor` | hex / CSS / token | — | **绝对**单态 bg 色（仅 targetGraphic，不扩散）；`selectedColor`=勾选时 bg 基色（同 `<Tab>` 的 selection-aware base，hover/pressed/disabled 叠在上面）；见 states.md |
 | `hoverModulate` · `pressedModulate` · `selectedModulate` · `disabledModulate` | hex / CSS / token | white | **相对**乘子，扩散到 bg + 所有子 Graphic；子节点 `stateReact="false"` 退出；见 states.md |
+| `pressedOffset` · `selectedOffset` | `x,y` px | — | 子内容位移（content-holder 平移；**负 y=下**）；瞬移；`selectedOffset`=选中(`isOn`)保持按入；Pressed 优先；`""`/`none`=不动；见 states.md |
 | `tint` | `multiply` / `linear` | — | 见 **Tint blend modes** |
 
 ### `<Slider>`
@@ -340,6 +342,7 @@ Tab 容器；私有 `ToggleGroup`（`allowSwitchOff=false`）+ `Horizontal` / `V
 | `selectedSprite` | sprite key | — | 选中（`isOn`）时把 bg `overrideSprite` 换成它、取消选中还原——无独立 overlay；keyed on `isOn` 故 hover/press 不扰动；设了切 transition off ColorTint（同 `<Btn pressedSprite>`）；`""` / `none`=不换 |
 | `hoverColor` · `pressedColor` · `selectedColor` · `disabledColor` | hex / CSS / token | — | **绝对**单态 bg 色（仅 targetGraphic，不扩散）；`selectedColor`=**选中时** bg 基色（hover/pressed/disabled 叠在上面）；见 states.md |
 | `hoverModulate` · `pressedModulate` · `selectedModulate` · `disabledModulate` | hex / CSS / token | white | **相对**乘子，扩散到 bg + 所有子 Graphic；子节点 `stateReact="false"` 退出；见 states.md |
+| `pressedOffset` · `selectedOffset` | `x,y` px | — | 子内容位移（content-holder 平移；**负 y=下**）；瞬移；`selectedOffset`=选中(`isOn`)保持按入；Pressed 优先；`""`/`none`=不动；见 states.md |
 | `tint` | `multiply` / `linear` | — | 作用于 bg（`selectedSprite` 换的也是 bg sprite，故选中图也被 tint）；见 **Tint blend modes** |
 
 ### `<Carousel>`

--- a/.claude/skills/authoring-promptugui-xml/reference/states.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/states.md
@@ -1,6 +1,6 @@
 # State visuals (Btn / Tab / Toggle)
 
-> Part of the **authoring-promptugui-xml** skill. Main reference: [`../SKILL.md`](../SKILL.md). Read this before using any `*Color` / `*Modulate` / `selectedColor` / `<Show on="state-*">` / `pressedSprite` / `disabledSprite` / `selectedSprite`. For the `state-*` `on=` event values and `<Trigger>` / `<Animation>`, see [`animations.md`](animations.md).
+> Part of the **authoring-promptugui-xml** skill. Main reference: [`../SKILL.md`](../SKILL.md). Read this before using any `*Color` / `*Modulate` / `selectedColor` / `<Show on="state-*">` / `pressedSprite` / `disabledSprite` / `selectedSprite` / `pressedOffset` / `selectedOffset`. For the `state-*` `on=` event values and `<Trigger>` / `<Animation>`, see [`animations.md`](animations.md).
 
 `<Btn>`, `<Tab>`, and `<Toggle>` all broadcast their uGUI interaction state. `<Btn>` emits `Normal` / `Hover` / `Pressed` / `Disabled` (Selectable's `Selected` is folded into `Normal`). `<Tab>` and `<Toggle>` also emit `Selected` (= the active/`isOn` control at rest; transient Hover/Pressed/Disabled override it and it reverts on release). Three ways to react, in increasing power:
 

--- a/.claude/skills/authoring-promptugui-xml/reference/states.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/states.md
@@ -101,3 +101,29 @@ In short: write `pressedSprite=""` or `pressedSprite="none"` to explicitly disab
   <Text anchor="center">Tap</Text>
 </Btn>
 ```
+
+## 4. Press offset — `pressedOffset` / `selectedOffset`
+
+A **tactile / physical-button** effect: while Pressed, the control's child content (label, icons, nested content) shifts by a fixed pixel offset — the background frame (the control's own bg `Image`) stays put — giving a "depressed into the button" feel. Shared by `<Btn>` / `<Tab>` / `<Toggle>`.
+
+| Attribute | Controls | Meaning |
+| --- | --- | --- |
+| `pressedOffset="x,y"` | Btn / Tab / Toggle | Content offset while **Pressed**. |
+| `selectedOffset="x,y"` | Tab / Toggle | Content offset held while **Selected** (`isOn`). `<Btn>` has no selected state and does not have this attribute. |
+
+```xml
+<Btn pressedOffset="0,-4">Buy</Btn>                    <!-- press: content sinks 4px -->
+<Tab pressedOffset="0,-2" selectedOffset="0,-3"/>      <!-- press sinks 2px; stays sunk 3px while selected -->
+```
+
+- **Sign is Unity's: negative `y` = down**, positive `x` = right (same convention as `<Animation translate>`). So "sink 4px" is `0,-4`, not `0,4`. This is the most common foot-gun.
+- **Instant, never tweened.** The offset snaps on state enter and snaps back on release (physical-button semantics + pixel-art-friendly; authored offsets are integer pixels). This deliberately differs from `*Color`'s ~0.1s fade.
+- `""` / `none` = no offset for that state.
+- **First-frame:** a `<Tab>` / `<Toggle>` authored `isOn` shows its `selectedOffset` on frame 1 (no animate-in).
+- **Selected being pressed:** pressing an already-selected `<Tab>` / `<Toggle>` shows `pressedOffset` while held, then reverts to `selectedOffset` on release. If you set `selectedOffset` but **not** `pressedOffset`, pressing a selected control momentarily pops the content back to zero — set both (often the same value) to avoid the pop.
+- **Composition:** independent of `<Animation translate>` (which moves its own proxy — the two stack), of `*Color` / `*Modulate` / `pressedSprite` (different channels), and of `tint`. All compose.
+- `stateReact="false"` does **not** exempt a child from the offset (it only governs `*Modulate` colour fan-out). The holder is a rigid translate — all content moves together.
+- Variant-overridable like any `[UIAttr]` (`pressedOffset.dark="0,-8"`).
+- **Disabled** has no offset (content rests at zero).
+
+Implementation: the control lazily wraps its content in a full-stretch holder (only when an offset is authored) and a `PressOffsetController` drives that holder's `anchoredPosition` from the control's `OnState` stream — same broadcaster the `*Color` family uses.

--- a/Editor/XsdGenerator.cs
+++ b/Editor/XsdGenerator.cs
@@ -96,6 +96,8 @@ namespace PromptUGUI.Editor
                     ("sprite", "xs:string", (string)null),
                     // Pressed-state bg swap ([UIAttr] Btn.PressedSprite).
                     ("pressedSprite", "xs:string", (string)null),
+                    // Press-offset content shift ([UIAttr] Btn.PressedOffset). Tab/Toggle get theirs by reflection.
+                    ("pressedOffset", "xs:string", (string)null),
                     // State-driven absolute [UIAttr]s (Btn.HoverColor/PressedColor/DisabledColor).
                     // Btn is hardcoded here (not reflected), so list them explicitly.
                     ("hoverColor", "xs:string", (string)null),

--- a/Runtime/Controls/Btn.cs
+++ b/Runtime/Controls/Btn.cs
@@ -32,6 +32,10 @@ namespace PromptUGUI.Controls
         private string _hoverModulate;
         private string _pressedModulate;
         private string _disabledModulate;
+        // Press-offset: content-holder shift while Pressed. _offsetHolder lazily created by
+        // StateOffsetInstaller (full-stretch wrapper around the content; bg stays on this GO).
+        private Vector2? _pressedOffset;
+        private RectTransform _offsetHolder;
 
         private const float HorizontalPadding = 16f;
         private const float VerticalPadding = 6f;
@@ -67,6 +71,11 @@ namespace PromptUGUI.Controls
         /// </summary>
         public Observable<InteractState> OnState => _btn.OnState;
 
+        // Children parent into the press-offset holder when it exists (so Add blocks land inside too),
+        // else directly onto this GO (identical to the default Control behaviour — no holder, no cost).
+        protected internal override Transform ChildHostTransform
+            => _offsetHolder != null ? _offsetHolder : RectTransform;
+
         /// <summary>
         /// Runtime override so setting <see cref="Interactable"/> from code (e.g. a modal
         /// <c>Configure</c> hook gating the OK button) also drives the underlying
@@ -99,6 +108,7 @@ namespace PromptUGUI.Controls
         {
             base.OnAfterApply();
             _btn.interactable = Interactable;
+            _offsetHolder = StateOffsetInstaller.Install(GameObject, _offsetHolder, new StateOffsetSet(_pressedOffset, null));
             var abs = StateColorSet.ResolveAbsolutes(_hoverColor, _pressedColor, null, _disabledColor);
             var mod = StateColorSet.ResolveModulates(_hoverModulate, _pressedModulate, null, StateColorSet.NoneToNull(_disabledModulate));
             StateTintInstaller.Install(GameObject, _btn, Children, abs, mod);
@@ -192,6 +202,9 @@ namespace PromptUGUI.Controls
         [UIAttr(IsColor = true), Preserve] public string PressedModulate { set => _pressedModulate = value; }
         /// <summary>Relative colour multiplier while Disabled.</summary>
         [UIAttr(IsColor = true), Preserve] public string DisabledModulate { set => _disabledModulate = value; }
+
+        /// <summary>Content offset (pixels, Unity sign: negative y = down) while Pressed. <c>""</c> / <c>none</c> = none.</summary>
+        [UIAttr, Preserve] public string PressedOffset { set => _pressedOffset = StateOffsetSet.Parse(value); }
 
         [UIAttr, Preserve]
         public string Tint

--- a/Runtime/Controls/Internal/PressOffsetController.cs
+++ b/Runtime/Controls/Internal/PressOffsetController.cs
@@ -1,0 +1,57 @@
+using System;
+using R3;
+using UnityEngine;
+
+namespace PromptUGUI.Controls.Internal
+{
+    /// <summary>
+    /// Drives a content-holder's <see cref="RectTransform.anchoredPosition"/> from the owning
+    /// <see cref="IStateSource"/>'s <see cref="InteractState"/> stream. On each state it snaps the
+    /// holder to <c>offsets.For(state)</c> — instant, no tween (physical-button feel, pixel-perfect;
+    /// authored offsets are integer pixels). One per control (lives on the holder), unlike the
+    /// per-graphic <see cref="StateTintReactor"/>.
+    /// </summary>
+    internal sealed class PressOffsetController : MonoBehaviour
+    {
+        private RectTransform _holder;
+        private StateOffsetSet _offsets;
+        private IStateSource _source;
+        private IDisposable _sub;
+
+        /// <summary>
+        /// (Re)set the per-state offsets. Safe to call repeatedly (Variant ReSolve). Assigns offsets
+        /// BEFORE the first subscription so the synchronous replay of the source's current state sees
+        /// them (mirrors <see cref="StateTintReactor.Configure"/>).
+        /// </summary>
+        public void Configure(StateOffsetSet offsets)
+        {
+            _offsets = offsets;
+            var firstInit = _holder == null;
+            EnsureInit();
+            // On a re-Configure the subscription does NOT replay; repaint the current state explicitly.
+            if (!firstInit && _source != null) OnState(_source.Current);
+        }
+
+        private void EnsureInit()
+        {
+            if (_holder != null) return;
+            _holder = (RectTransform)transform;
+            // includeInactive: the source control may sit on a hidden (SetActive(false)) page at Open.
+            _source = GetComponentInParent<IStateSource>(true);
+            if (_source != null)
+                _sub = _source.OnState.Subscribe(OnState);   // replays Current synchronously
+        }
+
+        private void OnState(InteractState state)
+        {
+            if (_holder != null)
+                _holder.anchoredPosition = _offsets.For(state);
+        }
+
+        private void OnDestroy()
+        {
+            _sub?.Dispose();
+            _sub = null;
+        }
+    }
+}

--- a/Runtime/Controls/Internal/PressOffsetController.cs.meta
+++ b/Runtime/Controls/Internal/PressOffsetController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 76abd21b6d5591a0b90fdfe68b2b0c27

--- a/Runtime/Controls/Internal/StateOffsetInstaller.cs
+++ b/Runtime/Controls/Internal/StateOffsetInstaller.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PromptUGUI.Controls.Internal
+{
+    /// <summary>
+    /// Lazily installs the press/select content-offset on a state-source control (Btn / Tab / Toggle):
+    /// creates a full-stretch content-holder, sweeps the control's direct children into it, and wires a
+    /// <see cref="PressOffsetController"/>. Idempotent: re-run on each Variant ReSolve, reusing the holder.
+    /// Returns the holder (or null when no offset was ever authored).
+    /// </summary>
+    internal static class StateOffsetInstaller
+    {
+        internal static RectTransform Install(GameObject go, RectTransform existing, StateOffsetSet offsets)
+        {
+            if (!offsets.HasAny && existing == null) return null;   // never authored → no holder
+
+            var holder = existing != null ? existing : CreateHolder(go);
+            SweepDirectChildrenInto(go, holder);
+            var ctrl = holder.GetComponent<PressOffsetController>()
+                       ?? holder.gameObject.AddComponent<PressOffsetController>();
+            ctrl.Configure(offsets);
+            return holder;
+        }
+
+        // Full-stretch RectTransform (transparent to layout — same rect as the control), à la
+        // Animation's _offsetProxy. The content lives under it so one anchoredPosition shift moves all.
+        private static RectTransform CreateHolder(GameObject go)
+        {
+            var holderGo = new GameObject("_offsetHolder", typeof(RectTransform));
+            var rt = (RectTransform)holderGo.transform;
+            rt.SetParent(go.transform, worldPositionStays: false);
+            rt.anchorMin = Vector2.zero;
+            rt.anchorMax = Vector2.one;
+            rt.offsetMin = Vector2.zero;
+            rt.offsetMax = Vector2.zero;
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            return rt;
+        }
+
+        // Move every direct child of `go` (except the holder) into the holder, preserving sibling order.
+        // Snapshot first: SetParent mutates the child list mid-iteration. On ReSolve the content is
+        // already inside the holder → no-op; a child that first appears later (a Variant ReSolve) is
+        // swept in then. The bg Image / PuiButton / CanvasGroup are components on `go`, not children.
+        private static void SweepDirectChildrenInto(GameObject go, RectTransform holder)
+        {
+            var parent = go.transform;
+            var count = parent.childCount;
+            var moved = new List<Transform>(count);
+            for (int i = 0; i < count; i++)
+            {
+                var child = parent.GetChild(i);
+                if (child != holder) moved.Add(child);
+            }
+            foreach (var child in moved)
+                child.SetParent(holder, worldPositionStays: false);
+        }
+    }
+}

--- a/Runtime/Controls/Internal/StateOffsetInstaller.cs.meta
+++ b/Runtime/Controls/Internal/StateOffsetInstaller.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 500c2eeaae7859e6b8fd96fec25eb489

--- a/Runtime/Controls/Internal/StateOffsetSet.cs
+++ b/Runtime/Controls/Internal/StateOffsetSet.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Globalization;
+using UnityEngine;
+
+namespace PromptUGUI.Controls.Internal
+{
+    /// <summary>
+    /// Per-state content offset (pixels) for a clickable control: how far the content-holder shifts
+    /// while Pressed / Selected. Unset states — and Normal / Hover / Disabled — resolve to
+    /// <see cref="Vector2.zero"/>. Pure data + parsing; mirrors <see cref="StateColorSet"/>.
+    /// </summary>
+    internal readonly struct StateOffsetSet
+    {
+        public readonly Vector2? Pressed;
+        public readonly Vector2? Selected;
+
+        public StateOffsetSet(Vector2? pressed, Vector2? selected)
+        {
+            Pressed = pressed;
+            Selected = selected;
+        }
+
+        public bool HasAny => Pressed.HasValue || Selected.HasValue;
+
+        /// <summary>Offset for a state; unset / Normal / Hover / Disabled → zero.</summary>
+        public Vector2 For(InteractState state) => state switch
+        {
+            InteractState.Pressed => Pressed ?? Vector2.zero,
+            InteractState.Selected => Selected ?? Vector2.zero,
+            _ => Vector2.zero,
+        };
+
+        /// <summary>
+        /// Parse an <c>"x,y"</c> pixel offset (Unity sign: negative y = down). <c>null</c> / empty /
+        /// whitespace / <c>"none"</c> → <c>null</c> (state has no offset). Mirrors AnimationSpec's
+        /// per-endpoint translate parse (kept local — AnimationSpec's is private).
+        /// </summary>
+        public static Vector2? Parse(string v)
+        {
+            if (string.IsNullOrWhiteSpace(v) || v == "none") return null;
+            var parts = v.Split(',');
+            if (parts.Length != 2)
+                throw new ArgumentException($"Expected offset 'x,y', got '{v}'");
+            return new Vector2(ParseFloat(parts[0]), ParseFloat(parts[1]));
+        }
+
+        private static float ParseFloat(string s)
+            => float.Parse(s.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture);
+    }
+}

--- a/Runtime/Controls/Internal/StateOffsetSet.cs.meta
+++ b/Runtime/Controls/Internal/StateOffsetSet.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 01dc586c1c786b61fbfd463931ba1ad4

--- a/Runtime/Controls/Tab.cs
+++ b/Runtime/Controls/Tab.cs
@@ -39,6 +39,11 @@ namespace PromptUGUI.Controls
         private string _selectedModulate;
         private string _disabledModulate;
 
+        // Press/select content-offset (see StateOffsetInstaller). _offsetHolder lazily created.
+        private Vector2? _pressedOffset;
+        private Vector2? _selectedOffset;
+        private RectTransform _offsetHolder;
+
         public override void OnAttached()
         {
             _bg = GameObject.GetComponent<UnityImage>() ?? GameObject.AddComponent<UnityImage>();
@@ -314,6 +319,11 @@ namespace PromptUGUI.Controls
         /// <summary>Relative colour multiplier while Disabled.</summary>
         [UIAttr(IsColor = true), Preserve] public string DisabledModulate { set => _disabledModulate = value; }
 
+        /// <summary>Content offset (px, Unity sign: negative y = down) while Pressed. <c>""</c>/<c>none</c>=none.</summary>
+        [UIAttr, Preserve] public string PressedOffset { set => _pressedOffset = StateOffsetSet.Parse(value); }
+        /// <summary>Content offset held while Selected (isOn). Composes with pressedOffset (Pressed wins).</summary>
+        [UIAttr, Preserve] public string SelectedOffset { set => _selectedOffset = StateOffsetSet.Parse(value); }
+
         /// <summary>Broadcasts the Tab's interaction state. Selected = this Tab is the active (isOn) one at rest.</summary>
         public Observable<InteractState> OnState => _toggle.OnState;
 
@@ -336,10 +346,14 @@ namespace PromptUGUI.Controls
         public Observable<bool> OnValueChanged => _changed;
         public Observable<Unit> OnSelected => _selected;
 
+        protected internal override Transform ChildHostTransform
+            => _offsetHolder != null ? _offsetHolder : RectTransform;
+
         internal override void OnAfterApply()
         {
             base.OnAfterApply();
             _toggle.interactable = Interactable;
+            _offsetHolder = StateOffsetInstaller.Install(GameObject, _offsetHolder, new StateOffsetSet(_pressedOffset, _selectedOffset));
             // selectedColor is the selection-aware BASE (not a Selected-state absolute), so pass null
             // for the Selected absolute; selectedModulate stays the Selected multiplier.
             var abs = StateColorSet.ResolveAbsolutes(_hoverColor, _pressedColor, null, _disabledColor);

--- a/Runtime/Controls/Toggle.cs
+++ b/Runtime/Controls/Toggle.cs
@@ -29,6 +29,10 @@ namespace PromptUGUI.Controls
         private string _pressedModulate;
         private string _selectedModulate;
         private string _disabledModulate;
+        // Press/select content-offset (see StateOffsetInstaller). _offsetHolder lazily created.
+        private Vector2? _pressedOffset;
+        private Vector2? _selectedOffset;
+        private RectTransform _offsetHolder;
 
         // Bound to OnAttached layout — changing these without changing OnAttached breaks the formula.
         // CheckmarkZoneWidth = Background sizeDelta.x (20) + 3px gap = Label offsetMin.x (23)
@@ -181,6 +185,11 @@ namespace PromptUGUI.Controls
         /// <summary>Relative colour multiplier while Disabled.</summary>
         [UIAttr(IsColor = true), Preserve] public string DisabledModulate { set => _disabledModulate = value; }
 
+        /// <summary>Content offset (px, Unity sign: negative y = down) while Pressed. <c>""</c>/<c>none</c>=none.</summary>
+        [UIAttr, Preserve] public string PressedOffset { set => _pressedOffset = StateOffsetSet.Parse(value); }
+        /// <summary>Content offset held while Selected (isOn). Composes with pressedOffset (Pressed wins).</summary>
+        [UIAttr, Preserve] public string SelectedOffset { set => _selectedOffset = StateOffsetSet.Parse(value); }
+
         /// <summary>Broadcasts the Toggle's interaction state. Selected = checked (isOn) and at rest.</summary>
         public Observable<InteractState> OnState => _toggle.OnState;
 
@@ -200,10 +209,14 @@ namespace PromptUGUI.Controls
             }
         }
 
+        protected internal override Transform ChildHostTransform
+            => _offsetHolder != null ? _offsetHolder : RectTransform;
+
         internal override void OnAfterApply()
         {
             base.OnAfterApply();
             _toggle.interactable = Interactable;
+            _offsetHolder = StateOffsetInstaller.Install(GameObject, _offsetHolder, new StateOffsetSet(_pressedOffset, _selectedOffset));
             // selectedColor is the selection-aware BASE (not a Selected-state absolute); selectedModulate
             // stays the Selected multiplier. Toggle keeps its Checkmark overlay unchanged.
             var abs = StateColorSet.ResolveAbsolutes(_hoverColor, _pressedColor, null, _disabledColor);

--- a/Tests/EditMode/Controls/BtnPressOffsetTests.cs
+++ b/Tests/EditMode/Controls/BtnPressOffsetTests.cs
@@ -1,0 +1,102 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using TMPro;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class BtnPressOffsetTests
+    {
+        private const int Normal = 0, Pressed = 2, Selected = 3, Disabled = 4;
+
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static Btn BuildBtn(string attrs, string body = "Hi")
+        {
+            string xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Btn id='b' {attrs}>{body}</Btn>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S").Get<Btn>("b");
+        }
+
+        private static RectTransform Holder(Control c)
+            => (RectTransform)c.GameObject.GetComponentInChildren<PressOffsetController>(true).transform;
+
+        [Test]
+        public void PressedOffset_ShiftsHolderDown_RevertsOnNormal()
+        {
+            var btn = BuildBtn("pressedOffset='0,-4'");
+            var puiBtn = btn.GameObject.GetComponent<PuiButton>();
+            var holder = Holder(btn);
+
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition, "rest at zero");
+            puiBtn.SimulateState(Pressed);
+            Assert.AreEqual(new Vector2(0, -4), holder.anchoredPosition, "pressed -> down 4px");
+            puiBtn.SimulateState(Normal);
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition, "release -> zero");
+        }
+
+        [Test]
+        public void NoOffset_CreatesNoHolder_LabelStaysDirectChild()
+        {
+            var btn = BuildBtn("");
+            Assert.IsNull(btn.GameObject.GetComponentInChildren<PressOffsetController>(true),
+                "plain Btn must not create an offset holder");
+            var label = btn.GameObject.GetComponentInChildren<TMP_Text>(true);
+            Assert.AreEqual(btn.GameObject.transform, label.transform.parent,
+                "label is a direct child when no offset");
+        }
+
+        [Test]
+        public void PressedOffset_ReparentsLabelIntoHolder()
+        {
+            var btn = BuildBtn("pressedOffset='0,-4'");
+            var holder = Holder(btn);
+            var label = btn.GameObject.GetComponentInChildren<TMP_Text>(true);
+            Assert.AreEqual((Transform)holder, label.transform.parent, "label moved under the holder");
+        }
+
+        [Test]
+        public void Disabled_StaysAtZero()
+        {
+            var btn = BuildBtn("pressedOffset='0,-4'");
+            var puiBtn = btn.GameObject.GetComponent<PuiButton>();
+            var holder = Holder(btn);
+            puiBtn.SimulateState(Disabled);
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition, "disabled has no offset");
+        }
+
+        [Test]
+        public void SelectedFolds_NoOffsetForMomentaryBtn()
+        {
+            // Btn has no isOn; Selected folds to Normal, so SimulateState(Selected) -> zero.
+            var btn = BuildBtn("pressedOffset='0,-4'");
+            var puiBtn = btn.GameObject.GetComponent<PuiButton>();
+            var holder = Holder(btn);
+            puiBtn.SimulateState(Selected);
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition);
+        }
+
+        [Test]
+        public void VariantReSolve_NoDuplicateHolder_ReResolves()
+        {
+            var btn = BuildBtn("pressedOffset='0,-4' pressedOffset.dark='0,-8'");
+            var puiBtn = btn.GameObject.GetComponent<PuiButton>();
+            Assert.AreEqual(1, btn.GameObject.GetComponentsInChildren<PressOffsetController>(true).Length,
+                "one holder after initial apply");
+
+            UI.Variants.Set("dark", true);   // VariantStore.Changed -> Screen ReSolve -> OnAfterApply re-runs
+
+            Assert.AreEqual(1, btn.GameObject.GetComponentsInChildren<PressOffsetController>(true).Length,
+                "Variant ReSolve must not add a second holder");
+            var holder = Holder(btn);
+            puiBtn.SimulateState(Pressed);
+            Assert.AreEqual(new Vector2(0, -8), holder.anchoredPosition, "dark override applies after ReSolve");
+        }
+    }
+}

--- a/Tests/EditMode/Controls/BtnPressOffsetTests.cs.meta
+++ b/Tests/EditMode/Controls/BtnPressOffsetTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8ccf11027f58972e4bf894344f06ce48

--- a/Tests/EditMode/Controls/StateOffsetSetTests.cs
+++ b/Tests/EditMode/Controls/StateOffsetSetTests.cs
@@ -1,0 +1,66 @@
+using System;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class StateOffsetSetTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void For_MapsPressedAndSelected_OthersZero()
+        {
+            var set = new StateOffsetSet(new Vector2(0, -4), new Vector2(1, -2));
+            Assert.AreEqual(new Vector2(0, -4), set.For(InteractState.Pressed));
+            Assert.AreEqual(new Vector2(1, -2), set.For(InteractState.Selected));
+            Assert.AreEqual(Vector2.zero, set.For(InteractState.Normal));
+            Assert.AreEqual(Vector2.zero, set.For(InteractState.Hover));
+            Assert.AreEqual(Vector2.zero, set.For(InteractState.Disabled));
+        }
+
+        [Test]
+        public void For_UnsetState_ReturnsZero()
+        {
+            var set = new StateOffsetSet(new Vector2(0, -4), null);
+            Assert.AreEqual(Vector2.zero, set.For(InteractState.Selected), "unset selected -> zero");
+            Assert.AreEqual(new Vector2(0, -4), set.For(InteractState.Pressed));
+        }
+
+        [Test]
+        public void HasAny_TrueWhenAnyPresent_FalseWhenDefault()
+        {
+            Assert.IsFalse(default(StateOffsetSet).HasAny);
+            Assert.IsTrue(new StateOffsetSet(new Vector2(0, -1), null).HasAny);
+            Assert.IsTrue(new StateOffsetSet(null, new Vector2(0, -1)).HasAny);
+        }
+
+        [Test]
+        public void Parse_ValidPair_NegativeYIsDown()
+        {
+            var v = StateOffsetSet.Parse("0,-4");
+            Assert.IsTrue(v.HasValue);
+            Assert.AreEqual(new Vector2(0f, -4f), v.Value);
+        }
+
+        [Test]
+        public void Parse_EmptyOrNone_ReturnsNull()
+        {
+            Assert.IsNull(StateOffsetSet.Parse(""));
+            Assert.IsNull(StateOffsetSet.Parse("  "));
+            Assert.IsNull(StateOffsetSet.Parse(null));
+            Assert.IsNull(StateOffsetSet.Parse("none"));
+        }
+
+        [Test]
+        public void Parse_BadFormat_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => StateOffsetSet.Parse("5"));
+            Assert.Throws<FormatException>(() => StateOffsetSet.Parse("a,b"));
+        }
+    }
+}

--- a/Tests/EditMode/Controls/StateOffsetSetTests.cs.meta
+++ b/Tests/EditMode/Controls/StateOffsetSetTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: af204a5a0011e8709a9a4a2bdd57d12f

--- a/Tests/EditMode/Controls/TabPressOffsetTests.cs
+++ b/Tests/EditMode/Controls/TabPressOffsetTests.cs
@@ -1,0 +1,68 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class TabPressOffsetTests
+    {
+        private const int Normal = 0, Pressed = 2;
+
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        // Two tabs so we can drive 'a' between Normal (select b) and Selected (select a).
+        private static (Tab a, Tab b) TwoTabs(string aAttrs)
+        {
+            string xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'><Tab id='a' {aAttrs}/><Tab id='b'/></TabBar>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var s = UI.Open("S");
+            return (s.Get<Tab>("bar/a"), s.Get<Tab>("bar/b"));
+        }
+
+        private static RectTransform Holder(Control c)
+            => (RectTransform)c.GameObject.GetComponentInChildren<PressOffsetController>(true).transform;
+
+        [Test]
+        public void SelectedOffset_HoldsWhileSelected()
+        {
+            var (a, b) = TwoTabs("selectedOffset='0,-3'");
+            var holder = Holder(a);
+            b.IsOn = true;   // a -> Normal
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition, "unselected -> zero");
+            a.IsOn = true;   // a -> Selected
+            Assert.AreEqual(new Vector2(0, -3), holder.anchoredPosition, "selected -> held offset");
+        }
+
+        [Test]
+        public void Pressed_OverridesSelected_RevertsToSelected()
+        {
+            var (a, b) = TwoTabs("pressedOffset='0,-1' selectedOffset='0,-3'");
+            var pt = a.GameObject.GetComponent<PuiToggle>();
+            var holder = Holder(a);
+            a.IsOn = true;                          // Selected -> -3
+            Assert.AreEqual(new Vector2(0, -3), holder.anchoredPosition);
+            pt.SimulateState(Pressed);              // Pressed -> -1
+            Assert.AreEqual(new Vector2(0, -1), holder.anchoredPosition);
+            pt.SimulateState(Normal);               // transient Normal + isOn -> Selected -> -3
+            Assert.AreEqual(new Vector2(0, -3), holder.anchoredPosition);
+        }
+
+        [Test]
+        public void PressedOffset_ShiftsOnPress()
+        {
+            var (a, b) = TwoTabs("pressedOffset='0,-2'");
+            var pt = a.GameObject.GetComponent<PuiToggle>();
+            var holder = Holder(a);
+            pt.SimulateState(Pressed);
+            Assert.AreEqual(new Vector2(0, -2), holder.anchoredPosition);
+            pt.SimulateState(Normal);
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition);
+        }
+    }
+}

--- a/Tests/EditMode/Controls/TabPressOffsetTests.cs.meta
+++ b/Tests/EditMode/Controls/TabPressOffsetTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dab108d37f7936be5872ba3b4ccd673b

--- a/Tests/EditMode/Controls/TogglePressOffsetTests.cs
+++ b/Tests/EditMode/Controls/TogglePressOffsetTests.cs
@@ -1,0 +1,62 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class TogglePressOffsetTests
+    {
+        private const int Normal = 0, Pressed = 2;
+
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static Toggle BuildToggle(string attrs)
+        {
+            string xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Toggle id='t' {attrs}>Opt</Toggle>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S").Get<Toggle>("t");
+        }
+
+        private static RectTransform Holder(Control c)
+            => (RectTransform)c.GameObject.GetComponentInChildren<PressOffsetController>(true).transform;
+
+        [Test]
+        public void SelectedOffset_HoldsWhenOn()
+        {
+            var tog = BuildToggle("selectedOffset='0,-3'");
+            var holder = Holder(tog);
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition, "off -> zero");
+            tog.IsOn = true;
+            Assert.AreEqual(new Vector2(0, -3), holder.anchoredPosition, "on -> held offset");
+            tog.IsOn = false;
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition, "off again -> zero");
+        }
+
+        [Test]
+        public void AuthoredIsOn_ShowsSelectedOffsetOnFrameOne()
+        {
+            var tog = BuildToggle("isOn='true' selectedOffset='0,-3'");
+            var holder = Holder(tog);
+            Assert.AreEqual(new Vector2(0, -3), holder.anchoredPosition,
+                "isOn at open -> selected offset established instantly (first-frame)");
+        }
+
+        [Test]
+        public void PressedOffset_ShiftsOnPress()
+        {
+            var tog = BuildToggle("pressedOffset='0,-2'");
+            var pt = tog.GameObject.GetComponent<PuiToggle>();
+            var holder = Holder(tog);
+            pt.SimulateState(Pressed);
+            Assert.AreEqual(new Vector2(0, -2), holder.anchoredPosition);
+            pt.SimulateState(Normal);
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition);
+        }
+    }
+}

--- a/Tests/EditMode/Controls/TogglePressOffsetTests.cs.meta
+++ b/Tests/EditMode/Controls/TogglePressOffsetTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 985c1c3bfc40e352fa7dec7bfa56daa4

--- a/docs~/superpowers/plans/2026-06-24-btn-press-offset.md
+++ b/docs~/superpowers/plans/2026-06-24-btn-press-offset.md
@@ -1,0 +1,929 @@
+# Btn/Tab/Toggle 实体按钮按压位移（state-offset）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 给 `Btn`/`Tab`/`Toggle` 加 `pressedOffset`（+ Tab/Toggle 的 `selectedOffset`），按下/选中时子内容整体瞬移、背景框不动，三控件共享一套机制。
+
+**Architecture:** 复用现有 `IStateSource.OnState` 广播 + installer/reactor 模式。新增纯数据 `StateOffsetSet`、挂在 content-holder 上的 `PressOffsetController`（订阅 `OnState` → 设 holder `anchoredPosition`，瞬移无补间）、以及懒建 holder 并把控件直接子节点扫入的 `StateOffsetInstaller`。三控件各加一个属性 + 一行 `OnAfterApply` 调用 + 一个 `ChildHostTransform` override。
+
+**Tech Stack:** Unity 6 / C# (LangVersion 9.0)、R3 (`Observable`)、uGUI（`RectTransform.anchoredPosition`）。无新增包。
+
+设计依据：`docs~/superpowers/specs/2026-06-24-btn-press-offset-design.md`。
+
+## Global Constraints
+
+- **分支**：全部工作在 `feat/btn-press-offset`（已建）。**绝不提交到 main。**
+- **LangVersion 9.0**：不得用 C# 10+ 特性（无 primary constructor、无 collection expression `[]`、无 `[field: SerializeField]`）。`readonly struct` / switch 表达式 / target-typed `new()` 可用。
+- **不用 System.Threading / Task**（WebGL）：本特性无异步，N/A。
+- **float 解析**：`float.Parse(s, NumberStyles.Float, CultureInfo.InvariantCulture)`（Mono 安全；**禁用** `AsSpan` 重载——会触发 lint CA1846 → CS1503）。
+- **lint**：写完代码从仓库根跑 `cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx`。**不要** `dotnet format analyzers --severity info`。
+- **同 PR 必改 SKILL**：功能性改动要同步 `authoring-promptugui-xml` 的 `reference/states.md` + 主 `SKILL.md`（英文）。见 Task 5。
+- **测试只由 controller 经 Unity MCP 跑**（子 agent 到不了 Unity MCP，见 [[sdd-unity-mcp-controller-runs-tests]]；子 agent 只写代码）。
+- **Sign 约定**：`pressedOffset="x,y"` 像素，Unity 符号——**负 y = 下**。
+- **InternalsVisibleTo** 已对 `PromptUGUI.Tests.EditMode` 开放，测试可见所有 `internal` 类型。
+
+**RUN(ClassName) = controller 跑 EditMode 测试的标准流程：**
+1. `mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)`
+2. `mcp__UnityMCP__read_console(action="get", types=["error"])` —— 编译错误必须为空才继续
+3. `mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["ClassName"])` → 轮询 `mcp__UnityMCP__get_test_job(job_id=...)` 直到完成，读 pass/fail。
+
+---
+
+## File Structure
+
+| 文件 | 责任 | 动作 |
+|---|---|---|
+| `Runtime/Controls/Internal/StateOffsetSet.cs` | per-state 位移数据 + `"x,y"` 解析 | Create |
+| `Runtime/Controls/Internal/PressOffsetController.cs` | 订阅 `OnState` → 设 holder 位置（瞬移） | Create |
+| `Runtime/Controls/Internal/StateOffsetInstaller.cs` | 懒建 holder + 扫子节点 + 挂 controller | Create |
+| `Runtime/Controls/Btn.cs` | `pressedOffset` 接线 | Modify |
+| `Runtime/Controls/Tab.cs` | `pressedOffset` + `selectedOffset` 接线 | Modify |
+| `Runtime/Controls/Toggle.cs` | `pressedOffset` + `selectedOffset` 接线 | Modify |
+| `Editor/XsdGenerator.cs` | Btn 手列属性加 `pressedOffset`（Tab/Toggle 反射自动覆盖） | Modify |
+| `Tests/EditMode/Controls/StateOffsetSetTests.cs` | 纯数据/解析测试 | Create |
+| `Tests/EditMode/Controls/BtnPressOffsetTests.cs` | Btn 集成测试 | Create |
+| `Tests/EditMode/Controls/TabPressOffsetTests.cs` | Tab 集成测试 | Create |
+| `Tests/EditMode/Controls/TogglePressOffsetTests.cs` | Toggle 集成测试 | Create |
+| `.claude/skills/authoring-promptugui-xml/reference/states.md` | 新增「Press offset」节 | Modify |
+| `.claude/skills/authoring-promptugui-xml/SKILL.md` | Btn/Tab/Toggle 属性目录行 | Modify |
+
+---
+
+## Task 1: `StateOffsetSet` 纯数据 + 解析
+
+**Files:**
+- Create: `Runtime/Controls/Internal/StateOffsetSet.cs`
+- Test: `Tests/EditMode/Controls/StateOffsetSetTests.cs`
+
+**Interfaces:**
+- Produces: `internal readonly struct StateOffsetSet`，构造 `new StateOffsetSet(Vector2? pressed, Vector2? selected)`；`bool HasAny`；`Vector2 For(InteractState)`；`static Vector2? Parse(string)`。
+
+- [ ] **Step 1: 写失败测试**
+
+Create `Tests/EditMode/Controls/StateOffsetSetTests.cs`:
+
+```csharp
+using System;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class StateOffsetSetTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        [Test]
+        public void For_MapsPressedAndSelected_OthersZero()
+        {
+            var set = new StateOffsetSet(new Vector2(0, -4), new Vector2(1, -2));
+            Assert.AreEqual(new Vector2(0, -4), set.For(InteractState.Pressed));
+            Assert.AreEqual(new Vector2(1, -2), set.For(InteractState.Selected));
+            Assert.AreEqual(Vector2.zero, set.For(InteractState.Normal));
+            Assert.AreEqual(Vector2.zero, set.For(InteractState.Hover));
+            Assert.AreEqual(Vector2.zero, set.For(InteractState.Disabled));
+        }
+
+        [Test]
+        public void For_UnsetState_ReturnsZero()
+        {
+            var set = new StateOffsetSet(new Vector2(0, -4), null);
+            Assert.AreEqual(Vector2.zero, set.For(InteractState.Selected), "unset selected -> zero");
+            Assert.AreEqual(new Vector2(0, -4), set.For(InteractState.Pressed));
+        }
+
+        [Test]
+        public void HasAny_TrueWhenAnyPresent_FalseWhenDefault()
+        {
+            Assert.IsFalse(default(StateOffsetSet).HasAny);
+            Assert.IsTrue(new StateOffsetSet(new Vector2(0, -1), null).HasAny);
+            Assert.IsTrue(new StateOffsetSet(null, new Vector2(0, -1)).HasAny);
+        }
+
+        [Test]
+        public void Parse_ValidPair_NegativeYIsDown()
+        {
+            var v = StateOffsetSet.Parse("0,-4");
+            Assert.IsTrue(v.HasValue);
+            Assert.AreEqual(new Vector2(0f, -4f), v.Value);
+        }
+
+        [Test]
+        public void Parse_EmptyOrNone_ReturnsNull()
+        {
+            Assert.IsNull(StateOffsetSet.Parse(""));
+            Assert.IsNull(StateOffsetSet.Parse("  "));
+            Assert.IsNull(StateOffsetSet.Parse(null));
+            Assert.IsNull(StateOffsetSet.Parse("none"));
+        }
+
+        [Test]
+        public void Parse_BadFormat_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => StateOffsetSet.Parse("5"));
+            Assert.Throws<FormatException>(() => StateOffsetSet.Parse("a,b"));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认红（编译错误 = 类型未定义）**
+
+Run: **RUN(StateOffsetSetTests)**
+Expected: `read_console` 报 `StateOffsetSet` 未定义的编译错误（红）。
+
+- [ ] **Step 3: 写实现**
+
+Create `Runtime/Controls/Internal/StateOffsetSet.cs`:
+
+```csharp
+using System;
+using System.Globalization;
+using UnityEngine;
+
+namespace PromptUGUI.Controls.Internal
+{
+    /// <summary>
+    /// Per-state content offset (pixels) for a clickable control: how far the content-holder shifts
+    /// while Pressed / Selected. Unset states — and Normal / Hover / Disabled — resolve to
+    /// <see cref="Vector2.zero"/>. Pure data + parsing; mirrors <see cref="StateColorSet"/>.
+    /// </summary>
+    internal readonly struct StateOffsetSet
+    {
+        public readonly Vector2? Pressed;
+        public readonly Vector2? Selected;
+
+        public StateOffsetSet(Vector2? pressed, Vector2? selected)
+        {
+            Pressed = pressed;
+            Selected = selected;
+        }
+
+        public bool HasAny => Pressed.HasValue || Selected.HasValue;
+
+        /// <summary>Offset for a state; unset / Normal / Hover / Disabled → zero.</summary>
+        public Vector2 For(InteractState state) => state switch
+        {
+            InteractState.Pressed => Pressed ?? Vector2.zero,
+            InteractState.Selected => Selected ?? Vector2.zero,
+            _ => Vector2.zero,
+        };
+
+        /// <summary>
+        /// Parse an <c>"x,y"</c> pixel offset (Unity sign: negative y = down). <c>null</c> / empty /
+        /// whitespace / <c>"none"</c> → <c>null</c> (state has no offset). Mirrors AnimationSpec's
+        /// per-endpoint translate parse (kept local — AnimationSpec's is private).
+        /// </summary>
+        public static Vector2? Parse(string v)
+        {
+            if (string.IsNullOrWhiteSpace(v) || v == "none") return null;
+            var parts = v.Split(',');
+            if (parts.Length != 2)
+                throw new ArgumentException($"Expected offset 'x,y', got '{v}'");
+            return new Vector2(ParseFloat(parts[0]), ParseFloat(parts[1]));
+        }
+
+        private static float ParseFloat(string s)
+            => float.Parse(s.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture);
+    }
+}
+```
+
+- [ ] **Step 4: 跑测试确认绿**
+
+Run: **RUN(StateOffsetSetTests)**
+Expected: PASS（6 tests）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Controls/Internal/StateOffsetSet.cs Tests/EditMode/Controls/StateOffsetSetTests.cs
+git commit -m "$(printf 'feat: StateOffsetSet —— per-state 内容位移数据 + x,y 解析\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 2: `PressOffsetController` + `StateOffsetInstaller` + `Btn.pressedOffset`
+
+整个 controller/installer 的纵切片在此通过 Btn 端到端验证。
+
+**Files:**
+- Create: `Runtime/Controls/Internal/PressOffsetController.cs`
+- Create: `Runtime/Controls/Internal/StateOffsetInstaller.cs`
+- Modify: `Runtime/Controls/Btn.cs`（字段 + `ChildHostTransform` override + `PressedOffset` 属性 + `OnAfterApply` 一行）
+- Test: `Tests/EditMode/Controls/BtnPressOffsetTests.cs`
+
+**Interfaces:**
+- Consumes: `StateOffsetSet`（Task 1）；`IStateSource` / `InteractState`（既有）；`PuiButton`（既有，`SimulateState(int)`）。
+- Produces:
+  - `internal sealed class PressOffsetController : MonoBehaviour`，`void Configure(StateOffsetSet offsets)`。
+  - `internal static class StateOffsetInstaller`，`static RectTransform Install(GameObject go, RectTransform existing, StateOffsetSet offsets)`。
+  - `Btn`：XML 属性 `pressedOffset`；`protected internal override Transform ChildHostTransform`。
+
+- [ ] **Step 1: 写失败测试**
+
+Create `Tests/EditMode/Controls/BtnPressOffsetTests.cs`:
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using TMPro;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class BtnPressOffsetTests
+    {
+        private const int Normal = 0, Pressed = 2, Selected = 3, Disabled = 4;
+
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static Btn BuildBtn(string attrs, string body = "Hi")
+        {
+            string xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Btn id='b' {attrs}>{body}</Btn>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S").Get<Btn>("b");
+        }
+
+        private static RectTransform Holder(Control c)
+            => (RectTransform)c.GameObject.GetComponentInChildren<PressOffsetController>(true).transform;
+
+        [Test]
+        public void PressedOffset_ShiftsHolderDown_RevertsOnNormal()
+        {
+            var btn = BuildBtn("pressedOffset='0,-4'");
+            var puiBtn = btn.GameObject.GetComponent<PuiButton>();
+            var holder = Holder(btn);
+
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition, "rest at zero");
+            puiBtn.SimulateState(Pressed);
+            Assert.AreEqual(new Vector2(0, -4), holder.anchoredPosition, "pressed -> down 4px");
+            puiBtn.SimulateState(Normal);
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition, "release -> zero");
+        }
+
+        [Test]
+        public void NoOffset_CreatesNoHolder_LabelStaysDirectChild()
+        {
+            var btn = BuildBtn("");
+            Assert.IsNull(btn.GameObject.GetComponentInChildren<PressOffsetController>(true),
+                "plain Btn must not create an offset holder");
+            var label = btn.GameObject.GetComponentInChildren<TMP_Text>(true);
+            Assert.AreEqual(btn.GameObject.transform, label.transform.parent,
+                "label is a direct child when no offset");
+        }
+
+        [Test]
+        public void PressedOffset_ReparentsLabelIntoHolder()
+        {
+            var btn = BuildBtn("pressedOffset='0,-4'");
+            var holder = Holder(btn);
+            var label = btn.GameObject.GetComponentInChildren<TMP_Text>(true);
+            Assert.AreEqual((Transform)holder, label.transform.parent, "label moved under the holder");
+        }
+
+        [Test]
+        public void Disabled_StaysAtZero()
+        {
+            var btn = BuildBtn("pressedOffset='0,-4'");
+            var puiBtn = btn.GameObject.GetComponent<PuiButton>();
+            var holder = Holder(btn);
+            puiBtn.SimulateState(Disabled);
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition, "disabled has no offset");
+        }
+
+        [Test]
+        public void SelectedFolds_NoOffsetForMomentaryBtn()
+        {
+            // Btn has no isOn; Selected folds to Normal, so SimulateState(Selected) -> zero.
+            var btn = BuildBtn("pressedOffset='0,-4'");
+            var puiBtn = btn.GameObject.GetComponent<PuiButton>();
+            var holder = Holder(btn);
+            puiBtn.SimulateState(Selected);
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition);
+        }
+
+        [Test]
+        public void VariantReSolve_NoDuplicateHolder_ReResolves()
+        {
+            var btn = BuildBtn("pressedOffset='0,-4' pressedOffset.dark='0,-8'");
+            var puiBtn = btn.GameObject.GetComponent<PuiButton>();
+            Assert.AreEqual(1, btn.GameObject.GetComponentsInChildren<PressOffsetController>(true).Length,
+                "one holder after initial apply");
+
+            UI.Variants.Set("dark", true);   // VariantStore.Changed -> Screen ReSolve -> OnAfterApply re-runs
+
+            Assert.AreEqual(1, btn.GameObject.GetComponentsInChildren<PressOffsetController>(true).Length,
+                "Variant ReSolve must not add a second holder");
+            var holder = Holder(btn);
+            puiBtn.SimulateState(Pressed);
+            Assert.AreEqual(new Vector2(0, -8), holder.anchoredPosition, "dark override applies after ReSolve");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认红**
+
+Run: **RUN(BtnPressOffsetTests)**
+Expected: 编译错误（`PressOffsetController` / `pressedOffset` 未定义）（红）。
+
+- [ ] **Step 3: 写 `PressOffsetController`**
+
+Create `Runtime/Controls/Internal/PressOffsetController.cs`:
+
+```csharp
+using System;
+using R3;
+using UnityEngine;
+
+namespace PromptUGUI.Controls.Internal
+{
+    /// <summary>
+    /// Drives a content-holder's <see cref="RectTransform.anchoredPosition"/> from the owning
+    /// <see cref="IStateSource"/>'s <see cref="InteractState"/> stream. On each state it snaps the
+    /// holder to <c>offsets.For(state)</c> — instant, no tween (physical-button feel, pixel-perfect;
+    /// authored offsets are integer pixels). One per control (lives on the holder), unlike the
+    /// per-graphic <see cref="StateTintReactor"/>.
+    /// </summary>
+    internal sealed class PressOffsetController : MonoBehaviour
+    {
+        private RectTransform _holder;
+        private StateOffsetSet _offsets;
+        private IStateSource _source;
+        private IDisposable _sub;
+
+        /// <summary>
+        /// (Re)set the per-state offsets. Safe to call repeatedly (Variant ReSolve). Assigns offsets
+        /// BEFORE the first subscription so the synchronous replay of the source's current state sees
+        /// them (mirrors <see cref="StateTintReactor.Configure"/>).
+        /// </summary>
+        public void Configure(StateOffsetSet offsets)
+        {
+            _offsets = offsets;
+            var firstInit = _holder == null;
+            EnsureInit();
+            // On a re-Configure the subscription does NOT replay; repaint the current state explicitly.
+            if (!firstInit && _source != null) OnState(_source.Current);
+        }
+
+        private void EnsureInit()
+        {
+            if (_holder != null) return;
+            _holder = (RectTransform)transform;
+            // includeInactive: the source control may sit on a hidden (SetActive(false)) page at Open.
+            _source = GetComponentInParent<IStateSource>(true);
+            if (_source != null)
+                _sub = _source.OnState.Subscribe(OnState);   // replays Current synchronously
+        }
+
+        private void OnState(InteractState state)
+        {
+            if (_holder != null)
+                _holder.anchoredPosition = _offsets.For(state);
+        }
+
+        private void OnDestroy()
+        {
+            _sub?.Dispose();
+            _sub = null;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: 写 `StateOffsetInstaller`**
+
+Create `Runtime/Controls/Internal/StateOffsetInstaller.cs`:
+
+```csharp
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PromptUGUI.Controls.Internal
+{
+    /// <summary>
+    /// Lazily installs the press/select content-offset on a state-source control (Btn / Tab / Toggle):
+    /// creates a full-stretch content-holder, sweeps the control's direct children into it, and wires a
+    /// <see cref="PressOffsetController"/>. Idempotent: re-run on each Variant ReSolve, reusing the holder.
+    /// Returns the holder (or null when no offset was ever authored).
+    /// </summary>
+    internal static class StateOffsetInstaller
+    {
+        internal static RectTransform Install(GameObject go, RectTransform existing, StateOffsetSet offsets)
+        {
+            if (!offsets.HasAny && existing == null) return null;   // never authored → no holder
+
+            var holder = existing != null ? existing : CreateHolder(go);
+            SweepDirectChildrenInto(go, holder);
+            var ctrl = holder.GetComponent<PressOffsetController>()
+                       ?? holder.gameObject.AddComponent<PressOffsetController>();
+            ctrl.Configure(offsets);
+            return holder;
+        }
+
+        // Full-stretch RectTransform (transparent to layout — same rect as the control), à la
+        // Animation's _offsetProxy. The content lives under it so one anchoredPosition shift moves all.
+        private static RectTransform CreateHolder(GameObject go)
+        {
+            var holderGo = new GameObject("_offsetHolder", typeof(RectTransform));
+            var rt = (RectTransform)holderGo.transform;
+            rt.SetParent(go.transform, worldPositionStays: false);
+            rt.anchorMin = Vector2.zero;
+            rt.anchorMax = Vector2.one;
+            rt.offsetMin = Vector2.zero;
+            rt.offsetMax = Vector2.zero;
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            return rt;
+        }
+
+        // Move every direct child of `go` (except the holder) into the holder, preserving sibling order.
+        // Snapshot first: SetParent mutates the child list mid-iteration. On ReSolve the content is
+        // already inside the holder → no-op; a child that first appears later (a Variant ReSolve) is
+        // swept in then. The bg Image / PuiButton / CanvasGroup are components on `go`, not children.
+        private static void SweepDirectChildrenInto(GameObject go, RectTransform holder)
+        {
+            var parent = go.transform;
+            var count = parent.childCount;
+            var moved = new List<Transform>(count);
+            for (int i = 0; i < count; i++)
+            {
+                var child = parent.GetChild(i);
+                if (child != holder) moved.Add(child);
+            }
+            foreach (var child in moved)
+                child.SetParent(holder, worldPositionStays: false);
+        }
+    }
+}
+```
+
+- [ ] **Step 5: 接线 `Btn.cs` —— 字段**
+
+In `Runtime/Controls/Btn.cs`, find the relative-modulate fields (the `_hoverModulate` / `_pressedModulate` / `_disabledModulate` block) and add after `private string _disabledModulate;`:
+
+```csharp
+        // Press-offset: content-holder shift while Pressed. _offsetHolder lazily created by
+        // StateOffsetInstaller (full-stretch wrapper around the content; bg stays on this GO).
+        private Vector2? _pressedOffset;
+        private RectTransform _offsetHolder;
+```
+
+- [ ] **Step 6: 接线 `Btn.cs` —— `ChildHostTransform` override**
+
+In `Runtime/Controls/Btn.cs`, add immediately after the `OnState` property (the `public Observable<InteractState> OnState => _btn.OnState;` line):
+
+```csharp
+
+        // Children parent into the press-offset holder when it exists (so Add blocks land inside too),
+        // else directly onto this GO (identical to the default Control behaviour — no holder, no cost).
+        protected internal override Transform ChildHostTransform
+            => _offsetHolder != null ? _offsetHolder : RectTransform;
+```
+
+- [ ] **Step 7: 接线 `Btn.cs` —— `OnAfterApply` 一行**
+
+In `Runtime/Controls/Btn.cs` `OnAfterApply`, find `_btn.interactable = Interactable;` and add the install line right after it (before the `StateColorSet.ResolveAbsolutes` line):
+
+```csharp
+            _btn.interactable = Interactable;
+            _offsetHolder = StateOffsetInstaller.Install(GameObject, _offsetHolder, new StateOffsetSet(_pressedOffset, null));
+```
+
+- [ ] **Step 8: 接线 `Btn.cs` —— `pressedOffset` 属性**
+
+In `Runtime/Controls/Btn.cs`, find the `DisabledModulate` attribute one-liner (`[UIAttr(IsColor = true), Preserve] public string DisabledModulate { set => _disabledModulate = value; }`) and add after it:
+
+```csharp
+
+        /// <summary>Content offset (pixels, Unity sign: negative y = down) while Pressed. <c>""</c> / <c>none</c> = none.</summary>
+        [UIAttr, Preserve] public string PressedOffset { set => _pressedOffset = StateOffsetSet.Parse(value); }
+```
+
+- [ ] **Step 9: 跑测试确认绿**
+
+Run: **RUN(BtnPressOffsetTests)**
+Expected: PASS（6 tests）。若 `read_console` 有编译错误先修。
+
+- [ ] **Step 10: 回归 BtnStateTests（确保未破坏现有状态视觉）**
+
+Run: **RUN(BtnStateTests)**
+Expected: PASS（全部既有 Btn 状态测试不回归）。
+
+- [ ] **Step 11: 提交**
+
+```bash
+git add Runtime/Controls/Internal/PressOffsetController.cs Runtime/Controls/Internal/StateOffsetInstaller.cs Runtime/Controls/Btn.cs Tests/EditMode/Controls/BtnPressOffsetTests.cs
+git commit -m "$(printf 'feat: Btn.pressedOffset —— 按下子内容瞬移（content-holder + OnState reactor）\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 3: `Tab.pressedOffset` + `Tab.selectedOffset`
+
+**Files:**
+- Modify: `Runtime/Controls/Tab.cs`（字段 + `ChildHostTransform` override + 两个属性 + `OnAfterApply` 一行）
+- Test: `Tests/EditMode/Controls/TabPressOffsetTests.cs`
+
+**Interfaces:**
+- Consumes: `StateOffsetInstaller` / `StateOffsetSet`（Task 1/2）；`PuiToggle.SimulateState(int)`、`Tab.IsOn`（既有）。
+- Produces: `Tab` XML 属性 `pressedOffset` + `selectedOffset`；`Tab.ChildHostTransform` override。
+
+- [ ] **Step 1: 写失败测试**
+
+Create `Tests/EditMode/Controls/TabPressOffsetTests.cs`:
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class TabPressOffsetTests
+    {
+        private const int Normal = 0, Pressed = 2;
+
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        // Two tabs so we can drive 'a' between Normal (select b) and Selected (select a).
+        private static (Tab a, Tab b) TwoTabs(string aAttrs)
+        {
+            string xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <TabBar id='bar'><Tab id='a' {aAttrs}/><Tab id='b'/></TabBar>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var s = UI.Open("S");
+            return (s.Get<Tab>("bar/a"), s.Get<Tab>("bar/b"));
+        }
+
+        private static RectTransform Holder(Control c)
+            => (RectTransform)c.GameObject.GetComponentInChildren<PressOffsetController>(true).transform;
+
+        [Test]
+        public void SelectedOffset_HoldsWhileSelected()
+        {
+            var (a, b) = TwoTabs("selectedOffset='0,-3'");
+            var holder = Holder(a);
+            b.IsOn = true;   // a -> Normal
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition, "unselected -> zero");
+            a.IsOn = true;   // a -> Selected
+            Assert.AreEqual(new Vector2(0, -3), holder.anchoredPosition, "selected -> held offset");
+        }
+
+        [Test]
+        public void Pressed_OverridesSelected_RevertsToSelected()
+        {
+            var (a, b) = TwoTabs("pressedOffset='0,-1' selectedOffset='0,-3'");
+            var pt = a.GameObject.GetComponent<PuiToggle>();
+            var holder = Holder(a);
+            a.IsOn = true;                          // Selected -> -3
+            Assert.AreEqual(new Vector2(0, -3), holder.anchoredPosition);
+            pt.SimulateState(Pressed);              // Pressed -> -1
+            Assert.AreEqual(new Vector2(0, -1), holder.anchoredPosition);
+            pt.SimulateState(Normal);               // transient Normal + isOn -> Selected -> -3
+            Assert.AreEqual(new Vector2(0, -3), holder.anchoredPosition);
+        }
+
+        [Test]
+        public void PressedOffset_ShiftsOnPress()
+        {
+            var (a, b) = TwoTabs("pressedOffset='0,-2'");
+            var pt = a.GameObject.GetComponent<PuiToggle>();
+            var holder = Holder(a);
+            pt.SimulateState(Pressed);
+            Assert.AreEqual(new Vector2(0, -2), holder.anchoredPosition);
+            pt.SimulateState(Normal);
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认红**
+
+Run: **RUN(TabPressOffsetTests)**
+Expected: 编译错误（`pressedOffset` / `selectedOffset` 在 Tab 上未定义）（红）。
+
+- [ ] **Step 3: 接线 `Tab.cs` —— 字段**
+
+In `Runtime/Controls/Tab.cs`, find the relative-modulate fields (ending with `private string _disabledModulate;`) and add after them:
+
+```csharp
+        // Press/select content-offset (see StateOffsetInstaller). _offsetHolder lazily created.
+        private Vector2? _pressedOffset;
+        private Vector2? _selectedOffset;
+        private RectTransform _offsetHolder;
+```
+
+- [ ] **Step 4: 接线 `Tab.cs` —— `ChildHostTransform` override**
+
+In `Runtime/Controls/Tab.cs`, add (place it near the other overrides, e.g. just before `internal override void OnAfterApply()`):
+
+```csharp
+        protected internal override Transform ChildHostTransform
+            => _offsetHolder != null ? _offsetHolder : RectTransform;
+
+```
+
+- [ ] **Step 5: 接线 `Tab.cs` —— `OnAfterApply` 一行**
+
+In `Runtime/Controls/Tab.cs` `OnAfterApply`, find `_toggle.interactable = Interactable;` and add right after it (before the `StateColorSet.ResolveAbsolutes` line):
+
+```csharp
+            _toggle.interactable = Interactable;
+            _offsetHolder = StateOffsetInstaller.Install(GameObject, _offsetHolder, new StateOffsetSet(_pressedOffset, _selectedOffset));
+```
+
+- [ ] **Step 6: 接线 `Tab.cs` —— 两个属性**
+
+In `Runtime/Controls/Tab.cs`, find the `DisabledModulate` one-liner attribute and add after it:
+
+```csharp
+
+        /// <summary>Content offset (px, Unity sign: negative y = down) while Pressed. <c>""</c>/<c>none</c>=none.</summary>
+        [UIAttr, Preserve] public string PressedOffset { set => _pressedOffset = StateOffsetSet.Parse(value); }
+        /// <summary>Content offset held while Selected (isOn). Composes with pressedOffset (Pressed wins).</summary>
+        [UIAttr, Preserve] public string SelectedOffset { set => _selectedOffset = StateOffsetSet.Parse(value); }
+```
+
+- [ ] **Step 7: 跑测试确认绿 + 回归**
+
+Run: **RUN(TabPressOffsetTests)** → Expected: PASS（3 tests）。
+Run: **RUN(TabStateTests)** → Expected: PASS（无回归）。
+
+- [ ] **Step 8: 提交**
+
+```bash
+git add Runtime/Controls/Tab.cs Tests/EditMode/Controls/TabPressOffsetTests.cs
+git commit -m "$(printf 'feat: Tab.pressedOffset + selectedOffset —— 选中保持按入\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 4: `Toggle.pressedOffset` + `Toggle.selectedOffset`
+
+**Files:**
+- Modify: `Runtime/Controls/Toggle.cs`（字段 + `ChildHostTransform` override + 两个属性 + `OnAfterApply` 一行）
+- Test: `Tests/EditMode/Controls/TogglePressOffsetTests.cs`
+
+**Interfaces:**
+- Consumes: `StateOffsetInstaller` / `StateOffsetSet`；`PuiToggle.SimulateState(int)`、`Toggle.IsOn`（既有）。
+- Produces: `Toggle` XML 属性 `pressedOffset` + `selectedOffset`；`Toggle.ChildHostTransform` override。
+
+- [ ] **Step 1: 写失败测试**
+
+Create `Tests/EditMode/Controls/TogglePressOffsetTests.cs`:
+
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    public class TogglePressOffsetTests
+    {
+        private const int Normal = 0, Pressed = 2;
+
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static Toggle BuildToggle(string attrs)
+        {
+            string xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Toggle id='t' {attrs}>Opt</Toggle>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S").Get<Toggle>("t");
+        }
+
+        private static RectTransform Holder(Control c)
+            => (RectTransform)c.GameObject.GetComponentInChildren<PressOffsetController>(true).transform;
+
+        [Test]
+        public void SelectedOffset_HoldsWhenOn()
+        {
+            var tog = BuildToggle("selectedOffset='0,-3'");
+            var holder = Holder(tog);
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition, "off -> zero");
+            tog.IsOn = true;
+            Assert.AreEqual(new Vector2(0, -3), holder.anchoredPosition, "on -> held offset");
+            tog.IsOn = false;
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition, "off again -> zero");
+        }
+
+        [Test]
+        public void AuthoredIsOn_ShowsSelectedOffsetOnFrameOne()
+        {
+            var tog = BuildToggle("isOn='true' selectedOffset='0,-3'");
+            var holder = Holder(tog);
+            Assert.AreEqual(new Vector2(0, -3), holder.anchoredPosition,
+                "isOn at open -> selected offset established instantly (first-frame)");
+        }
+
+        [Test]
+        public void PressedOffset_ShiftsOnPress()
+        {
+            var tog = BuildToggle("pressedOffset='0,-2'");
+            var pt = tog.GameObject.GetComponent<PuiToggle>();
+            var holder = Holder(tog);
+            pt.SimulateState(Pressed);
+            Assert.AreEqual(new Vector2(0, -2), holder.anchoredPosition);
+            pt.SimulateState(Normal);
+            Assert.AreEqual(Vector2.zero, holder.anchoredPosition);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认红**
+
+Run: **RUN(TogglePressOffsetTests)**
+Expected: 编译错误（Toggle 上 `pressedOffset`/`selectedOffset` 未定义）（红）。
+
+- [ ] **Step 3: 接线 `Toggle.cs` —— 字段**
+
+In `Runtime/Controls/Toggle.cs`, find the modulate fields (`private string _selectedModulate;` / `private string _disabledModulate;`) and add after `private string _disabledModulate;`:
+
+```csharp
+        // Press/select content-offset (see StateOffsetInstaller). _offsetHolder lazily created.
+        private Vector2? _pressedOffset;
+        private Vector2? _selectedOffset;
+        private RectTransform _offsetHolder;
+```
+
+- [ ] **Step 4: 接线 `Toggle.cs` —— `ChildHostTransform` override**
+
+In `Runtime/Controls/Toggle.cs`, add (place near the other overrides, e.g. just before `internal override void OnAfterApply()`):
+
+```csharp
+        protected internal override Transform ChildHostTransform
+            => _offsetHolder != null ? _offsetHolder : RectTransform;
+
+```
+
+- [ ] **Step 5: 接线 `Toggle.cs` —— `OnAfterApply` 一行**
+
+In `Runtime/Controls/Toggle.cs` `OnAfterApply`, find `_toggle.interactable = Interactable;` and add right after it (before the `StateColorSet.ResolveAbsolutes` line):
+
+```csharp
+            _toggle.interactable = Interactable;
+            _offsetHolder = StateOffsetInstaller.Install(GameObject, _offsetHolder, new StateOffsetSet(_pressedOffset, _selectedOffset));
+```
+
+- [ ] **Step 6: 接线 `Toggle.cs` —— 两个属性**
+
+In `Runtime/Controls/Toggle.cs`, find the `DisabledModulate` one-liner attribute and add after it:
+
+```csharp
+
+        /// <summary>Content offset (px, Unity sign: negative y = down) while Pressed. <c>""</c>/<c>none</c>=none.</summary>
+        [UIAttr, Preserve] public string PressedOffset { set => _pressedOffset = StateOffsetSet.Parse(value); }
+        /// <summary>Content offset held while Selected (isOn). Composes with pressedOffset (Pressed wins).</summary>
+        [UIAttr, Preserve] public string SelectedOffset { set => _selectedOffset = StateOffsetSet.Parse(value); }
+```
+
+- [ ] **Step 7: 跑测试确认绿 + 回归**
+
+Run: **RUN(TogglePressOffsetTests)** → Expected: PASS（3 tests）。
+Run: **RUN(ToggleStateTests)** → Expected: PASS（无回归）。
+
+- [ ] **Step 8: 提交**
+
+```bash
+git add Runtime/Controls/Toggle.cs Tests/EditMode/Controls/TogglePressOffsetTests.cs
+git commit -m "$(printf 'feat: Toggle.pressedOffset + selectedOffset\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 5: 文档 + XSD + 全量回归
+
+**Files:**
+- Modify: `Editor/XsdGenerator.cs`（Btn 手列属性加 `pressedOffset`）
+- Modify: `.claude/skills/authoring-promptugui-xml/reference/states.md`
+- Modify: `.claude/skills/authoring-promptugui-xml/SKILL.md`
+
+> Tab/Toggle 在 XSD 里是反射派生（`ReflectControlAttrs`），`pressedOffset`/`selectedOffset` 作为 `[UIAttr]` 自动覆盖——**无需**手改。只有 Btn 是手列。
+
+- [ ] **Step 1: XSD —— Btn 手列加 `pressedOffset`**
+
+In `Editor/XsdGenerator.cs`, find the Btn block's `("pressedSprite", "xs:string", (string)null),` line and add after it:
+
+```csharp
+                    ("pressedSprite", "xs:string", (string)null),
+                    // Press-offset content shift ([UIAttr] Btn.PressedOffset). Tab/Toggle get theirs by reflection.
+                    ("pressedOffset", "xs:string", (string)null),
+```
+
+- [ ] **Step 2: 编译确认无错**
+
+Run: `mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)` then `mcp__UnityMCP__read_console(action="get", types=["error"])`
+Expected: 无编译错误。
+
+- [ ] **Step 3: 回归 XSD 生成器测试**
+
+Run: **RUN(XsdGeneratorTests)**（若类名不同，先 `mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["XsdGeneratorTests"])`；substring 断言为加性，不应回归）
+Expected: PASS。
+
+- [ ] **Step 4: 文档 —— `reference/states.md` 新增 Press offset 节**
+
+In `.claude/skills/authoring-promptugui-xml/reference/states.md`, append this section at the end of the file:
+
+````markdown
+## 4. Press offset — `pressedOffset` / `selectedOffset`
+
+A **tactile / physical-button** effect: while Pressed, the control's child content (label, icons, nested content) shifts by a fixed pixel offset — the background frame (the control's own bg `Image`) stays put — giving a "depressed into the button" feel. Shared by `<Btn>` / `<Tab>` / `<Toggle>`.
+
+| Attribute | Controls | Meaning |
+| --- | --- | --- |
+| `pressedOffset="x,y"` | Btn / Tab / Toggle | Content offset while **Pressed**. |
+| `selectedOffset="x,y"` | Tab / Toggle | Content offset held while **Selected** (`isOn`). `<Btn>` has no selected state and does not have this attribute. |
+
+```xml
+<Btn pressedOffset="0,-4">Buy</Btn>                    <!-- press: content sinks 4px -->
+<Tab pressedOffset="0,-2" selectedOffset="0,-3"/>      <!-- press sinks 2px; stays sunk 3px while selected -->
+```
+
+- **Sign is Unity's: negative `y` = down**, positive `x` = right (same convention as `<Animation translate>`). So "sink 4px" is `0,-4`, not `0,4`. This is the most common foot-gun.
+- **Instant, never tweened.** The offset snaps on state enter and snaps back on release (physical-button semantics + pixel-art-friendly; authored offsets are integer pixels). This deliberately differs from `*Color`'s ~0.1s fade.
+- `""` / `none` = no offset for that state.
+- **First-frame:** a `<Tab>` / `<Toggle>` authored `isOn` shows its `selectedOffset` on frame 1 (no animate-in).
+- **Selected being pressed:** pressing an already-selected `<Tab>` / `<Toggle>` shows `pressedOffset` while held, then reverts to `selectedOffset` on release. If you set `selectedOffset` but **not** `pressedOffset`, pressing a selected control momentarily pops the content back to zero — set both (often the same value) to avoid the pop.
+- **Composition:** independent of `<Animation translate>` (which moves its own proxy — the two stack), of `*Color` / `*Modulate` / `pressedSprite` (different channels), and of `tint`. All compose.
+- `stateReact="false"` does **not** exempt a child from the offset (it only governs `*Modulate` colour fan-out). The holder is a rigid translate — all content moves together.
+- Variant-overridable like any `[UIAttr]` (`pressedOffset.dark="0,-8"`).
+- **Disabled** has no offset (content rests at zero).
+
+Implementation: the control lazily wraps its content in a full-stretch holder (only when an offset is authored) and a `PressOffsetController` drives that holder's `anchoredPosition` from the control's `OnState` stream — same broadcaster the `*Color` family uses.
+````
+
+- [ ] **Step 5: 文档 —— 主 `SKILL.md` Btn 行**
+
+In `.claude/skills/authoring-promptugui-xml/SKILL.md`, find the Btn `disabledSprite` table row (line containing `` | `disabledSprite` | sprite key | — | ``) and add a new row right after it:
+
+```markdown
+| `pressedOffset` | `x,y` px | — | 按下时子内容整体位移（content-holder 平移；**Unity 符号 负 y=下**）；瞬移不补间；与 `<Animation>`/`*Color`/`*Sprite` 叠加；`""`/`none`=不动；见 states.md |
+```
+
+- [ ] **Step 6: 文档 —— 主 `SKILL.md` Toggle + Tab 行**
+
+In `.claude/skills/authoring-promptugui-xml/SKILL.md`, find the Toggle `hoverModulate · pressedModulate · selectedModulate · disabledModulate` row (the one ending `子节点 stateReact="false" 退出；见 states.md`) and add after it:
+
+```markdown
+| `pressedOffset` · `selectedOffset` | `x,y` px | — | 子内容位移（content-holder 平移；**负 y=下**）；瞬移；`selectedOffset`=选中(`isOn`)保持按入；Pressed 优先；`""`/`none`=不动；见 states.md |
+```
+
+Then find the **Tab** `hoverModulate · pressedModulate · selectedModulate · disabledModulate` row (under the `<Tab>` section, line ~342) and add the same row after it:
+
+```markdown
+| `pressedOffset` · `selectedOffset` | `x,y` px | — | 子内容位移（content-holder 平移；**负 y=下**）；瞬移；`selectedOffset`=选中(`isOn`)保持按入；Pressed 优先；`""`/`none`=不动；见 states.md |
+```
+
+- [ ] **Step 7: lint**
+
+Run (from repo root):
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx
+```
+Expected: 无 diff（若首次需先 `dotnet restore PromptUGUI.Lint.slnx`）。
+
+- [ ] **Step 8: 全量 EditMode 回归**
+
+Run: `mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])` → 轮询 `get_test_job`。
+Expected: 全绿（含新 4 个测试类 + 所有既有）。
+
+- [ ] **Step 9: 提交**
+
+```bash
+git add Editor/XsdGenerator.cs .claude/skills/authoring-promptugui-xml/reference/states.md .claude/skills/authoring-promptugui-xml/SKILL.md
+git commit -m "$(printf 'docs: state-offset —— states.md / SKILL.md / XSD（Btn pressedOffset）\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## 完成标准
+
+- `pressedOffset`（Btn/Tab/Toggle）+ `selectedOffset`（Tab/Toggle）按 spec 工作：按下/选中瞬移子内容、背景不动、复位干净、ReSolve 幂等、无位移时零额外 GO。
+- 4 个新测试类全绿，既有 Btn/Tab/Toggle 状态测试无回归，XSD 测试无回归。
+- lint 干净。
+- states.md + SKILL.md（Btn/Tab/Toggle 行）+ XSD 同步。
+- 全程在 `feat/btn-press-offset`，未碰 main。

--- a/docs~/superpowers/specs/2026-06-24-btn-press-offset-design.md
+++ b/docs~/superpowers/specs/2026-06-24-btn-press-offset-design.md
@@ -110,15 +110,17 @@ struct/class StateOffsetSet {
 **`StateOffsetInstaller`（静态）**
 ```
 // 返回 holder（可能为 null）。go = 控件 GO；existing = 控件已缓存的 holder（首次为 null）。
-static RectTransform Install(GameObject go, RectTransform existing, IReadOnlyList<IControl> children, StateOffsetSet offsets) {
+static RectTransform Install(GameObject go, RectTransform existing, StateOffsetSet offsets) {
     if (!offsets.HasAny && existing == null) return null;        // 从未设 → 不建
-    var holder = existing ?? CreateHolderAndReparent(go, children);
+    var holder = existing ?? CreateHolder(go);                   // 建空 holder（全拉伸，仿 _offsetProxy）
+    SweepDirectChildrenInto(go, holder);                        // 把 go 的直接子节点（除 holder）搬进 holder
     var ctrl = holder.GetComponent<PressOffsetController>() ?? holder.gameObject.AddComponent<PressOffsetController>();
-    ctrl.Configure(offsets);                                     // offsets 全空也 Configure → For 全 zero → 归位
+    ctrl.Configure(offsets);                                    // offsets 全空也 Configure → For 全 zero → 归位
     return holder;
 }
 ```
-- `CreateHolderAndReparent`：**先快照** `go.transform` 当前所有子 transform（在建 holder 之前取，避免把 holder 自己也扫进去）→ 建全拉伸 RectTransform（anchorMin=0 / anchorMax=1 / offset=0 / pivot=0.5，仿 `_offsetProxy`，命名如 `"_offsetHolder"`）→ 把快照按序 `SetParent(holder,false)`（即 label / icon + 显式子节点；背景 Image / PuiButton / CanvasGroup 是组件不是子节点，留在原地）。
+- `CreateHolder`：建全拉伸 RectTransform（anchorMin=0 / anchorMax=1 / offset=0 / pivot=0.5，仿 `_offsetProxy`，命名 `"_offsetHolder"`），作为 go 的子节点。
+- `SweepDirectChildrenInto`：快照 `go.transform` 当前直接子节点 → **跳过 holder 自身** → 按序 `SetParent(holder,false)`（label / icon + 显式子节点；背景 Image / PuiButton / CanvasGroup 是组件不是子节点，不动）。**每次 Install 都跑**：首次把内容搬入；ReSolve 时内容已在 holder 内、且新子节点经 `ChildHostTransform` 直接落 holder，故通常 no-op；唯一非平凡场景是"内容在晚于 holder 创建的某个 Variant ReSolve 才首次出现为直挂子节点"——此时被扫入，集中覆盖该边界（无需改各控件的 `EnsureLabel`）。
 
 ### 4.2 控件侧改动（Btn / Tab / Toggle 各自，极小）
 
@@ -127,16 +129,16 @@ static RectTransform Install(GameObject go, RectTransform existing, IReadOnlyLis
 2. `override Transform ChildHostTransform => _offsetHolder != null ? _offsetHolder : RectTransform;`（让后续 Add 块也落进 holder）
 3. 加属性 setter（存进 `_pressedOffset` / `_selectedOffset` 字段，解析 `"x,y"`）。
 4. 在**已有的** `OnAfterApply` 里、`StateTintInstaller.Install` **之前**接一行：
-   `_offsetHolder = StateOffsetInstaller.Install(GameObject, _offsetHolder, Children, new StateOffsetSet{...});`
+   `_offsetHolder = StateOffsetInstaller.Install(GameObject, _offsetHolder, new StateOffsetSet{...});`
 
 `Btn` 只有 `pressedOffset`；`Tab`/`Toggle` 有 `pressedOffset` + `selectedOffset`。
 
-5. **label/icon 改挂 `ChildHostTransform`**：三控件的 `EnsureLabel`（及 Tab/Toggle 的 icon 创建）当前把子物体挂在 `RectTransform`（控件自身 GO）。改为挂 `ChildHostTransform`，使其在 holder 已存在时直接落进 holder。覆盖一个边界：label/icon 在某个非默认 Variant 的 ReSolve 里**晚于** holder 创建才首次出现时，仍能正确随按压位移（否则会变成 holder 外的直挂子节点、不跟着动）。holder 未建时 `ChildHostTransform == RectTransform`，行为与现状完全一致。
+控件的 `EnsureLabel` / icon 创建**无需改动**：它们仍挂在 `RectTransform`，由 installer 的 `SweepDirectChildrenInto` 在 `OnAfterApply` 统一扫进 holder（label 在 `OnAfterApply` 前已建好；晚于 holder 出现的也被后续 ReSolve 的 sweep 接住）。`stateReact="false"` **不**豁免位移（它只管 `*Modulate` 扇出；holder 是刚体平移，整块内容一起动）。
 
 ## 5. 数据流 / 生命周期
 
-- **懒建**（贴合库里「不挂空转 MonoBehaviour/GO」取舍）：`ChildHostTransform` 在实例化期被读取（属性应用之前），故初始子节点先挂到控件自身 RectTransform；到 `OnAfterApply`（`pressedOffset`/`selectedOffset` 已知、label/子节点已建好）时，若有位移则建 holder + reparent。
-- **ReSolve 幂等**：holder 已存在 → `existing` 非空 → 跳过建/搬，只 `Configure` 新 offsets。
+- **懒建**（贴合库里「不挂空转 MonoBehaviour/GO」取舍）：`ChildHostTransform` 在实例化期被读取（属性应用之前），故初始子节点先挂到控件自身 RectTransform；到 `OnAfterApply`（`pressedOffset`/`selectedOffset` 已知、label/子节点已建好）时，若有位移则建 holder 并把直接子节点扫入。
+- **ReSolve 幂等**：holder 已存在 → `existing` 非空 → 不重建（`CreateHolder` 跳过），`SweepDirectChildrenInto` 通常 no-op（内容已在 holder 内），只 `Configure` 新 offsets。
 - **顺序**：holder 建/搬在 `StateTintInstaller.Install` 之前。后者 `GetComponentsInChildren<Graphic>` 递归遍历不受中间层影响，逻辑 `Children` 列表也不变 → 颜色 / 去色 / id-path / 布局全不受影响（holder 全拉伸 = 与控件同矩形，子节点锚点解析结果一致）。
 - **raycast 不变**：holder 无 Graphic → 不拦截 raycast；背景 Image（在父 GO）照常被 PuiButton 接收点击。
 - **状态映射**：`For`：Pressed→`pressedOffset??zero`；Selected→`selectedOffset??zero`；Normal/Hover/Disabled→`zero`。

--- a/docs~/superpowers/specs/2026-06-24-btn-press-offset-design.md
+++ b/docs~/superpowers/specs/2026-06-24-btn-press-offset-design.md
@@ -1,0 +1,188 @@
+# Btn/Tab/Toggle 实体按钮按压位移（state-offset）设计
+
+**日期**: 2026-06-24
+**状态**: 设计阶段（待 review，未进入实施）
+**作用域**:
+1. `Runtime/Controls/Internal/StateOffsetSet.cs` —— 新增。纯 POCO，per-state `Vector2?`（pressed / selected），`For(InteractState)` 折算成 `Vector2`（Normal/Hover/Disabled → `zero`）。类比 `StateColorSet`。
+2. `Runtime/Controls/Internal/PressOffsetController.cs` —— 新增。`MonoBehaviour`，挂在 content-holder 上，订阅最近祖先 `IStateSource.OnState`，`OnState(state) → holder.anchoredPosition = set.For(state)`（瞬移）。
+3. `Runtime/Controls/Internal/StateOffsetInstaller.cs` —— 新增。静态。懒建 content-holder + 把现有可视子节点 reparent 进去 + 挂/Configure controller。幂等。
+4. `Runtime/Controls/Btn.cs` —— 加 `pressedOffset` 属性、`_offsetHolder` 字段、`ChildHostTransform` override、`OnAfterApply` 里接一行 `Install`。
+5. `Runtime/Controls/Tab.cs` —— 同 Btn，外加 `selectedOffset` 属性。
+6. `Runtime/Controls/Toggle.cs` —— 同 Tab。
+7. `Runtime/Core/Parser/` 或现有 vec2 解析工具 —— 复用解析 `"x,y"`（与 `translate` 同一条路）。
+8. `.claude/skills/authoring-promptugui-xml/reference/states.md` —— 新增「Press offset」一节（英文）。
+9. `.claude/skills/authoring-promptugui-xml/SKILL.md` —— Btn/Tab/Toggle 属性目录行 + stub 指针补新属性（英文）。
+10.（条件）XSD 生成器 —— 若枚举 per-control 属性，补 `pressedOffset` / `selectedOffset`。
+
+**依赖**: 无新增包。复用：`IStateSource` / `StateBroadcaster` 的 `OnState` 广播、`StateTintInstaller` / `StateTintReactor` 的 installer+reactor 模式、`StateSubtree` 思路、`<Animation>` 的 `_offsetProxy`（content-holder 同款全拉伸 RectTransform）、现有 `ChildHostTransform` 重定向机制、现有 `translate` 的 vec2 解析。
+
+---
+
+## 1. 背景与动机
+
+「实体按钮 / 果汁感按钮」是常见的游戏 UI 反馈：按下时按钮的可视内容下沉几像素，给出"被按进去"的触觉错觉。Unity 社区主流做法有四类：
+
+1. **Animator 动画过渡**（官方）：Button transition 设成 Animation，Pressed clip 里挪一个子 "Content" RectTransform。无代码但每按钮要 Animator + Controller 资产，重。
+2. **`IPointerDown`/`IPointerUp` 脚本挪子物体**（最常见轻量 DIY），常配 DOTween/LeanTween 快补间。
+3. **双层「阴影底 + 面」立体按钮**：底垫暗色阴影图，面整体下移贴住。
+4. **现成 juice 资产**（MoreMountains Feel、DOTween Pro 等）。
+
+核心原则：**hover 浮起、press 下沉**（emboss up/down）。
+
+本库现状：`Btn`/`Tab`/`Toggle` 已统一通过 `IStateSource`（`StateBroadcaster`）广播 `OnState`（Normal/Hover/Pressed/Selected/Disabled），并已有四套 per-state 视觉家族（`*Color` / `*Modulate` / `*Sprite` / 禁用去色），全部走「`OnAfterApply` 里装 installer，installer 给子树挂 reactor 订阅 `OnState`」的同一模式。
+
+该效果**今天已能用现有动画系统啰嗦地实现**：
+
+```xml
+<Btn>
+  <Animation translate="0,0:0,-4" duration="0.06s" on="state-pressed"><Frame anchor="stretch">…</Frame></Animation>
+  <Animation translate="0,-4:0,0" duration="0.06s" on="state-normal"><Frame anchor="stretch">…</Frame></Animation>
+</Btn>
+```
+
+缺点：要包两层 `<Animation>`、手写复位、每按钮重复、`Toggle`/`Tab` 不复用。故本设计加一个**一等公民 state-offset 家族**，与现有家族同构，三控件共享。
+
+## 2. 目标 / 非目标
+
+**目标**
+- `Btn` 支持 `pressedOffset="x,y"`：按下时子内容整体位移、背景框不动、瞬移到位、松开复位。
+- `Tab` / `Toggle` 额外支持 `selectedOffset="x,y"`：选中（`isOn`）静止态保持位移。
+- 三控件经共享 installer 复用同一机制。
+- 与 `<Animation>` / `*Color` / `*Sprite` 等正交可叠加。
+
+**非目标（留口不做）**
+- `hoverOffset`（PC 悬停浮起）。
+- 补间动画（`offsetDuration` / easing）—— MVP 一律瞬移。
+- 双层阴影底「3D 键」模式（需额外 shadow Graphic + 约定来源）。
+- pressed→selected 兜底（见 §5 已知边界）。
+
+## 3. XML 表面
+
+| 属性 | 控件 | 含义 |
+|---|---|---|
+| `pressedOffset="x,y"` | Btn / Tab / Toggle | 按下时子内容位移（像素，**Unity 符号：负 y = 下**） |
+| `selectedOffset="x,y"` | Tab / Toggle | 选中（`isOn`）静止态保持的位移；`Btn` **不声明**此属性 |
+
+- 值格式 `"x,y"`（两个数，可含负号/小数）。
+- `""` / `"none"` = 不设此态位移（沿用 `pressedSprite` 的 opt-out 约定）。
+- 非法格式 → parse error（复用现有 vec2 解析路径）。
+- 可被 Variant 覆盖（任意 `[UIAttr]` 通用：ReSolve 重解析、重 `Configure`）。
+- `selectedOffset` 只声明在 `Tab`/`Toggle` 上 —— 与现有 `selectedColor`/`selectedModulate` 只在 Tab/Toggle 的惯例一致（`Btn` 永不进 Selected 态）。
+
+示例：
+
+```xml
+<!-- 按下子内容下移 4px -->
+<Btn pressedOffset="0,-4">Buy</Btn>
+
+<!-- 按下沉 2px；选中后保持沉 3px -->
+<Tab pressedOffset="0,-2" selectedOffset="0,-3"/>
+
+<!-- 水平也能动（少见，但 x/y 都支持） -->
+<Toggle pressedOffset="1,-2"/>
+```
+
+## 4. 运行时架构
+
+### 4.1 新增组件（均在 `Runtime/Controls/Internal/`）
+
+**`StateOffsetSet`（POCO）**
+```
+struct/class StateOffsetSet {
+    Vector2? Pressed;
+    Vector2? Selected;
+    bool HasAny => Pressed.HasValue || Selected.HasValue;
+    Vector2 For(InteractState s) => s switch {
+        Pressed  => Pressed  ?? Vector2.zero,
+        Selected => Selected ?? Vector2.zero,
+        _        => Vector2.zero,   // Normal / Hover / Disabled
+    };
+}
+```
+类比 `StateColorSet`：纯数据 + `For` 查表，无 Unity 依赖（可纯 C# 单测）。
+
+**`PressOffsetController : MonoBehaviour`**（挂在 content-holder 上）
+- `Configure(StateOffsetSet set)`：存 set；首次 `EnsureInit` 时 `GetComponentInParent<IStateSource>(true)` 拿到拥有它的 Btn/Tab/Toggle，`OnState.Subscribe(OnState)`（`includeInactive` 同 `StateTintReactor`，应对开屏隐藏页）。
+- `OnState(InteractState s) { _holder.anchoredPosition = _set.For(s); }`（_holder = 自己的 RectTransform）。**瞬移，无 LitMotion**。
+- 重 `Configure`（Variant ReSolve）：更新 set 后，若已订阅则 `OnState(_source.Current)` 重绘一次当前态（对齐 `StateTintReactor` 的 re-Configure 重绘逻辑）。
+- `OnDestroy`：退订。
+
+**`StateOffsetInstaller`（静态）**
+```
+// 返回 holder（可能为 null）。go = 控件 GO；existing = 控件已缓存的 holder（首次为 null）。
+static RectTransform Install(GameObject go, RectTransform existing, IReadOnlyList<IControl> children, StateOffsetSet offsets) {
+    if (!offsets.HasAny && existing == null) return null;        // 从未设 → 不建
+    var holder = existing ?? CreateHolderAndReparent(go, children);
+    var ctrl = holder.GetComponent<PressOffsetController>() ?? holder.gameObject.AddComponent<PressOffsetController>();
+    ctrl.Configure(offsets);                                     // offsets 全空也 Configure → For 全 zero → 归位
+    return holder;
+}
+```
+- `CreateHolderAndReparent`：**先快照** `go.transform` 当前所有子 transform（在建 holder 之前取，避免把 holder 自己也扫进去）→ 建全拉伸 RectTransform（anchorMin=0 / anchorMax=1 / offset=0 / pivot=0.5，仿 `_offsetProxy`，命名如 `"_offsetHolder"`）→ 把快照按序 `SetParent(holder,false)`（即 label / icon + 显式子节点；背景 Image / PuiButton / CanvasGroup 是组件不是子节点，留在原地）。
+
+### 4.2 控件侧改动（Btn / Tab / Toggle 各自，极小）
+
+每个控件：
+1. 加字段 `private RectTransform _offsetHolder;`
+2. `override Transform ChildHostTransform => _offsetHolder != null ? _offsetHolder : RectTransform;`（让后续 Add 块也落进 holder）
+3. 加属性 setter（存进 `_pressedOffset` / `_selectedOffset` 字段，解析 `"x,y"`）。
+4. 在**已有的** `OnAfterApply` 里、`StateTintInstaller.Install` **之前**接一行：
+   `_offsetHolder = StateOffsetInstaller.Install(GameObject, _offsetHolder, Children, new StateOffsetSet{...});`
+
+`Btn` 只有 `pressedOffset`；`Tab`/`Toggle` 有 `pressedOffset` + `selectedOffset`。
+
+5. **label/icon 改挂 `ChildHostTransform`**：三控件的 `EnsureLabel`（及 Tab/Toggle 的 icon 创建）当前把子物体挂在 `RectTransform`（控件自身 GO）。改为挂 `ChildHostTransform`，使其在 holder 已存在时直接落进 holder。覆盖一个边界：label/icon 在某个非默认 Variant 的 ReSolve 里**晚于** holder 创建才首次出现时，仍能正确随按压位移（否则会变成 holder 外的直挂子节点、不跟着动）。holder 未建时 `ChildHostTransform == RectTransform`，行为与现状完全一致。
+
+## 5. 数据流 / 生命周期
+
+- **懒建**（贴合库里「不挂空转 MonoBehaviour/GO」取舍）：`ChildHostTransform` 在实例化期被读取（属性应用之前），故初始子节点先挂到控件自身 RectTransform；到 `OnAfterApply`（`pressedOffset`/`selectedOffset` 已知、label/子节点已建好）时，若有位移则建 holder + reparent。
+- **ReSolve 幂等**：holder 已存在 → `existing` 非空 → 跳过建/搬，只 `Configure` 新 offsets。
+- **顺序**：holder 建/搬在 `StateTintInstaller.Install` 之前。后者 `GetComponentsInChildren<Graphic>` 递归遍历不受中间层影响，逻辑 `Children` 列表也不变 → 颜色 / 去色 / id-path / 布局全不受影响（holder 全拉伸 = 与控件同矩形，子节点锚点解析结果一致）。
+- **raycast 不变**：holder 无 Graphic → 不拦截 raycast；背景 Image（在父 GO）照常被 PuiButton 接收点击。
+- **状态映射**：`For`：Pressed→`pressedOffset??zero`；Selected→`selectedOffset??zero`；Normal/Hover/Disabled→`zero`。
+- **首帧确立**：瞬移天然满足——开屏即 `isOn` 的 Tab/Toggle 第 1 帧就停在 `selectedOffset`（`OnState` 订阅重放当前态 → 直接定位），无需 BornFrame 特判。
+- **选中态被按下**：`StateBroadcaster` 把「选中+按下」折叠成 `Pressed`，故 → `pressedOffset`，松开回 `Selected` → `selectedOffset`。
+- **与 `<Animation>` 正交**：Animation 动它自己的 `_offsetProxy`（嵌在 holder 内），与 holder 位移叠加，互不干扰。
+
+**已知小边界**：若只设 `selectedOffset`、没设 `pressedOffset`，按一个已选中的 Tab → 进 Pressed → `For(Pressed)=zero` → 子内容瞬回 0、松开再弹回 `selectedOffset`（一次"弹"）。MVP 不做 pressed→selected 兜底（兜底需把 `isOn` 像 `StateTintReactor.SetSelected` 那样单独 push 给 controller，超出 MVP）。文档建议：设 `selectedOffset` 时一并设 `pressedOffset`（常取相同或更深值）。
+
+## 6. 边界与错误处理
+
+- 非法 `"x,y"` → parse error（与 `translate` 同一解析失败路径）。
+- `""` / `"none"` → 该态不设位移。
+- Disabled → `zero`（按住时被禁用会归位）。
+- `Btn` 不声明 `selectedOffset` → 作者误写会触发现有的未知属性报错，无需额外 lint。
+- 无新增 lint 规则。
+
+## 7. 测试计划（TDD，Red 先行）
+
+**纯 C# 单测**（`StateOffsetSet`）：
+- `For` 查表：Pressed/Selected 命中、Normal/Hover/Disabled→zero、未设态→zero。
+
+**EditMode**（经内部 seam 驱动 `StateBroadcaster.SetTransient` / `SetOn`，InternalsVisibleTo 已开）：
+- `Pressed_offset_shifts_holder`：Btn `pressedOffset="0,-4"`，驱动 Pressed → `holder.anchoredPosition == (0,-4)`；回 Normal → `(0,0)`。
+- `Selected_offset_on_toggle`：Toggle `isOn` → `selectedOffset`；切走 → 0。
+- `Btn_never_selected`：Btn 驱动 isOn 路径不存在 → 永不取 selected 值。
+- `No_offset_no_holder`：无位移属性的 Btn → `ChildHostTransform == RectTransform`，无额外 GO（性能断言）。
+- `Reparent_into_holder`：label + 显式子节点 transform.parent == holder。
+- `Resolve_idempotent`：两次 ReSolve 后仍只有一个 holder、子节点不被搬两次。
+- `Sign_convention`：`"0,-4"` → y == -4（下）。
+- `Instant_no_frame_wait`：位移同步生效（瞬移天然满足，无需 frame loop）。
+- （可选）`Compose_with_animation`：holder 位移与内层 `<Animation translate>` 叠加。
+
+> 注：按 [[sdd-unity-mcp-controller-runs-tests]]，测试由 controller 经 Unity MCP 跑（`refresh_unity` → `run_tests` EditMode → `get_test_job`），子 agent 只写代码。
+
+## 8. 文档（同 PR 必改，英文）
+
+- `reference/states.md`：新增「Press offset — `pressedOffset` / `selectedOffset`」一节：用途、`"x,y"` 格式、Unity 负=下符号（强调坑）、瞬移（与 `*Color` 0.1s 淡入的差异）、selected 只在 Tab/Toggle、与 `<Animation>` 叠加、§5 的"只设 selectedOffset 会弹"边界。
+- 主 `SKILL.md`：Btn/Tab/Toggle 属性目录行 + stub 指针补 `pressedOffset` / `selectedOffset`。
+- 若 XSD 生成器枚举 per-control 属性 → 同步补（plan 阶段确认实际生成器是否需要）。
+
+## 9. 实现顺序（给 plan 的提示）
+
+1. `StateOffsetSet` + 纯 C# 单测（Red→Green）。
+2. `PressOffsetController` + `StateOffsetInstaller`。
+3. `Btn.pressedOffset` 接线 + EditMode 测试。
+4. `Tab` / `Toggle` 的 `pressedOffset` + `selectedOffset` 接线 + 测试。
+5. 文档（states.md / SKILL.md / 可能的 XSD）。
+6. lint（`dotnet format --verify-no-changes`）+ 全量 EditMode 回归。


### PR DESCRIPTION
## 这是什么

给 `<Btn>` / `<Tab>` / `<Toggle>` 加「实体按钮」按压位移：按下时**子内容**整体下沉 N 像素、背景框不动、瞬移到位、松开复位；`<Tab>`/`<Toggle>` 选中态可保持「按入」。

## 新增 XML 属性

| 属性 | 控件 | 含义 |
|---|---|---|
| `pressedOffset="x,y"` | Btn / Tab / Toggle | 按下时子内容位移（像素，**Unity 符号：负 y = 下**），瞬移、松开复位 |
| `selectedOffset="x,y"` | Tab / Toggle | 选中（`isOn`）静止态保持的位移；Pressed 优先；`Btn` 不声明 |

```xml
<Btn pressedOffset="0,-4">Buy</Btn>                 <\!-- 按下子内容下移 4px -->
<Tab pressedOffset="0,-2" selectedOffset="0,-3"/>   <\!-- 按下沉 2px；选中保持沉 3px -->
```

## 实现

复用现有 `IStateSource.OnState` 广播 + installer/reactor 模式（与 `*Color` 家族同构）：
- **`StateOffsetSet`** — per-state `Vector2?` 数据 + `"x,y"` 解析
- **`PressOffsetController`** — 挂在 content-holder 上，订阅 `OnState` → 设 `anchoredPosition`（**瞬移，无补间**）
- **`StateOffsetInstaller`** — 懒建全拉伸 content-holder、把控件直接子节点扫入；**无位移时零开销**（不建 holder、不挂 MonoBehaviour）
- 三控件各加 `pressedOffset`(+`selectedOffset`) 属性 + `ChildHostTransform` override + 一行 `OnAfterApply` 接线

背景 `Image` 是控件 GO 上的**组件**（非子节点），故不随位移——这就是「框不动、内容沉」。与 `<Animation>` / `*Color` / `*Sprite` 正交可叠加。

## 设计 / 计划
- spec: `docs~/superpowers/specs/2026-06-24-btn-press-offset-design.md`
- plan: `docs~/superpowers/plans/2026-06-24-btn-press-offset.md`

## 测试 / 验证
- EditMode **1946/1946** 通过（+18 新测试：StateOffsetSet 6 / Btn 6 / Tab 3 / Toggle 3）；Btn/Tab/Toggle 既有状态测试**无回归**
- XSD 生成器测试无回归（Btn 手列加 `pressedOffset`；Tab/Toggle 反射自动覆盖）
- `dotnet format --verify-no-changes --severity warn` 干净
- 文档同步（CLAUDE.md 要求）：`reference/states.md` 新增「Press offset」节 + 主 `SKILL.md` 三控件属性行

## 实现方式
TDD 逐任务（red→green→commit），子 agent 写码 + Unity MCP 跑测试，每任务双阶段 review + 最终 whole-branch review。

🤖 Generated with [Claude Code](https://claude.com/claude-code)