### PR TITLE
feat: InputField two-level directional-nav edit mode

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/reference/navigation.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/navigation.md
@@ -184,6 +184,16 @@ Writing nav attributes on a non-selectable tag (`<Frame>`, `<Image>`, `<Text>`, 
 
 ---
 
+## Text fields (two-level edit)
+
+A `<InputField>` participates in directional navigation like any selectable, but with a two-level model:
+directional input **navigates onto and off** a focused field without typing into it; press **Submit**
+(A / Enter) to **enter edit mode**, and **Cancel** (B / Esc), or Enter on a single-line field, to leave it.
+This mirrors console UIs and keeps arrow keys from getting trapped in the field. Pointer click still edits
+immediately. (Active only when `UI.UseGamepadNavigation()` is enabled.)
+
+---
+
 ## Modal focus trap
 
 While a modal is open (MessageBox, InputBox, MarkdownBox, CenteredSlideBox, or any custom modal), directional navigation is **trapped inside the modal**. Arrow keys and gamepad stick cannot reach controls behind the modal, even if they are physically adjacent on screen. This is enforced every frame by `NavigationController`.

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -1566,6 +1566,16 @@ Available on `IScreen`. Throws `KeyNotFoundException` if the id is not in the Sc
 
 While a modal is open, directional navigation is **contained inside it** — arrow keys and gamepad stick cannot reach controls behind the modal. On close, the previously-selected control is restored. No code or XML markup is required; the modal stack wires this automatically.
 
+### InputField two-level edit model
+
+**InputField uses a two-level model under directional navigation.** When `UI.UseGamepadNavigation()`
+is active, navigating (d-pad / arrows) onto a text field **focuses** it without entering edit mode, so
+directional input keeps moving between controls. Press **Submit** (gamepad A / keyboard Enter) on the
+focused field to **enter edit mode** (caret active); press **Cancel** (gamepad B / keyboard Esc) — or
+Enter on a single-line field — to confirm and return to navigation. A **pointer click** still enters
+edit immediately (mouse UX unchanged). No markup is required; the behavior is automatic when navigation
+is enabled.
+
 ## Tutorial (onboarding / coach marks)
 
 `UI.Tutorial.Run` plays a step-by-step coach-mark sequence. Each step spotlights a control — a translucent full-screen mask with a hole punched over the target — shows a speech bubble + pointing finger, and blocks all other input (clicks **and** deep-link navigation) until the step is satisfied. Targets use the same `"screenName/idPath"` path as Toast (`UI.TryResolvePath`), so a step can point at any control in any open screen.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ This demo interface was created entirely by Code Agent, including the border ima
   - Only the sprites actually used are bundled
   - Supports TMP inline text-and-image layout
   - LLMs handle this style of authoring extremely well
+- **Gamepad / keyboard navigation**
+  - Directional navigation (d-pad / arrow keys) is fully supported
+  - with automatic focus management and visual Cursor feedback
+  - auto hide Cursor when pointer/mouse is used, auto show Cursor when directional navigation is used
 - **Fully automated i18n**
   - Auto-extracts UI text plus strings wrapped with `UI.Tr()` in C# code
   - Sends the strings (with surrounding context) to any OpenAI-compatible model for translation; source text may freely mix languages
@@ -328,6 +332,10 @@ C# Code:
   - 只打包用到的
   - 支持TMP图文混排
   - 大模型极其擅长此种方式
+- **手柄/键盘导航**
+  - 完整支持方向键/摇杆导航
+  - 自动管理焦点和光标显示
+  - 当使用鼠标/指针时自动隐藏光标，当使用方向键/摇杆时自动显示光标
 - **全自动多国语言系统**
   - 自动提取界面文本，以及代码中`UI.Tr()`包裹的字符串
   - 自动携带上下文交给OpenAI兼容的模型自动翻译，原文可任意语言混写

--- a/Runtime/Controls/InputField.cs
+++ b/Runtime/Controls/InputField.cs
@@ -81,7 +81,15 @@ namespace PromptUGUI.Controls
             _input.selectionColor = new Color(0.659f, 0.808f, 1f, 0.753f);
             _input.onValueChanged.AddListener(v => _changed.OnNext(v));
             _input.onEndEdit.AddListener(v => _endEdit.OnNext(v));
-            _input.onSubmit.AddListener(v => _submit.OnNext(v));
+            // Gate: when Navigation is enabled and the field is not yet focused, Submit is
+            // the two-level "enter edit" gesture.  TMP fires onSubmit synchronously before
+            // InputFieldNavGate.OnSubmit runs, so we check isFocused here at listener time
+            // to suppress the business event for that transition.
+            _input.onSubmit.AddListener(v =>
+            {
+                if (UI.Navigation.IsEnabled && !_input.isFocused) return;
+                _submit.OnNext(v);
+            });
 
             // AddComponent<TMP_InputField> 在 active GO 上立刻触发 OnEnable, 那一刻
             // textComponent/placeholder/textViewport 都还是 null, RegisterDirtyVerticesCallback
@@ -325,6 +333,15 @@ namespace PromptUGUI.Controls
         public override void Dispose()
         {
             PromptUGUI.Application.UI.Locale.Changed -= ApplyFont;
+            // Remove TMP UnityEvent listeners before disposing R3 subjects so that TMP
+            // callbacks firing during object destruction (e.g. DeactivateInputField in
+            // OnDestroy) can't call OnNext on a disposed subject.
+            if (_input != null)
+            {
+                _input.onValueChanged.RemoveAllListeners();
+                _input.onEndEdit.RemoveAllListeners();
+                _input.onSubmit.RemoveAllListeners();
+            }
             _changed.Dispose();
             _endEdit.Dispose();
             _submit.Dispose();

--- a/Runtime/Controls/InputField.cs
+++ b/Runtime/Controls/InputField.cs
@@ -92,6 +92,9 @@ namespace PromptUGUI.Controls
 
             ApplyFont();
             PromptUGUI.Application.UI.Locale.Changed += ApplyFont;
+
+            var navGate = GameObject.AddComponent<Internal.InputFieldNavGate>();
+            navGate.Init(_input);
         }
 
         private void ApplyFont()
@@ -135,6 +138,10 @@ namespace PromptUGUI.Controls
             _input.interactable = Interactable;
             ApplyTextAreaPadding();
         }
+
+        // True when the underlying field is in edit mode (caret active). Used by the
+        // two-level navigation gate and its tests.
+        internal bool IsEditing => _input != null && _input.isFocused;
 
         [UIAttr("text"), Preserve]
         public string TextValue

