### PR TITLE
feat: Unity 2022 支持（Awaitable → UniTask polyfill）

### DIFF
--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -58,6 +58,17 @@ async void Start() {
 
 Prefer to use (if `com.unity.addressables` package is installed) Addressables-backed `.ui.xml` loading (`UI.UseAddressableResolver()` + `AssetReferenceT<TextAsset>`), see the **using-promptugui-addressables** skill.
 
+## Unity version support (async backend)
+
+The async API returns `UnityEngine.Awaitable` / `Awaitable<T>` (e.g. `UI.LoadDocumentAsync`, modal `Open`, `SourceResolver` = `Func<string, Awaitable<string>>`).
+
+- **Unity 6+**: uses the native `UnityEngine.Awaitable` — no extra dependency.
+- **Unity 2022.3**: `Awaitable` does not exist in the engine, so install **UniTask** (`com.cysharp.unitask`, via OpenUPM). PromptUGUI ships a transparent `UnityEngine.Awaitable` / `AwaitableCompletionSource` polyfill (in the `PromptUGUI.Compat.UniTask` assembly, gated to `#if !UNITY_6000_0_OR_NEWER`) backed by UniTask. Missing UniTask on 2022 → one clear `#error` telling you to install it.
+
+**The public C# API is identical on both** — write `async Awaitable<T> Foo()`, `await UI.LoadDocumentAsync(...)`, `new AwaitableCompletionSource<T>()`, `.GetAwaiter().GetResult()` exactly the same way regardless of Unity version. On 2022 the shim also provides implicit `Awaitable<T>` ↔ `UniTask<T>` conversions, so an existing `UniTask<T>`-returning method plugs into a resolver via a lambda: `UI.SourceResolver = s => LoadXmlUniTask(s);`.
+
+> Any assembly of yours that itself *names* `Awaitable` in a signature on Unity 2022 must reference the `PromptUGUI.Compat.UniTask` and `UniTask` asmdefs (asmdef references are not transitive). Running PromptUGUI's own test suite on 2022 also needs `com.unity.test-framework` ≥ 1.4.
+
 ## Canvas configuration
 
 Each `Screen.Open()` creates its own root Canvas (+ `CanvasScaler` + `GraphicRaycaster`). The render mode comes from the XML `canvas` attribute on `<Screen>` (`overlay` / `camera` / `world`, default `overlay`). For everything _else_ — pinning a `worldCamera`, setting `sortingOrder` / `planeDistance`, swapping render mode at runtime, etc. — register a configurator. The configurator runs **after** the XML-declared mode is applied, so it can override anything:

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -63,7 +63,7 @@ Prefer to use (if `com.unity.addressables` package is installed) Addressables-ba
 The async API returns `UnityEngine.Awaitable` / `Awaitable<T>` (e.g. `UI.LoadDocumentAsync`, modal `Open`, `SourceResolver` = `Func<string, Awaitable<string>>`).
 
 - **Unity 6+**: uses the native `UnityEngine.Awaitable` — no extra dependency.
-- **Unity 2022.3**: `Awaitable` does not exist in the engine, so install **UniTask** (`com.cysharp.unitask`, via OpenUPM). PromptUGUI ships a transparent `UnityEngine.Awaitable` / `AwaitableCompletionSource` polyfill (in the `PromptUGUI.Compat.UniTask` assembly, gated to `#if !UNITY_6000_0_OR_NEWER`) backed by UniTask. Missing UniTask on 2022 → one clear `#error` telling you to install it.
+- **Unity 2022.3**: `Awaitable` does not exist in the engine, so install **UniTask** (`com.cysharp.unitask` — git UPM URL `https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask`, or OpenUPM). PromptUGUI ships a transparent `UnityEngine.Awaitable` / `AwaitableCompletionSource` polyfill (in the `PromptUGUI.Compat.UniTask` assembly, gated to `#if !UNITY_6000_0_OR_NEWER`) backed by UniTask. Missing UniTask on 2022 → one clear `#error` telling you to install it.
 
 **The public C# API is identical on both** — write `async Awaitable<T> Foo()`, `await UI.LoadDocumentAsync(...)`, `new AwaitableCompletionSource<T>()`, `.GetAwaiter().GetResult()` exactly the same way regardless of Unity version. On 2022 the shim also provides implicit `Awaitable<T>` ↔ `UniTask<T>` conversions, so an existing `UniTask<T>`-returning method plugs into a resolver via a lambda: `UI.SourceResolver = s => LoadXmlUniTask(s);`.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [English](#promptugui) | [中文](#promptugui-中文)
 
-A solution that enables Unity 6+ UI development through LLM.
+A solution that enables Unity 2022.3+ / Unity 6+ UI development through LLM.
 
 It provides an extremely concise UI description language `.ui.xml` & `.pxl` , and a runtime parser that translates it into a uGUI hierarchy + Sprite images.
 
@@ -85,6 +85,8 @@ Install NuGetForUnity: https://github.com/GlitchEnzo/NuGetForUnity
 Install R3: https://github.com/Cysharp/R3
 
 Install LitMotion: https://github.com/annulusgames/LitMotion.git
+
+Install UniTask — **only on Unity 2022.3** (Unity 6+ uses the native `Awaitable` API and needs no extra dependency): https://github.com/Cysharp/UniTask
 
 
 1. UPM
@@ -297,7 +299,7 @@ C# Code:
 
 [English](#promptugui) | [中文](#promptugui-中文)
 
-一个让 Unity 6+ 的 UI 可以用大模型进行开发的解决方案。
+一个让 Unity 2022.3+ / Unity 6+ 的 UI 可以用大模型进行开发的解决方案。
 
 通过描述语言 `.ui.xml` 以及 `.pxl` 和一个运行时解析器，翻译成uGUI结构 + Sprite图像。
 整体架构全面且简洁，适合大模型直接书写而脱离MCP。
@@ -382,6 +384,8 @@ Install NuGetForUnity: https://github.com/GlitchEnzo/NuGetForUnity
 Install R3: https://github.com/Cysharp/R3
 
 Install LitMotion: https://github.com/annulusgames/LitMotion.git
+
+Install UniTask —— **仅 Unity 2022.3 需要**（Unity 6+ 用原生 `Awaitable`，无需额外依赖）: https://github.com/Cysharp/UniTask
 
 
 1. UPM

--- a/Runtime/Compat.meta
+++ b/Runtime/Compat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ce8c3c0d504d7214bbaf3efa252d5798
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Compat/Awaitable.cs
+++ b/Runtime/Compat/Awaitable.cs
@@ -1,0 +1,31 @@
+#if !UNITY_6000_0_OR_NEWER
+using System.Runtime.CompilerServices;
+using Cysharp.Threading.Tasks;
+using PromptUGUI.Compat.CompilerServices;
+
+namespace UnityEngine
+{
+    // Polyfill for UnityEngine.Awaitable on Unity < 6 (where the type does not
+    // exist). Backed by UniTask. sealed class to mirror Unity's reference-type
+    // semantics. Compiled out on Unity 6+ where the native type is used.
+    [AsyncMethodBuilder(typeof(AwaitableAsyncMethodBuilder))]
+    public sealed class Awaitable
+    {
+        private readonly UniTask _task;
+        public Awaitable(UniTask task) { _task = task; }
+        public UniTask.Awaiter GetAwaiter() => _task.GetAwaiter();
+        public static implicit operator Awaitable(UniTask task) => new Awaitable(task);
+        public static implicit operator UniTask(Awaitable awaitable) => awaitable._task;
+    }
+
+    [AsyncMethodBuilder(typeof(AwaitableAsyncMethodBuilder<>))]
+    public sealed class Awaitable<T>
+    {
+        private readonly UniTask<T> _task;
+        public Awaitable(UniTask<T> task) { _task = task; }
+        public UniTask<T>.Awaiter GetAwaiter() => _task.GetAwaiter();
+        public static implicit operator Awaitable<T>(UniTask<T> task) => new Awaitable<T>(task);
+        public static implicit operator UniTask<T>(Awaitable<T> awaitable) => awaitable._task;
+    }
+}
+#endif

--- a/Runtime/Compat/Awaitable.cs.meta
+++ b/Runtime/Compat/Awaitable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a5f1093396ff754cb2acd71b3072367
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Compat/AwaitableAsyncMethodBuilder.cs
+++ b/Runtime/Compat/AwaitableAsyncMethodBuilder.cs
@@ -1,0 +1,51 @@
+#if !UNITY_6000_0_OR_NEWER
+using System;
+using System.Runtime.CompilerServices;
+using Cysharp.Threading.Tasks.CompilerServices;
+using UnityEngine;
+
+namespace PromptUGUI.Compat.CompilerServices
+{
+    // Async method builders for UnityEngine.Awaitable(<T>) on Unity < 6.
+    // Delegate to UniTask's builders (which correctly handle state-machine
+    // boxing + pooling); Task property wraps the produced UniTask into our shim
+    // via implicit conversion.
+    public struct AwaitableAsyncMethodBuilder
+    {
+        private AsyncUniTaskMethodBuilder _inner;
+        public static AwaitableAsyncMethodBuilder Create() =>
+            new AwaitableAsyncMethodBuilder { _inner = AsyncUniTaskMethodBuilder.Create() };
+        public Awaitable Task => _inner.Task; // UniTask -> Awaitable (implicit)
+        public void SetResult() => _inner.SetResult();
+        public void SetException(Exception e) => _inner.SetException(e);
+        public void SetStateMachine(IAsyncStateMachine stateMachine) => _inner.SetStateMachine(stateMachine);
+        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine
+            => _inner.Start(ref stateMachine);
+        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine
+            => _inner.AwaitOnCompleted(ref awaiter, ref stateMachine);
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine
+            => _inner.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine);
+    }
+
+    public struct AwaitableAsyncMethodBuilder<T>
+    {
+        private AsyncUniTaskMethodBuilder<T> _inner;
+        public static AwaitableAsyncMethodBuilder<T> Create() =>
+            new AwaitableAsyncMethodBuilder<T> { _inner = AsyncUniTaskMethodBuilder<T>.Create() };
+        public Awaitable<T> Task => _inner.Task; // UniTask<T> -> Awaitable<T> (implicit)
+        public void SetResult(T result) => _inner.SetResult(result);
+        public void SetException(Exception e) => _inner.SetException(e);
+        public void SetStateMachine(IAsyncStateMachine stateMachine) => _inner.SetStateMachine(stateMachine);
+        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine
+            => _inner.Start(ref stateMachine);
+        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine
+            => _inner.AwaitOnCompleted(ref awaiter, ref stateMachine);
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine
+            => _inner.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine);
+    }
+}
+#endif

