### PR TITLE
feat: PxlPreview CLI —— 把 .pxl 渲染成 PNG 供肉眼校验

### DIFF
--- a/.claude/skills/authoring-promptugui-pxl/SKILL.md
+++ b/.claude/skills/authoring-promptugui-pxl/SKILL.md
@@ -9,7 +9,7 @@ description: Use when creating or editing PromptUGUI .pxl pixel-grid sprite file
 
 Sweet spot: **UI chrome ≤48×48** — 9-slice frames, button skins, icons, badges, small decorations. NOT for large illustrations; a big grid is unmanageable text and pixel art quality drops with size anyway.
 
-The text IS the image: you can re-read your own output row by row and fix individual pixels. Import errors carry line numbers, so the loop is write → check Console → revise.
+The text IS the image: you can re-read your own output row by row and fix individual pixels. Import errors carry line numbers, and the `PxlPreview` CLI renders the grid to a PNG you can actually look at — so the loop is **write → render → look → revise**. Reading characters catches ragged rows; only looking at the render catches "the bevel points the wrong way".
 
 ## File format
 
@@ -116,6 +116,31 @@ You are drawing, not just encoding. Apply these when composing a grid:
 - **Design at the smallest size that reads**; let PPU / PromptUGUI scaling handle display size. A crisp 12×12 scaled up beats a fuzzy 48×48.
 - Use `.` (transparent) for *outside the silhouette* only — don't fake glow/anti-aliasing with semi-transparent pixels inside the shape; pixel art stays hard-edged (the importer is point-filtered for a reason).
 
+## Look at what you drew (`PxlPreview` CLI)
+
+Run this after writing or editing any `.pxl`, before reporting done. It needs no Unity instance and no Unity install — just a `dotnet` SDK:
+
+```bash
+dotnet run --project .lint/PxlPreview -- Buttons/ok.pxl            # -> <temp>/pxlpreview/ok.preview.png
+dotnet run --project .lint/PxlPreview -- Buttons/ok.pxl --scale 16 --guides
+dotnet run --project .lint/PxlPreview -- Assets/UI/ --out-dir /tmp/pxl-check   # whole tree
+```
+
+(Paths are relative to the PromptUGUI repo root. From a Unity project that consumes the UPM package, the project is at `Packages/com.heerozh.promptugui/.lint/PxlPreview`.)
+
+It prints the PNG's absolute path — **then read that PNG as an image**. That is the point of the tool: judging shading ramps, bevel direction, outline closure, silhouette consistency across states, or whether an edge strip really tiles is impossible from the character grid, and those are exactly the mistakes that survive a text re-read.
+
+One PNG per `.pxl`: every section side by side in file order, on a transparency checkerboard, labelled `name WxH bL,B,R,T`. So `normal` vs `pressed` is one glance — check the outline is identical and only the bevel/face changed.
+
+| Option | Use it for |
+|---|---|
+| `--scale N` (1..64, default 8) | Small glyphs need 16+; a 48×48 frame reads fine at 6. |
+| `--guides` | Overlays the 9-slice split lines — the fastest way to confirm the corners fall *inside* the border box and the edge strips are uniform between the lines. |
+| `--out-dir DIR` | Default is a temp folder. **Never aim it at a SpriteSet `sourceFolder`** — the PNGs would be ingested as sprite sources and collide with the `.pxl`'s own keys. |
+| `--palette FILE` | Skip the `@name` project search and name the `.gpl` directly. |
+
+It is also the `.pxl` linter: it compiles the importer's own parser / palette / colour-resolution sources, so every error below surfaces here first, with the same message and line number, and exit code 1 — no Unity Console round trip. Details: `.lint/PxlPreview/README.md`.
+
 ## Round-trip with art tools
 
 Selecting a `.pxl` asset in the Project window shows a custom Inspector — not the default ScriptedImporter settings panel. The importer has no editable settings (everything lives in the `.pxl` text), so the panel is read-only: it lists the palette reference, each section's name/dimensions/border, and a small sprite thumbnail per section. Two buttons appear below:
@@ -165,4 +190,8 @@ Import errors land in the **Unity Console with line numbers** and fail the asset
 | `cannot mix implicit (headerless) content with [section] headers` | Started drawing before the first `[section]` — add a header to the first sprite too. |
 | `'.' is reserved for transparent` / `duplicate chars key` / `duplicate section name` | Self-explanatory — rename. |
 
-**Self-verify before reporting done**: the grid is the image. Re-read your own output row by row — check the outline is closed, edge strips are uniform (9-slice), every row is the same width, and there are no stray pixels. Then confirm the Unity Console is clean and the sprite shows up under the expected `set:key`.
+**Self-verify before reporting done**, in this order:
+
+1. **Re-read the grid** row by row — same width everywhere, outline closed, no stray pixels, edge strips uniform along their axis.
+2. **Render it and look at it** — `dotnet run --project .lint/PxlPreview -- <file>.pxl --scale 16 --guides`, then read the PNG it prints. A clean parse says nothing about whether the art reads; step 1 cannot catch an inverted bevel, a muddy ramp, or corners bleeding past the 9-slice split. Do not claim a sprite looks right without having looked at it.
+3. **Confirm in Unity** — Console clean, and the sprite shows up under the expected `set:key`.

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ ExportedObj/
 !/.lint/*.csproj
 !/.lint/*.sln
 !/.lint/*.slnx
+# Standalone CLI tools live one level deeper (UIXmlLint/, PxlPreview/).
+!/.lint/**/*.csproj
 /.lint/bin/
 /.lint/obj/
 # Per-developer Unity install paths (copy Local.props.example to set yours).

--- a/.lint/PromptUGUI.Lint.slnx
+++ b/.lint/PromptUGUI.Lint.slnx
@@ -4,5 +4,6 @@
   <Project Path="Tests.EditMode.csproj" />
   <Project Path="Tests.EditorOnly.csproj" />
   <Project Path="Tests.PlayMode.csproj" />
+  <Project Path="PxlPreview/PxlPreview.csproj" />
   <Project Path="UIXmlLint/UIXmlLint.csproj" />
 </Solution>