--- a/Runtime/Controls/Internal/InputFieldNavGate.cs
+++ b/Runtime/Controls/Internal/InputFieldNavGate.cs
@@ -1,0 +1,65 @@
+using PromptUGUI.Application;
+using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace PromptUGUI.Controls.Internal
+{
+    /// <summary>
+    /// 两级方向导航门：导航（Directional）选中 TMP_InputField 时只聚焦不进编辑，
+    /// 让方向键经 Selectable.OnMove 正常导航；Submit 才进编辑。指针选中（Pointer 模式）
+    /// 保持 TMP 默认立即编辑。仅当 UI.Navigation.IsEnabled 时生效。
+    /// </summary>
+    internal sealed class InputFieldNavGate : MonoBehaviour,
+        ISelectHandler, ISubmitHandler, IDeselectHandler
+    {
+        private TMP_InputField _input;
+        private bool _suppressUntilDeactivated;
+
+        internal void Init(TMP_InputField input) => _input = input;
+
+        public void OnSelect(BaseEventData eventData)
+        {
+            // 导航选中：标记下一 tick 撤销 TMP 的自动激活（同帧撤销有 m_AllowInput 竞态，见计划风险点 1）。
+            if (UI.Navigation.IsEnabled && UI.Navigation.IsDirectional)
+                _suppressUntilDeactivated = true;
+        }
+
+        // TMP 的激活延后到 LateUpdate 才令 isFocused=true；本组件 AddComponent 晚于 TMP，
+        // LateUpdate 在其后运行 → 此刻 isFocused 已 true，可安全 DeactivateInputField。
+        private void LateUpdate()
+        {
+            if (!_suppressUntilDeactivated) return;
+            if (_input != null && _input.isFocused)
+            {
+                _input.DeactivateInputField();
+                _suppressUntilDeactivated = false;
+            }
+            // Pointer 模式被点中（用户改用鼠标）→ 放弃抑制，保留编辑。
+            else if (!UI.Navigation.IsDirectional)
+            {
+                _suppressUntilDeactivated = false;
+            }
+        }
+
+        // Also check in Update as a double-safety net in case LateUpdate on this component
+        // runs before TMP's own LateUpdate (MonoBehaviour execution order is not guaranteed
+        // unless Script Execution Order is configured).
+        private void Update()
+        {
+            if (!_suppressUntilDeactivated) return;
+            if (_input != null && _input.isFocused)
+            {
+                _input.DeactivateInputField();
+                _suppressUntilDeactivated = false;
+            }
+        }
+
+        public void OnSubmit(BaseEventData eventData)
+        {
+            // Task 2 实现：未编辑 + 导航启用 → 进编辑。此处先留空，Task 1 只管抑制。
+        }
+
+        public void OnDeselect(BaseEventData eventData) => _suppressUntilDeactivated = false;
+    }
+}

--- a/Runtime/Controls/Internal/InputFieldNavGate.cs
+++ b/Runtime/Controls/Internal/InputFieldNavGate.cs
@@ -53,11 +53,27 @@ namespace PromptUGUI.Controls.Internal
                 _input.DeactivateInputField();
                 _suppressUntilDeactivated = false;
             }
+            // Pointer 模式被点中（用户改用鼠标）→ 放弃抑制，保留编辑。
+            // (Symmetric with LateUpdate's escape-hatch — T1-M2 fold-in.)
+            else if (!UI.Navigation.IsDirectional)
+            {
+                _suppressUntilDeactivated = false;
+            }
         }
 
         public void OnSubmit(BaseEventData eventData)
         {
-            // Task 2 实现：未编辑 + 导航启用 → 进编辑。此处先留空，Task 1 只管抑制。
+            if (!UI.Navigation.IsEnabled) return;
+            if (_input == null || !_input.IsInteractable()) return;
+            if (!_input.isFocused)
+            {
+                // TMP's own ISubmitHandler (runs before this gate in component order)
+                // already called ActivateInputField().  We call it again to be safe if
+                // execution order ever changes, and to own the "enter edit" intent clearly.
+                _input.ActivateInputField();
+                _suppressUntilDeactivated = false;
+            }
+            // Already editing: let TMP's default OnSubmit handle confirm/newline.
         }
 
         public void OnDeselect(BaseEventData eventData) => _suppressUntilDeactivated = false;

--- a/Runtime/Controls/Internal/InputFieldNavGate.cs
+++ b/Runtime/Controls/Internal/InputFieldNavGate.cs
@@ -65,15 +65,13 @@ namespace PromptUGUI.Controls.Internal
         {
             if (!UI.Navigation.IsEnabled) return;
             if (_input == null || !_input.IsInteractable()) return;
+            // Enter-edit: TMP's own OnSubmit (runs first) already scheduled activation
+            // (m_ShouldActivateNextUpdate). Do NOT ActivateInputField() here — on a single-line
+            // *confirm* TMP has already DeactivateInputField()'d synchronously, so re-activating
+            // would bounce the field back into edit instead of returning to navigation. We only
+            // clear the suppress flag so the gate doesn't fight TMP's intentional activation.
             if (!_input.isFocused)
-            {
-                // TMP's own ISubmitHandler (runs before this gate in component order)
-                // already called ActivateInputField().  We call it again to be safe if
-                // execution order ever changes, and to own the "enter edit" intent clearly.
-                _input.ActivateInputField();
                 _suppressUntilDeactivated = false;
-            }
-            // Already editing: let TMP's default OnSubmit handle confirm/newline.
         }
 
         public void OnDeselect(BaseEventData eventData) => _suppressUntilDeactivated = false;

--- a/Runtime/Controls/Internal/InputFieldNavGate.cs.meta
+++ b/Runtime/Controls/Internal/InputFieldNavGate.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5df006f33755d7e40b685421956670e7

--- a/Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs
+++ b/Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using NUnit.Framework;
 using PromptUGUI.Application;
 using PromptUGUI.Controls;
+using R3;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.TestTools;
@@ -36,6 +37,43 @@ namespace PromptUGUI.Tests.PlayMode.Navigation
 
             Assert.IsFalse(field.IsEditing,
                 "directional-select must NOT activate edit mode (two-level nav)");
+        }
+
+        [UnityTest]
+        public IEnumerator Submit_OnFocusedNotEditingField_EntersEditMode()
+        {
+            UI.UseGamepadNavigation();
+            UI.Navigation.NoteDirectionalInput();
+            var s = Open("<InputField id='f'/>");
+            var field = s.Get<InputField>("f");
+            var es = EventSystem.current;
+            es.SetSelectedGameObject(field.GameObject);
+            yield return null; yield return null;
+            Assert.IsFalse(field.IsEditing, "precondition: selected-not-editing");
+
+            ExecuteEvents.Execute(field.GameObject, new BaseEventData(es), ExecuteEvents.submitHandler);
+            yield return null; yield return null;
+
+            Assert.IsTrue(field.IsEditing, "Submit must enter edit mode");
+        }
+
+        [UnityTest]
+        public IEnumerator Submit_ToEnterEdit_DoesNotFireSubmitEvent()
+        {
+            UI.UseGamepadNavigation();
+            UI.Navigation.NoteDirectionalInput();
+            var s = Open("<InputField id='f'/>");
+            var field = s.Get<InputField>("f");
+            bool fired = false;
+            field.OnSubmit.Subscribe(_ => fired = true).AddTo(s);
+            var es = EventSystem.current;
+            es.SetSelectedGameObject(field.GameObject);
+            yield return null; yield return null;
+
+            ExecuteEvents.Execute(field.GameObject, new BaseEventData(es), ExecuteEvents.submitHandler);
+            yield return null;
+
+            Assert.IsFalse(fired, "entering edit via Submit must not fire the OnSubmit business event");
         }
     }
 }