--- a/Runtime/Compat/AwaitableAsyncMethodBuilder.cs.meta
+++ b/Runtime/Compat/AwaitableAsyncMethodBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 204870bfbad970544a4c09dfffcea81e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Compat/AwaitableCompletionSource.cs
+++ b/Runtime/Compat/AwaitableCompletionSource.cs
@@ -1,0 +1,34 @@
+#if !UNITY_6000_0_OR_NEWER
+using System;
+using Cysharp.Threading.Tasks;
+
+namespace UnityEngine
+{
+    // Polyfill for UnityEngine.AwaitableCompletionSource on Unity < 6, backed by
+    // UniTaskCompletionSource. Mirrors Unity's API surface: both the throwing
+    // Set* setters and the boolean TrySet* variants (the library uses both).
+    public sealed class AwaitableCompletionSource
+    {
+        private readonly UniTaskCompletionSource _src = new UniTaskCompletionSource();
+        public Awaitable Awaitable => _src.Task; // UniTask -> Awaitable (implicit)
+        public void SetResult() => _src.TrySetResult();
+        public void SetException(Exception exception) => _src.TrySetException(exception);
+        public void SetCanceled() => _src.TrySetCanceled();
+        public bool TrySetResult() => _src.TrySetResult();
+        public bool TrySetException(Exception exception) => _src.TrySetException(exception);
+        public bool TrySetCanceled() => _src.TrySetCanceled();
+    }
+
+    public sealed class AwaitableCompletionSource<T>
+    {
+        private readonly UniTaskCompletionSource<T> _src = new UniTaskCompletionSource<T>();
+        public Awaitable<T> Awaitable => _src.Task; // UniTask<T> -> Awaitable<T> (implicit)
+        public void SetResult(T value) => _src.TrySetResult(value);
+        public void SetException(Exception exception) => _src.TrySetException(exception);
+        public void SetCanceled() => _src.TrySetCanceled();
+        public bool TrySetResult(T value) => _src.TrySetResult(value);
+        public bool TrySetException(Exception exception) => _src.TrySetException(exception);
+        public bool TrySetCanceled() => _src.TrySetCanceled();
+    }
+}
+#endif

--- a/Runtime/Compat/AwaitableCompletionSource.cs.meta
+++ b/Runtime/Compat/AwaitableCompletionSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83dad99af92ef684b86023d33ce68293
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Compat/PromptUGUI.Compat.UniTask.asmdef
+++ b/Runtime/Compat/PromptUGUI.Compat.UniTask.asmdef
@@ -1,0 +1,15 @@
+{
+    "name": "PromptUGUI.Compat.UniTask",
+    "rootNamespace": "",
+    "references": ["UniTask"],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "autoReferenced": true,
+    "defineConstraints": ["PROMPTUGUI_HAS_UNITASK", "!UNITY_6000_0_OR_NEWER"],
+    "versionDefines": [
+        { "name": "com.cysharp.unitask", "expression": "2.0.0", "define": "PROMPTUGUI_HAS_UNITASK" }
+    ],
+    "noEngineReferences": false
+}

--- a/Runtime/Compat/PromptUGUI.Compat.UniTask.asmdef.meta
+++ b/Runtime/Compat/PromptUGUI.Compat.UniTask.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bfb3f20c086066947b9b1afa3243a212
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Controls/InputField.cs
+++ b/Runtime/Controls/InputField.cs
@@ -64,7 +64,11 @@ namespace PromptUGUI.Controls
             _placeholder.fontStyle = FontStyles.Italic;
             _placeholder.color = ProceduralBuilders.DefaultPlaceholderColor;
             _placeholder.text = "Enter text...";
+#if UNITY_2023_1_OR_NEWER
             _placeholder.textWrappingMode = TextWrappingModes.NoWrap;
+#else
+            _placeholder.enableWordWrapping = false;
+#endif
             var phLE = _placeholder.gameObject.AddComponent<LayoutElement>();
             phLE.ignoreLayout = true;
 

--- a/Runtime/Controls/Text.cs
+++ b/Runtime/Controls/Text.cs
@@ -157,7 +157,11 @@ namespace PromptUGUI.Controls
         [UIAttr, Preserve]
         public bool Wrap
         {
+#if UNITY_2023_1_OR_NEWER
             set => _tmp.textWrappingMode = value ? TextWrappingModes.Normal : TextWrappingModes.NoWrap;
+#else
+            set => _tmp.enableWordWrapping = value;
+#endif
         }
 
         // What to do once auto-sizing (if any) has done its best and the text still doesn't fit the

--- a/Runtime/PromptUGUI.Runtime.asmdef
+++ b/Runtime/PromptUGUI.Runtime.asmdef
@@ -9,7 +9,9 @@
     "Unity.ResourceManager",
     "Unity.InputSystem",
     "LitMotion",
-    "LitMotion.Extensions"
+    "LitMotion.Extensions",
+    "PromptUGUI.Compat.UniTask",
+    "UniTask"
   ],
   "includePlatforms": [],
   "excludePlatforms": [],

--- a/Runtime/PromptUGUI.Runtime.asmdef
+++ b/Runtime/PromptUGUI.Runtime.asmdef
@@ -27,6 +27,11 @@
       "name": "com.unity.2d.aseprite",
       "expression": "1.0.0",
       "define": "PROMPTUGUI_HAS_ASEPRITE"
+    },
+    {
+      "name": "com.cysharp.unitask",
+      "expression": "2.0.0",
+      "define": "PROMPTUGUI_HAS_UNITASK"
     }
   ],
   "noEngineReferences": false

--- a/Runtime/UniTaskRequirement.cs
+++ b/Runtime/UniTaskRequirement.cs
@@ -1,5 +1,5 @@
 // PromptUGUI on Unity 2022 requires UniTask. This guard turns hundreds of
 // "Awaitable not found" errors into one clear message when UniTask is missing.
 #if !UNITY_6000_0_OR_NEWER && !PROMPTUGUI_HAS_UNITASK
-#error PromptUGUI on Unity 2022 requires UniTask (com.cysharp.unitask). Install it via OpenUPM: https://openupm.com/packages/com.cysharp.unitask/
+#error PromptUGUI on Unity 2022 requires UniTask (com.cysharp.unitask). Install it via : https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask
 #endif

--- a/Runtime/UniTaskRequirement.cs
+++ b/Runtime/UniTaskRequirement.cs
@@ -1,0 +1,5 @@
+// PromptUGUI on Unity 2022 requires UniTask. This guard turns hundreds of
+// "Awaitable not found" errors into one clear message when UniTask is missing.
+#if !UNITY_6000_0_OR_NEWER && !PROMPTUGUI_HAS_UNITASK
+#error PromptUGUI on Unity 2022 requires UniTask (com.cysharp.unitask). Install it via OpenUPM: https://openupm.com/packages/com.cysharp.unitask/
+#endif

--- a/Runtime/UniTaskRequirement.cs.meta
+++ b/Runtime/UniTaskRequirement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6fe07926bfed5f741ac0d7fe1b65877d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Compat.meta
+++ b/Tests/EditMode/Compat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3fb0f4a626216b74e83c63a1e09fd898
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Compat/AwaitableShimTests.cs
+++ b/Tests/EditMode/Compat/AwaitableShimTests.cs
@@ -1,0 +1,47 @@
+#if !UNITY_6000_0_OR_NEWER
+#pragma warning disable CS1998 // async without await: intentional for sync-completion tests
+using NUnit.Framework;
+using UnityEngine;
+using Cysharp.Threading.Tasks;
+
+namespace PromptUGUI.Tests.Compat
+{
+    public class AwaitableShimTests
+    {
+        private static async Awaitable<int> ProduceImmediate() => 7;
+
+        private static async Awaitable<int> ProduceAfterYield()
+        {
+            await UniTask.Yield();
+            return 9;
+        }
+
+        [Test]
+        public void AsyncBuilder_SyncCompletion_ReturnsValue()
+        {
+            // async Awaitable<int> with no await completes synchronously;
+            // exercises the builder's SetResult + Task property path.
+            var v = ProduceImmediate().GetAwaiter().GetResult();
+            Assert.AreEqual(7, v);
+        }
+
+        [Test]
+        public void ImplicitConversion_UniTask_To_Awaitable_And_Back()
+        {
+            UniTask<int> u = UniTask.FromResult(5);
+            Awaitable<int> a = u;      // implicit UniTask<int> -> Awaitable<int>
+            UniTask<int> back = a;      // implicit Awaitable<int> -> UniTask<int>
+            Assert.AreEqual(5, back.GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public void NonGeneric_Awaitable_Awaits()
+        {
+            UniTask u = UniTask.CompletedTask;
+            Awaitable a = u;            // implicit UniTask -> Awaitable
+            a.GetAwaiter().GetResult(); // completes without throwing
+            Assert.Pass();
+        }
+    }
+}
+#endif

--- a/Tests/EditMode/Compat/AwaitableShimTests.cs
+++ b/Tests/EditMode/Compat/AwaitableShimTests.cs
@@ -42,6 +42,32 @@ namespace PromptUGUI.Tests.Compat
             a.GetAwaiter().GetResult(); // completes without throwing
             Assert.Pass();
         }
+
+        [Test]
+        public void CompletionSource_Generic_SetResult_SyncUnwrap()
+        {
+            var src = new AwaitableCompletionSource<int>();
+            src.SetResult(11);
+            var v = src.Awaitable.GetAwaiter().GetResult();
+            Assert.AreEqual(11, v);
+        }
+
+        [Test]
+        public void CompletionSource_NonGeneric_SetResult_Completes()
+        {
+            var src = new AwaitableCompletionSource();
+            src.SetResult();
+            src.Awaitable.GetAwaiter().GetResult(); // no throw
+            Assert.Pass();
+        }
+
+        [Test]
+        public void CompletionSource_Generic_SetException_Throws()
+        {
+            var src = new AwaitableCompletionSource<int>();
+            src.SetException(new System.IO.IOException("boom"));
+            Assert.Throws<System.IO.IOException>(() => src.Awaitable.GetAwaiter().GetResult());
+        }
     }
 }
 #endif

--- a/Tests/EditMode/Compat/AwaitableShimTests.cs.meta
+++ b/Tests/EditMode/Compat/AwaitableShimTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 351ccf83c5525cf4490143e375ee6f19
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Compat/PromptUGUI.Tests.Compat.asmdef
+++ b/Tests/EditMode/Compat/PromptUGUI.Tests.Compat.asmdef
@@ -1,0 +1,15 @@
+{
+    "name": "PromptUGUI.Tests.Compat",
+    "rootNamespace": "PromptUGUI.Tests.Compat",
+    "references": ["PromptUGUI.Compat.UniTask", "UniTask", "UnityEngine.TestRunner", "UnityEditor.TestRunner"],
+    "includePlatforms": ["Editor"],
+    "excludePlatforms": [],
+    "overrideReferences": true,
+    "precompiledReferences": ["nunit.framework.dll"],
+    "autoReferenced": false,
+    "defineConstraints": ["UNITY_INCLUDE_TESTS", "PROMPTUGUI_HAS_UNITASK", "!UNITY_6000_0_OR_NEWER"],
+    "versionDefines": [
+        { "name": "com.cysharp.unitask", "expression": "2.0.0", "define": "PROMPTUGUI_HAS_UNITASK" }
+    ],
+    "noEngineReferences": false
+}

