### PR TITLE
fix: 模态方向导航逃逸到背后页面（焦点卡在首按钮、到不了同模态其它按钮）

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/reference/navigation.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/navigation.md
@@ -196,11 +196,11 @@ immediately. (Active only when `UI.UseGamepadNavigation()` is enabled.)
 
 ## Modal focus trap
 
-While a modal is open (MessageBox, InputBox, MarkdownBox, CenteredSlideBox, or any custom modal), directional navigation is **trapped inside the modal**. Arrow keys and gamepad stick cannot reach controls behind the modal, even if they are physically adjacent on screen. This is enforced every frame by `NavigationController`.
+While a modal is open (MessageBox, InputBox, MarkdownBox, CenteredSlideBox, or any custom modal), directional navigation is **confined to the modal**. Arrow keys and gamepad stick move freely among the modal's own controls but can never reach a control on the page behind the modal — even when a background control is physically closer on screen than the modal's own neighbour (uGUI's automatic navigation searches the whole scene and does not respect the modal boundary on its own).
 
-On close, the selection is **restored** to the control that was focused when the modal opened.
+This is achieved by wiring the modal's focusables into a self-contained navigation graph when it opens (re-wired on resize); `NavigationController` additionally snaps any stray selection back inside every frame as a backstop. On close, the selection is **restored** to the control that was focused when the modal opened.
 
-No XML markup is required for any of this — the modal stack wires the trap automatically.
+No XML markup is required for any of this — the modal stack wires it automatically.
 
 ---
 

--- a/Runtime/Application/Navigation/ExplicitNavigationResolver.cs
+++ b/Runtime/Application/Navigation/ExplicitNavigationResolver.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using PromptUGUI.Controls;
 using PromptUGUI.IR;
 using PromptUGUI.Variants;
+using UnityEngine;
 using UnityEngine.UI;
 
 namespace PromptUGUI.Application.Navigation
@@ -18,9 +19,32 @@ namespace PromptUGUI.Application.Navigation
         /// <c>null</c> at Screen.Open — no Add-block nodes are in <paramref name="nodeMap"/>
         /// yet at that point, so there is nothing to skip.
         /// </param>
+        /// <param name="confineRoot">
+        /// Non-null = confine mode (a modal). uGUI's <c>Automatic</c> navigation searches the
+        /// WHOLE scene, so a modal button's geometric neighbour can be a control on the page
+        /// behind the modal; pressing a direction then escapes the modal and the focus trap
+        /// snaps back to the first focusable, leaving the user stuck on the first button.
+        /// In confine mode EVERY focusable under <paramref name="confineRoot"/> is converted to
+        /// <c>Explicit</c> navigation whose neighbours are computed by the same geometric scoring
+        /// uGUI uses, but restricted to Selectables inside this subtree — so directional nav can
+        /// never leave the modal. Null = full-screen page: legacy behaviour (Automatic kept).
+        /// </param>
         public static void Resolve(Screen screen, IReadOnlyDictionary<ElementNode, Control> nodeMap,
-                                   VariantStore variants, HashSet<ElementNode> inactiveNodes = null)
+                                   VariantStore variants, HashSet<ElementNode> inactiveNodes = null,
+                                   GameObject confineRoot = null)
         {
+            // Candidate pool for confine mode: only Selectables inside the modal subtree.
+            List<Selectable> pool = null;
+            if (confineRoot != null)
+            {
+                // Confined neighbours are geometric, so the layout must be current. At modal open
+                // the overlay canvas is not sized yet and the HStack hasn't positioned its buttons;
+                // on ReSolve the preceding attribute/scale pass has dirtied the layout. A full
+                // canvas update sizes the canvas AND rebuilds the layout synchronously.
+                Canvas.ForceUpdateCanvases();
+                pool = new List<Selectable>(confineRoot.GetComponentsInChildren<Selectable>(false));
+            }
+
             foreach (var kv in nodeMap)
             {
                 var node = kv.Key;
@@ -32,42 +56,58 @@ namespace PromptUGUI.Application.Navigation
                 if (inactiveNodes != null && inactiveNodes.Contains(node)) continue;
 
                 var sel = control.GameObject.GetComponent<Selectable>();
+                if (sel == null) continue; // non-Selectable control: skip
 
                 var navMode = VariantResolver.ResolveAttribute(node, "nav", variants);
                 var up = VariantResolver.ResolveAttribute(node, "navUp", variants);
                 var down = VariantResolver.ResolveAttribute(node, "navDown", variants);
                 var left = VariantResolver.ResolveAttribute(node, "navLeft", variants);
                 var right = VariantResolver.ResolveAttribute(node, "navRight", variants);
-
                 bool hasExplicit = up != null || down != null || left != null || right != null;
-                if (navMode == null && !hasExplicit) continue;
-                if (sel == null) continue; // non-Selectable control: skip
 
                 if (navMode == "none")
                 {
                     sel.navigation = new UnityEngine.UI.Navigation { mode = UnityEngine.UI.Navigation.Mode.None };
                     continue;
                 }
-                if (!hasExplicit) continue;
 
-                // Fill unspecified directions with geometric neighbours so writing only one
-                // direction doesn't dead-end the other three (spec §7).
-                // Sel() returns null when the target is not currently live (e.g. it lives in
-                // an inactive variant Add block, or the id is a typo).  The ?? falls through
-                // to the geometric neighbour so the direction is never dead-ended.
-                // Inactive-block targets self-heal: ReSolve re-runs Resolve after
-                // ActivateAddBlock (Screen.cs:778 then :806), so the wire-up is automatic.
-                // Typo ids (declared nowhere) are also treated as geometric — the CLI lint rule
-                // PUI-NAV-UNKNOWN-TARGET is the sole static detector for typos.
-                var nav = new UnityEngine.UI.Navigation
+                if (confineRoot == null)
                 {
-                    mode = UnityEngine.UI.Navigation.Mode.Explicit,
-                    selectOnUp = Sel(screen, up) ?? sel.FindSelectableOnUp(),
-                    selectOnDown = Sel(screen, down) ?? sel.FindSelectableOnDown(),
-                    selectOnLeft = Sel(screen, left) ?? sel.FindSelectableOnLeft(),
-                    selectOnRight = Sel(screen, right) ?? sel.FindSelectableOnRight(),
-                };
-                sel.navigation = nav;
+                    // ── Full-screen page: only touch controls that opt in via nav attributes. ──
+                    if (!hasExplicit) continue;
+                    // Fill unspecified directions with geometric neighbours so writing only one
+                    // direction doesn't dead-end the other three (spec §7).
+                    // Sel() returns null when the target is not currently live (e.g. it lives in
+                    // an inactive variant Add block, or the id is a typo).  The ?? falls through
+                    // to the geometric neighbour so the direction is never dead-ended.
+                    // Inactive-block targets self-heal: ReSolve re-runs Resolve after
+                    // ActivateAddBlock (Screen.cs:778 then :806), so the wire-up is automatic.
+                    // Typo ids (declared nowhere) are also treated as geometric — the CLI lint rule
+                    // PUI-NAV-UNKNOWN-TARGET is the sole static detector for typos.
+                    sel.navigation = new UnityEngine.UI.Navigation
+                    {
+                        mode = UnityEngine.UI.Navigation.Mode.Explicit,
+                        selectOnUp = Sel(screen, up) ?? sel.FindSelectableOnUp(),
+                        selectOnDown = Sel(screen, down) ?? sel.FindSelectableOnDown(),
+                        selectOnLeft = Sel(screen, left) ?? sel.FindSelectableOnLeft(),
+                        selectOnRight = Sel(screen, right) ?? sel.FindSelectableOnRight(),
+                    };
+                }
+                else
+                {
+                    // ── Modal: cage EVERY focusable to in-subtree neighbours (no scene-wide escape). ──
+                    // Author-declared targets (by id) still win; unspecified directions fall to the
+                    // subtree-confined geometric neighbour instead of uGUI's scene-wide search.
+                    var t = sel.transform;
+                    sel.navigation = new UnityEngine.UI.Navigation
+                    {
+                        mode = UnityEngine.UI.Navigation.Mode.Explicit,
+                        selectOnUp = Sel(screen, up) ?? FindInSubtree(sel, t.rotation * Vector3.up, pool),
+                        selectOnDown = Sel(screen, down) ?? FindInSubtree(sel, t.rotation * Vector3.down, pool),
+                        selectOnLeft = Sel(screen, left) ?? FindInSubtree(sel, t.rotation * Vector3.left, pool),
+                        selectOnRight = Sel(screen, right) ?? FindInSubtree(sel, t.rotation * Vector3.right, pool),
+                    };
+                }
             }
         }
 