--- a/Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs
+++ b/Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs
@@ -54,6 +54,7 @@ namespace PromptUGUI.Tests.PlayMode.Navigation
             ExecuteEvents.Execute(field.GameObject, new BaseEventData(es), ExecuteEvents.submitHandler);
             yield return null; yield return null;
 
+            // Validates the gate does NOT interfere with TMP's native submit-to-activate path (not the gate's positive contribution).
             Assert.IsTrue(field.IsEditing, "Submit must enter edit mode");
         }
 
@@ -74,6 +75,29 @@ namespace PromptUGUI.Tests.PlayMode.Navigation
             yield return null;
 
             Assert.IsFalse(fired, "entering edit via Submit must not fire the OnSubmit business event");
+        }
+
+        [UnityTest]
+        public IEnumerator Submit_WhileEditingField_StillFiresSubmitEvent()
+        {
+            UI.UseGamepadNavigation();
+            UI.Navigation.NoteDirectionalInput();
+            var s = Open("<InputField id='f'/>");
+            var field = s.Get<InputField>("f");
+            // Enter edit mode first (nav-Submit on the focused-not-editing field).
+            ExecuteEvents.Execute(field.GameObject, new BaseEventData(EventSystem.current),
+                ExecuteEvents.submitHandler);
+            yield return null; yield return null;
+            Assert.IsTrue(field.IsEditing, "precondition: must be editing");
+
+            bool fired = false;
+            field.OnSubmit.Subscribe(_ => fired = true).AddTo(s);
+            // Confirm-submit while editing — the business event must fire.
+            ExecuteEvents.Execute(field.GameObject, new BaseEventData(EventSystem.current),
+                ExecuteEvents.submitHandler);
+            yield return null;
+
+            Assert.IsTrue(fired, "confirm-Submit on an editing field must fire the business event");
         }
     }
 }

--- a/Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs
+++ b/Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs
@@ -147,5 +147,26 @@ namespace PromptUGUI.Tests.PlayMode.Navigation
             yield return null; yield return null;
             Assert.IsFalse(field.IsEditing, "Cancel/Esc must exit edit mode back to navigation");
         }
+
+        [UnityTest]
+        public IEnumerator Submit_ConfirmOnSingleLineField_ExitsEditMode()
+        {
+            UI.UseGamepadNavigation();
+            UI.Navigation.NoteDirectionalInput();
+            var s = Open("<InputField id='f' lineType='single'/>");
+            var field = s.Get<InputField>("f");
+            var es = EventSystem.current;
+            es.SetSelectedGameObject(field.GameObject);
+            yield return null; yield return null;
+            // Enter edit, then confirm.
+            ExecuteEvents.Execute(field.GameObject, new BaseEventData(es), ExecuteEvents.submitHandler);
+            yield return null; yield return null;
+            Assert.IsTrue(field.IsEditing, "precondition: editing");
+
+            ExecuteEvents.Execute(field.GameObject, new BaseEventData(es), ExecuteEvents.submitHandler);  // confirm
+            yield return null; yield return null;
+
+            Assert.IsFalse(field.IsEditing, "single-line confirm-Submit must return to navigation, not bounce back to edit");
+        }
     }
 }

--- a/Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs
+++ b/Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs
@@ -99,5 +99,53 @@ namespace PromptUGUI.Tests.PlayMode.Navigation
 
             Assert.IsTrue(fired, "confirm-Submit on an editing field must fire the business event");
         }
+
+        [UnityTest]
+        public IEnumerator PointerSelect_StillEntersEditImmediately()
+        {
+            UI.UseGamepadNavigation();
+            UI.Navigation.NotePointerInput();                  // Mode = Pointer
+            var s = Open("<InputField id='f'/>");
+            var field = s.Get<InputField>("f");
+            var es = EventSystem.current;
+            // 指针点击路径：直接走 TMP 的 OnPointerClick → 默认激活，gate 不抑制
+            ExecuteEvents.Execute(field.GameObject, new PointerEventData(es), ExecuteEvents.pointerClickHandler);
+            yield return null; yield return null;
+            Assert.IsTrue(field.IsEditing, "pointer click must enter edit immediately (mouse UX unchanged)");
+        }
+
+        [UnityTest]
+        public IEnumerator NavDisabled_DefaultBehaviorUnchanged()
+        {
+            // 不调 UseGamepadNavigation：gate 挂着但 IsEnabled=false → OnSelect 不抑制
+            var s = Open("<InputField id='f'/>");
+            var field = s.Get<InputField>("f");
+            // SetSelectedGameObject 同步触发 OnSelect（即使无 InputModule），bare EventSystem 即可
+            if (EventSystem.current == null)
+                new GameObject("ES_NavDisabled", typeof(EventSystem));
+            EventSystem.current.SetSelectedGameObject(field.GameObject);
+            yield return null; yield return null;
+            // 桌面默认：选中即编辑；gate 因 IsEnabled=false 不撤销
+            Assert.IsTrue(field.IsEditing, "with nav disabled, default TMP behavior must be untouched");
+        }
+
+        [UnityTest]
+        public IEnumerator Cancel_ExitsEditMode()
+        {
+            UI.UseGamepadNavigation();
+            UI.Navigation.NoteDirectionalInput();
+            var s = Open("<InputField id='f'/>");
+            var field = s.Get<InputField>("f");
+            var es = EventSystem.current;
+            es.SetSelectedGameObject(field.GameObject);
+            yield return null; yield return null;
+            ExecuteEvents.Execute(field.GameObject, new BaseEventData(es), ExecuteEvents.submitHandler);  // 进编辑
+            yield return null; yield return null;
+            Assert.IsTrue(field.IsEditing, "precondition: editing");
+
+            ExecuteEvents.Execute(field.GameObject, new BaseEventData(es), ExecuteEvents.cancelHandler);  // Esc/B
+            yield return null; yield return null;
+            Assert.IsFalse(field.IsEditing, "Cancel/Esc must exit edit mode back to navigation");
+        }
     }
 }