--- a/Tests/EditMode/Compat/PromptUGUI.Tests.Compat.asmdef.meta
+++ b/Tests/EditMode/Compat/PromptUGUI.Tests.Compat.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 30b2af9956f226149a70818a4c8def78
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/PromptUGUI.Tests.EditMode.asmdef
+++ b/Tests/EditMode/PromptUGUI.Tests.EditMode.asmdef
@@ -6,7 +6,9 @@
     "UnityEngine.TestRunner",
     "UnityEditor.TestRunner",
     "Unity.TextMeshPro",
-    "Unity.Addressables"
+    "Unity.Addressables",
+    "PromptUGUI.Compat.UniTask",
+    "UniTask"
   ],
   "includePlatforms": ["Editor"],
   "excludePlatforms": [],

--- a/Tests/PlayMode/PromptUGUI.Tests.PlayMode.asmdef
+++ b/Tests/PlayMode/PromptUGUI.Tests.PlayMode.asmdef
@@ -7,7 +7,9 @@
     "UnityEditor.TestRunner",
     "Unity.TextMeshPro",
     "Unity.InputSystem",
-    "Unity.InputSystem.TestFramework"
+    "Unity.InputSystem.TestFramework",
+    "PromptUGUI.Compat.UniTask",
+    "UniTask"
   ],
   "includePlatforms": [],
   "excludePlatforms": [],

