### PR TITLE
fix: 隐藏焦点下首次确认只唤回光标、不误触陈旧焦点

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/reference/navigation.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/navigation.md
@@ -15,11 +15,13 @@ The library switches between two modes automatically based on the last device us
 | Mode | Triggered by |
 | --- | --- |
 | **Pointer** | Mouse move, mouse click, or touchscreen tap |
-| **Directional** | Gamepad left-stick / d-pad / South (confirm) / East (back); keyboard arrow keys, Tab, Enter |
+| **Directional** | Gamepad left-stick / d-pad / East (back); keyboard arrow keys, Tab |
 
 In **Pointer** mode the focus cursor is hidden and no selected control shows a highlight — the mouse pointer is the sole feedback. In **Directional** mode the cursor appears and the selected control shows its hover visual.
 
 Touch-only devices (phones, tablets with no mouse attached) remain in Pointer mode at all times; the cursor and the directional highlight never appear on them.
+
+**Confirming while the cursor is hidden wakes it first.** If the player last used the mouse (Pointer mode, cursor hidden) but a control is still selected from earlier directional input, the **first** Submit (gamepad A / keyboard Enter) only **wakes the cursor back onto that control without activating it** — press Submit again to act. This stops a confirm from silently triggering an invisible, stale focus (for example firing Cancel when the player expected OK). Mouse clicks and Cancel / Back (gamepad B) are unaffected. Submit / confirm therefore no longer appears in the Directional-trigger table above — it wakes the cursor rather than flipping the mode.
 
 ---
 

--- a/Runtime/Application/Navigation/NavigationController.cs
+++ b/Runtime/Application/Navigation/NavigationController.cs
@@ -15,10 +15,15 @@ namespace PromptUGUI.Application.Navigation
             // Detect input device, then fall through to EnforceContainment regardless.
             // (Early returns would skip the containment check the same frame a directional
             // key navigates the selection out of the modal.)
+            // Submit-class inputs (gamepad South / keyboard Enter) intentionally do NOT flip the
+            // mode here. If they did, the same-frame race with InputSystemUIInputModule's Submit
+            // dispatch could let the OnSubmit wake-gate read a stale Directional and act on a hidden
+            // focus. Only genuine *movement* establishes Directional; Submit is woken via the gate
+            // (PuiButton/PuiToggle.OnSubmit → UI.Navigation.TryWakeOnSubmit). buttonEast (Cancel/Back)
+            // stays — it is orthogonal to focus and handled by the modal escape listener.
             var gp = Gamepad.current;
             if (gp != null && (gp.leftStick.ReadValue().sqrMagnitude > 0.25f
                                || gp.dpad.ReadValue().sqrMagnitude > 0.25f
-                               || gp.buttonSouth.wasPressedThisFrame
                                || gp.buttonEast.wasPressedThisFrame))
             {
                 UI.Navigation.NoteDirectionalInput();
@@ -28,7 +33,7 @@ namespace PromptUGUI.Application.Navigation
                 var kb = Keyboard.current;
                 if (kb != null && (kb.leftArrowKey.wasPressedThisFrame || kb.rightArrowKey.wasPressedThisFrame
                                    || kb.upArrowKey.wasPressedThisFrame || kb.downArrowKey.wasPressedThisFrame
-                                   || kb.tabKey.wasPressedThisFrame || kb.enterKey.wasPressedThisFrame))
+                                   || kb.tabKey.wasPressedThisFrame))
                 {
                     UI.Navigation.NoteDirectionalInput();
                 }

--- a/Runtime/Application/Navigation/NavigationController.cs
+++ b/Runtime/Application/Navigation/NavigationController.cs
@@ -20,7 +20,9 @@ namespace PromptUGUI.Application.Navigation
             // dispatch could let the OnSubmit wake-gate read a stale Directional and act on a hidden
             // focus. Only genuine *movement* establishes Directional; Submit is woken via the gate
             // (PuiButton/PuiToggle.OnSubmit → UI.Navigation.TryWakeOnSubmit). buttonEast (Cancel/Back)