--- a/.lint/PxlPreview/Canvas.cs
+++ b/.lint/PxlPreview/Canvas.cs
@@ -1,0 +1,78 @@
+namespace PromptUGUI.PxlPreview
+{
+    internal struct Rgba
+    {
+        public byte R, G, B, A;
+
+        public Rgba(byte r, byte g, byte b, byte a = 255)
+        {
+            R = r; G = g; B = b; A = a;
+        }
+    }
+
+    /// <summary>Top-down RGBA8 pixel buffer with the two primitives this tool needs.
+    /// Out-of-bounds writes are clipped, not thrown — label text is allowed to run
+    /// past a narrow sprite block.</summary>
+    internal sealed class Canvas
+    {
+        public readonly int Width;
+        public readonly int Height;
+        public readonly byte[] Pixels;
+
+        public Canvas(int width, int height, Rgba fill)
+        {
+            Width = width;
+            Height = height;
+            Pixels = new byte[width * height * 4];
+            Fill(0, 0, width, height, fill);
+        }
+
+        public void Fill(int x, int y, int w, int h, Rgba color)
+        {
+            var x0 = x < 0 ? 0 : x;
+            var y0 = y < 0 ? 0 : y;
+            var x1 = x + w > Width ? Width : x + w;
+            var y1 = y + h > Height ? Height : y + h;
+            for (var py = y0; py < y1; py++)
+            {
+                for (var px = x0; px < x1; px++)
+                {
+                    var i = (py * Width + px) * 4;
+                    Pixels[i] = color.R;
+                    Pixels[i + 1] = color.G;
+                    Pixels[i + 2] = color.B;
+                    Pixels[i + 3] = color.A;
+                }
+            }
+        }
+
+        /// <summary>Source-over composite of an opaque-background rect. The preview
+        /// always lands on the checkerboard, so the destination is opaque and the
+        /// result stays opaque — semi-transparent .pxl pixels show as a tint of the
+        /// checker underneath, which is exactly how they read in-game over a panel.</summary>
+        public void Blend(int x, int y, int w, int h, Rgba color)
+        {
+            if (color.A == 0) return;
+            if (color.A == 255) { Fill(x, y, w, h, color); return; }
+
+            var x0 = x < 0 ? 0 : x;
+            var y0 = y < 0 ? 0 : y;
+            var x1 = x + w > Width ? Width : x + w;
+            var y1 = y + h > Height ? Height : y + h;
+            for (var py = y0; py < y1; py++)
+            {
+                for (var px = x0; px < x1; px++)
+                {
+                    var i = (py * Width + px) * 4;
+                    Pixels[i] = Mix(Pixels[i], color.R, color.A);
+                    Pixels[i + 1] = Mix(Pixels[i + 1], color.G, color.A);
+                    Pixels[i + 2] = Mix(Pixels[i + 2], color.B, color.A);
+                    Pixels[i + 3] = 255;
+                }
+            }
+        }
+
+        private static byte Mix(byte dst, byte src, byte alpha) =>
+            (byte)((src * alpha + dst * (255 - alpha) + 127) / 255);
+    }
+}

--- a/.lint/PxlPreview/PaletteLocator.cs
+++ b/.lint/PxlPreview/PaletteLocator.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace PromptUGUI.PxlPreview
+{
+    /// <summary>Outside Unity there is no AssetDatabase, so `palette: @ui` is
+    /// resolved by scanning a project root for `ui.gpl` — same contract as
+    /// PxlImporter.FindPalettePath: exactly one match, or an error that lists the
+    /// candidates.</summary>
+    internal static class PaletteLocator
+    {
+        private static readonly HashSet<string> SkipDirs =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            { "Library", "Temp", "Logs", "obj", "bin", "Build", "Builds", ".git", ".utmp", "node_modules" };
+
+        public static string Find(string pxlPath, string paletteRef, out string error)
+        {
+            var start = Path.GetDirectoryName(Path.GetFullPath(pxlPath));
+            var root = FindSearchRoot(start);
+            var matches = new List<string>();
+            Collect(root, paletteRef + ".gpl", matches, 0);
+            matches.Sort(StringComparer.Ordinal);
+
+            if (matches.Count == 1) { error = null; return matches[0]; }
+            error = matches.Count == 0
+                ? $"palette '@{paletteRef}' not found (no '{paletteRef}.gpl' under {root})"
+                : $"palette '@{paletteRef}' is ambiguous: {string.Join(", ", matches)}";
+            return null;
+        }
+
+        /// <summary>Nearest thing to "the project": the Unity project root (parent of
+        /// the outermost `Assets` ancestor, so embedded `Packages/` are searched too),
+        /// else the enclosing git repo, else the file's own folder.</summary>
+        private static string FindSearchRoot(string dir)
+        {
+            string assetsParent = null;
+            string repo = null;
+            var d = new DirectoryInfo(dir);
+            while (d != null)
+            {
+                if (string.Equals(d.Name, "Assets", StringComparison.Ordinal) && d.Parent != null)
+                    assetsParent = d.Parent.FullName;
+                if (repo == null && Directory.Exists(Path.Combine(d.FullName, ".git")))
+                    repo = d.FullName;
+                d = d.Parent;
+            }
+            return assetsParent ?? repo ?? dir;
+        }
+
+        private static void Collect(string dir, string fileName, List<string> into, int depth)
+        {
+            if (depth > 32) return; // symlink loop guard
+            try
+            {
+                foreach (var f in Directory.EnumerateFiles(dir, fileName))
+                    into.Add(f);
+                foreach (var sub in Directory.EnumerateDirectories(dir))
+                {
+                    var name = Path.GetFileName(sub);
+                    if (SkipDirs.Contains(name)) continue;
+                    Collect(sub, fileName, into, depth + 1);
+                }
+            }
+            catch (UnauthorizedAccessException) { }
+            catch (IOException) { }
+        }
+    }
+}