@@ -80,6 +120,50 @@ namespace PromptUGUI.Application.Navigation
             if (id == null) return null;
             if (!screen.TryGet(id, out var control)) return null;
             return control?.GameObject?.GetComponent<Selectable>();
+        }
+
+        // Subtree-confined mirror of uGUI's Selectable.FindSelectable(dir): picks the best
+        // candidate in direction <paramref name="dir"/> using the SAME scoring (dot / distance²
+        // from the source rect edge), but only among <paramref name="pool"/> (the modal subtree).
+        private static Selectable FindInSubtree(Selectable from, Vector3 dir, List<Selectable> pool)
+        {
+            if (pool == null) return null;
+            dir = dir.normalized;
+            var fromRt = from.transform as RectTransform;
+            Vector3 localDir = Quaternion.Inverse(from.transform.rotation) * dir;
+            Vector3 pos = from.transform.TransformPoint(GetPointOnRectEdge(fromRt, localDir));
+
+            float maxScore = Mathf.NegativeInfinity;
+            Selectable best = null;
+            for (int i = 0; i < pool.Count; i++)
+            {
+                var sel = pool[i];
+                if (sel == from || sel == null) continue;
+                if (!sel.IsInteractable() || sel.navigation.mode == UnityEngine.UI.Navigation.Mode.None) continue;
+
+                var selRt = sel.transform as RectTransform;
+                Vector3 selCenter = selRt != null ? (Vector3)selRt.rect.center : Vector3.zero;
+                Vector3 myVector = sel.transform.TransformPoint(selCenter) - pos;
+                float dot = Vector3.Dot(dir, myVector);
+                if (dot <= 0f) continue;
+
+                float score = dot / myVector.sqrMagnitude;
+                if (score > maxScore)
+                {
+                    maxScore = score;
+                    best = sel;
+                }
+            }
+            return best;
+        }
+
+        // Mirror of uGUI's Selectable.GetPointOnRectEdge.
+        private static Vector3 GetPointOnRectEdge(RectTransform rect, Vector2 dir)
+        {
+            if (rect == null) return Vector3.zero;
+            if (dir != Vector2.zero) dir /= Mathf.Max(Mathf.Abs(dir.x), Mathf.Abs(dir.y));
+            var r = rect.rect;
+            return r.center + Vector2.Scale(r.size, dir * 0.5f);
         }
     }
 }