--- a/Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs
+++ b/Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs
@@ -1,0 +1,41 @@
+using System.Collections;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.PlayMode.Navigation
+{
+    public class InputFieldNavPlayTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static PromptUGUI.Application.Screen Open(string body)
+        {
+            string xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{body}</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S");
+        }
+
+        [UnityTest]
+        public IEnumerator DirectionalSelect_DoesNotEnterEditMode()
+        {
+            UI.UseGamepadNavigation();
+            UI.Navigation.NoteDirectionalInput();              // Mode = Directional
+            var s = Open("<InputField id='f'/><Btn id='b'>B</Btn>");
+            var field = s.Get<InputField>("f");
+            var es = EventSystem.current;
+
+            es.SetSelectedGameObject(field.GameObject);        // 模拟导航选中
+            yield return null;                                  // 让 TMP 处理 activate-then-suppress
+            yield return null;
+
+            Assert.IsFalse(field.IsEditing,
+                "directional-select must NOT activate edit mode (two-level nav)");
+        }
+    }
+}

--- a/Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs.meta
+++ b/Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d26c94f0278c40e4faab08c91b2f9066

--- a/docs~/superpowers/plans/2026-06-29-inputfield-nav-edit-mode.md
+++ b/docs~/superpowers/plans/2026-06-29-inputfield-nav-edit-mode.md
@@ -1,0 +1,423 @@
+# InputField 方向导航两级编辑模式 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 `<InputField>` 在手柄/键盘方向导航下走"两级模型"——导航选中只聚焦不进编辑（方向键可移上/移出），按 Submit 才进编辑，Esc/Cancel 退出。
+
+**Architecture:** 在 InputField 根 GO 上挂一个伴随组件 `InputFieldNavGate`（`ISelectHandler`/`ISubmitHandler`/`IDeselectHandler`）。导航选中（`UI.Navigation.IsEnabled && IsDirectional`）时把 TMP 的自动激活在下一 tick 撤销（`DeactivateInputField`，避开同帧 `m_AllowInput=false` 的竞态）；Submit 在未编辑时 `ActivateInputField`。指针选中（Pointer 模式）保持默认立即编辑。纯指针项目门控关闭、完全 inert。
+
+**Tech Stack:** Unity 6, TMPro `TMP_InputField`, uGUI EventSystem (`ISelectHandler`/`ISubmitHandler`/`IDeselectHandler`), New Input System（仅设备检测在主特性里，本计划不碰 InputSystem 类型）, R3, NUnit + Unity Test Framework（PlayMode 主测 + EditMode 纯逻辑）。
+
+设计源：`docs~/superpowers/specs/2026-06-29-inputfield-nav-edit-mode-design.md`。
+承接主特性：`docs~/superpowers/specs/2026-06-29-gamepad-keyboard-navigation-design.md`。
+
+## Global Constraints
+
+- **严格附加**：不改 `<InputField>` 既有公共属性 / XML 语义；不新增 XML 属性（v1 行为自动）。
+- **门控**：所有新行为仅当 `UI.Navigation.IsEnabled` 为真时生效；Pointer 模式选中保持默认（鼠标点 = 立即编辑）。
+- **WebGL 安全**：同步逻辑，禁止 `System.Threading.Task` / `TaskCompletionSource`（本计划无异步）。
+- **不需 `#if ENABLE_INPUT_SYSTEM`**：只用 EventSystem/Selectable/TMP，不引用 InputSystem 类型。门控走 `UI.Navigation.IsEnabled` / `IsDirectional`（已是 `internal`，InputField 在 Runtime 同程序集可见）。
+- **Variant 不重建 GameObject**：gate 是 OnAttached 时一次性 AddComponent，不在 ReSolve 中增删。
+- **测试经 Unity MCP**：改源后 `refresh_unity(compile=request, mode=force)` → `read_console(types=[error])` 零编译错误 → `run_tests` 轮询 `get_test_job`。PlayMode `init_timeout=120000`。
+- **lint**：`dotnet format --verify-no-changes --severity warn .lint/PromptUGUI.Lint.slnx` exit 0；C# LangVersion 9（无 C#10+ 语法）。
+- **SKILL 同步**：本特性改变 InputField 在导航下的行为 → 必须在同 PR 更新 C# SKILL + `reference/navigation.md`（英文）。
+
+### ⚠️ TMP 内部经验性风险点（实现期用 PlayMode 实测校正，测试断言是判据）
+
+1. **同帧 activate→deactivate 竞态**：TMP `OnSelect` 调 `ActivateInputField()` 只置 `m_ShouldActivateNextUpdate`，`m_AllowInput` 当帧仍 false；此时同步 `DeactivateInputField()` 会因 `m_AllowInput==false` 提前返回、**不能**取消激活。故撤销必须**延后到激活已生效之后**（gate 用一个 suppress 标志 + `LateUpdate`/`Update` tick，在 `_input.isFocused` 变 true 后再 `DeactivateInputField`）。可能有 1 帧 caret（渲染在 LateUpdate 后，通常不可见）——PlayMode 测试确认无残留编辑态即可。
+2. **OnSubmit 在未聚焦时是否误发 submit 事件**：进编辑用的 Enter 不应触发 `OnSubmit` 业务事件。实测 TMP 未聚焦时 `OnSubmit` 行为；若会误发，gate 在"未编辑→激活"分支里需吞掉/不转发（Task 2 断言 `OnSubmit` 流在进编辑时不发）。
+3. **Esc/Cancel 退出**：TMP 默认 `ICancelHandler`/Escape 已会 `DeactivateInputField`。Task 3 仅**断言**该默认成立；若某版本不成立再补 gate 的 `OnCancel`。
+
+---
+
+## Task 1: InputFieldNavGate — 导航选中抑制自动编辑
+
+**Files:**
+- Create: `Runtime/Controls/Internal/InputFieldNavGate.cs`
+- Modify: `Runtime/Controls/InputField.cs`（OnAttached 末尾 AddComponent + 暴露 `internal bool IsEditing`）
+- Test: `Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs`
+
+**Interfaces:**
+- Consumes: `UI.Navigation.IsEnabled`（public）、`UI.Navigation.IsDirectional`（internal，同程序集可见）、`TMP_InputField.isFocused` / `ActivateInputField()` / `DeactivateInputField()`。
+- Produces:
+  - `InputFieldNavGate : MonoBehaviour, ISelectHandler, ISubmitHandler, IDeselectHandler`（internal），字段 `TMP_InputField _input`，方法 `internal void Init(TMP_InputField input)`。
+  - `InputField.IsEditing`（`internal bool` → `_input != null && _input.isFocused`），供测试与后续任务断言编辑态。
+
+- [ ] **Step 1: 写失败的 PlayMode 测试**
+
+`Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs`：
+```csharp
+using System.Collections;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.TestTools;
+
+namespace PromptUGUI.Tests.PlayMode.Navigation
+{
+    public class InputFieldNavPlayTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static Screen Open(string body)
+        {
+            string xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{body}</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S");
+        }
+
+        [UnityTest]
+        public IEnumerator DirectionalSelect_DoesNotEnterEditMode()
+        {
+            UI.UseGamepadNavigation();
+            UI.Navigation.NoteDirectionalInput();              // Mode = Directional
+            var s = Open("<InputField id='f'/><Btn id='b'>B</Btn>");
+            var field = s.Get<InputField>("f");
+            var es = EventSystem.current;
+
+            es.SetSelectedGameObject(field.GameObject);        // 模拟导航选中
+            yield return null;                                  // 让 TMP 处理 activate-then-suppress
+            yield return null;
+
+            Assert.IsFalse(field.IsEditing,
+                "directional-select must NOT activate edit mode (two-level nav)");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])      # 须先有 InputField.IsEditing 才能编译——见 Step 3 先补桩
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], init_timeout=120000)
+mcp__UnityMCP__get_test_job(job_id=..., wait_timeout=90)
+```
+Expected: `DirectionalSelect_DoesNotEnterEditMode` FAIL（默认 TMP 桌面会自动编辑 → `IsEditing==true`）。
+（注：为能编译，Step 3 先加 `InputField.IsEditing` 桩 + 测试引用；红是因为行为未实现，不是编译失败。）
+
+- [ ] **Step 3: 实现 gate + 接入 InputField**
+
+`Runtime/Controls/Internal/InputFieldNavGate.cs`：
+```csharp
+using PromptUGUI.Application;
+using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace PromptUGUI.Controls.Internal
+{
+    /// <summary>
+    /// 两级方向导航门：导航（Directional）选中 TMP_InputField 时只聚焦不进编辑，
+    /// 让方向键经 Selectable.OnMove 正常导航；Submit 才进编辑。指针选中（Pointer 模式）
+    /// 保持 TMP 默认立即编辑。仅当 UI.Navigation.IsEnabled 时生效。
+    /// </summary>
+    internal sealed class InputFieldNavGate : MonoBehaviour,
+        ISelectHandler, ISubmitHandler, IDeselectHandler
+    {
+        private TMP_InputField _input;
+        private bool _suppressUntilDeactivated;
+
+        internal void Init(TMP_InputField input) => _input = input;
+
+        public void OnSelect(BaseEventData eventData)
+        {
+            // 导航选中：标记下一 tick 撤销 TMP 的自动激活（同帧撤销有 m_AllowInput 竞态，见计划风险点 1）。
+            if (UI.Navigation.IsEnabled && UI.Navigation.IsDirectional)
+                _suppressUntilDeactivated = true;
+        }
+
+        // TMP 的激活延后到 LateUpdate 才令 isFocused=true；本组件 AddComponent 晚于 TMP，
+        // LateUpdate 在其后运行 → 此刻 isFocused 已 true，可安全 DeactivateInputField。
+        private void LateUpdate()
+        {
+            if (!_suppressUntilDeactivated) return;
+            if (_input != null && _input.isFocused)
+            {
+                _input.DeactivateInputField();
+                _suppressUntilDeactivated = false;
+            }
+            // Pointer 模式被点中（用户改用鼠标）→ 放弃抑制，保留编辑。
+            else if (!UI.Navigation.IsDirectional)
+            {
+                _suppressUntilDeactivated = false;
+            }
+        }
+
+        public void OnSubmit(BaseEventData eventData)
+        {
+            // Task 2 实现：未编辑 + 导航启用 → 进编辑。此处先留空，Task 1 只管抑制。
+        }
+
+        public void OnDeselect(BaseEventData eventData) => _suppressUntilDeactivated = false;
+    }
+}
+```
+
+`Runtime/Controls/InputField.cs`：OnAttached 末尾（`PromptUGUI.Application.UI.Locale.Changed += ApplyFont;` 之后）追加：
+```csharp
+            var navGate = GameObject.AddComponent<Internal.InputFieldNavGate>();
+            navGate.Init(_input);
+```
+并新增（放在 `TextValue` 属性附近）：
+```csharp
+        // True when the underlying field is in edit mode (caret active). Used by the
+        // two-level navigation gate and its tests.
+        internal bool IsEditing => _input != null && _input.isFocused;
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], init_timeout=120000)
+mcp__UnityMCP__get_test_job(job_id=..., wait_timeout=90)
+```
+Expected: `DirectionalSelect_DoesNotEnterEditMode` PASS。
+> 实测风险点 1：若 1 帧未撤销，加多一帧 yield 或把撤销逻辑也放进 `Update`（双保险）。撤销动作以"`isFocused` 由 true 变 false"为准。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Controls/Internal/InputFieldNavGate.cs Runtime/Controls/InputField.cs Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs
+git commit -m "feat(nav): InputField two-level — directional-select doesn't enter edit mode"
+```
+
+---
+
+## Task 2: Submit 进编辑（且不误发 submit 事件）
+
+**Files:**
+- Modify: `Runtime/Controls/Internal/InputFieldNavGate.cs:OnSubmit`
+- Test: `Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs`（新增 2 个 `[UnityTest]`）
+
+**Interfaces:**
+- Consumes: Task 1 的 `InputFieldNavGate` + `InputField.IsEditing` + `InputField.OnSubmit`（已存在 `Observable<string>`）。
+- Produces: 无新公共面；`OnSubmit` 行为：未编辑 + 导航启用 → `ActivateInputField()`。
+
+- [ ] **Step 1: 写失败测试**
+
+追加到 `InputFieldNavPlayTests`：
+```csharp
+        [UnityTest]
+        public IEnumerator Submit_OnFocusedNotEditingField_EntersEditMode()
+        {
+            UI.UseGamepadNavigation();
+            UI.Navigation.NoteDirectionalInput();
+            var s = Open("<InputField id='f'/>");
+            var field = s.Get<InputField>("f");
+            var es = EventSystem.current;
+            es.SetSelectedGameObject(field.GameObject);
+            yield return null; yield return null;
+            Assert.IsFalse(field.IsEditing, "precondition: selected-not-editing");
+
+            ExecuteEvents.Execute(field.GameObject, new BaseEventData(es), ExecuteEvents.submitHandler);
+            yield return null; yield return null;
+
+            Assert.IsTrue(field.IsEditing, "Submit must enter edit mode");
+        }
+
+        [UnityTest]
+        public IEnumerator Submit_ToEnterEdit_DoesNotFireSubmitEvent()
+        {
+            UI.UseGamepadNavigation();
+            UI.Navigation.NoteDirectionalInput();
+            var s = Open("<InputField id='f'/>");
+            var field = s.Get<InputField>("f");
+            bool fired = false;
+            field.OnSubmit.Subscribe(_ => fired = true).AddTo(s);
+            var es = EventSystem.current;
+            es.SetSelectedGameObject(field.GameObject);
+            yield return null; yield return null;
+
+            ExecuteEvents.Execute(field.GameObject, new BaseEventData(es), ExecuteEvents.submitHandler);
+            yield return null;
+
+            Assert.IsFalse(fired, "entering edit via Submit must not fire the OnSubmit business event");
+        }
+```
+（顶部按需 `using R3;`。）
+
+- [ ] **Step 2: 跑确认失败**（命令同 Task 1 Step 2）。Expected: 两个新测试 FAIL（OnSubmit 仍空，不进编辑）。
+
+- [ ] **Step 3: 实现 OnSubmit**
+
+`InputFieldNavGate.OnSubmit` 改为：
+```csharp
+        public void OnSubmit(BaseEventData eventData)
+        {
+            if (!UI.Navigation.IsEnabled) return;
+            if (_input == null || !_input.IsInteractable()) return;
+            if (!_input.isFocused)
+            {
+                _input.ActivateInputField();   // 进编辑级
+                _suppressUntilDeactivated = false;
+            }
+            // 已在编辑：交给 TMP 默认 OnSubmit（确认/换行），本 gate 不插手。
+        }
+```
+> 实测风险点 2：若 TMP 未聚焦时其 `OnSubmit` 仍会触发业务 `onSubmit`（令 `DoesNotFireSubmitEvent` 失败），则在此用一个一次性标志吞掉那一次 `_submit` 转发——但优先实测确认 TMP 是否真的会发；多数版本未聚焦不发。
+
+- [ ] **Step 4: 跑确认通过**（命令同上）。Expected: 两测试 PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Controls/Internal/InputFieldNavGate.cs Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs
+git commit -m "feat(nav): InputField two-level — Submit enters edit mode (no spurious submit)"
+```
+
+---
+
+## Task 3: 回归——指针仍立即编辑 / 导航未启用不变 / Esc 退出
+
+**Files:**
+- Test: `Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs`（新增 3 个 `[UnityTest]`）
+- （预期无源改动；若某断言因 TMP 版本不成立，最小补 `InputFieldNavGate`。）
+
+**Interfaces:** Consumes Task 1/2 成果；无新产出。
+
+- [ ] **Step 1: 写测试**
+
+```csharp
+        [UnityTest]
+        public IEnumerator PointerSelect_StillEntersEditImmediately()
+        {
+            UI.UseGamepadNavigation();
+            UI.Navigation.NotePointerInput();                  // Mode = Pointer（鼠标）
+            var s = Open("<InputField id='f'/>");
+            var field = s.Get<InputField>("f");
+            var es = EventSystem.current;
+            // 指针点击路径：直接走 TMP 的 OnPointerClick → 默认激活
+            ExecuteEvents.Execute(field.GameObject, new PointerEventData(es), ExecuteEvents.pointerClickHandler);
+            yield return null; yield return null;
+            Assert.IsTrue(field.IsEditing, "pointer click must enter edit immediately (mouse UX unchanged)");
+        }
+
+        [UnityTest]
+        public IEnumerator NavDisabled_DefaultBehaviorUnchanged()
+        {
+            // 不调 UseGamepadNavigation：gate 仍挂着但 IsEnabled=false → 不抑制
+            var s = Open("<InputField id='f'/>");
+            var field = s.Get<InputField>("f");
+            // 无 EventSystem 时建一个，模拟选中
+            if (EventSystem.current == null)
+                new GameObject("ES", typeof(EventSystem), typeof(StandaloneInputModule));
+            EventSystem.current.SetSelectedGameObject(field.GameObject);
+            yield return null; yield return null;
+            // 桌面默认：选中即编辑；gate 因 IsEnabled=false 不撤销
+            Assert.IsTrue(field.IsEditing, "with nav disabled, default TMP behavior must be untouched");
+        }
+
+        [UnityTest]
+        public IEnumerator Cancel_ExitsEditMode()
+        {
+            UI.UseGamepadNavigation();
+            UI.Navigation.NoteDirectionalInput();
+            var s = Open("<InputField id='f'/>");
+            var field = s.Get<InputField>("f");
+            var es = EventSystem.current;
+            es.SetSelectedGameObject(field.GameObject);
+            yield return null; yield return null;
+            ExecuteEvents.Execute(field.GameObject, new BaseEventData(es), ExecuteEvents.submitHandler);  // 进编辑
+            yield return null; yield return null;
+            Assert.IsTrue(field.IsEditing, "precondition: editing");
+
+            ExecuteEvents.Execute(field.GameObject, new BaseEventData(es), ExecuteEvents.cancelHandler);  // Esc/B
+            yield return null; yield return null;
+            Assert.IsFalse(field.IsEditing, "Cancel/Esc must exit edit mode back to navigation");
+        }
+```
+
+- [ ] **Step 2: 跑确认**（命令同上）。Expected: 三测试结果——`PointerSelect` / `NavDisabled` 应直接 PASS（验证门控正确）；`Cancel_ExitsEditMode` 验证 TMP 默认 Cancel→退出（风险点 3）。若 `Cancel` FAIL，进 Step 3。
+
+- [ ] **Step 3: （仅当 Cancel 失败）补 gate.OnCancel**
+
+让 gate 实现 `ICancelHandler`：
+```csharp
+        public void OnCancel(BaseEventData eventData)
+        {
+            if (_input != null && _input.isFocused) _input.DeactivateInputField();
+        }
+```
+（类签名加 `, ICancelHandler`。）否则本步无源改动。
+
+- [ ] **Step 4: 跑确认全绿**（命令同上）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Tests/PlayMode/Navigation/InputFieldNavPlayTests.cs Runtime/Controls/Internal/InputFieldNavGate.cs
+git commit -m "test(nav): InputField two-level regressions — pointer/disabled/cancel"
+```
+
+---
+
+## Task 4: SKILL 文档（英文）
+
+**Files:**
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md`（导航小节）
+- Modify: `.claude/skills/authoring-promptugui-xml/reference/navigation.md`（InputField 行为说明）
+
+**Interfaces:** 无代码；文档同步本特性行为（CLAUDE.md SKILL-sync 硬规矩）。
+
+- [ ] **Step 1: C# SKILL 导航小节追加**
+
+在 `scripting-promptugui-csharp/SKILL.md` 的 Gamepad/Keyboard Navigation 小节追加一段：
+```markdown
+**InputField uses a two-level model under directional navigation.** When `UI.UseGamepadNavigation()`
+is active, navigating (d-pad / arrows) onto a text field **focuses** it without entering edit mode, so
+directional input keeps moving between controls. Press **Submit** (gamepad A / keyboard Enter) on the
+focused field to **enter edit mode** (caret active); press **Cancel** (gamepad B / keyboard Esc) — or
+Enter on a single-line field — to confirm and return to navigation. A **pointer click** still enters
+edit immediately (mouse UX unchanged). No markup is required; the behavior is automatic when navigation
+is enabled.
+```
+
+- [ ] **Step 2: navigation.md 补 InputField 说明**
+
+在 `reference/navigation.md` 合适处（焦点视觉 / selectable-tag 列表附近）加：
+```markdown
+### Text fields (two-level edit)
+
+A `<InputField>` participates in directional navigation like any selectable, but with a two-level model:
+directional input **navigates onto and off** a focused field without typing into it; press **Submit**
+(A / Enter) to **enter edit mode**, and **Cancel** (B / Esc), or Enter on a single-line field, to leave it.
+This mirrors console UIs and keeps arrow keys from getting trapped in the field. Pointer click still edits
+immediately. (Active only when `UI.UseGamepadNavigation()` is enabled.)
+```
+
+- [ ] **Step 3: 跑 lint + 整套件终检**
+
+```bash
+dotnet format --verify-no-changes --severity warn .lint/PromptUGUI.Lint.slnx   # exit 0
+```
+```
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], init_timeout=120000)   # 全绿（含新 InputFieldNavPlayTests）
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])                        # 回归全绿
+```
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add .claude/skills/scripting-promptugui-csharp/SKILL.md .claude/skills/authoring-promptugui-xml/reference/navigation.md
+git commit -m "docs(nav): document InputField two-level edit mode in skills"
+```
+
+---
+
+## 自评（spec 覆盖检查）
+
+- spec §2 两级模型 → Task 1（抑制自动编辑）+ Task 2（Submit 进编辑）+ Task 3（Cancel 退出）。✅
+- spec §3 门控（仅启用时 / 指针仍立即编辑 / 全平台一致）→ Task 3 `PointerSelect` + `NavDisabled` 回归。✅
+- spec §5 边界（disabled 不参与）→ gate `OnSubmit` 检 `IsInteractable`；disabled 字段 TMP 本就不可选。✅
+- spec §4 单行 Up/Down 退出"可选增强" → **明确移出 v1**（与 TMP 抢键、收益小），留作后续；spec §4/§6 已标"可选"。计划不含。
+- spec §6 机制 A/B → 选 A（伴随组件，无 Selectable 内部复刻脆弱性）；风险点 1-3 已在 Global Constraints 下标注、由 PlayMode 测试敲定。✅
+- spec §9 SKILL → Task 4。✅
+- 类型一致性：`InputFieldNavGate`（Init/OnSelect/OnSubmit/OnDeselect[/OnCancel]）、`InputField.IsEditing` 在各任务引用一致。✅

--- a/docs~/superpowers/specs/2026-06-29-inputfield-nav-edit-mode-design.md
+++ b/docs~/superpowers/specs/2026-06-29-inputfield-nav-edit-mode-design.md
@@ -1,0 +1,91 @@
+# InputField 方向导航：两级编辑模式（设计）
+
+承接 `2026-06-29-gamepad-keyboard-navigation-design.md`（方向导航主特性，已合并 main / PR #91）。
+本文是其聚焦后续：让 `<InputField>` 在手柄/键盘方向导航下行为正确。
+
+## 1. 问题
+
+`<InputField>` 底层是 `TMP_InputField`（`Runtime/Controls/InputField.cs:57`，本身是 `Selectable`）。
+一旦它被**激活进入编辑态**（caret 闪烁），就独占键盘：方向键被 `OnUpdateSelected`
+拿去移动文本 caret，EventSystem 的 move 事件不再驱动导航 → 焦点卡在输入框上、移不出去。
+
+桌面平台上 Unity 默认**导航选中输入框即自动激活编辑态**（`shouldActivateOnSelect`，
+按**平台**而非输入设备门控）。所以：
+
+- PC 上键盘方向键选中输入框 → 立刻进编辑 → 方向键被吃；
+- **PC 上插手柄一样撞这堵墙**（平台门控，与设备无关）；
+- 真机主机平台才默认正确（主机上 `shouldActivateOnSelect=false`，选中只聚焦不编辑）。
+
+结论：库自己统一接管激活时机，而不是依赖平台默认。
+
+## 2. 设计：两级模型（导航 ↔ 编辑）
+
+| 级别 | 进入 | 方向输入 | 退出 |
+|---|---|---|---|
+| **导航级**（默认） | — | 在控件间移动焦点，**含移上/移出输入框**，焦点光标自由走 | — |
+| **编辑级** | 聚焦的输入框上按 **Submit**（手柄 A / 键盘 Enter） | 移动文本 caret | **Cancel**（手柄 B / 键盘 Esc）；单行框 Submit 确认即退出 |
+
+机理：导航选中输入框时**只聚焦不激活**（字段显示 Selected/Focused 视觉，作为普通
+Selectable 参与 `OnMove` 导航）；Submit 才 `ActivateInputField()` 进编辑。
+
+## 3. 范围与门控
+
+- **仅当 `UI.UseGamepadNavigation()` 已启用时生效**；纯指针项目零影响。
+- **指针点击输入框仍立即进编辑**（鼠标 UX 不变）——区分"指针选中"与"导航选中"。
+- 启用导航后**所有平台一致**（接管桌面默认，使 PC+键盘 / PC+手柄 / 主机 都走两级模型）。
+- "导航选中"判定 = 选中发生时 `UI.Navigation.IsDirectional`（Directional 模式）。
+  Pointer 模式下的选中（鼠标点）→ 保持默认激活。
+
+## 4. 退出与方向细节
+
+- **单行框**：Submit（Enter/A）确认并退出编辑回导航级。
+- **多行框**（`lineType=multi-newline`）：Enter 是插入换行，不能用来退出 → 用 Esc/Cancel 退出；
+  编辑态 Up/Down 移动 caret（多行有行间意义，**不**挪用）。
+- **可选增强（单行框）**：编辑态按 Up/Down（单行无 caret 意义）→ 退出编辑并向上/下导航，
+  少按一次 Esc。多行框不启用此增强。
+- **Tab**：保留经典逐框跳转（导航级），不受影响。
+
+## 5. 边界
+
+- `readOnly` / `password` / 数字等 contentType：同一模型（仍可进编辑态输入）。
+- `interactable=false`：本就不可聚焦（`TMP_InputField.interactable=false`），不参与。
+- **编辑中切到鼠标**（Mode 翻 Pointer）：保持编辑态（指针仍可编辑），不强制退出。
+- **焦点光标**：编辑态时输入框仍是选中项，光标默认仍显示在其旁（同时有 caret）。
+  v1 接受双指示；可选：编辑态隐藏导航光标以减干扰（标记为可选增强，非 v1 必须）。
+
+## 6. 机制决策（实现期定）
+
+抑制"导航选中即激活"两条候选路线，实现期用 TDD 验证择优：
+
+- **A. 伴随组件**：在 InputField 根 GO 挂一个 `MonoBehaviour`（`ISelectHandler`/`ISubmitHandler`），
+  `OnSelect` 时若 `IsEnabled && IsDirectional` → `DeactivateInputField()`（撤销 TMP 同帧激活，
+  或下帧守卫去激活）；`OnSubmit` 未编辑 → `ActivateInputField()`。
+  风险：TMP 的 `ActivateInputField` 延迟到 LateUpdate，同帧 Deactivate 的竞态需实测。
+- **B. 子类 `PuiInputField : TMP_InputField`**：override `OnSelect`，导航选中时只做 Selectable
+  高亮、跳过 `ActivateInputField()`；override/补 `OnSubmit` 进编辑。
+  风险：复刻 `Selectable.OnSelect` 行为的版本脆弱性；但无同帧竞态、更稳。
+
+倾向 B（无竞态），但以实测为准。无论哪条：**仅 `#if ENABLE_INPUT_SYSTEM` 不需要**
+（用的是 EventSystem/Selectable + TMP，不碰 InputSystem 类型）；门控走 `UI.Navigation.IsEnabled/IsDirectional`。
+
+## 7. 公共 API / 属性
+
+- v1 **不新增 XML 属性**，行为在导航启用后自动生效（橱窗 sample 已调 `UseGamepadNavigation`）。
+- 备选（暂不做）：`editOnFocus="true"` 让单个字段保留"选中即编辑"。记为未来选项。
+
+## 8. 测试（TDD 红先行）
+
+- **EditMode**（直接调接口，不依赖输入模拟）：
+  1. 启用导航 + `Mode=Directional`，对 InputField 触发"导航选中"→ 断言 `_input.isFocused == false`（未进编辑）。
+  2. 同上后触发 Submit → 断言 `isFocused == true`（进编辑）。
+  3. `Mode=Pointer` 触发选中（指针）→ 断言 `isFocused == true`（指针仍立即编辑）。
+  4. 未启用导航 → 默认行为不变（回归）。
+  5. 编辑态触发 Cancel/Esc → 断言退出编辑（`isFocused == false`）。
+- **PlayMode**（可选 smoke，InputTestFixture）：聚焦未编辑的输入框按方向键 → 选区移到相邻控件
+  （证明 `OnMove` 导航生效、字段没吃方向键）。
+
+## 9. SKILL 影响
+
+- **C# SKILL**（`scripting-promptugui-csharp`）：在导航小节补"InputField 两级编辑模式"——导航选中只聚焦、
+  Submit 进编辑、Cancel/Esc 退出；指针点击仍直接编辑。
+- **XML SKILL**：无新属性则仅在 `reference/navigation.md` 的 InputField 相关处补一句行为说明。