-            // stays — it is orthogonal to focus and handled by the modal escape listener.
+            // stays — a focus-independent back input that, lacking any ICancelHandler, cannot act on a
+            // stale focus; it only re-establishes Directional. (Modals close on Esc / gamepad Start via
+            // ModalEscapeListener, not on East.)
             var gp = Gamepad.current;
             if (gp != null && (gp.leftStick.ReadValue().sqrMagnitude > 0.25f
                                || gp.dpad.ReadValue().sqrMagnitude > 0.25f

--- a/Runtime/Application/UI.Navigation.cs
+++ b/Runtime/Application/UI.Navigation.cs
@@ -54,6 +54,20 @@ namespace PromptUGUI.Application
             internal static void NotePointerInput() => SetMode(NavMode.Pointer);
             internal static void NoteDirectionalInput() => SetMode(NavMode.Directional);
 
+            /// <summary>
+            /// 控件 <c>OnSubmit</c> 的唤醒门：导航启用且当前为 Pointer 模式（焦点光标隐藏）时，
+            /// 把这次确认解释为「先唤回光标」而非「点击隐藏焦点」——翻 Directional 让光标重现，
+            /// 返回 true 让调用方吞掉本次 Submit。其余情况返回 false（照常点击）。
+            /// 见 spec 2026-06-30-nav-hidden-submit-wake。
+            /// </summary>
+            internal static bool TryWakeOnSubmit()
+            {
+                if (!IsEnabled) return false;
+                if (IsDirectional) return false;
+                NoteDirectionalInput();
+                return true;
+            }
+
             private static void SetMode(NavMode m)
             {
                 if (Mode == m) return;

--- a/Runtime/Controls/Internal/PuiButton.cs
+++ b/Runtime/Controls/Internal/PuiButton.cs
@@ -1,5 +1,7 @@
 using System;
+using PromptUGUI.Application;
 using R3;
+using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
 namespace PromptUGUI.Controls.Internal
@@ -33,6 +35,16 @@ namespace PromptUGUI.Controls.Internal
             instant |= BornFrame.IsCurrent(_bornFrame);
             base.DoStateTransition(state, instant);
             _broadcaster.SetTransient(StateBroadcaster.MapTransient((int)state));
+        }
+
+        /// <summary>
+        /// 鼠标用过后焦点光标隐藏时，第一次 Submit 只唤回光标、不点击（见 nav-hidden-submit-wake）。
+        /// 仅拦键盘/手柄确认；鼠标点击走 OnPointerClick 不受影响。
+        /// </summary>
+        public override void OnSubmit(BaseEventData eventData)
+        {
+            if (UI.Navigation.TryWakeOnSubmit()) return;
+            base.OnSubmit(eventData);
         }
 
         /// <summary>Test hook: drive a transition without a live EventSystem (ordinal — the test

--- a/Runtime/Controls/Internal/PuiToggle.cs
+++ b/Runtime/Controls/Internal/PuiToggle.cs
@@ -1,5 +1,7 @@
 using System;
+using PromptUGUI.Application;
 using R3;
+using UnityEngine.EventSystems;
 using UnityToggle = UnityEngine.UI.Toggle;
 
 namespace PromptUGUI.Controls.Internal
@@ -43,6 +45,16 @@ namespace PromptUGUI.Controls.Internal
             instant |= BornFrame.IsCurrent(_bornFrame);
             base.DoStateTransition(state, instant);
             _broadcaster.SetTransient(StateBroadcaster.MapTransient((int)state));
+        }
+
+        /// <summary>
+        /// 鼠标用过后焦点光标隐藏时，第一次 Submit 只唤回光标、不翻转 isOn（见 nav-hidden-submit-wake）。
+        /// 仅拦键盘/手柄确认；鼠标点击走 OnPointerClick 不受影响。盖 Tab 与 Toggle。
+        /// </summary>
+        public override void OnSubmit(BaseEventData eventData)
+        {
+            if (UI.Navigation.TryWakeOnSubmit()) return;
+            base.OnSubmit(eventData);
         }
 
         /// <summary>Test hook: drive a transition without a live EventSystem (ordinal — the test

--- a/Tests/EditMode/Navigation/SubmitWakeTests.cs
+++ b/Tests/EditMode/Navigation/SubmitWakeTests.cs
@@ -1,0 +1,102 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using R3;
+using UnityEngine.EventSystems;
+using Object = UnityEngine.Object;
+
+namespace PromptUGUI.Tests.EditMode.Navigation
+{
+    public class SubmitWakeTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        // ── TryWakeOnSubmit 三分支（纯逻辑，无控件） ──────────────────────────
+        [Test]
+        public void TryWake_NavDisabled_ReturnsFalse_NoFlip()
+        {
+            Assert.IsFalse(UI.Navigation.IsEnabled);
+            UI.Navigation.Mode = UI.Navigation.NavMode.Pointer;
+            Assert.IsFalse(UI.Navigation.TryWakeOnSubmit());
+            Assert.AreEqual(UI.Navigation.NavMode.Pointer, UI.Navigation.Mode);
+        }
+
+        [Test]
+        public void TryWake_Directional_ReturnsFalse_NoFlip()
+        {
+            UI.UseGamepadNavigation();
+            UI.Navigation.Mode = UI.Navigation.NavMode.Directional;
+            Assert.IsFalse(UI.Navigation.TryWakeOnSubmit());
+            Assert.AreEqual(UI.Navigation.NavMode.Directional, UI.Navigation.Mode);
+        }
+
+        [Test]
+        public void TryWake_PointerEnabled_ReturnsTrue_FlipsToDirectional()
+        {
+            UI.UseGamepadNavigation();
+            UI.Navigation.Mode = UI.Navigation.NavMode.Pointer;
+            Assert.IsTrue(UI.Navigation.TryWakeOnSubmit());
+            Assert.AreEqual(UI.Navigation.NavMode.Directional, UI.Navigation.Mode);
+        }
+
+        // ── PuiButton.OnSubmit 吞掉分支（EditMode 干净：提前 return，不调 base 协程） ──
+        [Test]
+        public void PuiButton_Submit_InPointerMode_SwallowsClick_AndWakes()
+        {
+            UI.UseGamepadNavigation();
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'><Btn id='b'>Hi</Btn></Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            var btn = screen.Get<Btn>("b");
+            var pui = btn.GameObject.GetComponent<PuiButton>();
+            bool clicked = false;
+            btn.OnClick.Subscribe(_ => clicked = true).AddTo(screen);
+
+            UI.Navigation.Mode = UI.Navigation.NavMode.Pointer;
+            var es = Object.FindAnyObjectByType<EventSystem>();
+            pui.OnSubmit(new BaseEventData(es));
+
+            Assert.IsFalse(clicked, "Submit while cursor hidden (Pointer) must NOT click");
+            Assert.AreEqual(UI.Navigation.NavMode.Directional, UI.Navigation.Mode,
+                "first Submit wakes the cursor instead of acting");
+        }
+
+        // ── PuiToggle.OnSubmit 两条分支（EditMode 干净：Toggle.OnSubmit 无协程） ──
+        private static UnityEngine.UI.Toggle BuildToggle()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'><Toggle id='t'>On</Toggle></Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            return screen.Get<Toggle>("t").GameObject.GetComponent<UnityEngine.UI.Toggle>();
+        }
+
+        [Test]
+        public void PuiToggle_Submit_InPointerMode_DoesNotToggle_AndWakes()
+        {
+            UI.UseGamepadNavigation();
+            var tog = BuildToggle();
+            bool initial = tog.isOn;
+            UI.Navigation.Mode = UI.Navigation.NavMode.Pointer;
+            var es = Object.FindAnyObjectByType<EventSystem>();
+            tog.OnSubmit(new BaseEventData(es));
+            Assert.AreEqual(initial, tog.isOn, "Submit while hidden must not flip isOn");
+            Assert.AreEqual(UI.Navigation.NavMode.Directional, UI.Navigation.Mode);
+        }
+
+        [Test]
+        public void PuiToggle_Submit_InDirectionalMode_TogglesNormally()
+        {
+            UI.UseGamepadNavigation();
+            var tog = BuildToggle();
+            bool initial = tog.isOn;
+            UI.Navigation.Mode = UI.Navigation.NavMode.Directional;
+            var es = Object.FindAnyObjectByType<EventSystem>();
+            tog.OnSubmit(new BaseEventData(es));
+            Assert.AreNotEqual(initial, tog.isOn, "Submit while cursor visible toggles normally");
+        }
+    }
+}

--- a/Tests/EditMode/Navigation/SubmitWakeTests.cs.meta
+++ b/Tests/EditMode/Navigation/SubmitWakeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 59944d5800e63af42b272218df8b962f

--- a/Tests/PlayMode/Navigation/SubmitWakePlayTests.cs
+++ b/Tests/PlayMode/Navigation/SubmitWakePlayTests.cs
@@ -1,0 +1,95 @@
+using System.Collections;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using R3;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.TestTools;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
+
+namespace PromptUGUI.Tests.PlayMode.Navigation
+{
+    // 端到端复现用户报告的 bug：键盘选中 Cancel → 鼠标移动隐藏光标（选区仍 Cancel）→
+    // 真实回车不应触发 Cancel，而应唤回光标；第二次回车才触发。
+    public class SubmitWakePlayTests : UnityEngine.InputSystem.InputTestFixture
+    {
+        private GameObject _es;
+
+        public override void Setup()
+        {
+            base.Setup();
+            UI.ResetForTests();
+            DestroyAllEventSystems();   // 防前序 nav 测试泄漏的 EventSystem 抢 current
+            _es = new GameObject("EventSystem", typeof(EventSystem),
+                typeof(UnityEngine.InputSystem.UI.InputSystemUIInputModule));
+        }
+
+        public override void TearDown()
+        {
+            UI.ResetForTests();
+            DestroyAllEventSystems();
+            _es = null;
+            base.TearDown();
+        }
+
+        private static void DestroyAllEventSystems()
+        {
+            foreach (var es in Object.FindObjectsByType<EventSystem>(FindObjectsSortMode.None))
+                Object.DestroyImmediate(es.gameObject);
+        }
+
+        [UnityTest]
+        public IEnumerator EnterInPointerMode_WakesCursor_DoesNotTriggerStaleFocus()
+        {
+#if ENABLE_INPUT_SYSTEM
+            var kb = InputSystem.AddDevice<Keyboard>();
+            UI.UseGamepadNavigation();
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Btn id='ok'>OK</Btn><Btn id='cancel'>Cancel</Btn>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            yield return null;
+            var cancel = screen.Get<Btn>("cancel");
+            bool cancelFired = false;
+            cancel.OnClick.Subscribe(_ => cancelFired = true).AddTo(screen);
+
+            // 1) 键盘导航到 Cancel（Directional）
+            UI.Navigation.NoteDirectionalInput();
+            EventSystem.current.SetSelectedGameObject(cancel.GameObject);
+            yield return null;
+
+            // 2) 鼠标移动 → Pointer 模式，光标隐藏（选区仍是 Cancel）
+            UI.Navigation.NotePointerInput();
+            yield return null;
+            Assert.AreEqual(UI.Navigation.NavMode.Pointer, UI.Navigation.Mode);
+
+            // 3) 真实回车
+            Press(kb.enterKey);
+            yield return null; yield return null;
+            Release(kb.enterKey);
+            yield return null;
+
+            Assert.IsFalse(cancelFired,
+                "Enter while cursor hidden must NOT trigger the stale focus (Cancel)");
+            Assert.AreEqual(UI.Navigation.NavMode.Directional, UI.Navigation.Mode,
+                "first Enter wakes the cursor → Directional");
+
+            // 4) 现在 Directional + 选区 Cancel → 第二次回车正常触发 Cancel
+            Press(kb.enterKey);
+            yield return null; yield return null;
+            Release(kb.enterKey);
+            yield return null;
+            Assert.IsTrue(cancelFired,
+                "second Enter (cursor visible) triggers the focused button");
+            UI.ResetForTests();
+#else
+            yield break;
+#endif
+        }
+    }
+}

