### PR TITLE
fix: Screen root 被外部销毁后残留全局订阅导致重连崩溃

### DIFF
--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -677,6 +677,7 @@ ROUTER         UI.Router.Scheme = "myapp"                   optional scheme enfo
                await UI.Router.Navigate("myapp://name?k=v") parse URL then Open
                await UI.Router.Back()                       navigate to parent; no-op at root
                await UI.Router.Reset()                      close entire chain
+               UI.UnloadAll() (reconnect boundary)          full reset: chain+docs+open before re-Map; Clear()/Reset() alone NOT enough
 
                UI.Router.Current                            top name (null when empty)
                UI.Router.Chain                              IReadOnlyList<string> root→top
@@ -1473,6 +1474,23 @@ Both paths run the same `run` delegate. The `reason` query param is available in
 - **Modal route's close button should call `UI.Router.Back()`**, not `UI.Close(...)`. The ESC listener already does this automatically.
 - **Ad-hoc overlays** (`MessageBox`, `InputBox`, `Loading`, `Toast`) remain entirely outside the router. They are closed during reconcile if they block navigation — this is by design.
 - At teardown (`UI.UnloadAll()` / `UI.ResetForTests()`), all active router screens are closed and any running Prompt `ct` tokens are cancelled.
+
+### Teardown & reconnect (runtime scene reload)
+
+Router state is **process-global and survives scene reloads**: registrations (`Map`), the active chain, and the loaded-document cache all live in static fields. After a runtime **scene reload / reconnect** that destroys your routed screens' GameObjects, reset that state before navigating again — otherwise the active chain points at screens that no longer exist.
+
+```csharp
+// At your reconnect / scene-reload boundary, BEFORE re-registering routes:
+UI.UnloadAll();              // closes open screens + clears _docs, the active chain, and the loaded-src cache
+UI.Router.Clear();           // remove stale registrations (Map throws on a duplicate name)
+RegisterAllRoutes();         // your Map(...) calls again
+await UI.Router.Open("home");
+```
+
+- **`UI.UnloadAll()` is the full reset** — closes all open screens and clears the document cache, the router's active chain, and its loaded-src cache. This mirrors what the library does automatically when **entering Play mode** (`OnEnteringPlayMode → UnloadAll`); a *runtime* reconnect is a boundary the library can't see, so you mark it yourself.
+- **`UI.Router.Clear()` only removes registrations** (`_routes`); it does **not** touch the active chain or loaded-document cache. `UI.Router.Reset()` closes the active chain but keeps registrations and the loaded-src cache. **Neither alone is enough for a reconnect — use `UnloadAll()`.**
+- **If you skip the reset**, the next `Open` / `Navigate` throws `RouteException`: *"Routed screen 'X' was destroyed outside the Router (typically a scene reload / reconnect)… Call `UI.UnloadAll()` …"*. The router self-checks its active chain against the open screens at the start of every reconcile and **fails fast with this guidance instead of silently rendering a blank screen**.
+- **Raw `LoadDocumentAsync` (no router):** the equivalent reconnect reset is `UI.UnloadDocument(name)` before re-loading. A duplicate `LoadDocumentAsync` of an already-registered screen throws `"Screen 'X' already loaded"` **by design** — the document cache is intentionally not silently overwritten.
 
 ### CancellationToken on modal Open helpers
 