### PR DESCRIPTION
## What

Follow-up to gamepad/keyboard directional navigation (#91). A focused `TMP_InputField` in edit mode traps arrow keys, so directional nav couldn't move off it — pressing arrows on a field did nothing. This adds a **two-level model** so the field stops eating navigation.

| Level | Enter | Directional input | Exit |
|---|---|---|---|
| **Navigate** (default) | — | moves focus between controls, **including onto/off the field** | — |
| **Edit** | **Submit** (A / Enter) on the focused field | moves the text caret | **Cancel** (B / Esc), or Enter on a single-line field |

- **Pointer click still edits immediately** (mouse UX unchanged).
- Active only when `UI.UseGamepadNavigation()` is enabled; **nav-disabled projects are byte-for-byte unaffected**.
- No new XML attribute — automatic.

Mechanism: an `InputFieldNavGate` companion (`ISelect`/`ISubmit`/`IDeselectHandler`) on each `<InputField>`. On a directional select it suppresses TMP's auto-enter-edit (deferred `DeactivateInputField` once `isFocused`, avoiding the same-frame `m_AllowInput` race); the field then navigates like any Selectable. Submit enters edit (TMP's native path); the spurious business `OnSubmit` for that transition is suppressed by an `isFocused`-at-listener-time guard. No `#if ENABLE_INPUT_SYSTEM` needed (EventSystem/Selectable/TMP only).