--- a/docs~/superpowers/plans/2026-07-06-awaitable-unitask-2022.md
+++ b/docs~/superpowers/plans/2026-07-06-awaitable-unitask-2022.md
@@ -1,0 +1,530 @@
+# Unity 2022 Awaitable→UniTask Shim 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 PromptUGUI 在 Unity 2022.3 上编译/运行——在 `UnityEngine` 命名空间下补一套仅 2022 编译、内部包 UniTask 的 `Awaitable` / `AwaitableCompletionSource` polyfill，现有 71 文件 + 测试一行不改。
+
+**Architecture:** 新增受门控的 `PromptUGUI.Compat.UniTask` 程序集（`Runtime/Compat/`），内含 `namespace UnityEngine` 的 shim 类型；`Awaitable<T>` 带 `[AsyncMethodBuilder]`，builder 转发给 UniTask 的 `AsyncUniTaskMethodBuilder<T>`；shim 与 UniTask 之间双向隐式转换。Unity 6 上整套被 `#if !UNITY_6000_0_OR_NEWER` 剪掉，走 Unity 原生 Awaitable。
+
+**Tech Stack:** Unity 2022.3 / C# 9 / UniTask (`com.cysharp.unitask` ≥ 2.0) / NUnit（EditMode 测试）/ UnityMCP（在真实 2022 工程跑 refresh + run_tests）。
+
+**设计依据：** `docs~/superpowers/specs/2026-07-06-awaitable-unitask-2022-design.md`。核心机制已用隔离 spike 在真实 Unity 2022+UniTask 实测通过（见 spec §9）。
+
+## Global Constraints
+
+- **版本门控权威来源 = C# `#if !UNITY_6000_0_OR_NEWER`**，包住每个 shim/测试源文件全体。asmdef `defineConstraints` 里的 `!UNITY_6000_0_OR_NEWER` 只作 best-effort 早退（Unity 对内置版本宏的 defineConstraints 支持不确定），不可作为唯一门控。
+- **后端版本驱动**：Unity 6+ 用原生 `UnityEngine.Awaitable`；Unity <6 用 UniTask。不提供「6 上强制 UniTask」的 define。
+- shim 的 `Awaitable` / `Awaitable<T>` / `AwaitableCompletionSource(<T>)` 均为 **`sealed class`**（匹配 Unity 引用类型语义）。
+- **确切 UniTask API**（spike + context7 已核实）：`Cysharp.Threading.Tasks.CompilerServices.AsyncUniTaskMethodBuilder` / `AsyncUniTaskMethodBuilder<T>`（public，`Create()`/`Task`/`SetResult`/`SetException`/`SetStateMachine`/`Start`/`AwaitOnCompleted`/`AwaitUnsafeOnCompleted`）；`Cysharp.Threading.Tasks.UniTaskCompletionSource` / `UniTaskCompletionSource<T>`（`.Task` / `TrySetResult` / `TrySetException` / `TrySetCanceled`）。**`System.Runtime.CompilerServices.AsyncMethodBuilderAttribute` 跨程序集可访问（无需自补）。**
+- **公共 API 签名逐字不变**（仍 `UnityEngine.Awaitable<string>` 等）。
+- **提交卫生**：只显式 `git add <目标源> <新文件.meta>`，**绝不 `git add -A`**。**不改 `package.json` 的 `dependencies`**（用户在 Windows 侧管理 ugui/lit-motion 降级）。**不提交既有文件的 `.meta` churn**（2022↔6 双编辑器互写，248 个）；新文件的 `.meta` 需显式提交。
+- **不许提交到 main**（CLAUDE.md）。当前分支 `feat/awaitable-unitask-2022`。
+- **SKILL 更新**：C# skill 加「Unity 2022 支持」节（安装 UniTask；公共 API 无差异）。
+- **工作流**：文件用 bash 写进仓库（bind-mount 到 2022 工程 `C:\xsoft\PromptUGUI`）→ `refresh_unity(compile=request, mode=force)` → `read_console` / `run_tests`。已实测该回路可用。
+
+---
+
+### Task 1: 受门控的 Compat 程序集壳 + UniTask 缺失护栏
+
+**Files:**
+- Create: `Runtime/Compat/PromptUGUI.Compat.UniTask.asmdef`
+- Create: `Runtime/UniTaskRequirement.cs`（注意：**在 `Runtime/` 根，不在 `Runtime/Compat/`**——`Runtime/Compat/` 会被 Compat asmdef 认领；护栏必须留在永远编译的 Runtime 程序集里）
+- Modify: `Runtime/PromptUGUI.Runtime.asmdef`（加 `versionDefines` 一条）
+
+**Interfaces:**
+- Produces: 空的 `PromptUGUI.Compat.UniTask` 程序集（供后续 Task 放 shim 类型）；`PROMPTUGUI_HAS_UNITASK` 定义符（`com.cysharp.unitask` ≥ 2.0 时）。
+
+- [ ] **Step 1: 建 Compat asmdef**
+
+写 `Runtime/Compat/PromptUGUI.Compat.UniTask.asmdef`：
+
+```json
+{
+    "name": "PromptUGUI.Compat.UniTask",
+    "rootNamespace": "",
+    "references": ["UniTask"],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "autoReferenced": true,
+    "defineConstraints": ["PROMPTUGUI_HAS_UNITASK", "!UNITY_6000_0_OR_NEWER"],
+    "versionDefines": [
+        { "name": "com.cysharp.unitask", "expression": "2.0.0", "define": "PROMPTUGUI_HAS_UNITASK" }
+    ],
+    "noEngineReferences": false
+}
+```
+
+- [ ] **Step 2: 建 UniTask 缺失护栏**
+
+写 `Runtime/UniTaskRequirement.cs`：
+
+```csharp
+// PromptUGUI on Unity 2022 requires UniTask. This guard turns hundreds of
+// "Awaitable not found" errors into one clear message when UniTask is missing.
+#if !UNITY_6000_0_OR_NEWER && !PROMPTUGUI_HAS_UNITASK
+#error PromptUGUI on Unity 2022 requires UniTask (com.cysharp.unitask). Install it via OpenUPM: https://openupm.com/packages/com.cysharp.unitask/
+#endif
+```
+
+- [ ] **Step 3: 给 Runtime.asmdef 加 versionDefine**
+
+在 `Runtime/PromptUGUI.Runtime.asmdef` 的 `versionDefines` 数组里**追加**（保留现有 addressables / aseprite 两条）：
+
+```json
+{ "name": "com.cysharp.unitask", "expression": "2.0.0", "define": "PROMPTUGUI_HAS_UNITASK" }
+```
+
+- [ ] **Step 4: 刷新并确认无新错误**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"], count="60")
+```
+
+Expected: 仍是 Task 前就有的一堆 `Awaitable` / `AwaitableCompletionSource` CS0246/CS0234（shim 还没写），**但不得出现任何提到 `PromptUGUI.Compat.UniTask`、`UniTaskRequirement.cs`、"reference not found"、`#error` 的新错误**。护栏静默（UniTask 已装 → `PROMPTUGUI_HAS_UNITASK` 已定义）。若出现 `#error` 那条 → UniTask 没装或 versionDefine 没生效，先修。
+
+- [ ] **Step 5: 提交**
+
+```bash
+# 让 2022 编辑器生成新文件的 .meta 后再提交它们
+git add Runtime/Compat/PromptUGUI.Compat.UniTask.asmdef Runtime/Compat/PromptUGUI.Compat.UniTask.asmdef.meta \
+        Runtime/UniTaskRequirement.cs Runtime/UniTaskRequirement.cs.meta \
+        Runtime/PromptUGUI.Runtime.asmdef
+git commit -m "feat(compat): gated PromptUGUI.Compat.UniTask assembly + UniTask requirement guard"
+```
+
+---
+
+### Task 2: `Awaitable` / `Awaitable<T>` 类型 + AsyncMethodBuilder + 双向隐式转换（TDD）
+
+**Files:**
+- Create: `Tests/EditMode/Compat/PromptUGUI.Tests.Compat.asmdef`
+- Create: `Tests/EditMode/Compat/AwaitableShimTests.cs`
+- Create: `Runtime/Compat/Awaitable.cs`
+- Create: `Runtime/Compat/AwaitableAsyncMethodBuilder.cs`
+
+**Interfaces:**
+- Consumes: `PromptUGUI.Compat.UniTask` 程序集（Task 1）。
+- Produces:
+  - `UnityEngine.Awaitable`（sealed class，包 `UniTask`）+ `UnityEngine.Awaitable<T>`（sealed class，包 `UniTask<T>`）；各有 `GetAwaiter()`、隐式 `↔ UniTask(<T>)`。
+  - `PromptUGUI.Compat.CompilerServices.AwaitableAsyncMethodBuilder` / `AwaitableAsyncMethodBuilder<T>`（public struct，转发 UniTask builder）。
+
+- [ ] **Step 1: 建 Compat 测试 asmdef**
+
+写 `Tests/EditMode/Compat/PromptUGUI.Tests.Compat.asmdef`：
+
+```json
+{
+    "name": "PromptUGUI.Tests.Compat",
+    "rootNamespace": "PromptUGUI.Tests.Compat",
+    "references": ["PromptUGUI.Compat.UniTask", "UniTask", "UnityEngine.TestRunner", "UnityEditor.TestRunner"],
+    "includePlatforms": ["Editor"],
+    "overrideReferences": true,
+    "precompiledReferences": ["nunit.framework.dll"],
+    "autoReferenced": false,
+    "defineConstraints": ["UNITY_INCLUDE_TESTS", "PROMPTUGUI_HAS_UNITASK", "!UNITY_6000_0_OR_NEWER"],
+    "versionDefines": [
+        { "name": "com.cysharp.unitask", "expression": "2.0.0", "define": "PROMPTUGUI_HAS_UNITASK" }
+    ],
+    "noEngineReferences": false
+}
+```
+
+- [ ] **Step 2: 写失败测试（Awaitable 类型 + builder + 转换）**
+
+写 `Tests/EditMode/Compat/AwaitableShimTests.cs`：
+
+```csharp
+#if !UNITY_6000_0_OR_NEWER
+#pragma warning disable CS1998 // async without await: intentional for sync-completion tests
+using NUnit.Framework;
+using UnityEngine;
+using Cysharp.Threading.Tasks;
+
+namespace PromptUGUI.Tests.Compat
+{
+    public class AwaitableShimTests
+    {
+        private static async Awaitable<int> ProduceImmediate() => 7;
+
+        private static async Awaitable<int> ProduceAfterYield()
+        {
+            await UniTask.Yield();
+            return 9;
+        }
+
+        [Test]
+        public void AsyncBuilder_SyncCompletion_ReturnsValue()
+        {
+            // async Awaitable<int> with no await completes synchronously;
+            // exercises the builder's SetResult + Task property path.
+            var v = ProduceImmediate().GetAwaiter().GetResult();
+            Assert.AreEqual(7, v);
+        }
+
+        [Test]
+        public void ImplicitConversion_UniTask_To_Awaitable_And_Back()
+        {
+            UniTask<int> u = UniTask.FromResult(5);
+            Awaitable<int> a = u;      // implicit UniTask<int> -> Awaitable<int>
+            UniTask<int> back = a;      // implicit Awaitable<int> -> UniTask<int>
+            Assert.AreEqual(5, back.GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public void NonGeneric_Awaitable_Awaits()
+        {
+            UniTask u = UniTask.CompletedTask;
+            Awaitable a = u;            // implicit UniTask -> Awaitable
+            a.GetAwaiter().GetResult(); // completes without throwing
+            Assert.Pass();
+        }
+    }
+}
+#endif
+```
+
+- [ ] **Step 3: 跑测试确认失败（RED）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"], count="40", filter_text="AwaitableShimTests")
+```
+
+Expected: `AwaitableShimTests.cs` 报 CS0246 —— `Awaitable` / `Awaitable<>` 找不到（shim 类型尚未实现）。这是 RED。
+
+- [ ] **Step 4: 实现 Awaitable 类型**
+
+写 `Runtime/Compat/Awaitable.cs`：
+
+```csharp
+#if !UNITY_6000_0_OR_NEWER
+using System.Runtime.CompilerServices;
+using Cysharp.Threading.Tasks;
+using PromptUGUI.Compat.CompilerServices;
+
+namespace UnityEngine
+{
+    // Polyfill for UnityEngine.Awaitable on Unity < 6 (where the type does not
+    // exist). Backed by UniTask. sealed class to mirror Unity's reference-type
+    // semantics. Compiled out on Unity 6+ where the native type is used.
+    [AsyncMethodBuilder(typeof(AwaitableAsyncMethodBuilder))]
+    public sealed class Awaitable
+    {
+        private readonly UniTask _task;
+        public Awaitable(UniTask task) { _task = task; }
+        public UniTask.Awaiter GetAwaiter() => _task.GetAwaiter();
+        public static implicit operator Awaitable(UniTask task) => new Awaitable(task);
+        public static implicit operator UniTask(Awaitable awaitable) => awaitable._task;
+    }
+
+    [AsyncMethodBuilder(typeof(AwaitableAsyncMethodBuilder<>))]
+    public sealed class Awaitable<T>
+    {
+        private readonly UniTask<T> _task;
+        public Awaitable(UniTask<T> task) { _task = task; }
+        public UniTask<T>.Awaiter GetAwaiter() => _task.GetAwaiter();
+        public static implicit operator Awaitable<T>(UniTask<T> task) => new Awaitable<T>(task);
+        public static implicit operator UniTask<T>(Awaitable<T> awaitable) => awaitable._task;
+    }
+}
+#endif
+```
+
+- [ ] **Step 5: 实现 AsyncMethodBuilder（转发 UniTask）**
+
+写 `Runtime/Compat/AwaitableAsyncMethodBuilder.cs`（结构与 spike 实测通过的 `SpikeBuilder` 逐行一致）：
+
+```csharp
+#if !UNITY_6000_0_OR_NEWER
+using System;
+using System.Runtime.CompilerServices;
+using Cysharp.Threading.Tasks.CompilerServices;
+using UnityEngine;
+
+namespace PromptUGUI.Compat.CompilerServices
+{
+    // Async method builders for UnityEngine.Awaitable(<T>) on Unity < 6.
+    // Delegate to UniTask's builders (which correctly handle state-machine
+    // boxing + pooling); Task property wraps the produced UniTask into our shim
+    // via implicit conversion.
+    public struct AwaitableAsyncMethodBuilder
+    {
+        private AsyncUniTaskMethodBuilder _inner;
+        public static AwaitableAsyncMethodBuilder Create() =>
+            new AwaitableAsyncMethodBuilder { _inner = AsyncUniTaskMethodBuilder.Create() };
+        public Awaitable Task => _inner.Task; // UniTask -> Awaitable (implicit)
+        public void SetResult() => _inner.SetResult();
+        public void SetException(Exception e) => _inner.SetException(e);
+        public void SetStateMachine(IAsyncStateMachine stateMachine) => _inner.SetStateMachine(stateMachine);
+        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine
+            => _inner.Start(ref stateMachine);
+        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine
+            => _inner.AwaitOnCompleted(ref awaiter, ref stateMachine);
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine
+            => _inner.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine);
+    }
+
+    public struct AwaitableAsyncMethodBuilder<T>
+    {
+        private AsyncUniTaskMethodBuilder<T> _inner;
+        public static AwaitableAsyncMethodBuilder<T> Create() =>
+            new AwaitableAsyncMethodBuilder<T> { _inner = AsyncUniTaskMethodBuilder<T>.Create() };
+        public Awaitable<T> Task => _inner.Task; // UniTask<T> -> Awaitable<T> (implicit)
+        public void SetResult(T result) => _inner.SetResult(result);
+        public void SetException(Exception e) => _inner.SetException(e);
+        public void SetStateMachine(IAsyncStateMachine stateMachine) => _inner.SetStateMachine(stateMachine);
+        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine
+            => _inner.Start(ref stateMachine);
+        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine
+            => _inner.AwaitOnCompleted(ref awaiter, ref stateMachine);
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine
+            => _inner.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine);
+    }
+}
+#endif
+```
+
+- [ ] **Step 6: 跑测试确认通过（GREEN）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"], count="20", filter_text="AwaitableShimTests")   # 期望 0
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.Compat"])
+# 轮询 get_test_job 直到完成
+```
+
+Expected: 3 个测试全绿。
+
+- [ ] **Step 7: 提交**
+
+```bash
+git add Runtime/Compat/Awaitable.cs Runtime/Compat/Awaitable.cs.meta \
+        Runtime/Compat/AwaitableAsyncMethodBuilder.cs Runtime/Compat/AwaitableAsyncMethodBuilder.cs.meta \
+        Tests/EditMode/Compat/PromptUGUI.Tests.Compat.asmdef Tests/EditMode/Compat/PromptUGUI.Tests.Compat.asmdef.meta \
+        Tests/EditMode/Compat/AwaitableShimTests.cs Tests/EditMode/Compat/AwaitableShimTests.cs.meta
+git commit -m "feat(compat): UnityEngine.Awaitable(<T>) shim + async method builders (UniTask-backed)"
+```
+
+---
+
+### Task 3: `AwaitableCompletionSource` / `AwaitableCompletionSource<T>`（TDD）
+
+**Files:**
+- Create: `Runtime/Compat/AwaitableCompletionSource.cs`
+- Modify: `Tests/EditMode/Compat/AwaitableShimTests.cs`（加测试）
+
+**Interfaces:**
+- Consumes: `UnityEngine.Awaitable(<T>)`（Task 2）。
+- Produces: `UnityEngine.AwaitableCompletionSource`（`.Awaitable` / `SetResult()` / `SetException` / `SetCanceled`）+ `UnityEngine.AwaitableCompletionSource<T>`（`.Awaitable` / `SetResult(T)` / `SetException` / `SetCanceled`）。
+
+- [ ] **Step 1: 写失败测试**
+
+在 `AwaitableShimTests.cs` 的 `AwaitableShimTests` 类里**追加**（`#if` 块内）：
+
+```csharp
+        [Test]
+        public void CompletionSource_Generic_SetResult_SyncUnwrap()
+        {
+            var src = new AwaitableCompletionSource<int>();
+            src.SetResult(11);
+            var v = src.Awaitable.GetAwaiter().GetResult();
+            Assert.AreEqual(11, v);
+        }
+
+        [Test]
+        public void CompletionSource_NonGeneric_SetResult_Completes()
+        {
+            var src = new AwaitableCompletionSource();
+            src.SetResult();
+            src.Awaitable.GetAwaiter().GetResult(); // no throw
+            Assert.Pass();
+        }
+
+        [Test]
+        public void CompletionSource_Generic_SetException_Throws()
+        {
+            var src = new AwaitableCompletionSource<int>();
+            src.SetException(new System.IO.IOException("boom"));
+            Assert.Throws<System.IO.IOException>(() => src.Awaitable.GetAwaiter().GetResult());
+        }
+```
+
+- [ ] **Step 2: 跑测试确认失败（RED）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"], count="20", filter_text="AwaitableShimTests")
+```
+
+Expected: CS0246 —— `AwaitableCompletionSource` / `AwaitableCompletionSource<>` 找不到。RED。
+
+- [ ] **Step 3: 实现完成源**
+
+写 `Runtime/Compat/AwaitableCompletionSource.cs`：
+
+```csharp
+#if !UNITY_6000_0_OR_NEWER
+using System;
+using Cysharp.Threading.Tasks;
+
+namespace UnityEngine
+{
+    // Polyfill for UnityEngine.AwaitableCompletionSource on Unity < 6, backed by
+    // UniTaskCompletionSource. Method names mirror Unity's (SetResult/SetException/
+    // SetCanceled); implemented over UniTask's TrySet* (library sets each source once).
+    public sealed class AwaitableCompletionSource
+    {
+        private readonly UniTaskCompletionSource _src = new UniTaskCompletionSource();
+        public Awaitable Awaitable => _src.Task; // UniTask -> Awaitable (implicit)
+        public void SetResult() => _src.TrySetResult();
+        public void SetException(Exception exception) => _src.TrySetException(exception);
+        public void SetCanceled() => _src.TrySetCanceled();
+    }
+
+    public sealed class AwaitableCompletionSource<T>
+    {
+        private readonly UniTaskCompletionSource<T> _src = new UniTaskCompletionSource<T>();
+        public Awaitable<T> Awaitable => _src.Task; // UniTask<T> -> Awaitable<T> (implicit)
+        public void SetResult(T value) => _src.TrySetResult(value);
+        public void SetException(Exception exception) => _src.TrySetException(exception);
+        public void SetCanceled() => _src.TrySetCanceled();
+    }
+}
+#endif
+```
+
+- [ ] **Step 4: 跑测试确认通过（GREEN）**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.Compat"])
+# 轮询 get_test_job；期望 6 个测试全绿
+```
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Runtime/Compat/AwaitableCompletionSource.cs Runtime/Compat/AwaitableCompletionSource.cs.meta \
+        Tests/EditMode/Compat/AwaitableShimTests.cs
+git commit -m "feat(compat): UnityEngine.AwaitableCompletionSource(<T>) shim (UniTask-backed)"
+```
+
+---
+
+### Task 4: 整包在 2022 编译通过 + 全量 EditMode 回归（集成检查点）
+
+**Files:** 无新增；如出现遗漏用法/签名不匹配的 straggler，在对应文件就地修（应极少或没有——异步面已审计干净）。
+
+**Interfaces:** 依赖 Task 1-3 的完整 shim。
+
+- [ ] **Step 1: 整包编译，确认 Awaitable 错误清零**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"], count="100")
+```
+
+Expected: **零** `Awaitable` / `Awaitable<>` / `AwaitableCompletionSource` 相关 CS0246/CS0234（Task 前有几百条，现在全清）。若剩个别错误 → 是真 straggler（某处 Unity-6-only 用法 shim 没覆盖），逐条读、就地修，重跑至清零。
+
+- [ ] **Step 2: 全量 EditMode 回归（UniTask 后端）**
+
+```
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+# 轮询 get_test_job
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.Compat"])
+```
+
+Expected: 既有 EditMode 全绿（这是 shim 端到端跑通库真实异步路径的证据）+ Compat 6 个绿。PlayMode 若该 2022 工程可跑也跑一遍（`PromptUGUI.Tests.PlayMode`）；若 runner 在该工程不稳，记录为待 Task 6 一并确认，不阻塞。
+
+- [ ] **Step 3: 提交（若有 straggler 修复；否则跳过）**
+
+```bash
+# 仅当 Step 1 有就地修复时
+git add <被修文件.cs>
+git commit -m "fix(compat): cover straggler Awaitable usage on Unity 2022"
+```
+
+---
+
+### Task 5: package.json `unity` 下限 + 文档
+
+**Files:**
+- Modify: `package.json`（**仅** `"unity"` 字段；**不碰 `dependencies`**——用户管理）
+- Modify: `README.md`
+- Modify: `.claude/skills/scripting-promptugui-csharp/SKILL.md`
+
+**Interfaces:** 无代码接口。
+
+- [ ] **Step 1: 降 `unity` 字段**
+
+`package.json`：`"unity": "6000.0"` → `"unity": "2022.3"`。**保留** `dependencies` 现状（`com.unity.ugui: 1.0.0` / `lit-motion: 2.0.2` 是用户为跨版本兼容改的，勿动）。
+
+- [ ] **Step 2: README 加「Unity 2022 支持」节**
+
+在 `README.md` 合适位置加一节（英文），说明：Unity 2022.3 需安装 UniTask（`com.cysharp.unitask`，OpenUPM）；Unity 6+ 无需任何额外依赖，走原生 Awaitable；公共 API 在两版本上完全一致。
+
+- [ ] **Step 3: C# SKILL 加同款一节**
+
+在 `.claude/skills/scripting-promptugui-csharp/SKILL.md` 加一节（英文）：Unity 2022 backend note —— 装 UniTask 即可，`UI.*` / `Awaitable` 返回类型的用法与 Unity 6 无差异；`SourceResolver` 等 `Func<…, Awaitable<…>>` 委托签名不变。
+
+- [ ] **Step 4: 刷新 + 提交**
+
+```
+mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)
+mcp__UnityMCP__read_console(action="get", types=["error"], count="30")   # 期望仍清零
+```
+
+```bash
+git add package.json README.md .claude/skills/scripting-promptugui-csharp/SKILL.md
+git commit -m "docs: Unity 2022 support (unity floor 2022.3 + UniTask install note)"
+```
+
+---
+
+### Task 6: 双后端最终确认（Unity 6）+ 收尾
+
+**Files:** 无。
+
+- [ ] **Step 1: 请用户把 MCP 切回 Unity 6 工程**
+
+告诉用户切换（我无法自己切）。切回后 `refresh_unity(mode="force")`。
+
+- [ ] **Step 2: Unity 6 上确认 Awaitable 后端未受影响**
+
+```
+mcp__UnityMCP__read_console(action="get", types=["error"], count="40")   # 期望 0（Compat 被门控掉，原生 Awaitable 生效）
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])
+mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditorOnly"])
+mcp__UnityMCP__run_tests(mode="PlayMode", assembly_names=["PromptUGUI.Tests.PlayMode"])
+```
+
+Expected: 三套全绿、console 洁净（与 Task 前基线一致）。`PromptUGUI.Tests.Compat` 在 6 上被门控排除、不参与——正常。
+
+- [ ] **Step 3: 提交卫生——丢弃既有文件 meta churn**
+
+确认新文件的 `.meta` 已在各 Task 提交；然后丢弃 2022↔6 双编辑器造成的既有文件 meta churn：
+
+```bash
+git status --short | grep -v '\.meta$'                 # 应只剩预期内的已提交项（工作树应干净）
+git checkout -- '**/*.meta' 2>/dev/null || git checkout -- '*.meta'
+git status --short                                     # 期望干净
+```
+
+- [ ] **Step 4: 收尾**
+
+用 superpowers:finishing-a-development-branch 决定合并/PR 方式（CLAUDE.md：不许直接提交 main；走 PR / merge-commit + `--delete-branch`）。
+
+---
+
+## 附：范围外（本计划不做）
+
+- 不给 shim 加 Awaitable 帧/计时静态 API（库 0 使用）。
+- 不改 `package.json` 的 `dependencies`（用户管理 ugui/lit-motion 跨版本降级）。
+- 不做全库其它 2022-only API 审计——Task 4 的整包编译会暴露任何 straggler；异步面已确认 Awaitable 是唯一 6-only 依赖。