--- a/Tests/PlayMode/Navigation/SubmitWakePlayTests.cs.meta
+++ b/Tests/PlayMode/Navigation/SubmitWakePlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c00dcaaacc978db4d893c8ff4dd89dc2

--- a/docs~/superpowers/plans/2026-06-30-nav-hidden-submit-wake.md
+++ b/docs~/superpowers/plans/2026-06-30-nav-hidden-submit-wake.md
@@ -1,0 +1,471 @@
+# 隐藏焦点下 Submit 唤醒 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修复「鼠标用过后焦点光标隐藏、但 EventSystem 选区仍在旧控件上时，按确认键会误触发那个看不见的旧焦点」——改为第一次确认只唤回光标、不触发。
+
+**Architecture:** 在 `UI.Navigation` 加一个单一来源的唤醒门 `TryWakeOnSubmit()`；`PuiButton` / `PuiToggle` 各 override `OnSubmit` 一行调用它（Pointer 模式收到 Submit → 翻 Directional 唤回光标 + 吞掉点击）。同时把 Submit 类输入（`enterKey` / `buttonSouth`）从 `NavigationController` 的「翻 Directional」判定里移除，避免执行序竞争让门读到过期模式。
+
+**Tech Stack:** Unity 6, uGUI `Button`/`Toggle`（`OnSubmit` 均 `public virtual`）+ EventSystem, New Input System（仅 `NavigationController` 改动在 `#if ENABLE_INPUT_SYSTEM` 内）, R3, NUnit + Unity Test Framework（EditMode 纯逻辑主测 + 一个 PlayMode 真实输入集成）。
+
+设计源：`docs~/superpowers/specs/2026-06-30-nav-hidden-submit-wake-design.md`。
+承接母特性：`docs~/superpowers/specs/2026-06-29-gamepad-keyboard-navigation-design.md`（修订其 §3 模式翻转触发器、§11 边界表）。
+
+## Global Constraints
+
+- **严格附加 / 纯 runtime**：不改任何公共 C# API、不新增/改 XML 元素或属性、不改 `id` 路径语义。
+- **门控自洽**：唤醒门 + 两个 override **不需** `#if ENABLE_INPUT_SYSTEM`——它们只引用 `UI.Navigation`（`IsEnabled`/`IsDirectional`/`Mode`/`NoteDirectionalInput` 均定义在 `#if` 之外）与 `UnityEngine.EventSystems`，不碰 InputSystem 类型。导航未启用时 `IsEnabled==false` → `TryWakeOnSubmit` 恒返回 `false` → override 恒走 `base.OnSubmit` → 零行为变化。**只有 `NavigationController` 的删除动作在既有 `#if ENABLE_INPUT_SYSTEM` 块内。**
+- **只拦 Submit，不拦指针**：鼠标点击走 `IPointerClickHandler.OnPointerClick`（不动），鼠标点 OK 永远照常工作。
+- **InputField 排除在 v1 之外**：只 override `PuiButton` / `PuiToggle`（盖 Btn/Tab/Toggle）；`TMP_InputField` 的两级编辑不纳入。
+- **统一「先唤回」规则**：Pointer 模式下任何 Submit（含开屏首次回车）都先唤回不触发；这是已 review 接受的有意行为变更（spec §4 边界表「模态刚打开首次回车」行）。
+- **WebGL 安全**：纯同步逻辑，无 `System.Threading.Task` / `TaskCompletionSource`。
+- **C# LangVersion 9**：无 C#10+ 语法（无 primary constructor、无 `[]` collection expression、无 `[field: SerializeField]`）。
+- **测试经 Unity MCP**：改源后 `refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)` → `read_console(types=["error"])` 零编译错误 → `run_tests` 轮询 `get_test_job`。PlayMode 加 `init_timeout=120000`。
+- **lint**：`cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx` exit 0。
+- **提交**：每个 commit 消息正文末尾加一行 `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`（下文步骤只列 subject）。
+- **分支**：已在 `fix/nav-hidden-submit-wake`，**禁止提交到 main**。
+
+### ⚠️ 实现期注意点
+
+1. **`Button.OnSubmit` 走协程**（`StartCoroutine(OnFinishSubmit())`）→ EditMode 调 `base.OnSubmit` 会有协程噪声/报错。故 PuiButton 的 EditMode 测试**只测「吞掉」分支**（提前 return，不调 base，干净）；「放行点击」分支交给 PlayMode 集成（Task 2）+ `TryWakeOnSubmit` 的 Directional→false 单测覆盖。
+2. **`Toggle.OnSubmit` 无协程**（仅 `InternalToggle()` 翻 `isOn`）→ PuiToggle 的吞掉**和**放行两条分支都能在 EditMode 干净测。
+3. **PlayMode 真实输入集成对执行序敏感**：若 `NavigationController.Update` 在该帧先于 input module 运行、且控制器仍把 enter 当方向输入，则门会读到 Directional 而放行——本计划删 enter/South 后该竞争消失。集成测试在「控制器先跑」的执行序下能抓到回归；在「module 先跑」的执行序下两断言对缺失控制器改动不敏感（诚实记录，非完美守卫）。控制器改动的必要性主要由 spec §3.3 推理保证。
+4. **PlayMode runner 历史偶发不稳**（项目记忆）：失败先 `read_console` 排查环境（多余 EventSystem 泄漏等），再判真伪。
+
+---
+
+## Task 1: 唤醒门 `TryWakeOnSubmit` + `PuiButton`/`PuiToggle` 两个 override
+
+**Files:**
+- Modify: `Runtime/Application/UI.Navigation.cs`（在 `NoteDirectionalInput` 附近加 `TryWakeOnSubmit`）
+- Modify: `Runtime/Controls/Internal/PuiButton.cs`（加 `OnSubmit` override + usings）
+- Modify: `Runtime/Controls/Internal/PuiToggle.cs`（加 `OnSubmit` override + usings）
+- Test: `Tests/EditMode/Navigation/SubmitWakeTests.cs`（新建）
+
+**Interfaces:**
+- Consumes: `UI.Navigation.IsEnabled`（public）、`UI.Navigation.IsDirectional`（internal）、`UI.Navigation.NoteDirectionalInput()`（internal）、uGUI `Button.OnSubmit`/`Toggle.OnSubmit`（`public virtual`）。
+- Produces:
+  - `internal static bool UI.Navigation.TryWakeOnSubmit()` —— `true` = 调用方应吞掉本次 Submit；`false` = 照常点击。返回 `true` 时已把 `Mode` 翻成 `Directional`。
+  - `PuiButton.OnSubmit` / `PuiToggle.OnSubmit` override：`if (UI.Navigation.TryWakeOnSubmit()) return; base.OnSubmit(eventData);`
+
+- [ ] **Step 1: 写失败的 EditMode 测试**
+
+新建 `Tests/EditMode/Navigation/SubmitWakeTests.cs`：
+```csharp
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using R3;
+using UnityEngine.EventSystems;
+using Object = UnityEngine.Object;
+
+namespace PromptUGUI.Tests.EditMode.Navigation
+{
+    public class SubmitWakeTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        // ── TryWakeOnSubmit 三分支（纯逻辑，无控件） ──────────────────────────
+        [Test]
+        public void TryWake_NavDisabled_ReturnsFalse_NoFlip()
+        {
+            Assert.IsFalse(UI.Navigation.IsEnabled);
+            UI.Navigation.Mode = UI.Navigation.NavMode.Pointer;
+            Assert.IsFalse(UI.Navigation.TryWakeOnSubmit());
+            Assert.AreEqual(UI.Navigation.NavMode.Pointer, UI.Navigation.Mode);
+        }
+
+        [Test]
+        public void TryWake_Directional_ReturnsFalse_NoFlip()
+        {
+            UI.UseGamepadNavigation();
+            UI.Navigation.Mode = UI.Navigation.NavMode.Directional;
+            Assert.IsFalse(UI.Navigation.TryWakeOnSubmit());
+            Assert.AreEqual(UI.Navigation.NavMode.Directional, UI.Navigation.Mode);
+        }
+
+        [Test]
+        public void TryWake_PointerEnabled_ReturnsTrue_FlipsToDirectional()
+        {
+            UI.UseGamepadNavigation();
+            UI.Navigation.Mode = UI.Navigation.NavMode.Pointer;
+            Assert.IsTrue(UI.Navigation.TryWakeOnSubmit());
+            Assert.AreEqual(UI.Navigation.NavMode.Directional, UI.Navigation.Mode);
+        }
+
+        // ── PuiButton.OnSubmit 吞掉分支（EditMode 干净：提前 return，不调 base 协程） ──
+        [Test]
+        public void PuiButton_Submit_InPointerMode_SwallowsClick_AndWakes()
+        {
+            UI.UseGamepadNavigation();
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'><Btn id='b'>Hi</Btn></Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            var btn = screen.Get<Btn>("b");
+            var pui = btn.GameObject.GetComponent<PuiButton>();
+            bool clicked = false;
+            btn.OnClick.Subscribe(_ => clicked = true).AddTo(screen);
+
+            UI.Navigation.Mode = UI.Navigation.NavMode.Pointer;
+            var es = Object.FindAnyObjectByType<EventSystem>();
+            pui.OnSubmit(new BaseEventData(es));
+
+            Assert.IsFalse(clicked, "Submit while cursor hidden (Pointer) must NOT click");
+            Assert.AreEqual(UI.Navigation.NavMode.Directional, UI.Navigation.Mode,
+                "first Submit wakes the cursor instead of acting");
+        }
+
+        // ── PuiToggle.OnSubmit 两条分支（EditMode 干净：Toggle.OnSubmit 无协程） ──
+        private static UnityEngine.UI.Toggle BuildToggle()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'><Toggle id='t'>On</Toggle></Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            return screen.Get<Toggle>("t").GameObject.GetComponent<UnityEngine.UI.Toggle>();
+        }
+
+        [Test]
+        public void PuiToggle_Submit_InPointerMode_DoesNotToggle_AndWakes()
+        {
+            UI.UseGamepadNavigation();
+            var tog = BuildToggle();
+            bool initial = tog.isOn;
+            UI.Navigation.Mode = UI.Navigation.NavMode.Pointer;
+            var es = Object.FindAnyObjectByType<EventSystem>();
+            tog.OnSubmit(new BaseEventData(es));
+            Assert.AreEqual(initial, tog.isOn, "Submit while hidden must not flip isOn");
+            Assert.AreEqual(UI.Navigation.NavMode.Directional, UI.Navigation.Mode);
+        }
+
+        [Test]
+        public void PuiToggle_Submit_InDirectionalMode_TogglesNormally()
+        {
+            UI.UseGamepadNavigation();
+            var tog = BuildToggle();
+            bool initial = tog.isOn;
+            UI.Navigation.Mode = UI.Navigation.NavMode.Directional;
+            var es = Object.FindAnyObjectByType<EventSystem>();
+            tog.OnSubmit(new BaseEventData(es));
+            Assert.AreNotEqual(initial, tog.isOn, "Submit while cursor visible toggles normally");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败（编译失败即红——`TryWakeOnSubmit` 尚不存在）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+```
+Expected: 编译错误 `'UI.Navigation' does not contain a definition for 'TryWakeOnSubmit'`（红——证明测试在驱动实现）。
+
+- [ ] **Step 3: 实现唤醒门 + 两个 override**
+
+`Runtime/Application/UI.Navigation.cs`——在 `NoteDirectionalInput()`（约 55 行）之后追加：
+```csharp
+            /// <summary>
+            /// 控件 <c>OnSubmit</c> 的唤醒门：导航启用且当前为 Pointer 模式（焦点光标隐藏）时，
+            /// 把这次确认解释为「先唤回光标」而非「点击隐藏焦点」——翻 Directional 让光标重现，
+            /// 返回 true 让调用方吞掉本次 Submit。其余情况返回 false（照常点击）。
+            /// 见 spec 2026-06-30-nav-hidden-submit-wake。
+            /// </summary>
+            internal static bool TryWakeOnSubmit()
+            {
+                if (!IsEnabled) return false;
+                if (IsDirectional) return false;
+                NoteDirectionalInput();
+                return true;
+            }
+```
+
+`Runtime/Controls/Internal/PuiButton.cs`——顶部 usings 追加：
+```csharp
+using PromptUGUI.Application;
+using UnityEngine.EventSystems;
+```
+在 `DoStateTransition` override 之后、`SimulateState` 之前追加：
+```csharp
+        /// <summary>
+        /// 鼠标用过后焦点光标隐藏时，第一次 Submit 只唤回光标、不点击（见 nav-hidden-submit-wake）。
+        /// 仅拦键盘/手柄确认；鼠标点击走 OnPointerClick 不受影响。
+        /// </summary>
+        public override void OnSubmit(BaseEventData eventData)
+        {
+            if (UI.Navigation.TryWakeOnSubmit()) return;
+            base.OnSubmit(eventData);
+        }
+```
+
+`Runtime/Controls/Internal/PuiToggle.cs`——顶部 usings 追加：
+```csharp
+using PromptUGUI.Application;
+using UnityEngine.EventSystems;
+```
+在 `DoStateTransition` override 之后、`SimulateState` 之前追加：
+```csharp
+        /// <summary>
+        /// 鼠标用过后焦点光标隐藏时，第一次 Submit 只唤回光标、不翻转 isOn（见 nav-hidden-submit-wake）。
+        /// 仅拦键盘/手柄确认；鼠标点击走 OnPointerClick 不受影响。盖 Tab 与 Toggle。
+        /// </summary>
+        public override void OnSubmit(BaseEventData eventData)
+        {
+            if (UI.Navigation.TryWakeOnSubmit()) return;
+            base.OnSubmit(eventData);
+        }
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["SubmitWakeTests"])
+mcp__UnityMCP__get_test_job(job_id=...)
+```
+Expected: `SubmitWakeTests` 6 个全 PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Application/UI.Navigation.cs Runtime/Controls/Internal/PuiButton.cs Runtime/Controls/Internal/PuiToggle.cs Tests/EditMode/Navigation/SubmitWakeTests.cs
+git commit -m "fix(nav): Submit wakes hidden cursor instead of triggering stale focus"
+```
+
+---
+
+## Task 2: `NavigationController` 收窄 Submit 触发器 + PlayMode 真实输入集成
+
+**Files:**
+- Modify: `Runtime/Application/Navigation/NavigationController.cs:18-34`（删 `buttonSouth` + `enterKey`）
+- Test: `Tests/PlayMode/Navigation/SubmitWakePlayTests.cs`（新建）
+
+**Interfaces:**
+- Consumes: Task 1 的 `PuiButton.OnSubmit` 唤醒行为；`UI.Navigation.NoteDirectionalInput()`/`NotePointerInput()`/`Mode`；`Btn.OnClick`。
+- Produces: 无新公共面。`NavigationController` 不再把 Submit 类输入当方向输入——只有*移动*输入（摇杆/dpad/方向键/Tab）翻 `Directional`。
+
+- [ ] **Step 1: 写失败的 PlayMode 集成测试**
+
+新建 `Tests/PlayMode/Navigation/SubmitWakePlayTests.cs`：
+```csharp
+using System.Collections;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using R3;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.TestTools;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
+
+namespace PromptUGUI.Tests.PlayMode.Navigation
+{
+    // 端到端复现用户报告的 bug：键盘选中 Cancel → 鼠标移动隐藏光标（选区仍 Cancel）→
+    // 真实回车不应触发 Cancel，而应唤回光标；第二次回车才触发。
+    public class SubmitWakePlayTests : UnityEngine.InputSystem.InputTestFixture
+    {
+        private GameObject _es;
+
+        public override void Setup()
+        {
+            base.Setup();
+            UI.ResetForTests();
+            DestroyAllEventSystems();   // 防前序 nav 测试泄漏的 EventSystem 抢 current
+            _es = new GameObject("EventSystem", typeof(EventSystem),
+                typeof(UnityEngine.InputSystem.UI.InputSystemUIInputModule));
+        }
+
+        public override void TearDown()
+        {
+            UI.ResetForTests();
+            DestroyAllEventSystems();
+            _es = null;
+            base.TearDown();
+        }
+
+        private static void DestroyAllEventSystems()
+        {
+            foreach (var es in Object.FindObjectsByType<EventSystem>(FindObjectsSortMode.None))
+                Object.DestroyImmediate(es.gameObject);
+        }
+
+        [UnityTest]
+        public IEnumerator EnterInPointerMode_WakesCursor_DoesNotTriggerStaleFocus()
+        {
+#if ENABLE_INPUT_SYSTEM
+            var kb = InputSystem.AddDevice<Keyboard>();
+            UI.UseGamepadNavigation();
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Btn id='ok'>OK</Btn><Btn id='cancel'>Cancel</Btn>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            yield return null;
+            var cancel = screen.Get<Btn>("cancel");
+            bool cancelFired = false;
+            cancel.OnClick.Subscribe(_ => cancelFired = true).AddTo(screen);
+
+            // 1) 键盘导航到 Cancel（Directional）
+            UI.Navigation.NoteDirectionalInput();
+            EventSystem.current.SetSelectedGameObject(cancel.GameObject);
+            yield return null;
+
+            // 2) 鼠标移动 → Pointer 模式，光标隐藏（选区仍是 Cancel）
+            UI.Navigation.NotePointerInput();
+            yield return null;
+            Assert.AreEqual(UI.Navigation.NavMode.Pointer, UI.Navigation.Mode);
+
+            // 3) 真实回车
+            Press(kb.enterKey);
+            yield return null; yield return null;
+            Release(kb.enterKey);
+            yield return null;
+
+            Assert.IsFalse(cancelFired,
+                "Enter while cursor hidden must NOT trigger the stale focus (Cancel)");
+            Assert.AreEqual(UI.Navigation.NavMode.Directional, UI.Navigation.Mode,
+                "first Enter wakes the cursor → Directional");
+
+            // 4) 现在 Directional + 选区 Cancel → 第二次回车正常触发 Cancel
+            Press(kb.enterKey);
+            yield return null; yield return null;
+            Release(kb.enterKey);
+            yield return null;
+            Assert.IsTrue(cancelFired,
+                "second Enter (cursor visible) triggers the focused button");
+            UI.ResetForTests();
+#else
+            yield break;
+#endif
+        }
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], group_names=["SubmitWakePlayTests"], init_timeout=120000)
+mcp__UnityMCP__get_test_job(job_id=..., wait_timeout=90)
+```
+Expected: FAIL —— `enterKey` 仍在 `NavigationController` 方向输入列表里，按下回车那帧若控制器先于 module 运行则翻 Directional → 门放行 → `cancelFired==true`（在能抓到的执行序下红）。
+> 若该 runner 执行序恰为「module 先跑」，此步可能不红（注意点 3）；遇此情况以 Step 3 改动后行为是否符合断言为准，并在 Step 4 确认全绿。
+
+- [ ] **Step 3: 收窄 `NavigationController` 触发器**
+
+`Runtime/Application/Navigation/NavigationController.cs`——把 gamepad 与 keyboard 两段判定改成（删 `buttonSouth`、删 `enterKey`，保留 `buttonEast` 取消语义）：
+```csharp
+            // Submit-class inputs (gamepad South / keyboard Enter) intentionally do NOT flip the
+            // mode here. If they did, the same-frame race with InputSystemUIInputModule's Submit
+            // dispatch could let the OnSubmit wake-gate read a stale Directional and act on a hidden
+            // focus. Only genuine *movement* establishes Directional; Submit is woken via the gate
+            // (PuiButton/PuiToggle.OnSubmit → UI.Navigation.TryWakeOnSubmit). buttonEast (Cancel/Back)
+            // stays — it is orthogonal to focus and handled by the modal escape listener.
+            var gp = Gamepad.current;
+            if (gp != null && (gp.leftStick.ReadValue().sqrMagnitude > 0.25f
+                               || gp.dpad.ReadValue().sqrMagnitude > 0.25f
+                               || gp.buttonEast.wasPressedThisFrame))
+            {
+                UI.Navigation.NoteDirectionalInput();
+            }
+            else
+            {
+                var kb = Keyboard.current;
+                if (kb != null && (kb.leftArrowKey.wasPressedThisFrame || kb.rightArrowKey.wasPressedThisFrame
+                                   || kb.upArrowKey.wasPressedThisFrame || kb.downArrowKey.wasPressedThisFrame
+                                   || kb.tabKey.wasPressedThisFrame))
+                {
+                    UI.Navigation.NoteDirectionalInput();
+                }
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], group_names=["SubmitWakePlayTests"], init_timeout=120000)
+mcp__UnityMCP__get_test_job(job_id=..., wait_timeout=90)
+```
+Expected: `EnterInPointerMode_WakesCursor_DoesNotTriggerStaleFocus` PASS。
+> runner 不稳时先 `read_console(types=["error"])` 看是否多余 EventSystem / 设备未注入；排除环境后再判。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Application/Navigation/NavigationController.cs Tests/PlayMode/Navigation/SubmitWakePlayTests.cs
+git commit -m "fix(nav): stop Submit inputs from flipping nav mode (lets wake-gate read true mode)"
+```
+
+---
+
+## Task 3: 文档（reference/navigation.md 一句）+ 全套件回归 + lint
+
+**Files:**
+- Modify: `.claude/skills/authoring-promptugui-xml/reference/navigation.md`（模式切换 UX 处补一句）
+- （核查：若该文件不存在，则本特性按「纯 runtime 默认行为」豁免 SKILL，跳过文档改动，仅做回归 + lint。）
+
+**Interfaces:** 无代码产出；同步母 spec §14 规划的导航 UX 文档（spec §6 例外条款）。
+
+- [ ] **Step 1: 确认 reference/navigation.md 现状并补一句**
+
+```bash
+sed -n '1,40p' .claude/skills/authoring-promptugui-xml/reference/navigation.md   # 找「auto show/hide on input device」模式切换段
+```
+在描述「手柄/键盘显示焦点与光标、鼠标/触屏隐藏」的那段之后，追加（英文）：
+```markdown
+When the cursor is hidden (the player last used the mouse), the **first** Submit (gamepad A /
+keyboard Enter) only **wakes the cursor back onto the truly-focused control without activating it** —
+press Submit again to act. This prevents a confirm from hitting an invisible, stale focus. (Pointer
+clicks and Cancel/Back are unaffected.)
+```
+> 若 `reference/navigation.md` 不存在：本特性是纯 runtime 默认行为，按既有约定豁免 SKILL（spec §6）；跳过本步，直接 Step 2。
+
+- [ ] **Step 2: 全套件回归 + lint**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__get_test_job(job_id=...)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+mcp__UnityMCP__get_test_job(job_id=...)
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"], init_timeout=120000)
+mcp__UnityMCP__get_test_job(job_id=..., wait_timeout=120)
+```
+Expected: EditMode 全绿（含新 `SubmitWakeTests` 6 个）、EditorOnly 全绿、PlayMode 全绿（含新 `SubmitWakePlayTests`）。回归重点：既有 `FocusStateTests` / `NavEnableTests` / `InputFieldNavPlayTests` / `ModalNavRealInputPlayTests` 不受影响。
+
+```bash
+cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx   # exit 0
+```
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add .claude/skills/authoring-promptugui-xml/reference/navigation.md
+git commit -m "docs(nav): document Submit-wakes-hidden-cursor in navigation reference"
+```
+> 若 Step 1 跳过（文件不存在），本步无文档改动 → 跳过提交。
+
+---
+
+## 自评（spec 覆盖检查）
+
+- **spec §2/§3.1 唤醒门** → Task 1 `TryWakeOnSubmit`（3 分支单测）。✅
+- **spec §3.2 两个 override** → Task 1 `PuiButton`/`PuiToggle.OnSubmit`（PuiButton 吞掉 + PuiToggle 双分支单测）。✅
+- **spec §3.3 NavigationController 收窄** → Task 2（删 enter/South，保 buttonEast）+ PlayMode 集成。✅
+- **spec §3.4 数据流（含开屏首次确认）** → Task 2 集成测试覆盖「首次回车唤醒不触发 + 二次触发」；开屏首次确认是同一码路（Pointer→门→唤醒），无需独立任务。✅
+- **spec §4 边界**：鼠标点击不受影响（只 override Submit，注释明示）；buttonEast/Cancel 保留（Task 2 注释 + 保留判定）；InputField 排除（Global Constraints + 只 override Pui*）；空格走门（无需改 controller）。✅
+- **spec §5 测试** → Task 1 EditMode 5 类断言 + Task 2 PlayMode 集成；Task 3 全套件回归。✅
+- **spec §6 SKILL** → Task 3（reference/navigation.md 一句，带「文件不存在则豁免」分支）。✅
+- **类型一致性**：`TryWakeOnSubmit`（无参，`bool`）在 UI.Navigation 定义、在两个 override 与 EditMode 单测中引用一致；`PuiButton`/`PuiToggle.OnSubmit(BaseEventData)` 签名与 uGUI `public virtual` 一致；测试取件 `GetComponent<PuiButton>()` / `GetComponent<UnityEngine.UI.Toggle>()` 与控件实际组件类型一致。✅
+- **无占位符**：所有步骤含完整代码与确切命令。✅