--- a/Runtime/Application/Screen.cs
+++ b/Runtime/Application/Screen.cs
@@ -811,7 +811,27 @@ namespace PromptUGUI.Application
             ApplyCanvasScaler(RootGameObject.GetComponent<UnityEngine.UI.CanvasScaler>());
             ApplyScales();
             AttachPixelSnaps(RootGameObject);
-            Navigation.ExplicitNavigationResolver.Resolve(this, _nodeMap, Variants, inactiveNodes);
+            Navigation.ExplicitNavigationResolver.Resolve(this, _nodeMap, Variants, inactiveNodes, NavConfineRoot);
+        }
+
+        /// <summary>
+        /// Non-null = directional navigation is confined to this GameObject's subtree (a modal).
+        /// Set by <see cref="ConfineNavigationToSelf"/>; consumed by ReSolve so resizes re-cage.
+        /// </summary>
+        internal UnityEngine.GameObject NavConfineRoot { get; private set; }
+
+        /// <summary>
+        /// Cage directional navigation inside this screen so it cannot escape to controls on the
+        /// page behind it (modal focus correctness — see <see cref="Navigation.ExplicitNavigationResolver"/>).
+        /// Called by <see cref="UI.Modal"/> after the modal binds (buttons shown/hidden finalized).
+        /// </summary>
+        internal void ConfineNavigationToSelf()
+        {
+            NavConfineRoot = RootGameObject;
+            // The resolver forces a canvas update in confine mode so the geometric neighbours are
+            // computed against a current layout (the modal's overlay canvas is sized there too).
+            Navigation.ExplicitNavigationResolver.Resolve(this, _nodeMap, Variants,
+                inactiveNodes: null, confineRoot: NavConfineRoot);
         }
 
         // deferApplyTo 非 null（Screen.Open 首次构建）：Add 子树属性 Apply 延迟收进该列表，