Design: `docs~/superpowers/specs/2026-06-29-inputfield-nav-edit-mode-design.md` · Plan: `docs~/superpowers/plans/2026-06-29-inputfield-nav-edit-mode.md`

## Notable details (surfaced by review)

- **InputBox modal interaction verified.** A text-entry modal's field now opens focused-but-not-editing (press A/Enter to type); confirm still closes on the typed value, ESC still cancels. The `OnSubmit` suppression is precisely what stops the "enter-edit" keypress from prematurely dismissing the modal (TMP fires `SendOnSubmit` unconditionally, even when not focused).
- **`InputField.Dispose()` now removes the TMP UnityEvent listeners** before disposing the R3 subjects — fixes an `ObjectDisposedException` when a screen closes while a field is editing (e.g. closing a screen mid-edit). Correctly sequenced (Close disposes before the deferred Destroy).
- **Single-line confirm returns to navigation** (not bounce back to edit): the gate's `OnSubmit` does not re-activate — TMP already handles activation on enter-edit, and on a single-line confirm TMP deactivates synchronously, so re-activating would bounce. A red→green regression test locks this in.
- Business `OnSubmit` still fires on a real confirm (a Case-B test asserts TMP's `SendOnSubmit`-before-`DeactivateInputField` ordering, so a TMP upgrade reordering it would fail the test).

## Tests & lint

| Suite | Result |
|---|---|
| PlayMode | **168 / 168** (incl `InputFieldNavPlayTests` 8/8) |
| EditMode | **1973 / 1973** |
| LINT-CS `dotnet format --verify-no-changes --severity warn` | exit 0 |

Built subagent-driven: per-task review on each task, a whole-branch review at the end (found the single-line-confirm bounce defect → fixed + regression-tested), then controller verification.

## Visual QA (optional — automated tests cover the logic)

With `UI.UseGamepadNavigation()` enabled, on a screen with a text field:
1. Arrow/d-pad onto the field → it highlights but does NOT start editing; arrows keep moving to other controls.
2. Press A/Enter on the field → caret appears, you can type.
3. Single-line: Enter confirms and returns to navigation; multi-line: Esc/B exits.
4. Mouse click on the field → edits immediately (unchanged).

> Known follow-up (not blocking): `InputFieldNavPlayTests` leaks test EventSystems in TearDown (a pre-existing pattern in nav PlayMode tests) — a hygiene cleanup tracked for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)