--- a/docs~/superpowers/specs/2026-06-29-gamepad-keyboard-navigation-design.md
+++ b/docs~/superpowers/specs/2026-06-29-gamepad-keyboard-navigation-design.md
@@ -63,6 +63,7 @@ C# 表面只加 `UI.UseGamepadNavigation(...)` + `Screen.Focus(...)`(§8)。
 **`UI.Navigation.Mode`(internal 信号,枚举 `{ Pointer, Directional }`)**:
 - 初值 `Pointer`。
 - 翻 `Directional`:收到来自 `Gamepad` 的摇杆/方向键/按钮,或 `Keyboard` 的导航键(方向键 / Tab / Submit / Cancel / WASD)事件。
+  > **【2026-06-30 修订,见 `2026-06-30-nav-hidden-submit-wake-design.md`】** Submit/确认输入(`Keyboard.enterKey` / `Gamepad.buttonSouth`)**已从方向触发器中移除**——隐藏光标时它们不再翻 `Directional`,而是经 `UI.Navigation.TryWakeOnSubmit` 唤回光标(首次确认只唤醒不触发)。`buttonEast`(Back)与所有移动输入仍翻 `Directional`。
 - 翻 `Pointer`:`Mouse` 移动(delta 超阈值)/ 点击,或 `Touchscreen` 触摸。
 - 检测实现:新 Input System 的 `InputSystem.onEvent`(轻量,按产生事件的设备分类)或逐帧轮询 `Gamepad.current` / `Keyboard.current` / `Pointer.current` 的 `lastUpdateTime`。具体取舍留实施计划;spec 只约定行为。
 