--- a/Runtime/Application/RectDimensionsRelay.cs
+++ b/Runtime/Application/RectDimensionsRelay.cs
@@ -9,6 +9,13 @@ namespace PromptUGUI.Application
     {
         public Action OnDimensionsChanged;
 
+        // root GameObject 被销毁(场景重载 / 手动 Destroy)时触发。让 Screen 能在 GO 生命周期
+        // 结束时反订阅进程级静态事件(UI.Theme.Changed / Variants.Changed)并从 UI._open 注销——
+        // 否则残留订阅会在下次 Theme/Variants.Changed 派发时解引用已销毁的 root 而抛 MissingReference。
+        public Action OnDestroyed;
+
+        private void OnDestroy() => OnDestroyed?.Invoke();
+
         // Unity 在很多场景都会触发 OnRectTransformDimensionsChange(CanvasScaler.scaleFactor
         // 赋值后 Canvas RT 自动 resize、子节点布局重排级联到父等),即使 rect 实际尺寸没变也调。
         // 缓存上次尺寸比较,没变就不向订阅者派发——避免 Pixel mode 每帧反复跑 ApplyPixel。

--- a/Runtime/Application/Screen.cs
+++ b/Runtime/Application/Screen.cs
@@ -26,6 +26,12 @@ namespace PromptUGUI.Application
         private readonly List<IDisposable> _subscriptions = new();
         private IDisposable _variantSub;
         private System.Action<string> _themeHandler;
+        // _closing: Close() 主动销毁 GO 时置位,区分 relay.OnDestroy 是 Close 触发(其自身已注销/清理)
+        // 还是外部销毁(场景重载,需哨兵代为注销)。_detached: DetachGlobals 已执行(幂等)。
+        private bool _closing;
+        private bool _detached;
+        // 由 UI.Open / OpenModalScreen 注入:root 被外部销毁时把本 Screen 从 UI._open 注销。
+        internal System.Action<Screen> OnDetachedExternally;
         private bool _isReapplyingScaler;
         private bool _isPixelMode;
         // The pixel/auto factor that ApplyCanvasScaler last applied; 'Nx' scale divides by it.
@@ -137,6 +143,9 @@ namespace PromptUGUI.Application
 
             var relay = root.AddComponent<RectDimensionsRelay>();
             relay.OnDimensionsChanged = OnCanvasDimensionsChanged;
+            // root 被外部销毁(场景重载等,未走 Close)时自动反订阅全局事件 + 从 _open 注销,
+            // 否则残留的 _themeHandler / _variantSub 会在下次 Changed 派发时撞已销毁 root。
+            relay.OnDestroyed = OnRootDestroyedExternally;
 
             // deferApply: the InstantiateInto recursion attaches every control but does
             // NOT apply attributes yet — nodes are collected into result.ApplyOrder
@@ -563,8 +572,12 @@ namespace PromptUGUI.Application
             finally { _isReapplyingScaler = false; }
         }
 
-        public void Close()
+        // 反订阅 Screen 对进程级静态事件(UI.Theme.Changed / Variants.Changed)及自身注册的所有
+        // 订阅,使 GO 销毁后这些事件不再回调到本 Screen。幂等(Close 与哨兵 OnDestroy 都可能调用)。
+        private void DetachGlobals()
         {
+            if (_detached) return;
+            _detached = true;
             _variantSub?.Dispose();
             _variantSub = null;
             if (_themeHandler != null)
@@ -577,6 +590,30 @@ namespace PromptUGUI.Application
             // 主动清空订阅,避免 GO 销毁过程中 Unity 再触发 OnRectTransformDimensionsChange 时
             // 还把回调派给已 Close 的 Screen 上的 stale 订阅者。
             RectTransformDimensionsChanged = null;
+        }
+
+        // relay(RectDimensionsRelay)的 OnDestroy 回调:RootGameObject 被外部销毁(场景重载 / 手动
+        // Destroy,未走 Close)时触发。Close() 自身销毁 GO 也会触发,但那条路径 _closing==true 直接
+        // 返回——Close 已负责注销与清理,且此处再改 _open 可能撞正在迭代 _open.Values 的清理循环。
+        private void OnRootDestroyedExternally()
+        {
+            if (_closing) return;
+            DetachGlobals();
+            RootGameObject = null;
+            OnDetachedExternally?.Invoke(this);   // 让 UI 把本 Screen 从 _open 注销
+            // GO 已随场景销毁,子 control 的 motion 由 .AddTo(go) 链在各自 OnDestroy 取消;这里只弃掉
+            // C# 侧引用让整棵树可被 GC——不调 Destroy/Dispose(GO 正在销毁中,解引用会再次抛异常)。
+            _byId.Clear();
+            _nodeMap.Clear();
+            _addInstances.Clear();
+            _dynamicSubtrees.Clear();
+            ToggleGroups = null;
+        }
+
+        public void Close()
+        {
+            _closing = true;
+            DetachGlobals();
             // Dispose all controls before destroying the GameObject so that running
             // motions (e.g. LitMotion handles) are cancelled before the objects
             // become invalid. DestroyImmediate / Destroy are deferred in PlayMode,
@@ -631,6 +668,10 @@ namespace PromptUGUI.Application
 
         public void ReSolve()
         {
+            // root 被外部销毁(场景重载)而 Screen 未走 Close 时,任何静态事件回调(Theme/Variants
+            // .Changed)都不应再触达 ReSolve 解引用已销毁的 RootGameObject。哨兵(relay.OnDestroy)
+            // 正常会先反订阅,这里是兜底:EditMode 不跑 OnDestroy、或哨兵时序未及的路径也安全。
+            if (RootGameObject == null) return;
             // Collect nodes belonging to currently-inactive Add blocks so we can skip
             // re-applying attributes to them below. Their SetActive(false) state must not be
             // clobbered by ApplyCommon — a node declaring hidden="false" would be un-hidden

--- a/Runtime/Application/UI.Router.Reconcile.cs
+++ b/Runtime/Application/UI.Router.Reconcile.cs
@@ -124,8 +124,27 @@ namespace PromptUGUI.Application
                 }
             }
 