--- a/docs~/superpowers/specs/2026-07-06-awaitable-unitask-2022-design.md
+++ b/docs~/superpowers/specs/2026-07-06-awaitable-unitask-2022-design.md
@@ -1,0 +1,185 @@
+# Unity 2022 支持：Awaitable → UniTask 后端切换（polyfill 方案）设计
+
+**日期**: 2026-07-06
+**状态**: 设计阶段（待 review，未进入实施）
+**作用域**:
+
+- 让 PromptUGUI 在 Unity 2022.3 LTS 上编译/运行（当前 `package.json` 要求 `6000.0`）。
+- 唯一的 Unity-6-only 依赖是异步类型 `UnityEngine.Awaitable` / `AwaitableCompletionSource`（Unity 2023.1 / 6 才引入）。在 Unity <6 上用 **UniTask**（`com.cysharp.unitask`）作底座。
+- **现有 71 个源文件 + 全部测试一行不改**——通过在 `UnityEngine` 命名空间下补一个仅 2022 编译的 polyfill 实现。
+
+**依赖**: Unity <6 上新增可选依赖 **UniTask**（`com.cysharp.unitask` ≥ 2.0，OpenUPM/git 安装，无法做硬 UPM 依赖）。Unity 6+ 无新增依赖，走原生 `Awaitable`。复用：UniTask 自带的 `AsyncUniTaskMethodBuilder(<T>)`、`UniTaskCompletionSource(<T>)`。
+
+---
+
+## 1. 背景与动机
+
+项目大量使用 Unity 6 的 `Awaitable`（`Awaitable<T>` 34 处、裸 `Awaitable` 126 处、`AwaitableCompletionSource` 24 处，散落 71 个文件）。`Awaitable` 在 Unity 2022 不存在，是当前无法降到 2022 的唯一硬阻塞。
+
+目标是让 Unity 2022 用户装上 UniTask 后**无缝**使用本库，且**不牺牲** Unity 6 用户的任何东西（原生 Awaitable、零额外依赖、现有代码/测试完全不动）。
+
+### 1.1 关键前置审计（决定了方案可行性，务必保留）
+
+在选型前审计了整个异步面，三条结论是本方案成立的基础：
+
+1. **完全不用 `Awaitable` 的帧/计时静态 API**——`Awaitable.NextFrameAsync` / `WaitForSecondsAsync` / `EndOfFrameAsync` / `FixedUpdateAsync` / `FromAsyncOperation` / `MainThreadAsync` / `BackgroundThreadAsync` 全 0 命中。异步面只是「返回 `Awaitable`/`Awaitable<T>` + `AwaitableCompletionSource` + `await` 内部 awaitable + resolver 委托」这一小子集。shim 只需覆盖这个子集。
+
+2. **没有任何 `await` 依赖 Unity 内置 awaiter**（这条决定「零文件改动」成立，不是假设）：
+   - UnityWebRequest 走**手动 completion-source 桥**：`op.completed += _ => acs.SetResult(true); if(!op.isDone) await acs.Awaitable;`（`UI.Markdown.cs:61`、`MarkdownBoxRequest.cs:166`）——由 shim 的 `AwaitableCompletionSource<T>` 覆盖。
+   - Addressables 走 `await handle.Task`（`AddressableResolverHelper.cs:67` 等 3 处）——`.Task` 是 `System.Threading.Tasks.Task<T>`，全 Unity 版本通用的 .NET awaiter，与后端无关；源码注释亦注明「.Task 兼容更广」。
+   - 其余 `await` 都是 await 我们自己返回 `Awaitable`/`AwaitableCompletionSource.Awaitable` 的方法——由 shim 覆盖。
+
+   ⇒ **没有任何文件需要新增 `using Cysharp.Threading.Tasks;`**。
+
+3. **不 await 任何后端相关 awaitable**（R3/LitMotion/AsyncOperation 直接 await 均 0），不会有「后端类型泄漏到公共面」的地方。
+
+## 2. 目标 / 非目标
+
+**目标**
+
+- Unity 2022.3 上编译通过、可加载文档 / 开模态 / 跑 EditMode 同步解包。
+- 公共 API 签名**逐字不变**（仍是 `UnityEngine.Awaitable<string>` 等），2022 下仅底座换成 UniTask。
+- Unity 6 路径**零影响**：原生 Awaitable、无新增依赖、源文件与测试不动。
+- 用户**零语义转换**：写 `async Awaitable<string>` resolver、`await UI.LoadDocumentAsync(...)`、把现成 `UniTask<T>` 塞进 `Func<…,Awaitable<T>>` 都直通。
+
+**非目标（留口不做）**
+
+- 不给 shim 加 Awaitable 的帧/计时静态 API（库里 0 使用）。2022 用户要就直接用 UniTask。日后如需可在同一 shim 追加。
+- 不做全库 2022 兼容大审计。基于 §1.1，Awaitable 是异步路径唯一的 6-only 依赖；其余包（LitMotion 最低 2021.3 / Addressables / Newtonsoft / uGUI 2.0）均支持 2022.3，在 §9 的 2022 验证步骤一并确认。
+- UniTask 不做硬 UPM 依赖（不在 Unity registry）。
+- 后端选择**版本驱动**，不提供「Unity 6 上也强制走 UniTask」的 define（已与用户确认）。
+
+## 3. 程序集与门控
+
+新增 `Runtime/Compat/PromptUGUI.Compat.UniTask.asmdef`（Unity 惯用的「可选依赖」模式）：
+
+```jsonc
+{
+  "name": "PromptUGUI.Compat.UniTask",
+  "rootNamespace": "",
+  "references": ["UniTask"],
+  "autoReferenced": true,
+  "defineConstraints": ["!UNITY_6000_0_OR_NEWER", "PROMPTUGUI_HAS_UNITASK"],
+  "versionDefines": [
+    { "name": "com.cysharp.unitask", "expression": "2.0.0", "define": "PROMPTUGUI_HAS_UNITASK" }
+  ]
+}
+```
+
+- asmdef 层面：只在 **装了 UniTask** 时才产出程序集（`PROMPTUGUI_HAS_UNITASK` 约束）。那条 `UniTask` 引用因此**永远不会报 missing reference**——这正是**不把 `UniTask` 引用塞进 `PromptUGUI.Runtime`** 的原因（避免 Unity 6 上的 missing-reference 噪音，对比现有 Addressables 直引用的告警方式）。
+- shim 类型放在 `namespace UnityEngine`，且 asmdef `autoReferenced: true`，故 `PromptUGUI.Runtime` / `PromptUGUI.Editor` **无需显式引用**即可看到 `UnityEngine.Awaitable`。
+
+**版本门控的权威来源是 C# `#if`，不是 defineConstraints**（重要）：
+
+- **`defineConstraints` 里的 `!UNITY_6000_0_OR_NEWER` 只是「尽力而为」的早退**。Unity 的 `defineConstraints` 对内置 `UNITY_*_OR_NEWER` 宏的支持历来不确定（它稳定支持的是 versionDefine 符号）。若它认这个宏→Unity 6 上 asmdef 直接不编译（最干净）；若不认→见下。
+- **所有 shim 源文件整体包在 `#if !UNITY_6000_0_OR_NEWER … #endif`（§4）——这是权威门控**，C# 预处理器 100% 认得该宏。于是：
+  - Unity 6 + 装了 UniTask（万一 asmdef 没被早退掉）：Compat 编译成**空程序集**（所有类型被 `#if` 剪掉）→ 不产出 `UnityEngine.Awaitable` → 与 Unity 原生零冲突。
+  - Unity 6 + 没装 UniTask：asmdef 被 `PROMPTUGUI_HAS_UNITASK` 约束掉。
+  - Unity <6 + 装了 UniTask：正常产出 shim。
+  - Unity <6 + 没装 UniTask：asmdef 约束掉 → 命中 §7 护栏单条报错。
+- 结论：设计对「defineConstraints 认不认版本宏」这一不确定性**免疫**——无论认不认，Unity 6 上都绝不会与原生 `Awaitable` 撞。
+
+> versionDefine 与 defineConstraint 放在同一 asmdef 上是 Unity 标准惯用法（先算 versionDefines 再算 defineConstraints），与本仓 `PromptUGUI.Markdown` 的 `PROMPTUGUI_HAS_MARKDIG` 门控同构。
+
+## 4. shim 类型面（`Runtime/Compat/`，`namespace UnityEngine`）
+
+**所有 shim 源文件整体包在 `#if !UNITY_6000_0_OR_NEWER … #endif`**（§3 的权威门控）。按 §1.1 的实际用量精确匹配，均做成 **`sealed class`**（逐位匹配 Unity 语义：引用类型、可空、可 `= null`；代价是每次异步操作一次分配，UI 场景可接受，日后可池化）。
+
+| 类型 | 内部字段 | 关键成员 |
+|---|---|---|
+| `Awaitable`（sealed class） | `UniTask _task` | `[AsyncMethodBuilder(typeof(AwaitableAsyncMethodBuilder))]`、`GetAwaiter()`、隐式 `↔ UniTask` |
+| `Awaitable<T>`（sealed class） | `UniTask<T> _task` | `[AsyncMethodBuilder(typeof(AwaitableAsyncMethodBuilder<>))]`、`GetAwaiter()`（`GetResult()` 返回 `T`）、隐式 `↔ UniTask<T>` |
+| `AwaitableCompletionSource`（class） | `UniTaskCompletionSource _src` | `Awaitable Awaitable { get; }`、`SetResult()`、`SetException(Exception)`、`SetCanceled()` |
+| `AwaitableCompletionSource<T>`（class） | `UniTaskCompletionSource<T> _src` | `Awaitable<T> Awaitable { get; }`、`SetResult(T)`、`SetException(Exception)`、`SetCanceled()` |
+
+> `SetResult`（库内 12 处）/ `SetException`（2 处）是库实际用到的；`SetCanceled` 库内 0 使用，但它是 Unity `AwaitableCompletionSource` 的公共成员，保留以对齐 Unity API（用户代码可能调用），实现即 `_src.TrySetCanceled()`。
+
+`GetAwaiter()` 转发到内部 `UniTask(<T>)` 的 awaiter，从而同时撑起：
+
+- 全部 `await`（含 `await acs.Awaitable`）。
+- 测试里 232 处 `.GetAwaiter().GetResult()` 同步解包——与现状同语义：仅对**已同步完成**的 awaitable 有效（fake resolver 走 `AwaitableHelpers.Completed`→已完成的 UniTask→`GetResult()` 同步返回；未完成不阻塞、直接抛，与 Unity 原生 Awaitable 行为一致）。
+
+## 5. AsyncMethodBuilder + 隐式转换
+
+**两个 builder**（`AwaitableAsyncMethodBuilder`、`AwaitableAsyncMethodBuilder<T>`）——**直接转发**给 UniTask 的 `Cysharp.Threading.Tasks.CompilerServices.AsyncUniTaskMethodBuilder(<T>)`，白嫖其池化：
+
+```csharp
+public struct AwaitableAsyncMethodBuilder<T>
+{
+    AsyncUniTaskMethodBuilder<T> _inner;
+    public static AwaitableAsyncMethodBuilder<T> Create() => new() { _inner = AsyncUniTaskMethodBuilder<T>.Create() };
+    public Awaitable<T> Task => _inner.Task;            // UniTask<T> --隐式--> Awaitable<T>
+    public void SetResult(T value)            => _inner.SetResult(value);
+    public void SetException(Exception e)     => _inner.SetException(e);
+    public void SetStateMachine(IAsyncStateMachine sm) => _inner.SetStateMachine(sm);
+    public void Start<TSM>(ref TSM sm) where TSM : IAsyncStateMachine => _inner.Start(ref sm);
+    public void AwaitOnCompleted<TA, TSM>(ref TA a, ref TSM sm) where TA : INotifyCompletion where TSM : IAsyncStateMachine
+        => _inner.AwaitOnCompleted(ref a, ref sm);
+    public void AwaitUnsafeOnCompleted<TA, TSM>(ref TA a, ref TSM sm) where TA : ICriticalNotifyCompletion where TSM : IAsyncStateMachine
+        => _inner.AwaitUnsafeOnCompleted(ref a, ref sm);
+}
+```
+
+（非泛型 builder 同构，`Task` 返回 `Awaitable`。）
+
+**双向 implicit 转换**（在 shim 类型上）——因为 2022 下 `Awaitable(<T>)` 内部就是一个 `UniTask(<T>)` 字段，拆包/重包平凡：
+
+- `Awaitable<T> ⇐ UniTask<T>` / `UniTask<T> ⇒ Awaitable<T>`（及非泛型版）。
+
+## 6. 用户零转换的三处保障（缺一不可）
+
+| 用户写法 | 靠什么直通 |
+|---|---|
+| `async Awaitable<string> MyResolver(...) { ... return xml; }` | **builder**（§5） |
+| `await UI.LoadDocumentAsync(...)`、`.GetAwaiter().GetResult()` | **`GetAwaiter()`**（§4） |
+| `UI.SourceResolver = s => LoadXmlUniTask(s);`（lambda 体是 `UniTask<string>`，目标 `Awaitable<string>`） | **隐式转换**（§5） |
+| `UniTask.WhenAll(UI.LoadDocumentAsync(a), UI.LoadDocumentAsync(b))` | **隐式转换**（`Awaitable ⇒ UniTask`） |
+
+> 注：委托赋值不会对**返回类型**插入隐式转换，故 `UI.SourceResolver = LoadXmlUniTask;`（方法组直赋、返回类型不匹配）仍需包成 lambda `s => LoadXmlUniTask(s)`——这是 C# 语言限制，非本方案缺陷；常见的 `async` lambda 写法本就直通。
+
+## 7. 友好护栏 + package.json + 文档
+
+**编译护栏**——`Runtime/` 下加一个永远编译的小文件 `Runtime/Compat/UniTaskRequirement.cs`：
+
+```csharp
+#if !UNITY_6000_0_OR_NEWER && !PROMPTUGUI_HAS_UNITASK
+#error PromptUGUI on Unity 2022 requires UniTask (com.cysharp.unitask). Install it via OpenUPM: https://openupm.com/packages/com.cysharp.unitask/
+#endif
+```
+
+一条清晰报错替代几百个 CS0246。为让护栏在 Runtime 里看得见该 define，**`PromptUGUI.Runtime.asmdef` 的 `versionDefines` 也补上** `{ com.cysharp.unitask ≥ 2.0.0 → PROMPTUGUI_HAS_UNITASK }`。
+
+**package.json**——`"unity": "6000.0"` → `"2022.3"`。UniTask 无法列为 `dependencies`（不在 Unity registry），故不改 `dependencies`，改由文档说明。
+
+**文档**——README + `scripting-promptugui-csharp` skill 加一节「Unity 2022 支持」：说明装 UniTask（OpenUPM）即可，公共 API 无差异。公共 API 签名不变，其余 skill 无需改。
+
+## 8. 边界与错误处理
+
+- **Unity 6 上加了这套东西是否有副作用？** 无。Compat asmdef 要么被 `PROMPTUGUI_HAS_UNITASK` 约束掉（没装 UniTask），要么编成空程序集（装了 UniTask 但被 `#if` 剪空）；护栏 `#if` 短路；`package.json` 降 min-version 不影响 6。可在宿主（Unity 6）上验证：refresh 后 console 无新 error/warning。
+- **2022 上没装 UniTask**：命中 §7 护栏，单条明确报错。
+- **重复类型风险**：仅当 2022 工程里**另有**一个包也往 `UnityEngine` 塞 `Awaitable` 才冲突——概率极低；真遇到再文档指引。Unity 6 上因整个 asmdef 被约束掉，绝不可能与 Unity 原生 `Awaitable` 撞。
+- **单次消费语义**：UniTask 与 Unity Awaitable 同为「只能 await 一次」，shim 包装不改变该语义，与现状一致。
+
+## 9. 测试计划（含硬限制，如实说明）
+
+**Unity 6 宿主（可 MCP 自动化，本 PR 的回归证据）**
+
+- 现有全部 EditMode / EditorOnly / PlayMode 套件保持绿（源码未动，天然成立，仍需实跑确认无意外）。
+- 新 asmdef + 护栏 + package.json 改动后 refresh，`read_console` 无新 error/warning。
+
+**Unity 2022 + UniTask（宿主上无法自动化——这是硬限制）**
+
+- shim **在 Unity 6 上根本无法编译**（`UnityEngine.Awaitable` 已存在→重复类型），只能在真实 2022 工程验证。
+- shim 验证测试写成 `#if !UNITY_6000_0_OR_NEWER` 门控（放 `Tests/EditMode/Compat/`），覆盖：`async Awaitable<T>` 经 builder 产出并 `await` / 同步 `GetResult()` / `AwaitableCompletionSource<T>` 桥 / 双向隐式转换。它们在 Unity 6 宿主上不参与编译、不运行；在 2022 工程打开时才跑。
+- **最终由用户在自己的 Unity 2022 工程里过一遍**：shim 编译通过、构建成功、冒烟（加载文档 + 开一个模态）。已与用户确认接受此边界。
+
+## 10. 实现顺序（给 plan 的提示）
+
+1. `PromptUGUI.Compat.UniTask.asmdef` + `.meta`（门控壳先立起来）。
+2. shim 类型 `Awaitable` / `Awaitable<T>` / `AwaitableCompletionSource(<T>)`（§4）。
+3. 两个 AsyncMethodBuilder（§5）+ 双向隐式转换。
+4. `UniTaskRequirement.cs` 护栏 + `PromptUGUI.Runtime.asmdef` versionDefine（§7）。
+5. `package.json` min-version + README/C# skill 文档节（§7）。
+6. `#if !UNITY_6000_0_OR_NEWER` 门控的 shim 验证测试（§9）。
+7. Unity 6 宿主回归：refresh + 全套件 + console 洁净（§9）。
+8. 交付 → 用户 2022 工程最终验证（§9）。