--- a/docs~/superpowers/specs/2026-06-30-nav-hidden-submit-wake-design.md
+++ b/docs~/superpowers/specs/2026-06-30-nav-hidden-submit-wake-design.md
@@ -1,0 +1,139 @@
+# 隐藏焦点下的 Submit 唤醒：鼠标用过后第一次确认只唤回光标、不误触
+
+**日期**：2026-06-30
+**状态**：设计阶段（已 review 通过，待实施计划）
+**作用域**：修复方向导航的一个交互缺陷——鼠标用过后焦点光标隐藏、但 `EventSystem` 选区仍停在上次键盘/手柄选中的控件上，此时按确认键（回车 / 手柄 A）会**误触发那个看不见的旧焦点**。改为「先唤回光标、不触发」。
+
+- 改 `NavigationController`：把 **Submit 类输入**（`Keyboard.enterKey` / `Gamepad.buttonSouth`）从「方向输入（翻 `Directional`）」判定里移除，只留真正的*移动*输入（摇杆 / dpad / 方向键 / Tab）翻模式。
+- 新增单一来源的拦截入口 `UI.Navigation.TryWakeOnSubmit()`，在 `PuiButton` / `PuiToggle` 的 `OnSubmit` override 里各调用一行：Pointer 模式收到 Submit → 翻 `Directional` 唤回光标 **+ 吞掉本次点击**。
+- **不碰公共 C# API、不碰 XML 语义**——纯 runtime 行为修复。
+
+**关联**：
+- 修订 `2026-06-29-gamepad-keyboard-navigation-design.md`（手柄/键盘导航母 spec）§3（导航模式翻转触发器）与 §11（边界表）的既有行为；沿用其 `UI.Navigation.Mode` 中枢、`FocusCursorView` 显隐门控、`IStateSource`/`StateBroadcaster`。
+- 拦截范式沿用 `Runtime/Controls/Internal/InputFieldNavGate.cs`（实现 `ISubmitHandler` + 看 `UI.Navigation.IsDirectional` 决定行为）。
+
+---
+
+## 1. 背景与缺陷
+
+母 spec 落地后，方向导航有两套并存的输入模型：
+
+- **鼠标 = 指针模型**：点哪是哪，没有「持久焦点」概念。
+- **手柄 / 键盘 = 焦点模型**：`EventSystem.currentSelectedGameObject` 是一个持久选中项。
+
+`FocusCursorView.Tick()` 在 `Mode == Directional` 且选中项属于本屏时显示光标，否则把 `CanvasGroup.alpha` 设 0 **隐藏**（`FocusCursorView.cs:50`）。但隐藏光标时，**`EventSystem` 的选区并没有被清除**——`NavigationController` 从不清选区。于是「光标看不见」≠「焦点没了」：焦点仍在旧控件上，仍能被确认键触发。
+
+**复现（用户报告场景，界面上只有 OK / Cancel 两个按钮）**：
+
+1. 用键盘把焦点移到 **Cancel**（`Directional`，光标停在 Cancel 上）。
+2. 用户移动鼠标 → `NavigationController` 判 `NotePointerInput()` → `Mode=Pointer` → 光标隐藏；**但选区仍是 Cancel**。
+3. 用户没看到光标，自然以为「焦点没了」，想确认 OK，按下回车。
+4. `NavigationController.Update` 当帧把 `enterKey` 当成方向输入（`NavigationController.cs:31`）→ `NoteDirectionalInput()` → `Mode` 翻 `Directional`；**与此同时** `InputSystemUIInputModule` 把 Submit 派发给 `currentSelectedGameObject`（Cancel）→ **Cancel.onClick 触发**。
+
+结果：用户想点 OK，实际触发了 Cancel；下一帧光标才重新出现在 Cancel 上（此时已经晚了）。模式翻转并不能阻止 Submit——Submit 作用在陈旧选区上，翻转只是让光标事后重现。
+
+## 2. 根因：可见性与可触发性被解耦
+
+核心一句话：**焦点的「可见性」（由 `Mode` 驱动的光标显隐）与「可触发性」（`EventSystem` 选区）被解耦了。** 用户用「看不看得见光标」来判断「焦点在不在」，但系统用「选区指向谁」来决定 Submit 作用于谁。两者一旦不一致，就会出现「看不见的焦点被确认键命中」。
+
+修复就是把两者重新绑死：**看不见焦点时，确认键不能作用在那个隐藏焦点上。** 用户选定的具体行为（见母 spec 之外的本次 brainstorming）是「**先唤回光标、不触发**」——鼠标之后第一次确认只把光标唤回它真正所在的元素，让用户看清后再决定，第二次确认才真正点击。这正是主机 / Steam Big Picture 的约定。
+
+## 3. 设计
+
+### 3.1 拦截逻辑（单一来源，放进 `UI.Navigation`）
+
+```csharp
+// internal —— 控件 OnSubmit 调它决定「这次确认是唤醒还是点击」
+internal static bool TryWakeOnSubmit()
+{
+    if (!IsEnabled)     return false;   // 没开导航 → 正常点击（旧行为）
+    if (IsDirectional)  return false;   // 光标可见 → 正常点击
+    NoteDirectionalInput();             // Pointer 模式收到 Submit → 翻 Directional，下一帧光标唤回
+    return true;                        // 吞掉这次 Submit
+}
+```
+
+返回 `true` = 调用方应**直接 return、不执行点击**；返回 `false` = 照常 `base.OnSubmit`。逻辑只此一处，三种控件共用。
+
+### 3.2 两个 override（盖住 Btn / Tab / Toggle）
+
+`PuiButton : Button` 与 `PuiToggle : UnityEngine.UI.Toggle`（`PuiToggle` 同时服务 `Tab` 和 `Toggle`），二者的 `OnSubmit` 都是 `public virtual`，各加一行守卫：
+
+```csharp
+// PuiButton
+public override void OnSubmit(BaseEventData eventData)
+{
+    if (UI.Navigation.TryWakeOnSubmit()) return;
+    base.OnSubmit(eventData);   // 原生 Press()/onClick
+}
+
+// PuiToggle
+public override void OnSubmit(BaseEventData eventData)
+{
+    if (UI.Navigation.TryWakeOnSubmit()) return;
+    base.OnSubmit(eventData);   // 原生 InternalToggle()
+}
+```
+
+**只拦 Submit，不拦指针**：鼠标点击走 `IPointerClickHandler.OnPointerClick`（uGUI `Button`/`Toggle` 各自实现，未被本设计触碰）→ 鼠标点 OK 永远照常工作。
+
+### 3.3 `NavigationController` 触发器收窄（关键前置）
+
+把 `NavigationController.Update` 的方向输入判定里 **`Gamepad.buttonSouth.wasPressedThisFrame` 与 `Keyboard.enterKey.wasPressedThisFrame` 两项删除**，只保留真正的*移动*输入：
+
+```
+翻 Directional 的输入 = 摇杆 leftStick / dpad / 方向键 / Tab        （移动类，保留）
+不再翻模式的输入     = buttonSouth / enterKey（Submit 类）          （删除）
+buttonEast（Cancel/Back）保持不变                                   （取消语义，见 §4）
+```
+
+**为什么必删**：`TryWakeOnSubmit` 靠读 `IsDirectional` 判断「光标是否可见」。若 Submit 输入仍会翻模式，则按下确认键的那一帧——`NavigationController.Update` 与 `InputSystemUIInputModule` 的 `OnSubmit` 派发之间 **MonoBehaviour 执行序不保证**——一旦控制器先把 `Mode` 翻成 `Directional`，`OnSubmit` 里的守卫就会读到 `Directional` 而放行点击，bug 重现。删掉 Submit 触发器后，确认键那帧 `Mode` 稳定停在 `Pointer`，守卫可靠地走「唤醒」分支；确认键改由守卫内的 `NoteDirectionalInput()` 来翻模式（唤回路径），不再走控制器。
+
+> 副作用方向是好的：确认键不再「建立」方向模式，只有移动输入才建立——这与「先唤回、再确认」完全自洽。纯键盘流不受影响：方向键负责建立 `Directional`，回车只在已 `Directional` 时点击。
+
+### 3.4 数据流验证
+
+**缺陷场景（修复后）**：键盘移到 Cancel（`Directional`，光标在 Cancel）→ 鼠标动（`Pointer`，光标隐藏，选区仍 Cancel）→ 按回车：`enterKey` 不再翻模式，`Mode` 稳定 `Pointer` → `InputSystemUIInputModule` 派 Submit 给 Cancel → `PuiButton.OnSubmit` → `TryWakeOnSubmit()` 读到 `!IsDirectional` → `NoteDirectionalInput()` + 返回 `true` → **Cancel 不触发**，下一帧 `FocusCursorView` 见 `Directional` + 选区 Cancel → 光标重现在 Cancel → 用户看清后按方向键移到 OK（移动输入，停在 `Directional`）→ 回车 → 守卫读到 `IsDirectional` → 放行 → **点 OK**。✓
+
+**纯键盘流（无鼠标）**：方向键 → `Directional` 光标显示 → 回车 → 守卫 `IsDirectional` → 正常点击。✓
+
+**开屏首次输入是确认键**（§6.1 初始焦点已设、`Pointer` 初值、光标隐藏）：按手柄 A / 回车 → 守卫 `!IsDirectional` → 唤回光标到初始焦点、不触发。第一次确认只是让光标现身，自洽。✓
+
+## 4. 边界与取舍
+
+| 场景 | 行为 |
+|---|---|
+| 未调 `UseGamepadNavigation`（`IsEnabled==false`） | `TryWakeOnSubmit` 立即返回 `false` → 完全旧行为，零影响 |
+| 已 `Directional`（光标可见）按确认 | 守卫返回 `false` → 正常点击/toggle（无额外延迟） |
+| 鼠标直接点按钮（任何模式） | 走 `OnPointerClick`，不经本守卫 → 照常触发 |
+| 取消键（ESC / 手柄 B = `buttonEast`） | **不经本守卫**：取消由模态的 `ModalEscapeListener`/`Cancel` action 处理，语义与焦点无关（关栈顶模态），光标隐藏时也应照常生效 → 故 `buttonEast` 保留在模式翻转列表、且 Cancel 不要求「先唤醒」 |
+| 空格确认（Submit action 默认绑定之一） | 空格本就不在 `NavigationController` 触发列表 → `Pointer` 模式按空格同样走守卫唤醒，无需额外改动 |
+| 屏上无选区（`currentSelectedGameObject==null`） | 不派发 `OnSubmit` → 守卫不运行；按确认无反应（与现状一致，按方向键开始导航） |
+| **模态/屏刚打开、用户首次就按确认键**（从未拨过方向键，`Pointer` 初值、光标隐藏、初始焦点已设在 OK） | 第一次确认**唤回光标到 OK、不确认**，需第二次确认才点 OK。这是「先唤回」规则的统一后果（修复前是首次回车直接点 OK，类似 Windows 默认按钮）。属**有意的行为变更**——用户选定「光标不可见时确认必须先唤醒」，故快速 Enter 关对话框从冷态起需两下 |
+| **InputField 排除在 v1 之外** | `TMP_InputField`（非我们的子类）的两级编辑由 `InputFieldNavGate` + TMP 自身 `OnSubmit` 处理，路径更复杂；且「误按回车进编辑」远没有「误触 Cancel」有害。`InputFieldNavGate` 依赖*方向键*已建立 `Directional`，不受 §3.3 删 `enterKey` 影响。本次范围聚焦 Btn/Tab/Toggle |
+| Carousel（非 Selectable） | 本就不参与手柄导航（母 spec §13），与本设计无关 |
+
+## 5. 测试（TDD——红先行）
+
+**EditMode**（`UI.ResetForTests` + `UI.Navigation.Mode` 内部可设，仿现有 Navigation 测试）：
+
+1. `TryWakeOnSubmit` 三分支：`IsEnabled==false` → `false` 且 `Mode` 不变；`Mode==Directional` → `false` 且不变；`IsEnabled && Mode==Pointer` → 返回 `true` 且 `Mode` 翻 `Directional`。
+2. `PuiButton.OnSubmit` 在 `Pointer` 模式（导航已启用）：`onClick` **不**触发，`Mode` 翻 `Directional`（构一个挂 `PuiButton` 的 GO，订阅 `onClick`，直接调 `OnSubmit(new BaseEventData(es))`）。
+3. `PuiButton.OnSubmit` 在 `Directional` 模式：`onClick` 正常触发一次。
+4. `PuiToggle.OnSubmit` 在 `Pointer` 模式：`isOn` 不翻转、`Mode` 翻 `Directional`；`Directional` 模式：`isOn` 正常翻转。
+5. 导航未启用（`IsEnabled==false`）：`PuiButton.OnSubmit` 在任意 `Mode` 都正常点击（回归保护）。
+
+**PlayMode**（仿 `CarouselPlayTests`，真实 EventSystem + InputSystem TestFramework，可选——若 runner 不稳先以 EditMode 守底）：
+
+6. 键盘选中 Cancel → 注入鼠标移动（光标隐藏）→ 注入回车 → 断言 Cancel `onClick` 未触发、光标下一帧重现；再注入方向键到 OK + 回车 → OK 触发。
+
+## 6. SKILL 更新与风险
+
+**SKILL**：本次为**纯 runtime 默认行为修复**，无新增 XML 元素/属性、无新增公共 C# API → 按既有约定（透明默认行为豁免）**默认不需要 SKILL 改动**。唯一例外：若母 spec §14 规划的 `reference/navigation.md` 已落地并描述了「鼠标↔手柄模式切换」的 UX，则补一句「鼠标之后第一次确认只唤回光标、不触发」。实施时核查该文件是否存在再定。
+
+| 风险 | 缓解 |
+|---|---|
+| 执行序导致守卫读到过期 `Mode` | §3.3 删 Submit 触发器后，确认键那帧 `Mode` 不会被控制器翻动，守卫读数稳定；EditMode #2/#3 锁住「Pointer 吞、Directional 放」 |
+| 删 `enterKey`/`buttonSouth` 误伤其它依赖确认键翻模式的逻辑 | 全仓 grep `Mode`/`IsDirectional` 消费方共四处：`FocusCursorView`（光标显隐）、`StateBroadcaster.cs:59`（焦点 tint 门，母 spec §4.2）、`InputFieldNavGate`（两级编辑门）、`RepokeSelected`（翻转重绘）。四者**都只读「当前是否 `Directional`」**，而 `Directional` 由*移动*输入建立并持续保持——删 Submit 触发器至多让「指针输入→紧接 Submit」这一序列里 `Mode` 多停留 `Pointer` 一帧，绝不会让导航序列中的 `Directional` 变弱；故无一受损（InputField 两级编辑由方向键建立 `Directional`，与回车无关） |
+| 漏盖某种可点击控件 | Btn=`PuiButton`、Tab/Toggle=`PuiToggle` 已是全部走 Submit 的内置可点击控件；Slider/Dropdown 的 Submit 语义（拖动/展开）不属于「误触按钮」类，v1 不纳入，留作后续 |
+| `base.OnSubmit` 签名/可见性变化 | uGUI `Button.OnSubmit`/`Toggle.OnSubmit` 均 `public virtual`，override 稳定；编译期校验 |