--- a/.lint/PxlPreview/PngWriter.cs
+++ b/.lint/PxlPreview/PngWriter.cs
@@ -1,0 +1,127 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+
+namespace PromptUGUI.PxlPreview
+{
+    /// <summary>Minimal RGBA8 PNG encoder on pure BCL (DeflateStream + hand-rolled
+    /// zlib wrapper). .NET has no cross-platform image encoder — System.Drawing is
+    /// Windows-only — and this tool must run wherever `dotnet` runs, so the ~80
+    /// lines below are the price of portability.</summary>
+    internal static class PngWriter
+    {
+        private static readonly byte[] Signature = { 137, 80, 78, 71, 13, 10, 26, 10 };
+
+        /// <param name="rgba">width*height*4 bytes, row-major, top-down, non-premultiplied.</param>
+        public static void Write(string path, int width, int height, byte[] rgba)
+        {
+            using (var fs = File.Create(path))
+            {
+                fs.Write(Signature, 0, Signature.Length);
+
+                var ihdr = new byte[13];
+                WriteBe32(ihdr, 0, width);
+                WriteBe32(ihdr, 4, height);
+                ihdr[8] = 8;    // bit depth
+                ihdr[9] = 6;    // color type: truecolour with alpha
+                ihdr[10] = 0;   // compression: deflate
+                ihdr[11] = 0;   // filter: adaptive
+                ihdr[12] = 0;   // interlace: none
+                WriteChunk(fs, "IHDR", ihdr);
+
+                WriteChunk(fs, "IDAT", Zlib(Scanlines(width, height, rgba)));
+                WriteChunk(fs, "IEND", Array.Empty<byte>());
+            }
+        }
+
+        /// <summary>Prefix every row with filter byte 0 (None). Filtering would shrink
+        /// the file further, but scaled-up pixel art is already ~all flat runs and
+        /// deflate handles those well.</summary>
+        private static byte[] Scanlines(int width, int height, byte[] rgba)
+        {
+            var stride = width * 4;
+            var raw = new byte[height * (stride + 1)];
+            for (var y = 0; y < height; y++)
+            {
+                raw[y * (stride + 1)] = 0;
+                Buffer.BlockCopy(rgba, y * stride, raw, y * (stride + 1) + 1, stride);
+            }
+            return raw;
+        }
+
+        private static byte[] Zlib(byte[] raw)
+        {
+            using (var ms = new MemoryStream())
+            {
+                ms.WriteByte(0x78); // CMF: deflate, 32K window
+                ms.WriteByte(0x9C); // FLG: default level; (0x78<<8|0x9C) % 31 == 0
+                using (var deflate = new DeflateStream(ms, CompressionLevel.Optimal, leaveOpen: true))
+                    deflate.Write(raw, 0, raw.Length);
+                var adler = Adler32(raw);
+                ms.WriteByte((byte)(adler >> 24));
+                ms.WriteByte((byte)(adler >> 16));
+                ms.WriteByte((byte)(adler >> 8));
+                ms.WriteByte((byte)adler);
+                return ms.ToArray();
+            }
+        }
+
+        private static void WriteChunk(Stream s, string type, byte[] data)
+        {
+            var header = new byte[4];
+            WriteBe32(header, 0, data.Length);
+            s.Write(header, 0, 4);
+
+            var typed = new byte[4 + data.Length];
+            for (var i = 0; i < 4; i++) typed[i] = (byte)type[i];
+            Buffer.BlockCopy(data, 0, typed, 4, data.Length);
+            s.Write(typed, 0, typed.Length);
+
+            var crc = new byte[4];
+            WriteBe32(crc, 0, unchecked((int)Crc32(typed)));
+            s.Write(crc, 0, 4);
+        }
+
+        private static void WriteBe32(byte[] buf, int offset, int value)
+        {
+            buf[offset] = (byte)(value >> 24);
+            buf[offset + 1] = (byte)(value >> 16);
+            buf[offset + 2] = (byte)(value >> 8);
+            buf[offset + 3] = (byte)value;
+        }
+
+        private static readonly uint[] CrcTable = BuildCrcTable();
+
+        private static uint[] BuildCrcTable()
+        {
+            var table = new uint[256];
+            for (uint n = 0; n < 256; n++)
+            {
+                var c = n;
+                for (var k = 0; k < 8; k++)
+                    c = (c & 1) != 0 ? 0xEDB88320u ^ (c >> 1) : c >> 1;
+                table[n] = c;
+            }
+            return table;
+        }
+
+        private static uint Crc32(byte[] data)
+        {
+            var c = 0xFFFFFFFFu;
+            foreach (var b in data)
+                c = CrcTable[(c ^ b) & 0xFF] ^ (c >> 8);
+            return c ^ 0xFFFFFFFFu;
+        }
+
+        private static uint Adler32(byte[] data)
+        {
+            uint a = 1, b = 0;
+            foreach (var t in data)
+            {
+                a = (a + t) % 65521;
+                b = (b + a) % 65521;
+            }
+            return (b << 16) | a;
+        }
+    }
+}