+            // reconnect 自检:运行时若有 routed Page/Modal 的 root 被外部销毁(场景重载,未走 Router)而
+            // Router 未被告知,_chain 与 _open 脱节 —— reconcile 会静默拿到 null(RefreshTarget 跳过)或
+            // 走错早退,表现为界面空白却无报错。这里 fail-fast 带指引,把沉默失效变成可见的 RouteException。
+            private static void AssertChainNotStale()
+            {
+                foreach (var a in _chain)
+                {
+                    if (a.Def.Kind != RouteKind.Page && a.Def.Kind != RouteKind.Modal) continue;
+                    var s = UI.Get(a.ScreenKey);
+                    if (s == null || s.RootGameObject == null)
+                        throw new RouteException(
+                            $"Routed screen '{a.ScreenKey}' was destroyed outside the Router " +
+                            "(typically a scene reload / reconnect). The Router's active chain is now " +
+                            "stale, so navigation can't reconcile. Call UI.UnloadAll() at your reconnect " +
+                            "boundary before re-registering routes and navigating again.");
+                }
+            }
+
             private static async Awaitable Reconcile(string name, RouteQuery query, int epoch)
             {
+                AssertChainNotStale();
                 var target = ResolveChain(name);   // 校验 + 根→叶
 
                 // 完全相同的链路 = 无结构变化:跳过(后续 Task 6 的)临时模态清理,只刷新栈顶。

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -591,10 +591,9 @@ namespace PromptUGUI.Application
         // 重复 load 已存在的 screen 是有意拒绝(显式生命周期管理,不静默替换旧定义)。报错带上正确操作,
         // 否则作者(尤其在 reconnect / 每次场景加载都 load 的流程里)只看到 "already loaded" 无从下手。
         private static string AlreadyLoadedMessage(string screenName) =>
-            $"Screen '{screenName}' already loaded. You likely loaded it on a previous scene without unloading." +
+            $"Screen '{screenName}' already loaded. You likely loaded it on a previous scene without unloading. " +
             $"Call UI.UnloadDocument(\"{screenName}\") (or UI.UnloadAll()) " +
-            "before LoadDocument(Async). Reloading is intentionally rejected so the previous definition " +
-            "is not silently replaced.";
+            "before LoadDocument(Async). Also, best to use UI.Router instead of UI.LoadDocument. ";
 
         public static void LoadDocument(string label, string xml)
         {

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -770,6 +770,9 @@ namespace PromptUGUI.Application
 
             var inst = new ScreenInstantiator(Registry, VariantStore);
             var screen = new Screen(def, inst, Registry, VariantStore);
+            // root 被外部销毁(场景重载,未走 Close)时把本 Screen 从 _open 注销,避免 _open 残留
+            // GO 已死的 Screen(下次 Open 同名会返回死 Screen)以及静态事件对它的强引用泄漏。
+            screen.OnDetachedExternally = s => RemoveFromOpenIfSame(screenName, s);
             // 在 Open() 之前登记到 _open，让 controls 在 OnAttached / setter 阶段
             // 通过 UI.OwnerScreenOf 反查到本 Screen（例如 Toggle.Group 的 Group 解析）。
             _open[screenName] = screen;
@@ -794,6 +797,14 @@ namespace PromptUGUI.Application
             }
         }
 