--- a/docs~/superpowers/specs/2026-06-30-nav-hidden-submit-wake-design.md
+++ b/docs~/superpowers/specs/2026-06-30-nav-hidden-submit-wake-design.md
@@ -106,7 +106,7 @@ buttonEast（Cancel/Back）保持不变                                   （取
 | 未调 `UseGamepadNavigation`（`IsEnabled==false`） | `TryWakeOnSubmit` 立即返回 `false` → 完全旧行为，零影响 |
 | 已 `Directional`（光标可见）按确认 | 守卫返回 `false` → 正常点击/toggle（无额外延迟） |
 | 鼠标直接点按钮（任何模式） | 走 `OnPointerClick`，不经本守卫 → 照常触发 |
-| 取消键（ESC / 手柄 B = `buttonEast`） | **不经本守卫**：取消由模态的 `ModalEscapeListener`/`Cancel` action 处理，语义与焦点无关（关栈顶模态），光标隐藏时也应照常生效 → 故 `buttonEast` 保留在模式翻转列表、且 Cancel 不要求「先唤醒」 |
+| 手柄 B（`buttonEast`，back 语义） | **不经本守卫**：库内无 `ICancelHandler` 实现，故 East 不会作用在任何（隐藏的）焦点上——它只重新建立 `Directional`，因此保留在模式翻转列表无害。（模态关闭走 `ModalEscapeListener` 绑定的 Esc / 手柄 Start，**非** East。） |
 | 空格确认（Submit action 默认绑定之一） | 空格本就不在 `NavigationController` 触发列表 → `Pointer` 模式按空格同样走守卫唤醒，无需额外改动 |
 | 屏上无选区（`currentSelectedGameObject==null`） | 不派发 `OnSubmit` → 守卫不运行；按确认无反应（与现状一致，按方向键开始导航） |
 | **模态/屏刚打开、用户首次就按确认键**（从未拨过方向键，`Pointer` 初值、光标隐藏、初始焦点已设在 OK） | 第一次确认**唤回光标到 OK、不确认**，需第二次确认才点 OK。这是「先唤回」规则的统一后果（修复前是首次回车直接点 OK，类似 Windows 默认按钮）。属**有意的行为变更**——用户选定「光标不可见时确认必须先唤醒」，故快速 Enter 关对话框从冷态起需两下 |