--- a/.lint/PxlPreview/Program.cs
+++ b/.lint/PxlPreview/Program.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using PromptUGUI.Editor;
+using UnityEngine;
+
+namespace PromptUGUI.PxlPreview
+{
+    public static class Program
+    {
+        public static int Main(string[] args)
+        {
+            var opt = new RenderOptions();
+            string outDir = null;
+            string paletteOverride = null;
+            var inputs = new List<string>();
+
+            for (var i = 0; i < args.Length; i++)
+            {
+                var a = args[i];
+                switch (a)
+                {
+                    case "--scale":
+                    case "-s":
+                        if (++i >= args.Length || !int.TryParse(args[i], out opt.Scale) ||
+                            opt.Scale < 1 || opt.Scale > 64)
+                        {
+                            Console.Error.WriteLine("PxlPreview: --scale needs an integer 1..64");
+                            return 2;
+                        }
+                        break;
+                    case "--out-dir":
+                    case "-o":
+                        if (++i >= args.Length) { Console.Error.WriteLine("PxlPreview: --out-dir needs a path"); return 2; }
+                        outDir = args[i];
+                        break;
+                    case "--palette":
+                        if (++i >= args.Length) { Console.Error.WriteLine("PxlPreview: --palette needs a .gpl path"); return 2; }
+                        paletteOverride = args[i];
+                        break;
+                    case "--guides":
+                        opt.Guides = true;
+                        break;
+                    case "--help":
+                    case "-h":
+                        PrintUsage();
+                        return 0;
+                    default:
+                        if (a.StartsWith("-", StringComparison.Ordinal))
+                        {
+                            Console.Error.WriteLine($"PxlPreview: unknown option '{a}'");
+                            return 2;
+                        }
+                        inputs.Add(a);
+                        break;
+                }
+            }
+
+            if (inputs.Count == 0) { PrintUsage(); return 2; }
+
+            var paths = ExpandPaths(inputs);
+            if (paths.Count == 0)
+            {
+                Console.Error.WriteLine("PxlPreview: no .pxl files matched.");
+                return 2;
+            }
+
+            outDir = Path.GetFullPath(outDir ?? Path.Combine(Path.GetTempPath(), "pxlpreview"));
+            try { Directory.CreateDirectory(outDir); }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"PxlPreview: cannot create out-dir {outDir}: {ex.Message}");
+                return 2;
+            }
+
+            var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var failed = 0;
+            foreach (var path in paths)
+            {
+                if (!RenderFile(path, outDir, paletteOverride, opt, used)) failed++;
+            }
+
+            if (failed > 0)
+            {
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"PxlPreview: {failed} of {paths.Count} file(s) failed.");
+                return 1;
+            }
+            return 0;
+        }
+
+        private static void PrintUsage()
+        {
+            Console.Error.WriteLine("Usage: PxlPreview <path>... [--scale N] [--out-dir DIR] [--palette FILE] [--guides]");
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Renders each .pxl to one PNG (all sections side by side, on a transparency");
+            Console.Error.WriteLine("checkerboard, labelled) so the art can be looked at instead of read as text.");
+            Console.Error.WriteLine("Parse / palette errors are reported exactly as the Unity importer reports them.");
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("  <path>        a .pxl file or a directory (recursed for *.pxl)");
+            Console.Error.WriteLine("  --scale N     pixel magnification, 1..64 (default 8)");
+            Console.Error.WriteLine("  --out-dir DIR where PNGs are written (default: <temp>/pxlpreview)");
+            Console.Error.WriteLine("  --palette F   use this .gpl instead of searching the project for @<name>");
+            Console.Error.WriteLine("  --guides      overlay the 9-slice border split lines");
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Never point --out-dir at a SpriteSet sourceFolder: the PNGs would be ingested");
+            Console.Error.WriteLine("as new sprite sources and collide with the .pxl's own keys.");
+        }
+
+        private static List<string> ExpandPaths(List<string> args)
+        {
+            var result = new List<string>();
+            foreach (var arg in args)
+            {
+                if (File.Exists(arg))
+                {
+                    result.Add(arg);
+                }
+                else if (Directory.Exists(arg))
+                {
+                    var found = new List<string>(Directory.EnumerateFiles(arg, "*.pxl", SearchOption.AllDirectories));
+                    found.Sort(StringComparer.Ordinal);
+                    result.AddRange(found);
+                }
+                else
+                {
+                    Console.Error.WriteLine($"PxlPreview: path not found: {arg}");
+                }
+            }
+            return result;
+        }
+
+        private static bool RenderFile(string path, string outDir, string paletteOverride,
+            RenderOptions opt, HashSet<string> used)
+        {
+            string text;
+            try { text = File.ReadAllText(path); }
+            catch (IOException ex)
+            {
+                Console.Error.WriteLine($"{path}: cannot read: {ex.Message}");
+                return false;
+            }
+
+            PxlDocument doc;
+            try { doc = PxlParser.Parse(text); }
+            catch (PxlParseException ex)
+            {
+                Console.Error.WriteLine($"{path}: {ex.Message}");
+                return false;
+            }
+
+            GplPalette palette = null;
+            if (doc.PaletteRef != null || paletteOverride != null)
+            {
+                var gplPath = paletteOverride;
+                if (gplPath == null)
+                {
+                    gplPath = PaletteLocator.Find(path, doc.PaletteRef, out var error);
+                    if (gplPath == null)
+                    {
+                        Console.Error.WriteLine($"{path}: {error}");
+                        return false;
+                    }
+                }
+                try { palette = GplPalette.Parse(File.ReadAllText(gplPath)); }
+                catch (IOException ex)
+                {
+                    Console.Error.WriteLine($"{gplPath}: cannot read: {ex.Message}");
+                    return false;
+                }
+                catch (FormatException ex)
+                {
+                    Console.Error.WriteLine($"{gplPath}: {ex.Message}");
+                    return false;
+                }
+            }
+
+            Dictionary<char, Color32> colors;
+            try { colors = PxlColorResolver.Resolve(doc, doc.PaletteRef != null ? palette : null); }
+            catch (PxlParseException ex)
+            {
+                Console.Error.WriteLine($"{path}: {ex.Message}");
+                return false;
+            }
+
+            var basename = Path.GetFileNameWithoutExtension(path);
+            var canvas = Renderer.Render(doc, colors, basename, opt);
+            var outPath = UniquePath(outDir, basename, used);
+            try { PngWriter.Write(outPath, canvas.Width, canvas.Height, canvas.Pixels); }
+            catch (IOException ex)
+            {
+                Console.Error.WriteLine($"{outPath}: cannot write: {ex.Message}");
+                return false;
+            }
+
+            Console.Out.WriteLine(outPath);
+            foreach (var s in doc.Sections)
+            {
+                var name = s.Name ?? "(implicit)";
+                var line = $"  {name}  {s.Width}x{s.Height}";
+                if (s.Border.x != 0 || s.Border.y != 0 || s.Border.z != 0 || s.Border.w != 0)
+                    line += $"  border {(int)s.Border.x},{(int)s.Border.y},{(int)s.Border.z},{(int)s.Border.w}";
+                if (s.Tiled) line += "  tiled";
+                Console.Out.WriteLine(line);
+            }
+            return true;
+        }
+
+        /// <summary>Same basename in two folders would otherwise overwrite silently
+        /// when a whole tree is rendered into one flat out-dir.</summary>
+        private static string UniquePath(string outDir, string basename, HashSet<string> used)
+        {
+            var candidate = basename;
+            var n = 2;
+            while (!used.Add(candidate))
+                candidate = basename + "-" + n++;
+            return Path.Combine(outDir, candidate + ".preview.png");
+        }
+    }
+}