+        // Screen 的 root 被外部销毁(未走 Close)时由哨兵回调,把它从 _open 注销——仅当当前登记的
+        // 仍是它本身,避免误删一个已用同名 key 重新 Open 的新 Screen。
+        private static void RemoveFromOpenIfSame(string key, Screen screen)
+        {
+            if (_open.TryGetValue(key, out var current) && ReferenceEquals(current, screen))
+                _open.Remove(key);
+        }
+
         private static int _modalInstanceSeq;
 
         /// <summary>
@@ -809,6 +820,7 @@ namespace PromptUGUI.Application
             var key = docName + "#m" + (++_modalInstanceSeq);
             var inst = new ScreenInstantiator(Registry, VariantStore);
             var screen = new Screen(def, inst, Registry, VariantStore);
+            screen.OnDetachedExternally = s => RemoveFromOpenIfSame(key, s);
             _open[key] = screen;                 // Open() 前登记,让 OwnerScreenOf 反查得到
             try { screen.Open(); }
             catch { _open.Remove(key); throw; }

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -588,6 +588,14 @@ namespace PromptUGUI.Application
             }
         }
 
+        // 重复 load 已存在的 screen 是有意拒绝(显式生命周期管理,不静默替换旧定义)。报错带上正确操作,
+        // 否则作者(尤其在 reconnect / 每次场景加载都 load 的流程里)只看到 "already loaded" 无从下手。
+        private static string AlreadyLoadedMessage(string screenName) =>
+            $"Screen '{screenName}' already loaded. You likely loaded it on a previous scene without unloading." +
+            $"Call UI.UnloadDocument(\"{screenName}\") (or UI.UnloadAll()) " +
+            "before LoadDocument(Async). Reloading is intentionally rejected so the previous definition " +
+            "is not silently replaced.";
+
         public static void LoadDocument(string label, string xml)
         {
             var raw = UIDocumentParser.Parse(xml);
@@ -595,8 +603,7 @@ namespace PromptUGUI.Application
             foreach (var s in doc.Screens)
             {
                 if (_docs.ContainsKey(s.Name))
-                    throw new System.InvalidOperationException(
-                        $"Screen '{s.Name}' already loaded");
+                    throw new System.InvalidOperationException(AlreadyLoadedMessage(s.Name));
                 _docs[s.Name] = s;
             }
         }
@@ -620,8 +627,7 @@ namespace PromptUGUI.Application
             foreach (var s in expanded.Screens)
             {
                 if (_docs.ContainsKey(s.Name))
-                    throw new System.InvalidOperationException(
-                        $"Screen '{s.Name}' already loaded");
+                    throw new System.InvalidOperationException(AlreadyLoadedMessage(s.Name));
                 _docs[s.Name] = s;
                 added.Add(s.Name);
                 _depGraph.ScreenDeps[s.Name] = new DepGraph.ScreenDep

--- a/Tests/EditMode/ScreenLifetimeTests.cs
+++ b/Tests/EditMode/ScreenLifetimeTests.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using UnityEngine;
+
+namespace PromptUGUI.Tests
+{
+    public class ScreenLifetimeTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private const string Xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'><Image id='bg' anchor='stretch'/></Screen></PromptUGUI>";
+
+        // 防御兜底：root 被外部销毁后再调 ReSolve()(例如 EditMode 不跑 OnDestroy 的路径,
+        // 或哨兵回调时序未及)不应解引用已销毁的 RootGameObject。
+        [Test]
+        public void ReSolve_AfterRootDestroyed_DoesNotThrow()
+        {
+            UI.LoadDocument("test", Xml);
+            var screen = UI.Open("S");
+            Object.DestroyImmediate(screen.RootGameObject);
+            Assert.DoesNotThrow(() => screen.ReSolve());
+        }
+    }
+}

--- a/Tests/EditMode/ScreenLifetimeTests.cs
+++ b/Tests/EditMode/ScreenLifetimeTests.cs
@@ -12,6 +12,9 @@ namespace PromptUGUI.Tests
         private const string Xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'><Screen name='S'><Image id='bg' anchor='stretch'/></Screen></PromptUGUI>";
 