--- a/docs~/superpowers/specs/2026-07-06-awaitable-unitask-2022-design.md
+++ b/docs~/superpowers/specs/2026-07-06-awaitable-unitask-2022-design.md
@@ -149,7 +149,14 @@ public struct AwaitableAsyncMethodBuilder<T>
 
 一条清晰报错替代几百个 CS0246。为让护栏在 Runtime 里看得见该 define，**`PromptUGUI.Runtime.asmdef` 的 `versionDefines` 也补上** `{ com.cysharp.unitask ≥ 2.0.0 → PROMPTUGUI_HAS_UNITASK }`。
 
-**package.json**——`"unity": "6000.0"` → `"2022.3"`。UniTask 无法列为 `dependencies`（不在 Unity registry），故不改 `dependencies`，改由文档说明。
+**package.json**——`"unity": "6000.0"` → `"2022.3"`（本库唯一要改的一处）。UniTask 无法列为 `dependencies`（不在 Unity registry），改由文档说明。
+
+依赖也须同时兼容两版本（2026-07-06 在真实 2022 工程实测确认）——这部分**由用户在 Windows 侧管理，本计划不改 `dependencies`**：
+
+- `com.unity.ugui`：`"2.0.0"` → `"1.0.0"`。UPM 把 dependency 版本当「最低版本」：Unity 6 解析到内置 2.0.0、2022 解析到 1.0.0 → **一份 manifest 通吃**。
+- `com.annulusgames.lit-motion`：git URL → `"2.0.2"`（用户确认两版本均可解析）。
+
+> 教训：`ugui 2.0.0` 需 Unity 2023.2+，是 2022 加载本包的第一道坎；先把 deps 降到可解析，2022 才会「编到 Awaitable 才失败」（而非「包根本加载不了」）。
 
 **文档**——README + `scripting-promptugui-csharp` skill 加一节「Unity 2022 支持」：说明装 UniTask（OpenUPM）即可，公共 API 无差异。公共 API 签名不变，其余 skill 无需改。
 