--- a/.lint/PxlPreview/PxlPreview.csproj
+++ b/.lint/PxlPreview/PxlPreview.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    PxlPreview: stand-alone CLI that renders .pxl pixel-grid files to PNG so the
+    art can be LOOKED AT (and the parse / palette errors read) without an open
+    Unity instance. The .pxl text is the image, but nobody — human or LLM — can
+    judge shading, bevels or 9-slice edge strips by reading characters.
+
+    Compile set: the three Unity-agnostic .pxl sources straight out of
+    Editor/Pxl/ — PxlParser (grid + section structure), GplPalette (.gpl) and
+    PxlColorResolver (chars -> colour, incl. the off-palette enforcement).
+    Compiling the importer's own sources, rather than reimplementing the format,
+    is what keeps this preview honest: if the importer rejects a file, so does
+    this tool, with the same message and line number.
+
+    Those three files reference exactly two UnityEngine value types (Color32,
+    Vector4); UnityValueShims.cs supplies them. Everything else here (renderer,
+    PNG encoder, tiny font) is CLI-local and pure BCL, so the tool runs anywhere
+    `dotnet` runs — System.Drawing would have pinned it to Windows.
+  -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>PxlPreview</AssemblyName>
+    <RootNamespace>PromptUGUI.PxlPreview</RootNamespace>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\Editor\Pxl\PxlParser.cs" />
+    <Compile Include="..\..\Editor\Pxl\GplPalette.cs" />
+    <Compile Include="..\..\Editor\Pxl\PxlColorResolver.cs" />
+    <Compile Include="*.cs" />
+  </ItemGroup>
+
+  <!--
+    Directory.Build.props hands every .lint project an R3 PackageReference plus
+    (when Local.props points at a Unity install) wildcard <Reference>s to the
+    real UnityEngine / UnityEditor DLLs. Neither is wanted here: R3 is unused,
+    and the real UnityEngine.dll would collide with UnityValueShims.cs (CS0433).
+    Stripping them also keeps the tool buildable on machines with no Unity.
+  -->
+  <ItemGroup>
+    <PackageReference Remove="R3" />
+    <Reference Remove="@(Reference)" />
+  </ItemGroup>
+
+</Project>

--- a/.lint/PxlPreview/README.md
+++ b/.lint/PxlPreview/README.md
@@ -1,0 +1,98 @@
+# PxlPreview
+
+Standalone `.NET` CLI that renders PromptUGUI `.pxl` pixel-grid files to **PNG**
+— without Unity.
+
+`.pxl` is text, and the text *is* the image, but that only goes so far: row
+widths and stray characters can be checked by reading, while shading ramps,
+bevel direction, outline closure and whether a 9-slice edge strip actually
+tiles cannot. This tool closes that gap — render, look, revise. It is
+especially the missing feedback loop for an LLM author, which can view the
+resulting PNG directly.
+
+It doubles as the `.pxl` counterpart to [UIXmlLint](../UIXmlLint/README.md):
+every parse / palette error the Unity importer would raise is reported here
+first, with the same message and line number, and a non-zero exit code.
+
+## How it stays honest
+
+The CLI compiles the importer's own sources — `PxlParser`, `GplPalette`,
+`PxlColorResolver` from `Editor/Pxl/` — rather than reimplementing the format.
+A file this tool accepts is a file the ScriptedImporter accepts, and the
+colours are resolved through the same palette-enforcement path.
+
+Those three sources touch exactly two UnityEngine value types (`Color32`,
+`Vector4`); `UnityValueShims.cs` supplies them so the files compile verbatim
+outside Unity. Everything else — renderer, PNG encoder, 3x5 label font — is
+CLI-local and pure BCL, so the tool runs wherever `dotnet` runs (System.Drawing
+would have pinned it to Windows).
+
+## Usage
+
+From the repo root:
+
+```bash
+# One file (writes to <temp>/pxlpreview, prints the path)
+dotnet run --project .lint/PxlPreview -- Runtime/Resources/PromptUGUI/Defaults/pugui.pxl
+
+# Bigger magnification + 9-slice split lines overlaid
+dotnet run --project .lint/PxlPreview -- Buttons/ok.pxl --scale 16 --guides
+
+# A whole directory (recurses for *.pxl) into a chosen folder
+dotnet run --project .lint/PxlPreview -- Assets/UI/ --out-dir /tmp/pxl-check
+```
+
+| Option | Meaning |
+|---|---|
+| `--scale N` / `-s N` | Pixel magnification, 1..64 (default 8). |
+| `--out-dir DIR` / `-o DIR` | Where PNGs are written (default `<temp>/pxlpreview`). |
+| `--palette FILE` | Use this `.gpl` instead of searching the project for `@<name>`. |
+| `--guides` | Overlay the 9-slice border split lines in magenta. |
+
+Output: **one PNG per `.pxl`**, named `<basename>.preview.png`, with every
+section laid out left-to-right in file order, each on a transparency
+checkerboard under a `name WxH bL,B,R,T` label. One image per file is what
+makes state comparison (`normal` vs `pressed`) a single glance. The absolute
+PNG path is printed to stdout, followed by one metadata line per section.
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| 0 | Every file parsed, resolved and rendered. |
+| 1 | At least one file failed to parse / resolve / write. |
+| 2 | Bad arguments, or no `.pxl` matched. |
+
+> **Never point `--out-dir` at a SpriteSet `sourceFolder`.** The PNGs would be
+> ingested as new sprite sources and collide with the `.pxl`'s own keys — the
+> same hazard the Inspector's *Export PNG...* warns about. The default temp
+> folder is outside any sprite pipeline.
+
+## Palette lookup outside Unity
+
+There is no `AssetDatabase` here, so `palette: @ui` is resolved by scanning for
+`ui.gpl` under a project root — the parent of the outermost `Assets` ancestor
+if there is one (so embedded `Packages/` are covered), else the enclosing git
+repo, else the `.pxl`'s own folder. `Library`, `Temp`, `Logs`, `obj`, `bin` and
+`.git` are skipped. Exactly one match is required; zero or several produce the
+same error the importer produces. `--palette FILE` bypasses the search.
+
+## Downstream Unity projects
+
+The `.lint/` directory ships with the UPM package:
+
+```bash
+dotnet run --project Packages/com.heerozh.promptugui/.lint/PxlPreview -- Assets/UI/
+```
+
+You need a local `dotnet` SDK matching `TargetFramework` in
+`.lint/Directory.Build.props`. No Unity install required.
+
+## What this tool does NOT do
+
+- **No atlas / SpriteSet resolution.** It renders the `.pxl` in isolation; it
+  does not tell you whether the resulting `set:key` is reachable from XML.
+- **No PPU / layout simulation.** `ppu:` is parsed (and enforced) but the
+  preview is magnified by `--scale`, not by the in-game size.
+- **Not a round-trip editor.** Editing the PNG changes nothing; use the
+  Inspector's *Export PNG...* / *Sync from PNG...* pair for that.