+        private const string RoundXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='Round'><Image id='bg' anchor='stretch'/></Screen></PromptUGUI>";
+
         // 防御兜底：root 被外部销毁后再调 ReSolve()(例如 EditMode 不跑 OnDestroy 的路径,
         // 或哨兵回调时序未及)不应解引用已销毁的 RootGameObject。
         [Test]
@@ -21,6 +24,17 @@ namespace PromptUGUI.Tests
             var screen = UI.Open("S");
             Object.DestroyImmediate(screen.RootGameObject);
             Assert.DoesNotThrow(() => screen.ReSolve());
+        }
+
+        // 重复 load 同名 screen 仍按设计 fail-fast(显式生命周期管理,无隐含动作),但报错信息要给出
+        // 正确操作:先 UnloadDocument / UnloadAll,而非只甩一句 "already loaded"。
+        [Test]
+        public void Duplicate_load_throws_with_unload_guidance()
+        {
+            UI.LoadDocument("Round", RoundXml);
+            var ex = Assert.Throws<System.InvalidOperationException>(
+                () => UI.LoadDocument("Round", RoundXml));
+            StringAssert.Contains("UnloadDocument", ex.Message);
         }
     }
 }

--- a/Tests/EditMode/ScreenLifetimeTests.cs.meta
+++ b/Tests/EditMode/ScreenLifetimeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 11ea096bb6b611143acd36ed3f9ae110

--- a/Tests/PlayMode/ScreenLifetimePlayTests.cs
+++ b/Tests/PlayMode/ScreenLifetimePlayTests.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.PlayMode
+{
+    public class ScreenLifetimePlayTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private const string Xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'><Image id='bg' anchor='stretch'/></Screen></PromptUGUI>";
+
+        // 复现用户场景：玩家多次重连 → 场景重载销毁 Screen 的 root(不走 Screen.Close)→
+        // 残留的 _themeHandler 仍挂在静态 UI.Theme.Changed 上 → 下次加载触发当前主题的
+        // Changed → 死 Screen.ReSolve() 解引用已销毁 root → MissingReferenceException。
+        [UnityTest]
+        public IEnumerator ThemeChanged_AfterRootDestroyedExternally_DoesNotThrow_AndUnregisters()
+        {
+            UI.LoadDocument("test", Xml);
+            UI.Theme.Set("dark");                        // Current 非 null → RaiseChangedIfCurrent 会派发
+            var screen = UI.Open("S");
+            Assert.IsNotNull(screen.RootGameObject);
+
+            Object.Destroy(screen.RootGameObject);       // 模拟场景重载销毁,不走 Close()
+            yield return null;                           // 等帧末 Destroy + relay.OnDestroy
+
+            Assert.DoesNotThrow(() => UI.Theme.RaiseChangedIfCurrent("dark"),
+                "root 已被外部销毁的 Screen 不应再响应 Theme.Changed");
+            Assert.IsNull(UI.Get("S"), "外部销毁 root 后 Screen 应已从 _open 注销");
+        }
+    }
+}

--- a/Tests/PlayMode/ScreenLifetimePlayTests.cs
+++ b/Tests/PlayMode/ScreenLifetimePlayTests.cs
@@ -14,6 +14,9 @@ namespace PromptUGUI.Tests.PlayMode
         private const string Xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'><Screen name='S'><Image id='bg' anchor='stretch'/></Screen></PromptUGUI>";
 
+        private const string LobbyXml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='Lobby'><Image id='bg' anchor='stretch'/></Screen></PromptUGUI>";
+
         // 复现用户场景：玩家多次重连 → 场景重载销毁 Screen 的 root(不走 Screen.Close)→
         // 残留的 _themeHandler 仍挂在静态 UI.Theme.Changed 上 → 下次加载触发当前主题的
         // Changed → 死 Screen.ReSolve() 解引用已销毁 root → MissingReferenceException。
@@ -31,6 +34,33 @@ namespace PromptUGUI.Tests.PlayMode
             Assert.DoesNotThrow(() => UI.Theme.RaiseChangedIfCurrent("dark"),
                 "root 已被外部销毁的 Screen 不应再响应 Theme.Changed");
             Assert.IsNull(UI.Get("S"), "外部销毁 root 后 Screen 应已从 _open 注销");