@@ -160,18 +167,22 @@ public struct AwaitableAsyncMethodBuilder<T>
 - **重复类型风险**：仅当 2022 工程里**另有**一个包也往 `UnityEngine` 塞 `Awaitable` 才冲突——概率极低；真遇到再文档指引。Unity 6 上因整个 asmdef 被约束掉，绝不可能与 Unity 原生 `Awaitable` 撞。
 - **单次消费语义**：UniTask 与 Unity Awaitable 同为「只能 await 一次」，shim 包装不改变该语义，与现状一致。
 
-## 9. 测试计划（含硬限制，如实说明）
+## 9. 测试计划
 
-**Unity 6 宿主（可 MCP 自动化，本 PR 的回归证据）**
+> **环境更新（2026-07-06）**：MCP 现已切到一个真实 **Unity 2022.3 + UniTask** 工程，且该工程通过 bind-mount（`C:\xsoft\PromptUGUI` == 仓库 `/workspace-PromptUGUI`）直接编译本包源码。因此原「宿主是 Unity 6、shim 无法在宿主编译/测试」的硬限制**已解除**：可在 2022 上跑真·红→绿 TDD。核心机制已用隔离 spike（独立 asmdef 只引用 UniTask）实测通过——`[AsyncMethodBuilder]` 自定义类型 + 转发 `AsyncUniTaskMethodBuilder<T>` + 隐式转换 + `async`/`await` 全绿，且 `AsyncMethodBuilderAttribute` 跨程序集可访问（**故无需自补该 attribute**）。
 
-- 现有全部 EditMode / EditorOnly / PlayMode 套件保持绿（源码未动，天然成立，仍需实跑确认无意外）。
-- 新 asmdef + 护栏 + package.json 改动后 refresh，`read_console` 无新 error/warning。
+**主验证：Unity 2022 + UniTask（MCP 当前指向，可自动化）**
 
-**Unity 2022 + UniTask（宿主上无法自动化——这是硬限制）**
+- 加 shim 前：`read_console` 里全是 `Awaitable` / `Awaitable<>` / `AwaitableCompletionSource` 的 CS0246/CS0234（已实测，且**仅**这三种类型缺失 → 佐证 Awaitable 是唯一 6-only 依赖）。这是天然的整包级 RED。
+- 逐步加 shim：每加一块 refresh，看对应错误消失 → 整包级 GREEN。
+- shim 行为测试放 `Tests/EditMode/Compat/`，`#if !UNITY_6000_0_OR_NEWER` 门控，覆盖：`async Awaitable<T>` 经 builder 产出并 `await` / 同步 `GetResult()` / `AwaitableCompletionSource<T>` 桥 / 双向隐式转换。在 2022 上 `run_tests` 实跑绿。
+- 全量既有 EditMode/PlayMode 套件在 2022 上跑（UniTask 后端），作回归。
 
-- shim **在 Unity 6 上根本无法编译**（`UnityEngine.Awaitable` 已存在→重复类型），只能在真实 2022 工程验证。
-- shim 验证测试写成 `#if !UNITY_6000_0_OR_NEWER` 门控（放 `Tests/EditMode/Compat/`），覆盖：`async Awaitable<T>` 经 builder 产出并 `await` / 同步 `GetResult()` / `AwaitableCompletionSource<T>` 桥 / 双向隐式转换。它们在 Unity 6 宿主上不参与编译、不运行；在 2022 工程打开时才跑。
-- **最终由用户在自己的 Unity 2022 工程里过一遍**：shim 编译通过、构建成功、冒烟（加载文档 + 开一个模态）。已与用户确认接受此边界。
+**次验证：Unity 6（Awaitable 后端，需把 MCP 切回 6 或用户自测）**
+
+- shim 源全在 `#if !UNITY_6000_0_OR_NEWER` 内 → 6 上不参与编译；现有 71 文件 + 测试一字未改 → Awaitable 后端**天然不受影响**。仍应在收尾时把 MCP 切回 Unity 6 跑一次全套件 + console 洁净，作最终双后端确认。
+
+> **工作树卫生（bind-mount 副作用）**：2022 编辑器 refresh 会把包里几百个极简 `.meta` 展开成完整 `MonoImporter` 块（GUID 不变，无害 churn）；Unity 6 又会改回去。**提交时只显式 `git add` 目标源文件 + 新文件的 `.meta`，绝不 `git add -A`**；收尾用 `git checkout -- '**/*.meta'` 丢弃既有文件的 meta churn（新文件的 meta 已先行显式提交）。
 
 ## 10. 实现顺序（给 plan 的提示）
 
@@ -181,5 +192,5 @@ public struct AwaitableAsyncMethodBuilder<T>
 4. `UniTaskRequirement.cs` 护栏 + `PromptUGUI.Runtime.asmdef` versionDefine（§7）。
 5. `package.json` min-version + README/C# skill 文档节（§7）。
 6. `#if !UNITY_6000_0_OR_NEWER` 门控的 shim 验证测试（§9）。
-7. Unity 6 宿主回归：refresh + 全套件 + console 洁净（§9）。
-8. 交付 → 用户 2022 工程最终验证（§9）。
+7. 2022 主验证：整包 console 洁净（Awaitable 错误清零）+ Compat 行为测试 + 全量既有套件在 2022 跑绿（§9）。
+8. 次验证：把 MCP 切回 Unity 6，全套件 + console 洁净，确认 Awaitable 后端未受影响（§9）。

--- a/docs~/superpowers/specs/2026-07-06-awaitable-unitask-2022-design.md
+++ b/docs~/superpowers/specs/2026-07-06-awaitable-unitask-2022-design.md
@@ -194,3 +194,15 @@ public struct AwaitableAsyncMethodBuilder<T>
 6. `#if !UNITY_6000_0_OR_NEWER` 门控的 shim 验证测试（§9）。
 7. 2022 主验证：整包 console 洁净（Awaitable 错误清零）+ Compat 行为测试 + 全量既有套件在 2022 跑绿（§9）。
 8. 次验证：把 MCP 切回 Unity 6，全套件 + console 洁净，确认 Awaitable 后端未受影响（§9）。