### PR DESCRIPTION
## 问题

方向导航的焦点光标在鼠标移动后自动隐藏，但 `EventSystem` 选区仍停在上次键盘/手柄选中的控件上。此时按确认键（回车 / 手柄 A）会**误触发那个看不见的旧焦点**——例如界面只有 OK / Cancel，焦点之前在 Cancel，用户没看到光标、以为焦点没了、按回车想确认 OK，结果触发的却是 Cancel。

根因：焦点的「可见性」（由 `Mode` 驱动的光标显隐）与「可触发性」（`EventSystem` 选区）被解耦了。

## 修复：「先唤回，再确认」

鼠标用过后（Pointer 模式、光标隐藏）第一次确认只把光标唤回它真正所在的控件、**不触发**；用户看清后再操作，第二次确认才生效（主机 / Steam Big Picture 约定）。

- **`UI.Navigation.TryWakeOnSubmit()`** — 单一来源唤醒门：导航启用 + 当前 Pointer 模式 → 翻 `Directional` 唤回光标 + 返回 `true` 吞掉本次 Submit；否则返回 `false` 照常点击。
- **`PuiButton` / `PuiToggle`** 各 override `OnSubmit` 一行调用它（盖 Btn / Tab / Toggle）。
- **`NavigationController`** 不再把 Submit 类输入（`enterKey` / `buttonSouth`）当方向触发器（保留 `buttonEast`），避免同帧执行序竞争让唤醒门读到过期模式。