--- a/.lint/PxlPreview/Renderer.cs
+++ b/.lint/PxlPreview/Renderer.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using PromptUGUI.Editor;
+using UnityEngine;
+
+namespace PromptUGUI.PxlPreview
+{
+    internal sealed class RenderOptions
+    {
+        public int Scale = 8;
+        public bool Guides;
+        public int LabelScale = 2;
+    }
+
+    /// <summary>Lays every section of one .pxl out left-to-right in file order,
+    /// each on a transparency checkerboard under a text label. One image per file
+    /// keeps state comparison (normal vs pressed) a single glance.</summary>
+    internal static class Renderer
+    {
+        private static readonly Rgba Background = new Rgba(30, 30, 36);
+        private static readonly Rgba CheckerA = new Rgba(86, 86, 94);
+        private static readonly Rgba CheckerB = new Rgba(112, 112, 120);
+        private static readonly Rgba LabelColor = new Rgba(228, 228, 232);
+        private static readonly Rgba GuideColor = new Rgba(255, 0, 255);
+
+        private const int Margin = 12;
+        private const int Gap = 12;
+        private const int LabelGap = 4;
+
+        public static Canvas Render(PxlDocument doc, IReadOnlyDictionary<char, Color32> colors,
+            string basename, RenderOptions opt)
+        {
+            var n = doc.Sections.Count;
+            var labels = new string[n];
+            var colWidths = new int[n];
+            var labelHeight = TinyFont.GlyphHeight * opt.LabelScale;
+            var maxBlockHeight = 0;
+            var totalWidth = Margin * 2 + Gap * (n - 1);
+
+            for (var i = 0; i < n; i++)
+            {
+                var s = doc.Sections[i];
+                labels[i] = Label(s, basename);
+                var blockWidth = s.Width * opt.Scale;
+                var labelWidth = TinyFont.MeasureWidth(labels[i], opt.LabelScale);
+                colWidths[i] = blockWidth > labelWidth ? blockWidth : labelWidth;
+                totalWidth += colWidths[i];
+                var blockHeight = s.Height * opt.Scale;
+                if (blockHeight > maxBlockHeight) maxBlockHeight = blockHeight;
+            }
+
+            var canvas = new Canvas(totalWidth,
+                Margin * 2 + labelHeight + LabelGap + maxBlockHeight, Background);
+
+            var x = Margin;
+            var blockTop = Margin + labelHeight + LabelGap;
+            for (var i = 0; i < n; i++)
+            {
+                var s = doc.Sections[i];
+                TinyFont.Draw(canvas, labels[i], x, Margin, opt.LabelScale, LabelColor);
+                DrawSection(canvas, s, colors, x, blockTop, opt);
+                x += colWidths[i] + Gap;
+            }
+            return canvas;
+        }
+
+        private static string Label(PxlSection s, string basename)
+        {
+            var label = (s.Name ?? basename) + " " + s.Width + "x" + s.Height;
+            if (s.Border.x != 0 || s.Border.y != 0 || s.Border.z != 0 || s.Border.w != 0)
+            {
+                label += " b" + (int)s.Border.x + "," + (int)s.Border.y + "," +
+                         (int)s.Border.z + "," + (int)s.Border.w;
+            }
+            if (s.Tiled) label += " tiled";
+            return label;
+        }
+
+        private static void DrawSection(Canvas canvas, PxlSection s,
+            IReadOnlyDictionary<char, Color32> colors, int left, int top, RenderOptions opt)
+        {
+            var scale = opt.Scale;
+            var checker = scale >= 4 ? scale : 8;
+
+            for (var y = 0; y < s.Height * scale; y += checker)
+            {
+                for (var x = 0; x < s.Width * scale; x += checker)
+                {
+                    var tone = ((x / checker) + (y / checker)) % 2 == 0 ? CheckerA : CheckerB;
+                    canvas.Fill(left + x, top + y,
+                        Clamp(checker, s.Width * scale - x), Clamp(checker, s.Height * scale - y), tone);
+                }
+            }
+
+            for (var row = 0; row < s.Height; row++)
+            {
+                var line = s.Rows[row];
+                for (var col = 0; col < s.Width; col++)
+                {
+                    var c = colors[line[col]];
+                    if (c.a == 0) continue;
+                    canvas.Blend(left + col * scale, top + row * scale, scale, scale,
+                        new Rgba(c.r, c.g, c.b, c.a));
+                }
+            }
+
+            if (opt.Guides) DrawGuides(canvas, s, left, top, scale);
+        }
+
+        /// <summary>9-slice split lines, in Unity's L,B,R,T border order. Drawn 1
+        /// canvas pixel wide (not 1 source pixel) so they mark the seam without
+        /// hiding the art underneath.</summary>
+        private static void DrawGuides(Canvas canvas, PxlSection s, int left, int top, int scale)
+        {
+            if (s.Border.x == 0 && s.Border.y == 0 && s.Border.z == 0 && s.Border.w == 0) return;
+            var w = s.Width * scale;
+            var h = s.Height * scale;
+            if (s.Border.x > 0) canvas.Fill(left + (int)s.Border.x * scale, top, 1, h, GuideColor);
+            if (s.Border.z > 0) canvas.Fill(left + w - (int)s.Border.z * scale - 1, top, 1, h, GuideColor);
+            if (s.Border.w > 0) canvas.Fill(left, top + (int)s.Border.w * scale, w, 1, GuideColor);
+            if (s.Border.y > 0) canvas.Fill(left, top + h - (int)s.Border.y * scale - 1, w, 1, GuideColor);
+        }
+
+        private static int Clamp(int value, int max) => value > max ? max : value;
+    }
+}