+
+## 11. 实现修正与验证结果（2026-07-06 真机双后端）
+
+实现时以下几处偏离了原设计（都已在真机验证）：
+
+1. **asmdef 引用不传递**（原 §3 说 Runtime 靠 `autoReferenced` 自动看见 Compat——错）。`autoReferenced` 只让**预定义程序集**（Assembly-CSharp）自动引用；自定义 asmdef 之间必须显式引用。⇒ **每个在签名里用到 `Awaitable` 的程序集都显式引用 `PromptUGUI.Compat.UniTask`**：`Runtime` + `Tests.EditMode` + `Tests.PlayMode`。
+2. **`await Awaitable` 泄漏 `UniTask.Awaiter`**（`GetAwaiter()` 返回 UniTask 的 awaiter，编译器需其可访问）⇒ 这些程序集**再加 `UniTask` 引用**。**实测 Unity 6（未装 UniTask）：0 错误、0 告警**——缺失的 `UniTask` 引用与被门控的 `Compat` 引用都被 Unity **静默丢弃**。故未采用 class-awaiter 隐藏方案（原 §5 note 的备选），保持简单。
+3. **`AwaitableCompletionSource` 还需 `TrySetResult`/`TrySetException`/`TrySetCanceled`**（原 §4 审计只列了 `Set*`；库两者都用）——shim 两套都实现。
+4. **TMP straggler（Awaitable 之外的唯一 6-only 依赖）**：`Text.cs`/`InputField.cs` 的 `textWrappingMode`/`TextWrappingModes` 是 TMP 3.2（Unity 2023.1+）API，2022 旧 TMP 用 `enableWordWrapping` ⇒ 按 `#if UNITY_2023_1_OR_NEWER` 条件化（改了这 2 个既有文件，是 §2 非目标里「全库审计」由 Task 4 整包编译自然暴露的）。
+5. **测试基建（2022 侧，非包代码）**：新测试集要进 `package.json` `testables` **且重启编辑器**才被 Test Runner 发现；跑既有套件需 `com.unity.test-framework` ≥ 1.4（旧 1.1.33/ext.nunit 1.0.6 无 `Assert.ThrowsAsync`）；新工程须先 **Import TMP Essentials**（否则 Text/Btn 实例化 NRE，仅全量跑时暴露）。
+
+**验证结果**：Unity 2022.3 + UniTask — 整包+全程序集编译，EditMode **2372/2372**，PlayMode **169/171**（2 个 InputFieldNav 失败=2022 InputSystem/TMP 输入时序，零 async，非 shim）。Unity 6 原生 Awaitable — 0 错误/告警，EditMode **2274/2274**，PlayMode **171/171**（含那 2 个 nav，坐实其为 2022 环境特有）。

--- a/install_for_claude.md
+++ b/install_for_claude.md
@@ -7,7 +7,7 @@ All paths are relative to the **user's Unity project root** (`<project root>`, i
 
 ## Prerequisites
 
-1. A Unity 6000.0+ project
+1. A Unity 2022.3+ project (Unity 2022.3 LTS or Unity 6+)
 2. `<project root>/Packages/manifest.json` exists
 3. R3 (Cysharp) is installed — the PromptUGUI runtime depends on it. It is usually installed as the `R3` package via NuGetForUnity; if it isn't installed, tell the user to install it before continuing.
 4. .NET SDK 10 — this is important; it is needed to check lint outside of Unity. If it isn't installed, tell the user to install it before continuing:
@@ -26,6 +26,14 @@ Read `<project root>/Packages/manifest.json` and add 2 lines to the `dependencie
 ```
 
 Alternatively, have the user go to Unity → Window → Package Manager → "+" → "Add package from git URL", using the same URLs.
+
+**Unity 2022.3 only — add UniTask.** PromptUGUI needs an async backend on Unity versions below 6 (where the engine has no native `UnityEngine.Awaitable` type). Detect the version: read `<project root>/ProjectSettings/ProjectVersion.txt` and look at `m_EditorVersion`. **If it starts with `2022`** (i.e. below Unity 6), also add this line to `dependencies`:
+
+```json
+"com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask"
+```
+
+**On Unity 6+ do NOT add UniTask** — PromptUGUI transparently uses the engine's native `Awaitable` API and needs no extra dependency. (If UniTask is missing on a Unity 2022 project, compilation fails with one clear message: `#error PromptUGUI on Unity 2022 requires UniTask ...` — installing the line above resolves it.)
 
 **Verification**: Wait for Unity to finish importing (you can call `mcp__UnityMCP__refresh_unity(compile="request", mode="standard", wait_for_ready=true)`), then confirm that the `<project root>/Library/PackageCache/com.promptugui.core@<hash>/` directory exists (the hash is a random value) and contains `Runtime/`, `Editor/`, and `package.json`.
 
@@ -103,7 +111,7 @@ Confirm in order:
 2. ✓ The four SKILL.md files under `.claude/skills/` — `authoring-promptugui-xml/`, `authoring-promptugui-pxl/`, `scripting-promptugui-csharp/`, `using-promptugui-addressables/` — all exist, with complete frontmatter
 3. ✓ `CLAUDE.md` contains the Tr() wrapping convention section, with the original content preserved
 4. ✓ Check whether `dotnet --list-sdks` shows a version 10 installed.
-5. ✓ (Optional) After `mcp__UnityMCP__refresh_unity(compile="request", mode="standard")`, `mcp__UnityMCP__read_console(action="get", types=["error"])` reports no compile errors
+5. ✓ (Optional) After `mcp__UnityMCP__refresh_unity(compile="request", mode="standard")`, `mcp__UnityMCP__read_console(action="get", types=["error"])` reports no compile errors (on a Unity 2022 project, a `requires UniTask` error here means the UniTask line from Step 1 is still missing — add it)
 6. ✓ (Optional) Check whether `xmllint` is runnable, and remind the user to install it
 
 Once all pass, installation is complete. In the next session Claude Code will load `CLAUDE.md` automatically; when the user edits `.ui.xml` the `authoring-promptugui-xml` skill triggers, when creating/editing `.pxl` pixel art (9-slice borders, button skins, icons) the `authoring-promptugui-pxl` skill triggers, when writing C# that calls `UI.*` the `scripting-promptugui-csharp` skill triggers, and when integrating Unity Addressables the `using-promptugui-addressables` skill triggers.

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
     "version": "1.0.0",
     "displayName": "PromptUGUI",
     "description": "Comprehensive solution for LLM to write uGUI, it not only for assembling the structure and writing code, but also allows the LLM to generate images directly.",
-    "unity": "6000.0",
+    "unity": "2022.3",
     "dependencies": {
-        "com.unity.ugui": "2.0.0",
-        "com.annulusgames.lit-motion": "https://github.com/annulusgames/LitMotion.git?path=src/LitMotion/Assets/LitMotion",
+        "com.unity.ugui": "1.0.0",
+        "com.annulusgames.lit-motion": "2.0.2",
         "com.unity.nuget.newtonsoft-json": "3.2.1"
     },
     "author": {
@@ -17,7 +17,8 @@
     "testables": [
         "PromptUGUI.Tests.EditMode",
         "PromptUGUI.Tests.EditMode.Addressables",
-        "PromptUGUI.Tests.PlayMode"
+        "PromptUGUI.Tests.PlayMode",
+        "PromptUGUI.Tests.Compat"
     ],
     "samples": [
         {


### PR DESCRIPTION
## 目标

让 PromptUGUI 在 **Unity 2022.3 LTS** 上编译/运行（此前要求 Unity 6+）。唯一的 6-only 硬阻塞是异步类型 `UnityEngine.Awaitable` / `AwaitableCompletionSource`（Unity 2023.1/6 才引入）。

## 方案

在 `namespace UnityEngine` 下补一套**仅 `#if !UNITY_6000_0_OR_NEWER` 编译**的 polyfill（新程序集 `PromptUGUI.Compat.UniTask`，受 `PROMPTUGUI_HAS_UNITASK` 门控），内部用 **UniTask** 作底座：

- `Awaitable` / `Awaitable<T>`（`[AsyncMethodBuilder]` 转发 UniTask 的 `AsyncUniTaskMethodBuilder`，`GetAwaiter` 转发 `UniTask.Awaiter`，双向隐式 `↔ UniTask`）
- `AwaitableCompletionSource` / `<T>`（`Set*` 与 `TrySet*` 两套，包 `UniTaskCompletionSource`）
- `Runtime/UniTaskRequirement.cs`：2022 缺 UniTask 时单条 `#error` 指引安装

**Unity 6+ 完全不受影响**：整套被 `#if` 剪掉，走原生 `Awaitable`，无新增依赖。**公共 C# API 签名逐字不变**（仍是 `UnityEngine.Awaitable<T>` 等）。

## 双后端验证（真机 MCP）

| | Unity 2022.3 + UniTask | Unity 6 原生 Awaitable |
|---|---|---|
| 编译 | 整包 + 全部程序集 0 错误 | 0 错误、0 告警（宿主未装 UniTask，缺失/门控引用被静默丢弃） |
| EditMode | **2372 / 2372** | **2274 / 2274** |
| PlayMode | 169 / 171 | **171 / 171** |

> 2022 上那 2 个 `InputFieldNavPlayTests` 失败是 InputSystem/TMP 输入时序差异（零 async，nav 路径不碰 Awaitable），在 Unity 6 上全绿 → 坐实其为 2022 环境特有，与本 PR 无关。

## 附带修正（真机暴露）

- **每个在签名里用 `Awaitable` 的程序集都显式引用 `PromptUGUI.Compat.UniTask` + `UniTask`**（asmdef 引用不传递；`autoReferenced` 只对预定义程序集）：`Runtime` + `Tests.EditMode` + `Tests.PlayMode`。Unity 6 上这些引用被静默丢弃（实测 0 告警）。
- **TMP straggler**（Awaitable 之外唯一的 6-only 依赖）：`Text` / `InputField` 的 `textWrappingMode` 是 TMP 3.2/Unity 2023.1+ API → 按 `#if UNITY_2023_1_OR_NEWER` 退回 `enableWordWrapping`。
- `package.json`：`unity` 6000.0 → 2022.3；`dependencies` 保持一份 manifest 通吃两版本（`com.unity.ugui` `1.0.0` floor / `lit-motion` `2.0.2`）。

## 使用（2022）

安装 **UniTask**（git UPM：`https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask`）即可，用法与 Unity 6 无差异。跑本包测试套件需 `com.unity.test-framework` ≥ 1.4。

设计/计划见 `docs~/superpowers/specs|plans/2026-07-06-awaitable-unitask-2022*`（spec §11 记录了全部实现修正）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