只拦键盘 / 手柄确认；鼠标点击（`OnPointerClick`）不受影响。**纯 runtime，不碰公共 C# API / XML 语义**；导航未启用时唤醒门恒返回 `false`，零行为变化。InputField 两级编辑排除在 v1 外。

## 测试

- **EditMode 1979/1979**（含新 `SubmitWakeTests` 6 个：唤醒门三分支 + PuiButton 吞掉 + PuiToggle 吞掉/放行）
- **PlayMode 171/171**（含新 `SubmitWakePlayTests`：真实回车端到端复现——键盘选 Cancel → Pointer 隐藏光标 → 回车唤醒不触发 + `Mode` 翻 Directional → 二次回车触发）
- **EditorOnly 275/275**，**lint exit 0**

## 文档

- `authoring-promptugui-xml/reference/navigation.md`：新增「隐藏光标时首次确认唤回光标」说明 + **修正陈旧的 Directional-trigger 表**（Submit / Enter 不再翻模式）
- master nav spec（`2026-06-29-…`）§3 加 2026-06-30 修订超链说明

## 后续（非阻塞）

- **v2**：`Dropdown.OnSubmit` 在隐藏陈旧焦点上仍会展开下拉列表（比误触 Cancel 轻、ESC 可恢复，故 v1 延后合理，但为最高价值的 v2 目标）。
- 视觉 QA 待确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