--- a/.lint/PxlPreview/TinyFont.cs
+++ b/.lint/PxlPreview/TinyFont.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+
+namespace PromptUGUI.PxlPreview
+{
+    /// <summary>3x5 bitmap font, just enough to stamp a section's name / size /
+    /// border onto the preview itself. Without labels a multi-section montage is
+    /// ambiguous ("which one is [pressed]?") the moment you stop counting columns.
+    /// Uppercase-only; unknown glyphs render blank.</summary>
+    internal static class TinyFont
+    {
+        public const int GlyphWidth = 3;
+        public const int GlyphHeight = 5;
+        public const int Tracking = 1; // blank columns between glyphs
+
+        private static readonly Dictionary<char, string[]> Glyphs = new Dictionary<char, string[]>
+        {
+            ['A'] = new[] { "010", "101", "111", "101", "101" },
+            ['B'] = new[] { "110", "101", "110", "101", "110" },
+            ['C'] = new[] { "011", "100", "100", "100", "011" },
+            ['D'] = new[] { "110", "101", "101", "101", "110" },
+            ['E'] = new[] { "111", "100", "110", "100", "111" },
+            ['F'] = new[] { "111", "100", "110", "100", "100" },
+            ['G'] = new[] { "011", "100", "101", "101", "011" },
+            ['H'] = new[] { "101", "101", "111", "101", "101" },
+            ['I'] = new[] { "111", "010", "010", "010", "111" },
+            ['J'] = new[] { "001", "001", "001", "101", "010" },
+            ['K'] = new[] { "101", "101", "110", "101", "101" },
+            ['L'] = new[] { "100", "100", "100", "100", "111" },
+            ['M'] = new[] { "101", "111", "111", "101", "101" },
+            ['N'] = new[] { "110", "101", "101", "101", "101" },
+            ['O'] = new[] { "010", "101", "101", "101", "010" },
+            ['P'] = new[] { "110", "101", "110", "100", "100" },
+            ['Q'] = new[] { "010", "101", "101", "111", "011" },
+            ['R'] = new[] { "110", "101", "110", "101", "101" },
+            ['S'] = new[] { "011", "100", "010", "001", "110" },
+            ['T'] = new[] { "111", "010", "010", "010", "010" },
+            ['U'] = new[] { "101", "101", "101", "101", "111" },
+            ['V'] = new[] { "101", "101", "101", "101", "010" },
+            ['W'] = new[] { "101", "101", "111", "111", "101" },
+            ['X'] = new[] { "101", "101", "010", "101", "101" },
+            ['Y'] = new[] { "101", "101", "010", "010", "010" },
+            ['Z'] = new[] { "111", "001", "010", "100", "111" },
+            ['0'] = new[] { "111", "101", "101", "101", "111" },
+            ['1'] = new[] { "010", "110", "010", "010", "111" },
+            ['2'] = new[] { "110", "001", "010", "100", "111" },
+            ['3'] = new[] { "110", "001", "010", "001", "110" },
+            ['4'] = new[] { "101", "101", "111", "001", "001" },
+            ['5'] = new[] { "111", "100", "110", "001", "110" },
+            ['6'] = new[] { "011", "100", "110", "101", "010" },
+            ['7'] = new[] { "111", "001", "010", "010", "010" },
+            ['8'] = new[] { "010", "101", "010", "101", "010" },
+            ['9'] = new[] { "010", "101", "011", "001", "110" },
+            [':'] = new[] { "000", "010", "000", "010", "000" },
+            [','] = new[] { "000", "000", "000", "010", "100" },
+            ['.'] = new[] { "000", "000", "000", "000", "010" },
+            ['-'] = new[] { "000", "000", "111", "000", "000" },
+            ['_'] = new[] { "000", "000", "000", "000", "111" },
+            ['/'] = new[] { "001", "001", "010", "100", "100" },
+            ['('] = new[] { "001", "010", "010", "010", "001" },
+            [')'] = new[] { "100", "010", "010", "010", "100" },
+            ['*'] = new[] { "000", "101", "010", "101", "000" },
+            ['!'] = new[] { "010", "010", "010", "000", "010" },
+            ['?'] = new[] { "110", "001", "010", "000", "010" },
+            [' '] = new[] { "000", "000", "000", "000", "000" },
+        };
+
+        public static int MeasureWidth(string text, int scale) =>
+            text.Length == 0 ? 0 : (text.Length * (GlyphWidth + Tracking) - Tracking) * scale;
+
+        public static void Draw(Canvas canvas, string text, int x, int y, int scale, Rgba color)
+        {
+            var penX = x;
+            foreach (var raw in text)
+            {
+                var c = char.ToUpperInvariant(raw);
+                if (Glyphs.TryGetValue(c, out var rows))
+                {
+                    for (var gy = 0; gy < GlyphHeight; gy++)
+                    {
+                        for (var gx = 0; gx < GlyphWidth; gx++)
+                        {
+                            if (rows[gy][gx] != '1') continue;
+                            canvas.Fill(penX + gx * scale, y + gy * scale, scale, scale, color);
+                        }
+                    }
+                }
+                penX += (GlyphWidth + Tracking) * scale;
+            }
+        }
+    }
+}