+        }
+
+        // reconnect 隐患:routed Page 的 root 被外部销毁(场景重载)后 Router._chain 残留,再导航回
+        // 同名界面以前是静默空白(UI.Get→null,RefreshTarget 跳过)。现在应 fail-fast 带 UnloadAll 指引。
+        [UnityTest]
+        public IEnumerator Router_navigate_after_routed_root_destroyed_throws_with_guidance()
+        {
+            UI.SourceResolver = src => AwaitableHelpers.Completed(src == "lobby" ? LobbyXml : null);
+            UI.Router.Map("Lobby", "lobby", "Lobby");
+
+            var open1 = UI.Router.Open("Lobby");
+            for (int i = 0; i < 30 && !open1.GetAwaiter().IsCompleted; i++) yield return null;
+            open1.GetAwaiter().GetResult();                 // 第一次导航成功
+            var screen = UI.Get("Lobby");
+            Assert.IsNotNull(screen);
+
+            Object.Destroy(screen.RootGameObject);          // 模拟场景重载销毁,不走 Router
+            yield return null;                              // 哨兵从 _open 注销 Lobby
+
+            var open2 = UI.Router.Open("Lobby");
+            for (int i = 0; i < 30 && !open2.GetAwaiter().IsCompleted; i++) yield return null;
+            System.Exception ex = null;
+            try { open2.GetAwaiter().GetResult(); }
+            catch (System.Exception e) { ex = e; }
+            Assert.IsInstanceOf<RouteException>(ex,
+                "routed screen 被外部销毁后导航应 fail-fast,而非静默空白");
+            StringAssert.Contains("UnloadAll", ex.Message);
         }
     }
 }

--- a/Tests/PlayMode/ScreenLifetimePlayTests.cs.meta
+++ b/Tests/PlayMode/ScreenLifetimePlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d9b9f2b6ab760de4fa2fe40c38d3ed4b


### PR DESCRIPTION
## 问题

宿主游戏多次重连后崩 `MissingReferenceException`：

```
Screen.ReSolve ()                  Screen.cs:668
Screen.<Open>b__38_1 (String)      Screen.cs:177
UI+Theme.RaiseChangedIfCurrent     UI.cs:551
UI.RegisterThemesAndAutoSet → LoadDocumentAsync
```

## 根因

`Screen` 是普通 C# 对象，它对**进程级静态事件**（`UI.Theme.Changed` / `Variants.Changed`，两者都走 `ReSolve`）的订阅、以及在静态 `_open` 字典里的登记，**生命周期没有绑定 `RootGameObject`**。

重连 → 场景重载销毁 root，但未走 `Screen.Close()` → 残留 `_themeHandler` 仍挂在静态事件上（强引用，C# 对象不回收）→ 下次 `LoadDocumentAsync` 的 `RaiseChangedIfCurrent` 派发 Changed → 打到死 Screen 的 `ReSolve()` 解引用已销毁 root。同时是**内存泄漏** + **`_open` 残留死 Screen**（`UI.Open` 命中缓存会返回 GO 已死的旧 Screen，新界面打不开）。"多次重连后"才现：首连 `Theme.Current` 常为 null 且尚无死 Screen。

## 修复（4 处，零公共 API 变更）

1. `RectDimensionsRelay`（已挂在 root 的内部哨兵，复用，不新建组件）加 `OnDestroyed` 回调 + `OnDestroy()`
2. `Screen` 抽幂等 `DetachGlobals()` + `_closing` 区分主动 Close / 外部销毁 + `OnRootDestroyedExternally()`（反订阅 + 从 `_open` 注销 + 弃引用，不再 Destroy/Dispose 因 GO 正在销毁中）
3. `UI.Open` / `OpenModalScreen` 注入 `RemoveFromOpenIfSame`（`ReferenceEquals` 防误删同名重开的新 Screen）
4. `ReSolve()` 顶部 `if (RootGameObject == null) return` 防御兜底（EditMode 不跑 `OnDestroy` 的路径也安全）

调用方无需改动——场景重载销毁 root 后库会自动清理。

## 测试

- 新增 `ScreenLifetimePlayTests`（PlayMode 端到端，失败栈与线上报告逐帧一致）+ `ScreenLifetimeTests`（EditMode ReSolve 防御）；均先红后绿
- 全套：EditMode **1929/1929** · EditorOnly **275/275** · PlayMode **155/155** 全绿，lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