--- a/Runtime/Application/UI.Modal.cs
+++ b/Runtime/Application/UI.Modal.cs
@@ -144,6 +144,12 @@ namespace PromptUGUI.Application
                             if (UI.Navigation.IsEnabled)
                             {
                                 slot.PrevSelected = prevSelected;
+                                // Cage directional nav inside this modal — Bind has finalized which
+                                // buttons are shown, so the geometric neighbours wire up correctly.
+                                // Without this, uGUI's scene-wide search lets a modal button's
+                                // neighbour be a control on the page behind it (focus escapes, then
+                                // the trap snaps back to the first button → "stuck on OK").
+                                screen.ConfineNavigationToSelf();
                                 // Re-apply after RunBind: Bind may show/hide buttons, so the
                                 // initial focus set by screen.Open() might be on a now-hidden
                                 // control. This ensures the first *visible* focusable is selected.

--- a/Tests/PlayMode/Navigation/ModalNavConfinementPlayTests.cs
+++ b/Tests/PlayMode/Navigation/ModalNavConfinementPlayTests.cs
@@ -1,0 +1,103 @@
+using System.Collections;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using PromptUGUI.Controls;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Tests.PlayMode.Navigation
+{
+    // Regression for the "focus stuck on OK, can't reach Cancel" bug: uGUI's Automatic
+    // navigation searches the whole scene, so a modal button's geometric neighbour can be a
+    // control on the page BEHIND the modal. Directional nav must be confined to the modal.
+    public class ModalNavConfinementPlayTests
+    {
+        private GameObject _es;
+        private GameObject _bgPage;
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            MessageBox.XmlSrc = "PromptUGUI/Modals/MessageBox.ui";
+            UI.SourceResolver = src =>
+            {
+                var ta = UnityEngine.Resources.Load<UnityEngine.TextAsset>(src);
+                if (ta == null)
+                    return AwaitableHelpers.Faulted<string>(
+                        new System.IO.IOException($"Resources lookup failed: {src}"));
+                return AwaitableHelpers.Completed(ta.text);
+            };
+            _es = new GameObject("EventSystem");
+            _es.AddComponent<EventSystem>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UI.ResetForTests();
+            if (_es != null) Object.DestroyImmediate(_es);
+            if (_bgPage != null) Object.DestroyImmediate(_bgPage);
+        }
+
+        private static bool InModalOrNull(Selectable s, GameObject root) =>
+            s == null || s.transform.IsChildOf(root.transform);
+
+        // A dense grid of active Buttons on a separate canvas — the "page behind the modal".
+        private void BuildBackgroundPage()
+        {
+            _bgPage = new GameObject("BgCanvas", typeof(Canvas), typeof(GraphicRaycaster));
+            _bgPage.GetComponent<Canvas>().renderMode = RenderMode.ScreenSpaceOverlay;
+            for (int i = 0; i < 48; i++)
+            {
+                var b = new GameObject($"bg{i}", typeof(RectTransform), typeof(UnityEngine.UI.Image),
+                    typeof(UnityEngine.UI.Button));
+                b.transform.SetParent(_bgPage.transform, false);
+                var rt = (RectTransform)b.transform;
+                rt.sizeDelta = new Vector2(120, 50);
+                rt.anchoredPosition = new Vector2((i % 8) * 230 - 805, (i / 8) * 170 - 425);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator ModalButtons_CagedToInModalNeighbours()
+        {
+            UI.UseGamepadNavigation();
+            BuildBackgroundPage();
+
+            var task = MessageBox.Open("confine", MsgBtn.OK | MsgBtn.Cancel, title: "确认");
+            yield return null;
+            yield return null;
+            Canvas.ForceUpdateCanvases();
+            yield return null;
+
+            var modal = UI.Modal.TopScreen;
+            Assert.IsNotNull(modal, "modal open");
+            var root = modal.RootGameObject;
+            var ok = modal.Get<Btn>("ok").GameObject.GetComponent<Selectable>();
+            var cancel = modal.Get<Btn>("cancel").GameObject.GetComponent<Selectable>();
+
+            // The cage converts Automatic -> Explicit and wires only in-modal neighbours.
+            Assert.AreEqual(UnityEngine.UI.Navigation.Mode.Explicit, ok.navigation.mode,
+                "OK must be caged to Explicit navigation (not scene-wide Automatic)");
+            Assert.AreSame(cancel, ok.navigation.selectOnRight,
+                "OK's right neighbour must be the in-modal Cancel, not a background button");
+
+            // No direction may point outside the modal subtree.
+            var n = ok.navigation;
+            Assert.IsTrue(InModalOrNull(n.selectOnLeft, root), "OK.left must stay in modal");
+            Assert.IsTrue(InModalOrNull(n.selectOnUp, root), "OK.up must stay in modal");
+            Assert.IsTrue(InModalOrNull(n.selectOnDown, root), "OK.down must stay in modal");
+
+            // Cancel mirrors back to OK.
+            Assert.AreSame(ok, cancel.navigation.selectOnLeft,
+                "Cancel's left neighbour must be the in-modal OK");
+
+            modal.Get<Btn>("ok").SimulateClick();
+            yield return null;
+        }
+    }
+}

--- a/Tests/PlayMode/Navigation/ModalNavConfinementPlayTests.cs.meta
+++ b/Tests/PlayMode/Navigation/ModalNavConfinementPlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 82e8ccc7ebf974c449f5b15239a4147e

--- a/Tests/PlayMode/Navigation/ModalNavRealInputPlayTests.cs
+++ b/Tests/PlayMode/Navigation/ModalNavRealInputPlayTests.cs
@@ -1,0 +1,117 @@
+using System.Collections;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Application.Modals;
+using PromptUGUI.Controls;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
+
+namespace PromptUGUI.Tests.PlayMode.Navigation
+{
+    // End-to-end repro of the reported bug: in CommonControls' MessageBox, pressing a direction
+    // could not reach Cancel because a button on the page BEHIND the modal was a closer geometric
+    // neighbour, so focus escaped and the trap snapped it back to OK. Drives a REAL key press
+    // through the live InputSystemUIInputModule with an adversarial background button.
+    public class ModalNavRealInputPlayTests : UnityEngine.InputSystem.InputTestFixture
+    {
+        private GameObject _es;
+        private GameObject _bgPage;
+
+        public override void Setup()
+        {
+            base.Setup();
+            UI.ResetForTests();
+            // Defensive isolation: prior nav tests leak their EventSystem (UI.ResetForTests keeps
+            // it). A stray second EventSystem would make our module non-current, so the real key
+            // press would generate no nav event and selection would never move. Start from one.
+            DestroyAllEventSystems();
+            MessageBox.XmlSrc = "PromptUGUI/Modals/MessageBox.ui";
+            UI.SourceResolver = src =>
+            {
+                var ta = UnityEngine.Resources.Load<UnityEngine.TextAsset>(src);
+                if (ta == null)
+                    return AwaitableHelpers.Faulted<string>(
+                        new System.IO.IOException($"Resources lookup failed: {src}"));
+                return AwaitableHelpers.Completed(ta.text);
+            };
+            _es = new GameObject("EventSystem", typeof(EventSystem),
+                typeof(UnityEngine.InputSystem.UI.InputSystemUIInputModule));
+        }
+
+        public override void TearDown()
+        {
+            UI.ResetForTests();
+            if (_bgPage != null) Object.DestroyImmediate(_bgPage);
+            DestroyAllEventSystems();   // also removes the one UseGamepadNavigation may have kept
+            _es = null;
+            base.TearDown();
+        }
+
+        private static void DestroyAllEventSystems()
+        {
+            foreach (var es in Object.FindObjectsByType<EventSystem>(FindObjectsSortMode.None))
+                Object.DestroyImmediate(es.gameObject);
+        }
+
+        [UnityTest]
+        public IEnumerator RealRightKey_ReachesCancel_DespiteCloserBackgroundButton()
+        {
+#if ENABLE_INPUT_SYSTEM
+            var kb = InputSystem.AddDevice<Keyboard>();
+            UI.UseGamepadNavigation();
+
+            var task = MessageBox.Open("e2e", MsgBtn.OK | MsgBtn.Cancel, title: "确认");
+            yield return null;
+            yield return null;
+            Canvas.ForceUpdateCanvases();
+            yield return null;
+
+            var modal = UI.Modal.TopScreen;
+            Assert.IsNotNull(modal, "modal must be open");
+            var okGo = modal.Get<Btn>("ok").GameObject;
+            var cancelGo = modal.Get<Btn>("cancel").GameObject;
+            var okPos = okGo.transform.position;
+            var cancelPos = cancelGo.transform.position;
+
+            // Adversarial background button (outside the modal subtree) placed BETWEEN OK and
+            // Cancel — closer to OK's right edge than Cancel, so uGUI's scene-wide Automatic search
+            // would prefer it. The cage (applied at modal open) must make this irrelevant.
+            _bgPage = new GameObject("BgCanvas", typeof(Canvas), typeof(GraphicRaycaster));
+            _bgPage.GetComponent<Canvas>().renderMode = RenderMode.ScreenSpaceOverlay;
+            var bg = new GameObject("adversarialBg", typeof(RectTransform), typeof(UnityEngine.UI.Image),
+                typeof(UnityEngine.UI.Button));
+            bg.transform.SetParent(_bgPage.transform, false);
+            var bgRt = (RectTransform)bg.transform;
+            bgRt.sizeDelta = new Vector2(40, 40);
+            bgRt.position = new Vector3(okPos.x + (cancelPos.x - okPos.x) * 0.5f, okPos.y, okPos.z);
+            yield return null;
+
+            // Focus OK and enter Directional mode (what NavigationController does on a key press).
+            UI.Navigation.NoteDirectionalInput();
+            EventSystem.current.SetSelectedGameObject(okGo);
+            yield return null;
+
+            Press(kb.rightArrowKey);
+            yield return null;
+            yield return null;
+            yield return null;
+            Release(kb.rightArrowKey);
+            yield return null;
+
+            var after = EventSystem.current.currentSelectedGameObject;
+            Assert.AreSame(cancelGo, after,
+                "real Right key must reach Cancel, not escape to the background button / bounce back to OK");
+
+            modal.Get<Btn>("cancel").SimulateClick();
+            yield return null;
+#else
+            yield break;
+#endif
+        }
+    }
+}

--- a/Tests/PlayMode/Navigation/ModalNavRealInputPlayTests.cs.meta
+++ b/Tests/PlayMode/Navigation/ModalNavRealInputPlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7e8fdb2b7fba874479b895b6434b2dcd

--- a/docs~/superpowers/specs/2026-06-29-gamepad-keyboard-navigation-design.md
+++ b/docs~/superpowers/specs/2026-06-29-gamepad-keyboard-navigation-design.md
@@ -163,13 +163,12 @@ Current      = (effTransient == Normal) ? (isOn ? Selected : Normal) : effTransi
 - 在 Pointer 模式下设置选区**无视觉副作用**(`Focused` 被门控折回 `Normal`、光标隐藏),故开屏即设是安全的。
 - 多个 `focus="true"`:取第一个;CLI lint 可出重复警告(§14,可选)。
 
-### 6.2 模态 trap(选区限制)
+### 6.2 模态 trap(导航笼 + 选区限制)
 
-uGUI 的 `Automatic` 导航**不认 Canvas 排序/raycast 遮挡**——方向键能从模态"逃"到背后的按钮(指针被 backdrop 吃掉,但键盘/手柄不会)。故需显式限制:
+uGUI 的 `Automatic` 导航**不认 Canvas 排序/raycast 遮挡**——方向键能从模态"逃"到背后的按钮(指针被 backdrop 吃掉,但键盘/手柄不会)。实测病征:背后一页的某按钮在屏幕坐标上比模态内的相邻按钮更"贴"焦点控件,几何搜索就选了它 → 选区逃出模态 → 守卫吸回栈顶模态首个可聚焦控件 → **焦点黏在首按钮、方向键到不了同模态的其它按钮**。两层防护:
 
-- 导航控制器维护"当前限制根":有模态开启时 = **栈顶模态的 Screen 根**(复用 `UI.Modal._stack` + `RefreshTopListener` 同款"仅栈顶生效"),否则 = 普通开启屏。
-- 每帧(或选区变更时)校验 `currentSelectedGameObject` 是否在限制根子树内;**逃逸则吸回**栈顶模态的初始/上次焦点。
-- 这是 trap 的最小可靠实现,不改 uGUI 的 `FindSelectable`,只做"事后纠偏"。
+- **导航笼(主):** 模态绑定完成后由 `UI.Modal` 调 `Screen.ConfineNavigationToSelf` → `ExplicitNavigationResolver` 的 confine 分支把模态内每个可聚焦控件转成 `Explicit` 导航,四向邻居用**限定在模态子树候选内**的几何打分算出(复刻 uGUI `FindSelectable`/`GetPointOnRectEdge` 的评分,但只在子树里挑)。于是方向键从根上到不了模态外,且模态内相邻控件可靠互达。几何须在布局稳定后取,故 confine 分支先 `Canvas.ForceUpdateCanvases()`(开屏时叠加 canvas 尚未定尺寸 + HStack 未排版);resize/ReSolve 经 `Screen.NavConfineRoot` 重算。
+- **吸回(兜底):** 导航控制器维护"当前限制根" = 栈顶模态 Screen 根(复用 `UI.Modal._stack` + `RefreshTopListener` 同款"仅栈顶生效");每帧校验 `currentSelectedGameObject` 在限制根子树内,逃逸则吸回。装笼后正常不再触发,留作兜底。
 
 ### 6.3 关闭还原
 
@@ -318,7 +317,7 @@ Modal 关闭(RemoveSlot)
 | 解封 `Selected→Focused` 让鼠标点完粘高亮 | §3 模式门控:Pointer 模式照旧折回 `Normal`;回归测试 #2 覆盖 |
 | `InteractState` 追加值漏改某 `switch`(穷举) | 编译/测试驱动:`StateTintReactor`/`<Show>`/triggers 都 `switch` 它,缺分支编译告警或测试失败;新值置末尾、`default` 兜底 |
 | uGUI `FindSelectableOnX` 在布局未稳时算错邻居 | `ExplicitNavigationResolver` 在 Screen 打开/重排**末尾**跑;resize/ReSolve 重算 |
-| 模态 trap"事后纠偏"有一帧选区在外 | 守卫每帧吸回;一帧延迟无实际可操作窗口(同帧无输入处理)。彻底零延迟需重写 `FindSelectable`,留非目标 |
+| 模态方向键逃到背后控件 / 焦点黏首按钮 | §6.2 导航笼:模态内控件转 `Explicit` + 子树内几何邻居,从根上不外溢、模态内可靠互达;每帧吸回降为兜底(装笼后正常不触发) |
 | 设备检测误判(同时插手柄又动鼠标) | 以"最近一次事件设备"为准,逐帧更新;边界是用户主动切设备,符合直觉 |
 | `<FocusCursor>` hoist 进 overlay 与 scale/PixelSnap 交互 | 复用 `InstantiateNode` 的 `_dynamicSubtrees` 既有 scale 路径 + `PixelSnap`;EditMode #7/#8 覆盖定位与 hoist |
 | New Input System 未装时整个特性编译/运行 | `#if ENABLE_INPUT_SYSTEM` 全包;`#else` no-op + 一次性警告;不进硬依赖 |


### PR DESCRIPTION
## 问题

CommonControls 的 `MessageBox(OK | Cancel)` 里，手柄/键盘方向键**到不了 Cancel**，按任何方向焦点都黏在 OK 上。

用户在调试器里实测：`okButton.FindSelectableOnRight()` 返回的是**模态背后那一页**的 `loadingBtn`，而不是相邻的 `cancel`。

**根因**：uGUI 的 `Automatic` 导航是全场景几何搜索、不认 Canvas 排序/模态边界。竖屏布局下，背后页的某按钮在屏幕坐标上比模态内相邻按钮更"贴"焦点控件 → 几何搜索选了它 → 选区逃出模态 → `NavigationController.EnforceContainment` 每帧把焦点吸回栈顶模态首个可聚焦控件(OK) → 方向键永远回到 OK、到不了同模态的其它按钮。

## 修复：导航笼

模态绑定完成后由 `UI.Modal` 调 `Screen.ConfineNavigationToSelf` → `ExplicitNavigationResolver` 的 confine 分支：把模态内**每个**可聚焦控件转成 `Explicit` 导航，四向邻居用**限定在模态子树候选内**的几何打分算出（复刻 uGUI `FindSelectable` / `GetPointOnRectEdge` 的评分，但只在子树里挑）。

- 方向键从根上到不了模态外，且模态内相邻控件可靠互达。
- 每帧 `EnforceContainment` 吸回降为**兜底**（装笼后正常不触发）。
- 几何须在布局稳定后取 → confine 分支先 `Canvas.ForceUpdateCanvases()`（开屏时叠加 canvas 尚未定尺寸、HStack 未排版，否则邻居全 null）。
- resize/ReSolve 经新增 `Screen.NavConfineRoot` 重算。
- 仅对**模态**生效（`UI.Navigation.IsEnabled` 门控）；普通整屏页面行为不变（confineRoot=null 走原 Automatic/显式分支）。

## 测试

- `ModalNavConfinementPlayTests` — 笼结构断言（OK 转 Explicit、`selectOnRight==cancel`、四向都在模态内）。**RED→GREEN** 验证。
- `ModalNavRealInputPlayTests` — 真键盘 Right + 对抗性背景按钮（放在 OK 与 Cancel 之间、几何上盖过 Cancel），复现"卡在 OK"症状并验证修复；`InputTestFixture`，清理残留 EventSystem 保证顺序无关。**关掉笼时确认两测试都 RED（real-input 报 `Expected cancel, But was ok`，正是用户症状）。**
- EditMode 1973/1973 + 全 PlayMode（全部 ~47 个类分批跑）绿 + lint clean。
- 更新 nav SKILL（`reference/navigation.md` 模态焦点 trap 段）+ spec §6.2（导航笼）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)