--- a/.lint/PxlPreview/UnityValueShims.cs
+++ b/.lint/PxlPreview/UnityValueShims.cs
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------------------
+// Minimal stand-ins for the two UnityEngine value types that the SHARED .pxl
+// sources (PxlParser / GplPalette / PxlColorResolver, compiled straight out of
+// Editor/Pxl/) reference. They exist so those files compile verbatim outside
+// Unity — no #if, no forked copy, no refactor of the Unity-side code.
+//
+// Contract: keep these byte-for-byte semantically identical to Unity's types
+// for the members the shared sources touch:
+//     Color32(byte r, byte g, byte b, byte a) + public fields r/g/b/a
+//     Vector4(float x, float y, float z, float w) + public fields x/y/z/w
+// Nothing else is used, and nothing else should be added here — if a shared
+// file starts needing more of UnityEngine, that is the signal to purify the
+// file instead of growing the shim.
+//
+// PxlPreview.csproj strips every inherited <Reference> so the real Unity DLLs
+// (pulled in by .lint/Local.props for the Roslyn-workspace projects) can never
+// collide with these definitions (CS0433).
+// ---------------------------------------------------------------------------
+
+namespace UnityEngine
+{
+    internal struct Color32
+    {
+        public byte r, g, b, a;
+
+        public Color32(byte r, byte g, byte b, byte a)
+        {
+            this.r = r; this.g = g; this.b = b; this.a = a;
+        }
+    }
+
+    internal struct Vector4
+    {
+        public float x, y, z, w;
+
+        public Vector4(float x, float y, float z, float w)
+        {
+            this.x = x; this.y = y; this.z = z; this.w = w;
+        }
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,20 @@ dotnet run --project .lint/UIXmlLint -- Runtime/Resources/                   # �
 
 规则代码在 `Runtime/Core/Lint/`（纯 C#），跟 `ScreenInstantiator` 的 warning 路径共用同一份实现 —— 新增规则时只改一处。详见 `.lint/UIXmlLint/README.md`。
 
+### `.pxl` 渲染预览（PxlPreview CLI）
+
+写完或编辑任何 `.pxl` 之后，渲染成 PNG **然后真的去看那张图**——像素画的明暗、斜面方向、9-slice 边条是否均匀，逐行读字符是判断不出来的：
+
+```bash
+dotnet run --project .lint/PxlPreview -- Runtime/Resources/PromptUGUI/Defaults/pugui.pxl
+dotnet run --project .lint/PxlPreview -- Assets/UI/Buttons/ok.pxl --scale 16 --guides
+dotnet run --project .lint/PxlPreview -- Assets/UI/ --out-dir /tmp/pxl-check    # 整个目录递归
+```
+
+每个 `.pxl` 出一张 PNG（各 section 横向并排 + 透明棋盘格 + 标签），路径打到 stdout；`--guides` 叠加 9-slice 分割线。同时它也是 `.pxl` 的 linter：直接编译 `Editor/Pxl/` 里导入器自己的 `PxlParser` / `GplPalette` / `PxlColorResolver`，所以报错信息和行号跟 Unity 导入完全一致，exit code 非零。
+
+那三个共享源文件只依赖 `Color32` / `Vector4` 两个 UnityEngine 值类型，由 `.lint/PxlPreview/UnityValueShims.cs` 顶替 —— **改这三个文件时别引入新的 Unity 类型**，否则 CLI 编译不过（届时应该把该文件提纯，而不是往 shim 里加东西）。详见 `.lint/PxlPreview/README.md`。
+
 ## Pipeline (mental model)
 
 ```


### PR DESCRIPTION
## 为什么

`.pxl` 的文本就是图，但**逐行读字符只能查出结构问题**（行宽、野字符）。明暗层次、斜面方向、轮廓是否闭合、两个状态的剪影是否一致、9-slice 边条是否真的能平铺 —— 这些不看图判断不了，而它们恰恰是文本自查能全须全尾放过去的错误。

skill 里原本只有两条路：末尾的"逐行重读自己的输出"，和 Inspector 上的 **Export PNG...** 按钮（人类 GUI 流程，弹文件夹选择器，定位是导出去 Aseprite 编辑）。也就是说，写完 `.pxl` 之后没有任何一条**能被 LLM 自己走完**的验证路径。这个 PR 补上它。

## 是什么

`.lint/PxlPreview` —— 与 UIXmlLint 同构的独立 .NET CLI，不需要 Unity 实例，也不需要装 Unity：

```bash
dotnet run --project .lint/PxlPreview -- Buttons/ok.pxl --scale 16 --guides
```

每个 `.pxl` 出一张 PNG：各 section 按文件顺序横向并排、透明棋盘格打底、上方标 `name WxH bL,B,R,T tiled`，绝对路径打到 stdout（LLM 直接 Read 那张图）。一个文件一张图，所以 `normal` / `pressed` 对比是一眼的事。

| 选项 | 用途 |
|---|---|
| `--scale N`（1..64，默认 8） | 小图标要 16+，48×48 的框 6 就够 |
| `--guides` | 洋红线叠出 9-slice 分割位置 —— 确认圆角落在 border 框内、边条在两线之间保持均匀 |
| `--out-dir DIR` | 默认临时目录。**别指向 SpriteSet sourceFolder**，PNG 会被当成新 sprite 来源，跟 `.pxl` 自己的 key 撞车 |
| `--palette FILE` | 跳过 `@name` 的项目搜索，直接给 `.gpl` |

它同时是 `.pxl` 的 linter：解析 / 调色板错误按导入器原文报，带行号，exit code 1。

## 怎么保证跟导入器一致

CLI **直接编译 `Editor/Pxl/` 里导入器自己的** `PxlParser` / `GplPalette` / `PxlColorResolver`，不复制任何格式逻辑 —— 这个工具接受的文件就是 ScriptedImporter 接受的文件，颜色也走同一条调色板强制路径。

这三个文件只碰 `Color32` / `Vector4` 两个 UnityEngine 值类型，由 `UnityValueShims.cs` 顶替；`PxlPreview.csproj` 剥掉了 `Directory.Build.props` 继承来的 Unity DLL 通配引用 —— 否则真的 `UnityEngine.dll` 会跟 shim 撞 CS0433（本机 `Local.props` 配了真路径，这条护栏是被实际验证过的，不是纸面推理）。

渲染器 / PNG 编码器（zlib + CRC32 手写，压缩走 BCL 的 `DeflateStream`）/ 3×5 标签字体全部 CLI 本地纯 BCL —— 用 `System.Drawing` 会把工具钉死在 Windows 上，而 skill 是要发给所有使用者的。

> 备注：曾考虑把 `PxlParser` 下沉到 `Runtime/Core/` 来共享，但 `Runtime/` 是要编进 Player 的，而 `.pxl` 解析只在 Editor 导入期用得上；且拔掉 `Color32` 会波及 `PxlQuantizer` / `PxlFromPng` / `PxlPngSync` 等 8 个源文件 + 6 个测试。**Unity 侧最终一行未改。**

## 验证

- **像素级交叉校验**：跟一个独立实现（PowerShell + System.Drawing + 独立 `.gpl` 解析）逐像素比对 —— palette 模式 344 点、内联 hex 模式 564 点，**0 处不一致**；产出的 PNG 能被 System.Drawing 正常解码，说明编码器合法。
- **错误路径**：ragged row / unknown char / palette not found / off-palette，消息与行号同导入器，exit 1。
- **场景覆盖**：隐式单节、7 节混合尺寸、半透明 `#RRGGBBAA`、`tiled`、目录递归（12 个文件）、同名冲突、`--palette` 覆盖。
- `dotnet format --verify-no-changes --severity warn`：新文件 0 诊断。（全解决方案仍有 4 条 WHITESPACE，全在 `Editor/Pxl/PxlParser.cs:24-26` 那几行对齐注释上，既有问题，本 PR 未触碰该文件。）
- **`PromptUGUI.Tests.EditorOnly` 284/284 通过**（UnityMCP EditMode）。

## 文档同步

- `authoring-promptugui-pxl/SKILL.md`：新增 **Look at what you drew** 一节；开头的循环改成 write → render → look → revise；结尾自查从"逐行重读"升级为三步，第 2 步写死 *"Do not claim a sprite looks right without having looked at it"*；补了下游 UPM 项目的调用路径。
- `CLAUDE.md`：UIXmlLint 之后新增并列一节，含给后来者的护栏 —— 那三个共享文件别引入新的 Unity 类型，要加就该提纯文件而不是往 shim 里塞。
- `.lint/PxlPreview/README.md`：用法 / 退出码 / 无 AssetDatabase 时的调色板查找规则 / 边界。
- `.gitignore`：补 `!/.lint/**/*.csproj` —— 全局 `*.csproj` 规则会吃掉子目录里的 csproj（UIXmlLint 那个当年是强制 add 进去的，规则其实没覆盖到）。
