### PR TITLE
feat: 主题驱动样式 + lint 展开化 + 属性可逆性修复 (M0–M2)

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -698,7 +698,7 @@ inline 属性  >  右边的 class  >  左边的 class
 - `class="{{param}}"` inside a `<Template>` body is fine — the class name is substituted first, so a template can take its skin as a parameter.
 - `<Screen>` takes no `class` (it is not a control). `class=""` (no names) and an unknown style name are both errors.
 
-**Sharing** works exactly like `<Template>`: styles travel through `<Import>`, land in the commons pool, hot-reload with their file, and a name colliding between commons and the entry document is a hard error. A namespaced commons library is referenced with a colon — `class="ui:card"` — mirroring the `Set:Name` form used for sprites and icons (tags use a dot, `ui.TitledPanel`; class references use a colon).
+**Sharing** works exactly like `<Template>`: styles travel through `<Import>`, land in the commons pool, hot-reload with their file, and a name colliding between commons and the entry document is a hard error. An unknown style name is caught by the lint CLI as `PUI-EXPAND` whenever it can read the imported files from disk; otherwise it surfaces at `UI.Open()`. A namespaced commons library is referenced with a colon — `class="ui:card"` — mirroring the `Set:Name` form used for sprites and icons (tags use a dot, `ui.TitledPanel`; class references use a colon).
 
 Swapping which commons library is loaded therefore re-skins everything at once.
 
@@ -1273,7 +1273,10 @@ GAMEPAD NAV   UI.UseGamepadNavigation()        enable once at startup (new Input
 STYLE LINT    PUI-CLASS-EMPTY                  class="" / whitespace-only — names no style
               PUI-PROCEDURAL-VALUE             bad radius / borderWidth / glow value (also checked inside <Style>)
               PUI-CONTAINER-VISUAL-ATTR        sprite= on any container; color/radius/border/glow on *Stack/Grid/SafeArea
-              (unknown class name is a RUNTIME error — the CLI can't see the commons pool)
+                                               — also fires when the attribute arrives through class=
+              PUI-EXPAND                       unknown template / style name, or an <Import> cycle
+              (PUI-EXPAND needs the imported files on disk; with an Addressables / custom resolver
+               the CLI skips that check and the name stays a runtime error)
 ```
 
 ## Triggers and Animations

--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -65,7 +65,7 @@ mcp__UnityMCP__read_console(action="get", types=["error","warning"])
 | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `<PromptUGUI version="1">`                                                                           | Root, **always**.                                         | NOT `<UI>`. `version="1"` is required.                                                                                                                                                                                                                                                        |
 | `<Import src="..." [as="ns"]/>`                                                                      | Pull templates from another file.                         | Top-level only. `as=` adds namespace prefix.                                                                                                                                                                                                                                                  |
-| `<Theme name=... base=...?>`                                                                         | Top-level. Declares a named color theme.                  | `base` (optional) inherits tokens from another theme by name. Children must be `<Color>` only.                                                                                                                                                                                                |
+| `<Theme name=... base=...?>`                                                                         | Top-level. Declares a named skin: color tokens + style packs. | `base` (optional) inherits from another theme by name. Children are `<Color>` and/or `<Style>`. See **Color Tokens** and **Theme-scoped styles**.                                                                                                                                          |
 | `<Color name=... value=...>`                                                                         | Inside `<Theme>`. Defines a named color token.            | `name` is kebab-case `[a-z0-9-]`. `value` is hex (`#rgb` / `#rrggbb` / `#rrggbbaa`) or a Unity CSS named color (`red` / `white` / ...).                                                                                                                                                       |
 | `<Screen name="..." [canvas="..."] [reference="..."] [scale-mode="..."] [reference.portrait="..."]>` | A complete UI scene; opened by code with `UI.Open(name)`. | One Screen = one Canvas. Names unique across all loaded files. `canvas="overlay\|camera\|world"`, default `overlay`. Optional `reference="WxH"` (+ `.variant`) switches CanvasScaler to ScaleWithScreenSize. Optional `scale-mode="auto\|pixel"` (+ `.variant`); pixel = integer scaleFactor. |
 | `<Template name="...">`                                                                              | Reusable subtree, expanded at parse time.                 | Body must have **exactly one root element**.                                                                                                                                                                                                                                                  |
@@ -702,6 +702,53 @@ inline 属性  >  右边的 class  >  左边的 class
 
 Swapping which commons library is loaded therefore re-skins everything at once.
 
+### Theme-scoped styles
+
+A `<Theme>` may declare `<Style>` packs alongside its `<Color>` tokens. Because `class=` is an
+attribute macro, this gives a theme the **whole attribute surface** — sprite, radius, font size,
+padding, glass parameters — not just colours. Switching `UI.Theme.Current` re-derives every `class=`
+node and replays the attributes; **no GameObject is rebuilt**, so references and subscriptions live.
+
+```xml
+<Style name="card" sprite="ui:panel" color="surface/0.85" radius="16" borderWidth="1"/>
+
+<Theme name="modern">
+  <Color name="surface" value="#f7f8fa"/>
+</Theme>
+<Theme name="pixel" base="modern">
+  <Color name="surface" value="#e8d8b0"/>
+  <Style name="card" sprite="px:panel" radius="0" borderWidth="2"/>   <!-- only what differs -->
+</Theme>
+```
+
+**The global `<Style>` is the implicit root of every theme chain.** Folding order is
+`global → base= chain → active theme`, atomic per attribute name (same rule multiple classes get).
+Three consequences worth internalising:
+
+- A theme spells out only what differs; everything else comes from the global pack.
+- **Always declare the global `<Style>` with the full attribute set.** An attribute one theme sets
+  and another doesn't is never reset on a switch — the control keeps the old value. `PUI-THEME-STYLE-SHAPE`
+  catches this; `PUI-THEME-STYLE-NO-BASELINE` catches a style that exists only inside a theme
+  (unreachable — `class=` resolves against the global pool).
+- A project with no theme styles costs exactly nothing; this is all opt-in.
+
+**Rejected inside a `<Theme>`'s `<Style>`** (all parse errors; a global `<Style>` still accepts the
+last two groups):
+
+| Group | Names | Why |
+|---|---|---|
+| node identity | `id` `if` `class` `bind` | same as a global `<Style>` |
+| runtime-owned state | `text` `isOn` `value` `current` | the applier stops replaying these once code sets them, so a theme's value would be swallowed *some* of the time |
+| mask family | `mask` `showMask` `maskPadding` | `PUI-MASK-VARIANT` already rejects switching mask mode per state; a theme must not be a second door into it |
+
+**Don't put a themed `class=` on a Template invocation** (`<ui.Card class="skin"/>`): half the pack
+becomes `<Param>` values that get baked into the body at expansion, and the invocation node is gone
+afterwards, so nothing re-derives. Put the `class=` on a node **inside** the template body instead.
+`PUI-THEME-STYLE-ON-INVOCATION` flags it.
+
+Theme styles address the **un-namespaced** style pool only — `class="ui:card"` (from a library
+imported with `as="ui"`) cannot be themed.
+
 ## Templates
 
 ```xml
@@ -892,6 +939,7 @@ Define named colors in `<Theme>` blocks; reference them by name in any color att
 - `<Theme>` MUST have `name`. Optional `base="other-theme"` makes missing tokens fall back along the chain.
 - `<Color>` MUST have `name` (kebab-case, `[a-z0-9-]`) and `value` (hex / CSS-named, anything Unity's `ColorUtility.TryParseHtmlString` accepts).
 - Theme XML loads via `UI.LoadCommonLibraryAsync(...)` at boot, or via `<Import src="themes/main.ui"/>` from any screen's `.ui.xml` — both register the same `ThemeStore`.
+- A `<Theme>` can also carry `<Style>` packs, which turns a theme from "swap the palette" into "swap the skin" — see **Theme-scoped styles** below.
 
 ### Reference
 
@@ -1277,6 +1325,9 @@ STYLE LINT    PUI-CLASS-EMPTY                  class="" / whitespace-only — na
               PUI-EXPAND                       unknown template / style name, or an <Import> cycle
               (PUI-EXPAND needs the imported files on disk; with an Addressables / custom resolver
                the CLI skips that check and the name stays a runtime error)
+              PUI-THEME-STYLE-NO-BASELINE      <Style> declared only inside a <Theme> — unreachable
+              PUI-THEME-STYLE-SHAPE            two themes resolve a style to different attribute sets
+              PUI-THEME-STYLE-ON-INVOCATION    themed class= on a Template invocation won't re-skin
 ```
 
 ## Triggers and Animations

--- a/.claude/skills/authoring-promptugui-xml/reference/controls-progress.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/controls-progress.md
@@ -31,6 +31,14 @@ Radial fill（冷却环）不在 `<Progress>` 范围；以后用单独的 `<Cool
           bgColor="#000"/>
 ```
 
+## bg / frame 图层的显隐
+
+`bg` / `frame` 图层在**声明了 sprite 或颜色**（`bg` / `bgColor`，`frame` / `frameColor`）时显示，两者都没有时隐藏。这是从当前声明**算出来**的，不是一次性打开：`bg=""` / `bg="none"` 会把图层关掉，所以 Variant 切换、主题换肤、运行时赋值都能把它收回去，不会留着上一次的图素。
+
+```xml
+<Progress bg="ui:track" bg.mobile=""/>   <!-- 手机上不要底图，直接关掉该图层 -->
+```
+
 ## mask × bg 四种组合
 
 | 条件                   | MaskWrapper.UnityImage | MaskWrapper.Mask | MaskWrapper.showMaskGraphic | Bg.SetActive | Frame.SetActive |

--- a/.claude/skills/authoring-promptugui-xml/reference/states.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/states.md
@@ -90,6 +90,8 @@ Note: an authored `disabledSprite=` also switches the Btn off ColorTint (same `O
 
 In short: write `pressedSprite=""` or `pressedSprite="none"` to explicitly disable the built-in fallback and keep the default skin unchanged on press.
 
+**Reversible.** The ColorTint switch is *computed* from what is currently in play, not latched: clearing `pressedSprite` / `disabledSprite` / `selectedSprite` (a Variant flip, a theme switch, a runtime assignment) hands interaction feedback back to uGUI's ColorTint — unless a `*Color` / `*Modulate` / `selectedColor` is still installed, in which case the reactors keep ownership and ColorTint stays off. Without this the control would be left with **no** feedback at all and no attribute the author could write to get it back.
+
 ## 3. State-triggered animation — `<Trigger>` / `<Animation on="state-...">`
 
 `state-normal` / `state-hover` / `state-pressed` / `state-selected` / `state-disabled` (each also `@<id>`) are `on=` values on `<Trigger>` / `<Animation>` / `<Show>` — see the `on=` table in [`animations.md`](animations.md). Source resolution is **upward** to the nearest `<Btn>` / `<Tab>` / `<Toggle>` ancestor (opposite of `click` / `press`), and they fire **on entering** the state. `state-selected` is meaningful only with a `<Tab>` / `<Toggle>` source. Pair a press animation with its revert:

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -501,6 +501,13 @@ For Addressables-backed `.po` loading (`UI.Locale.UseAddressableResolver`, `Loca
 
 ## Theme switching
 
+`UI.Theme.Set` re-derives **colour tokens and `<Style>` packs** — a theme that declares `<Style>`
+children re-skins sprites, radii, font sizes and everything else `class=` can carry, in place: the
+attributes are replayed through the same path a resize takes, so **no GameObject is rebuilt** and
+your `Get<T>` references and R3 subscriptions survive. Cost is one extra pass over the `class=` nodes
+on top of the ReSolve a theme switch already triggered; a project whose themes carry only `<Color>`
+pays nothing. See authoring-promptugui-xml → **Theme-scoped styles**.
+
 `UI.Theme.Set` is order-independent — it never blocks on the load. You can fire it before `LoadCommonLibraryAsync` resolves; when the named theme registers, `Theme.Changed` re-fires and open Screens repaint. While pending, color attribute resolution falls back to `Color.white` for token names (literal hex / CSS named values resolve as usual).
 
 ```csharp

--- a/.lint/UIXmlLint/Program.cs
+++ b/.lint/UIXmlLint/Program.cs
@@ -95,7 +95,9 @@ namespace PromptUGUI.UIXmlLint
             foreach (var issue in DocumentLinter.Walk(doc, SrcKeyOf(path),
                                                       closure == null ? null : s => Lookup(closure, s)))
             {
-                Console.Error.WriteLine($"{path}: [{issue.Code}] {issue.Message}");
+                // Origin is the file the markup was WRITTEN in — for a finding inside an imported
+                // Template body that is the library, not the entry document that invoked it.
+                Console.Error.WriteLine($"{issue.Origin ?? path}: [{issue.Code}] {issue.Message}");
                 count++;
             }
             return count;
@@ -120,7 +122,7 @@ namespace PromptUGUI.UIXmlLint
 
             try
             {
-                var doc = UIDocumentParser.Parse(xml);
+                var doc = UIDocumentParser.Parse(xml, path);
                 failed = false;
                 return doc;
             }
@@ -162,7 +164,9 @@ namespace PromptUGUI.UIXmlLint
                 if (file == null) { unresolved = imp.Src; return false; }
 
                 UIDocument child;
-                try { child = UIDocumentParser.Parse(File.ReadAllText(file)); }
+                // Stamped with the RESOLVED path, not imp.Src: OriginSrc exists so a finding can
+                // name a file the author can open, while imp.Src stays the assembler's lookup key.
+                try { child = UIDocumentParser.Parse(File.ReadAllText(file), file); }
                 catch (Exception) { unresolved = imp.Src; return false; }
 
                 // Record before recursing so a cyclic Import terminates here; DocumentAssembler owns

--- a/.lint/UIXmlLint/Program.cs
+++ b/.lint/UIXmlLint/Program.cs
@@ -76,6 +76,37 @@ namespace PromptUGUI.UIXmlLint
 
         private static int LintFile(string path)
         {
+            var doc = TryParse(path, out var parseFailed);
+            if (parseFailed) return 1;
+
+            // Everything about WHICH rules run and how the two passes dedup lives in
+            // PromptUGUI.Lint.DocumentLinter, so it is covered by PromptUGUI.Tests.EditMode. The CLI
+            // owns only I/O: reading files and guessing src -> path (the runtime resolves src through
+            // a caller-supplied SourceResolver, which has no on-disk ground truth).
+            var closure = TryLoadImportClosure(path, doc, out var unresolved);
+            if (closure == null)
+            {
+                Console.Out.WriteLine(
+                    $"{path}: skipping expanded pass - cannot resolve <Import src=\"{unresolved}\"> " +
+                    "on disk (Addressables / custom resolver?). Raw-IR rules still applied.");
+            }
+
+            var count = 0;
+            foreach (var issue in DocumentLinter.Walk(doc, SrcKeyOf(path),
+                                                      closure == null ? null : s => Lookup(closure, s)))
+            {
+                Console.Error.WriteLine($"{path}: [{issue.Code}] {issue.Message}");
+                count++;
+            }
+            return count;
+        }
+
+        private static UIDocument Lookup(Dictionary<string, UIDocument> closure, string src)
+            => closure.TryGetValue(src, out var d) ? d : null;
+
+        private static UIDocument TryParse(string path, out bool failed)
+        {
+            failed = true;
             string xml;
             try
             {
@@ -84,32 +115,93 @@ namespace PromptUGUI.UIXmlLint
             catch (Exception ex)
             {
                 Console.Error.WriteLine($"{path}: read failed: {ex.Message}");
-                return 1;
+                return null;
             }
 
-            UIDocument doc;
             try
             {
-                doc = UIDocumentParser.Parse(xml);
+                var doc = UIDocumentParser.Parse(xml);
+                failed = false;
+                return doc;
             }
             catch (ParseException ex)
             {
                 Console.Error.WriteLine($"{path}: parse error: {ex.Message}");
-                return 1;
+                return null;
             }
             catch (System.Xml.XmlException ex)
             {
                 Console.Error.WriteLine($"{path}: xml error (line {ex.LineNumber}, pos {ex.LinePosition}): {ex.Message}");
-                return 1;
+                return null;
             }
-
-            var count = 0;
-            foreach (var issue in IRWalker.Walk(doc))
-            {
-                Console.Error.WriteLine($"{path}: [{issue.Code}] {issue.Message}");
-                count++;
-            }
-            return count;
         }
+
+        /// <summary>
+        /// Parses everything reachable through <c>&lt;Import&gt;</c>. Returns null (with the offending
+        /// src) as soon as one cannot be found on disk — a partial closure would make
+        /// <c>DocumentLinter</c> report a phantom "unknown template" for a name that resolves fine at
+        /// runtime, so it is all or nothing.
+        /// </summary>
+        private static Dictionary<string, UIDocument> TryLoadImportClosure(
+            string path, UIDocument doc, out string unresolved)
+        {
+            var closure = new Dictionary<string, UIDocument>();
+            unresolved = null;
+            return Prefetch(path, doc, closure, ref unresolved) ? closure : null;
+        }
+
+        private static bool Prefetch(
+            string importingPath, UIDocument doc,
+            Dictionary<string, UIDocument> closure, ref string unresolved)
+        {
+            foreach (var imp in doc.Imports)
+            {
+                if (closure.ContainsKey(imp.Src)) continue;
+
+                var file = ResolveSrc(imp.Src, importingPath);
+                if (file == null) { unresolved = imp.Src; return false; }
+
+                UIDocument child;
+                try { child = UIDocumentParser.Parse(File.ReadAllText(file)); }
+                catch (Exception) { unresolved = imp.Src; return false; }
+
+                // Record before recursing so a cyclic Import terminates here; DocumentAssembler owns
+                // the diagnostic itself, so the CLI and the runtime word it identically.
+                closure[imp.Src] = child;
+                if (!Prefetch(file, child, closure, ref unresolved)) return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// The runtime resolves <c>src</c> through a caller-supplied <c>SourceResolver</c>, so there
+        /// is no single ground truth on disk. Approximate the shipped Resources resolver
+        /// (<c>UseResourcesResolver(root)</c> maps src to <c>root/src</c>) by trying the importing
+        /// file's own directory first, then each ancestor up to and including a <c>Resources</c> one.
+        /// </summary>
+        private static string ResolveSrc(string src, string importingPath)
+        {
+            if (string.IsNullOrEmpty(src)) return null;
+            var dir = Path.GetDirectoryName(Path.GetFullPath(importingPath));
+
+            while (!string.IsNullOrEmpty(dir))
+            {
+                var withExt = Path.Combine(dir, src + ".xml");
+                if (File.Exists(withExt)) return withExt;
+                var verbatim = Path.Combine(dir, src);
+                if (File.Exists(verbatim)) return verbatim;
+
+                if (string.Equals(Path.GetFileName(dir), "Resources", StringComparison.Ordinal))
+                    break;
+                dir = Path.GetDirectoryName(dir);
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// A stable identity for the entry document. It is only ever compared against
+        /// <c>&lt;Import src&gt;</c> values, which are resolver keys, so a full path cannot collide.
+        /// </summary>
+        private static string SrcKeyOf(string path) => Path.GetFullPath(path);
     }
 }

--- a/.lint/UIXmlLint/README.md
+++ b/.lint/UIXmlLint/README.md
@@ -3,11 +3,48 @@
 Standalone `.NET` CLI that lints PromptUGUI `.ui.xml` files **without Unity**.
 
 It compiles the Unity-agnostic Core subset of the PromptUGUI runtime (`Parser` /
-`IR` / `Lint`) and runs the same rule implementations that
+`IR` / `Lint` / `Template`) and runs the same rule implementations that
 `ScreenInstantiator` invokes at Unity runtime — single source of truth, no
 duplicated rule logic. The CLI surfaces every rule violation as an **error**
 (non-zero exit code); the Unity runtime path surfaces them as
 `Debug.LogWarning` so `UI.Open()` is not interrupted.
+
+## Two passes: raw + expanded
+
+`PromptUGUI.Lint.DocumentLinter` walks each document **twice**, deduplicating
+identical findings. Neither view is a superset of the other:
+
+| Pass | Sees | Misses |
+|---|---|---|
+| **raw** (as written) | subtrees behind `if="false"`, templates nobody invokes | anything decided at expansion time |
+| **expanded** (as `ScreenInstantiator` builds it) | a template invocation's real parent/child context, attributes arriving through `class=`, the resolved configuration rules like `GlassRules` need before they will speak at all | code the expander drops |
+
+The expanded pass is why `<VStack class="boxed"/>` now reports
+`PUI-CONTAINER-VISUAL-ATTR` when `boxed` supplies a `sprite` — the raw walk
+reads `n.Attributes`, and before expansion the sprite lives in a `<Style>` the
+node merely references.
+
+Expansion failures (unknown template / style name, Import cycle) surface as
+`PUI-EXPAND` instead of waiting until `UI.Open()` throws at runtime.
+
+## `<Import>` resolution
+
+To lint the expanded tree the CLI has to read the imported files. The runtime
+maps `src` through a caller-supplied `SourceResolver`, so there is no on-disk
+ground truth; the CLI approximates the shipped Resources resolver
+(`UseResourcesResolver(root)` → `root/src`) by trying the importing file's own
+directory first, then each ancestor up to and including a `Resources/` folder,
+with and without a trailing `.xml`.
+
+**An unresolvable `<Import>` is not an error.** A project may serve its commons
+from Addressables or a custom resolver with no filesystem shape at all. Such a
+document simply skips the expanded pass (a note on stdout says so) and keeps
+exactly the pre-existing raw-IR behaviour — failing a today-clean file over an
+environment gap would cost more than the missed coverage.
+
+The two-pass logic lives in `Runtime/Core/Lint/DocumentLinter.cs`, not in
+`Program.cs`, so it is covered by `PromptUGUI.Tests.EditMode`
+(`DocumentLinterTests`). The CLI owns only I/O and the src → path guess.
 
 Some rules are **CLI-only** — they catch author confusion that runtime
 silently absorbs (e.g. `sprite=` on `<Frame>` is dropped without a visible

--- a/.lint/UIXmlLint/README.md
+++ b/.lint/UIXmlLint/README.md
@@ -42,9 +42,27 @@ document simply skips the expanded pass (a note on stdout says so) and keeps
 exactly the pre-existing raw-IR behaviour — failing a today-clean file over an
 environment gap would cost more than the missed coverage.
 
+### Which file a finding is reported against
+
+Once imports are followed, the node a rule complains about is often **not** in
+the file being linted — it was written in a library and inlined here. Every
+`ElementNode` therefore carries `OriginSrc` (stamped by
+`UIDocumentParser.Parse(xml, src)`, propagated through every expansion copy),
+and the CLI reports against it:
+
+```
+$ UIXmlLint uses-tmpl.ui.xml
+tmpl.ui.xml: [PUI-MASK-FRAME-SELF] <Frame id='card'>: mask="self" requires ...
+```
+
+The mistake is in `tmpl.ui.xml`; `uses-tmpl.ui.xml` merely invoked the template.
+Findings in the linted file itself are unaffected — they report against it as
+before.
+
 The two-pass logic lives in `Runtime/Core/Lint/DocumentLinter.cs`, not in
 `Program.cs`, so it is covered by `PromptUGUI.Tests.EditMode`
-(`DocumentLinterTests`). The CLI owns only I/O and the src → path guess.
+(`DocumentLinterTests`, `LintOriginTests`). The CLI owns only I/O and the
+src → path guess.
 
 Some rules are **CLI-only** — they catch author confusion that runtime
 silently absorbs (e.g. `sprite=` on `<Frame>` is dropped without a visible

--- a/.lint/UIXmlLint/UIXmlLint.csproj
+++ b/.lint/UIXmlLint/UIXmlLint.csproj
@@ -5,11 +5,17 @@
     violations. Runs OUTSIDE Unity (pure .NET) so authors / LLMs without an
     open Unity instance can validate XML before runtime.
 
-    Compile set: only the truly self-contained Core subset of the Runtime
-    asmdef (Parser / IR / Lint). Template/Variants were excluded — those
-    still type-reference PromptUGUI.Application (DocumentLoader, VariantStore)
-    even though the *algorithm* is pure. The lint CLI only walks raw IR; it
-    doesn't run TemplateExpander or VariantResolver, so we don't need them.
+    Compile set: the self-contained Core subset of the Runtime asmdef —
+    Parser / IR / Lint / Template. Template joined the set once TemplateKey /
+    StyleKey / LoadedDoc moved to Core/IR and the Import merge algorithm moved
+    to Core/Template/DocumentAssembler, which is what lets the CLI follow
+    <Import> and walk the EXPANDED tree (the same one ScreenInstantiator sees)
+    instead of guessing at an unseen commons library.
+
+    Core/Variants stays out: VariantResolver type-references
+    PromptUGUI.Application.VariantStore, and expansion doesn't need it —
+    variant overrides survive expansion untouched and are resolved at runtime.
+
     The result is verified pure C# — no Unity types, no Awaitable, no Debug.*.
 
     Rule code is shared with ScreenInstantiator via PromptUGUI.Lint
@@ -29,6 +35,7 @@
     <Compile Include="..\..\Runtime\Core\Parser\**\*.cs" />
     <Compile Include="..\..\Runtime\Core\IR\**\*.cs" />
     <Compile Include="..\..\Runtime\Core\Lint\**\*.cs" />
+    <Compile Include="..\..\Runtime\Core\Template\**\*.cs" />
     <Compile Include="*.cs" />
   </ItemGroup>
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,9 @@ dotnet run --project .lint/UIXmlLint -- Runtime/Resources/PromptUGUI/Modals/Mess
 dotnet run --project .lint/UIXmlLint -- Runtime/Resources/                   # 整个目录递归
 ```
 
-规则代码在 `Runtime/Core/Lint/`（纯 C#），跟 `ScreenInstantiator` 的 warning 路径共用同一份实现 —— 新增规则时只改一处。详见 `.lint/UIXmlLint/README.md`。
+规则代码在 `Runtime/Core/Lint/`（纯 C#），跟 `ScreenInstantiator` 的 warning 路径共用同一份实现 —— 新增规则时只改一处。
+
+CLI 对每份文档跑**两遍**（`Core/Lint/DocumentLinter.cs`，按 issue 去重）：**raw**（作者写的原样，能看到 `if="false"` 背后和没人调用的模板）+ **expanded**（`ScreenInstantiator` 真正构建的那棵树，能看到模板调用的真实父子关系、`class=` 带来的属性、以及 `GlassRules` 这类规则开口前必须知道的最终形态）。两者互不包含。它会跟着 `<Import>` 读盘（按「导入方所在目录 → 逐级上溯到 `Resources/`」猜 `src`）；**解析不到的 import 不算错误**，那份文档只是跳过展开遍、退回今天的行为（Addressables / 自定义 resolver 的工程没有磁盘形态）。展开失败（未知模板/样式名、Import 循环）报 `PUI-EXPAND`。详见 `.lint/UIXmlLint/README.md`。
 
 ### `.pxl` 渲染预览（PxlPreview CLI）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ dotnet run --project .lint/UIXmlLint -- Runtime/Resources/                   # �
 
 规则代码在 `Runtime/Core/Lint/`（纯 C#），跟 `ScreenInstantiator` 的 warning 路径共用同一份实现 —— 新增规则时只改一处。
 
-CLI 对每份文档跑**两遍**（`Core/Lint/DocumentLinter.cs`，按 issue 去重）：**raw**（作者写的原样，能看到 `if="false"` 背后和没人调用的模板）+ **expanded**（`ScreenInstantiator` 真正构建的那棵树，能看到模板调用的真实父子关系、`class=` 带来的属性、以及 `GlassRules` 这类规则开口前必须知道的最终形态）。两者互不包含。它会跟着 `<Import>` 读盘（按「导入方所在目录 → 逐级上溯到 `Resources/`」猜 `src`）；**解析不到的 import 不算错误**，那份文档只是跳过展开遍、退回今天的行为（Addressables / 自定义 resolver 的工程没有磁盘形态）。展开失败（未知模板/样式名、Import 循环）报 `PUI-EXPAND`。详见 `.lint/UIXmlLint/README.md`。
+CLI 对每份文档跑**两遍**（`Core/Lint/DocumentLinter.cs`，按 issue 去重）：**raw**（作者写的原样，能看到 `if="false"` 背后和没人调用的模板）+ **expanded**（`ScreenInstantiator` 真正构建的那棵树，能看到模板调用的真实父子关系、`class=` 带来的属性、以及 `GlassRules` 这类规则开口前必须知道的最终形态）。两者互不包含。它会跟着 `<Import>` 读盘（按「导入方所在目录 → 逐级上溯到 `Resources/`」猜 `src`）；**解析不到的 import 不算错误**，那份文档只是跳过展开遍、退回今天的行为（Addressables / 自定义 resolver 的工程没有磁盘形态）。展开失败（未知模板/样式名、Import 循环）报 `PUI-EXPAND`。**报错归属按 `ElementNode.OriginSrc`**（`Parse(xml, src)` 打戳、展开期逐层传递）—— 问题出在被 import 的库里就报那个库的文件名，不是入口文件。详见 `.lint/UIXmlLint/README.md`。
 
 ### `.pxl` 渲染预览（PxlPreview CLI）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,14 +46,20 @@ Internal refactors, test-only changes, performance work, and Editor tooling that
 `Runtime/AssemblyInfo.cs` exposes internals to `PromptUGUI.Tests.EditMode`, `PromptUGUI.Tests.PlayMode`, `PromptUGUI.Editor`, and `PromptUGUI.Tests.EditMode.Addressables` via `InternalsVisibleTo`.
 
 `Runtime/` is split into:
-- `Core/IR/` — pure POCOs (`UIDocument`, `ScreenDef`, `TemplateDef`, `ElementNode`, `ImportRef`, `VariantBlock`, `AddDirective`)
+- `Core/IR/` — pure POCOs (`UIDocument`, `ScreenDef`, `TemplateDef`, `ElementNode`, `ImportRef`, `VariantBlock`, `AddDirective`, `StyleDef`, `ThemeBlock`) + 合并产物 `LoadedDoc` 与它的键 `TemplateKey` / `StyleKey`
 - `Core/Parser/` — `UIDocumentParser` (XML → IR) + `ParseException`
-- `Core/Template/` — `TemplateExpander` (inlines Template invocations) + `Substitution` / `Truthy`
+- `Core/Template/` — `DocumentAssembler` (Import 闭包合并 → `LoadedDoc`) + `TemplateExpander` (inlines Template invocations) + `StyleMerger` (`class=` 属性包合并) + `Substitution` / `Truthy`
 - `Core/Variants/` — `VariantResolver` (last-active-wins for `attr.var` overrides)
 - `Core/Layout/` — `AnchorResolver` / `MarginResolver` / `SizeSpec`
 - `Controls/` — built-in primitives (`Frame`, `Image`, `Text`, `VStack`, `HStack`, `Grid`, `Btn`) + the `Control` base class
 - `Registry/` — `ControlRegistry` + `ControlMeta` (reflects `[UIAttr]` / `[Bind]`)
 - `Application/` — `UI` static facade (loading/lifecycle), `Screen`, `ScreenInstantiator`, `DocumentLoader`, `DepGraph`, `VariantStore`, `BuiltinPrimitives`
+
+**Core 的 CLI 编译子集必须保持纯 C#。** `Core/IR` / `Core/Parser` / `Core/Template` / `Core/Lint` 这四个目录被 UIXmlLint 直接编译进一个在 Unity 之外运行的 exe —— **不得引用 `UnityEngine`，也不得反向依赖 `PromptUGUI.Application`**。一旦破例，CLI 的编译集就得缩水，规则与运行时的「单一实现」保证随之破裂。
+
+不在该子集内、因此不受此限的：`Core/Layout`（用 `Vector2` / `Vector4`）、`Core/Variants`（依赖 `VariantStore`）。
+
+这条约束决定了 IO 与语义的切线：异步取源（`Awaitable` + `SourceResolver`）留在 `Application/DocumentLoader`，Import 闭包的**合并语义**在 `Core/Template/DocumentAssembler` —— 两条路径（Unity 异步预取 / CLI 文件系统预取）都落到同一份合并实现上。
 
 Write Red test first, and then write implementation. Always use Unity MCP to run tests in the host Unity project.
 If MCP is unavailable, try reconnect or tell user to restart MCP.

--- a/Editor/I18n/XmlStringScanner.cs
+++ b/Editor/I18n/XmlStringScanner.cs
@@ -59,17 +59,17 @@ namespace PromptUGUI.Editor.I18n
         {
             try
             {
-                var loaded = new DocumentLoader.LoadedDoc { EntrySrc = "<scan>" };
+                var loaded = new LoadedDoc { EntrySrc = "<scan>" };
                 foreach (var s in doc.Screens) loaded.Screens.Add(s);
                 if (externalTemplates != null)
                 {
                     foreach (var kv in externalTemplates)
-                        loaded.Templates[new DocumentLoader.TemplateKey(null, kv.Key)] = kv.Value;
+                        loaded.Templates[new TemplateKey(null, kv.Key)] = kv.Value;
                 }
                 // File-local templates win over external when names collide — same precedence
                 // the runtime loader applies for entry-file templates over commons.
                 foreach (var kv in doc.Templates)
-                    loaded.Templates[new DocumentLoader.TemplateKey(null, kv.Key)] = kv.Value;
+                    loaded.Templates[new TemplateKey(null, kv.Key)] = kv.Value;
                 return TemplateExpander.Expand(loaded);
             }
             catch (TemplateException)

--- a/Runtime/Application/DocumentLoader.cs
+++ b/Runtime/Application/DocumentLoader.cs
@@ -11,63 +11,14 @@ namespace PromptUGUI.Application
     /// 把一个 src 解析成"已合并 Templates 与 Screens 的 IR 文档"。
     /// 递归解析其 Import 链；同 src 在一次 Load 内只解析一次（cache）；A→B→A 循环报错。
     /// 不接触 commons pool；不入 depGraph。这两件事由 UI 上层负责。
+    ///
+    /// <para>这一层只负责 <b>取</b>：把 <c>SourceResolver</c> 的异步取字符串 + 解析收拢成一张
+    /// src → <see cref="UIDocument"/> 的表（<see cref="PrefetchAsync"/>），随后把合并语义整个交给
+    /// 纯 C# 的 <see cref="Template.DocumentAssembler"/>。这样 UIXmlLint CLI 能用同一份合并实现跟进
+    /// <c>&lt;Import&gt;</c>，而不必在 Unity 之外重写一遍 —— 见 2026-08-26 theme-driven-style spec §9。</para>
     /// </summary>
     internal static class DocumentLoader
     {
-        internal sealed class LoadedDoc
-        {
-            public string EntrySrc;
-            public HashSet<string> AllSrcs = new();
-            public List<ScreenDef> Screens = new();
-            public Dictionary<TemplateKey, TemplateDef> Templates = new();
-            public Dictionary<StyleKey, StyleDef> Styles = new();
-            // Each entry carries the original src so cross-doc duplicate detection
-            // can name both conflicting files in the error message.
-            public List<(IR.ThemeBlock Theme, string Src)> Themes = new();
-        }
-
-        internal readonly struct TemplateKey : IEquatable<TemplateKey>
-        {
-            public readonly string Namespace;
-            public readonly string Name;
-            public TemplateKey(string ns, string name) { Namespace = ns; Name = name; }
-            public bool Equals(TemplateKey o) => Namespace == o.Namespace && Name == o.Name;
-            public override bool Equals(object o) => o is TemplateKey k && Equals(k);
-            public override int GetHashCode() =>
-                (Namespace?.GetHashCode() ?? 0) * 397 ^ (Name?.GetHashCode() ?? 0);
-            public override string ToString() =>
-                Namespace == null ? Name : $"{Namespace}.{Name}";
-        }
-
-        /// <summary>
-        /// Mirrors <see cref="TemplateKey"/> for <c>&lt;Style&gt;</c>. Namespaced references are
-        /// written <c>class="ui:card"</c> — a colon, not the dot templates use for tags, matching
-        /// the <c>Set:Name</c> form authors already write for sprite / icon references.
-        /// </summary>
-        internal readonly struct StyleKey : IEquatable<StyleKey>
-        {
-            public const char NamespaceSeparator = ':';
-
-            public readonly string Namespace;
-            public readonly string Name;
-            public StyleKey(string ns, string name) { Namespace = ns; Name = name; }
-            public bool Equals(StyleKey o) => Namespace == o.Namespace && Name == o.Name;
-            public override bool Equals(object o) => o is StyleKey k && Equals(k);
-            public override int GetHashCode() =>
-                (Namespace?.GetHashCode() ?? 0) * 397 ^ (Name?.GetHashCode() ?? 0);
-            public override string ToString() =>
-                Namespace == null ? Name : $"{Namespace}{NamespaceSeparator}{Name}";
-
-            /// <summary>Splits an author-written <c>class</c> entry into (namespace, name).</summary>
-            public static StyleKey ParseReference(string reference)
-            {
-                var sep = reference.IndexOf(NamespaceSeparator);
-                return sep < 0
-                    ? new StyleKey(null, reference)
-                    : new StyleKey(reference.Substring(0, sep), reference.Substring(sep + 1));
-            }
-        }
-
         internal static async Awaitable<LoadedDoc> LoadAsync(
             string src,
             Func<string, Awaitable<string>> resolver,
@@ -77,11 +28,10 @@ namespace PromptUGUI.Application
                 throw new InvalidOperationException(
                     "UI.SourceResolver is not set; required for src-based loading");
 
-            var loaded = new LoadedDoc { EntrySrc = src };
-            var visiting = new Stack<string>();
-            await LoadInternalAsync(src, resolver, allowScreens, loaded, visiting,
-                                    applyNamespace: null);
-            return loaded;
+            var parsed = new Dictionary<string, UIDocument>();
+            await PrefetchAsync(src, resolver, parsed);
+            return DocumentAssembler.Assemble(
+                src, s => parsed.TryGetValue(s, out var d) ? d : null, allowScreens);
         }
 
         internal static async Awaitable<LoadedDoc> LoadAndMergeAsync(
@@ -91,42 +41,22 @@ namespace PromptUGUI.Application
             IReadOnlyDictionary<StyleKey, StyleDef> commonsStyles = null)
         {
             var loaded = await LoadAsync(src, resolver, allowScreens: true);
-
-            foreach (var kv in commonsPool)
-            {
-                if (loaded.Templates.ContainsKey(kv.Key))
-                    throw new TemplateException(
-                        $"template '{kv.Key}' conflicts with commons pool");
-                loaded.Templates[kv.Key] = kv.Value;
-            }
-            if (commonsStyles != null)
-            {
-                foreach (var kv in commonsStyles)
-                {
-                    if (loaded.Styles.ContainsKey(kv.Key))
-                        throw new TemplateException(
-                            $"style '{kv.Key}' conflicts with commons pool");
-                    loaded.Styles[kv.Key] = kv.Value;
-                }
-            }
+            DocumentAssembler.MergeCommons(loaded, commonsPool, commonsStyles);
             return loaded;
         }
 
-        private static async Awaitable LoadInternalAsync(
+        /// <summary>
+        /// Depth-first over the Import graph, fetching and parsing each src exactly once.
+        /// Deliberately does NOT detect cycles: recording the document before recursing makes a
+        /// cycle terminate here, and <see cref="Template.DocumentAssembler"/> is the one that reports it —
+        /// keeping that diagnostic in the shared layer so the CLI produces the identical message.
+        /// </summary>
+        private static async Awaitable PrefetchAsync(
             string src,
             Func<string, Awaitable<string>> resolver,
-            bool allowScreens,
-            LoadedDoc agg,
-            Stack<string> visiting,
-            string applyNamespace)
+            Dictionary<string, UIDocument> parsed)
         {
-            if (visiting.Contains(src))
-            {
-                var chain = string.Join(" → ", visiting);
-                throw new ParseException(
-                    $"cyclic Import detected: {chain} → {src}");
-            }
-            if (!agg.AllSrcs.Add(src)) return;
+            if (parsed.ContainsKey(src)) return;
 
             var xml = await resolver(src);
             if (string.IsNullOrEmpty(xml))
@@ -141,47 +71,10 @@ namespace PromptUGUI.Application
                 throw new ParseException($"parsing src='{src}' failed: {e.Message}", e);
             }
 
-            if (!allowScreens && doc.Screens.Count > 0)
-                throw new ParseException(
-                    $"src='{src}' is loaded as common library / nested import; <Screen> not allowed");
+            parsed[src] = doc;
 
-            if (allowScreens)
-            {
-                foreach (var s in doc.Screens) agg.Screens.Add(s);
-            }
-
-            foreach (var kv in doc.Templates)
-            {
-                var key = new TemplateKey(applyNamespace, kv.Key);
-                if (agg.Templates.ContainsKey(key))
-                    throw new TemplateException(
-                        $"duplicate template '{key}' (loaded from src='{src}')");
-                agg.Templates[key] = kv.Value;
-            }
-
-            foreach (var kv in doc.Styles)
-            {
-                var key = new StyleKey(applyNamespace, kv.Key);
-                if (agg.Styles.ContainsKey(key))
-                    throw new TemplateException(
-                        $"duplicate style '{key}' (loaded from src='{src}')");
-                agg.Styles[key] = kv.Value;
-            }
-
-            foreach (var theme in doc.Themes)
-                agg.Themes.Add((theme, src));
-
-            visiting.Push(src);
-            try
-            {
-                foreach (var imp in doc.Imports)
-                {
-                    var childNs = imp.Namespace ?? applyNamespace;
-                    await LoadInternalAsync(imp.Src, resolver, allowScreens: false,
-                                            agg, visiting, childNs);
-                }
-            }
-            finally { visiting.Pop(); }
+            foreach (var imp in doc.Imports)
+                await PrefetchAsync(imp.Src, resolver, parsed);
         }
     }
 }

--- a/Runtime/Application/DocumentLoader.cs
+++ b/Runtime/Application/DocumentLoader.cs
@@ -64,7 +64,7 @@ namespace PromptUGUI.Application
                     $"SourceResolver returned null/empty for src='{src}'");
 
             UIDocument doc;
-            try { doc = UIDocumentParser.Parse(xml); }
+            try { doc = UIDocumentParser.Parse(xml, src); }
             catch (ParseException) { throw; }
             catch (Exception e)
             {

--- a/Runtime/Application/Screen.cs
+++ b/Runtime/Application/Screen.cs
@@ -101,6 +101,7 @@ namespace PromptUGUI.Application
 
         public void Open()
         {
+            ReMergeThemeStyles();
             var root = new GameObject(Def.Name,
                 typeof(RectTransform),
                 typeof(Canvas),
@@ -779,6 +780,26 @@ namespace PromptUGUI.Application
                    && sel.navigation.mode != UnityEngine.UI.Navigation.Mode.None;
         }
 
+        /// <summary>
+        /// Re-derives every <c>class=</c> node from the active theme's style table. Sits at the head
+        /// of both <see cref="Open"/> and <see cref="ReSolve"/> rather than on a theme-changed hook:
+        /// it is idempotent, and ReSolve is already what a theme switch triggers
+        /// (<c>_themeHandler</c>), so one call site covers resize, Variant, Theme and first build.
+        ///
+        /// <para>Two early-outs keep this free for everyone who does not use theme styles: a Screen
+        /// whose document declares no <c>&lt;Style&gt;</c> at all, and — the case that matters — a
+        /// project where no registered theme carries one, which is every project written before this
+        /// feature existed.</para>
+        /// </summary>
+        private void ReMergeThemeStyles()
+        {
+            if (Def.Styles.Count == 0) return;
+            if (!ThemeStore.Instance.AnyThemeStyles) return;
+
+            var effective = ThemeStore.Instance.ResolveStyles(Def.Styles, UI.Theme.Current);
+            Template.ThemeStyleApplier.Apply(Def, effective);
+        }
+
         public void Track(IDisposable d) => _subscriptions.Add(d);
 
         public void Dispose() => Close();
@@ -789,6 +810,7 @@ namespace PromptUGUI.Application
             // .Changed)都不应再触达 ReSolve 解引用已销毁的 RootGameObject。哨兵(relay.OnDestroy)
             // 正常会先反订阅,这里是兜底:EditMode 不跑 OnDestroy、或哨兵时序未及的路径也安全。
             if (RootGameObject == null) return;
+            ReMergeThemeStyles();
             // Collect nodes belonging to currently-inactive Add blocks so we can skip
             // re-applying attributes to them below. Their SetActive(false) state must not be
             // clobbered by ApplyCommon — a node declaring hidden="false" would be un-hidden

--- a/Runtime/Application/ThemeStore.cs
+++ b/Runtime/Application/ThemeStore.cs
@@ -102,6 +102,44 @@ namespace PromptUGUI.Application
             }
         }
 
+        /// <summary>
+        /// True when any registered theme declares a <c>&lt;Style&gt;</c>. Screens check this before
+        /// re-deriving their <c>class=</c> nodes, so a project that themes only colours — every
+        /// project until now — pays nothing on Open or ReSolve.
+        /// </summary>
+        public bool AnyThemeStyles
+        {
+            get
+            {
+                foreach (var e in _themes.Values)
+                    if (e.Styles != null && e.Styles.Count > 0) return true;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// <paramref name="globalStyles"/> with the active theme's packs folded over it. Returns the
+        /// argument itself when nothing applies, which callers use as a cheap "nothing to re-merge".
+        /// </summary>
+        public IReadOnlyDictionary<StyleKey, StyleDef> ResolveStyles(
+            IReadOnlyDictionary<StyleKey, StyleDef> globalStyles, string activeTheme)
+        {
+            if (string.IsNullOrEmpty(activeTheme) || !_themes.ContainsKey(activeTheme))
+                return globalStyles;
+
+            // ThemeStyleResolver walks base= chains itself and lives in Core so the lint CLI shares
+            // it; hand it a view of what this store holds.
+            var view = new Dictionary<string, ThemeBlock>(_themes.Count);
+            foreach (var e in _themes.Values)
+            {
+                var block = new ThemeBlock { Name = e.Name, BaseName = e.BaseName };
+                if (e.Styles != null)
+                    foreach (var kv in e.Styles) block.Styles[kv.Key] = kv.Value;
+                view[e.Name] = block;
+            }
+            return Template.ThemeStyleResolver.Resolve(globalStyles, view, activeTheme);
+        }
+
         public ColorSpec? LookupChained(string themeName, string token)
         {
             if (!_themes.TryGetValue(themeName, out var e)) return null;

--- a/Runtime/Application/ThemeStore.cs
+++ b/Runtime/Application/ThemeStore.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using PromptUGUI.IR;
 using PromptUGUI.Parser;
 using UnityEngine;
 
@@ -18,6 +19,7 @@ namespace PromptUGUI.Application
             public string Name;
             public string BaseName;
             public Dictionary<string, ColorSpec> Colors;
+            public Dictionary<string, StyleDef> Styles;
             public string Src;
             public Entry ResolvedBase;
         }
@@ -26,8 +28,14 @@ namespace PromptUGUI.Application
 
         public IReadOnlyCollection<string> Available => _themes.Keys;
 
+        /// <summary>Colour-only overload: a theme that declares no style packs.</summary>
         public void Register(string name, string baseName,
                              IReadOnlyDictionary<string, ColorSpec> colors, string src)
+            => Register(name, baseName, colors, styles: null, src);
+
+        public void Register(string name, string baseName,
+                             IReadOnlyDictionary<string, ColorSpec> colors,
+                             IReadOnlyDictionary<string, StyleDef> styles, string src)
         {
             if (_themes.TryGetValue(name, out var existing) && existing.Src != src)
                 throw new ParseException(
@@ -47,12 +55,17 @@ namespace PromptUGUI.Application
                 Name = name,
                 BaseName = baseName,
                 Colors = new Dictionary<string, ColorSpec>(colors),
+                Styles = styles == null
+                    ? new Dictionary<string, StyleDef>()
+                    : new Dictionary<string, StyleDef>(styles),
                 Src = src,
             };
         }
 
         public void ReplaceFromSrc(string src,
-            IReadOnlyList<(string name, string baseName, IReadOnlyDictionary<string, ColorSpec> colors)> blocks)
+            IReadOnlyList<(string name, string baseName,
+                           IReadOnlyDictionary<string, ColorSpec> colors,
+                           IReadOnlyDictionary<string, StyleDef> styles)> blocks)
         {
             // Hot reload: drop everything previously from src, then register new.
             var toRemove = new List<string>();
@@ -60,7 +73,7 @@ namespace PromptUGUI.Application
                 if (kv.Value.Src == src) toRemove.Add(kv.Key);
             foreach (var k in toRemove) _themes.Remove(k);
             foreach (var b in blocks)
-                Register(b.name, b.baseName, b.colors, src);
+                Register(b.name, b.baseName, b.colors, b.styles, src);
             ResolveBases();
         }
 

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -1018,7 +1018,7 @@ namespace PromptUGUI.Application
                     theme.Colors.Count);
                 foreach (var ce in theme.Colors)
                     colors[ce.Name] = ParseThemeColor(ce.Value);
-                ThemeStore.Instance.Register(theme.Name, theme.BaseName, colors, themeSrc);
+                ThemeStore.Instance.Register(theme.Name, theme.BaseName, colors, theme.Styles, themeSrc);
             }
             ThemeStore.Instance.ResolveBases();
 
@@ -1076,7 +1076,8 @@ namespace PromptUGUI.Application
             var bySrc = new System.Collections.Generic.Dictionary<
                 string,
                 System.Collections.Generic.List<(string name, string baseName,
-                    System.Collections.Generic.IReadOnlyDictionary<string, ColorSpec> colors)>>();
+                    System.Collections.Generic.IReadOnlyDictionary<string, ColorSpec> colors,
+                    System.Collections.Generic.IReadOnlyDictionary<string, IR.StyleDef> styles)>>();
             foreach (var (theme, themeSrc) in loaded.Themes)
             {
                 var colors = new System.Collections.Generic.Dictionary<string, ColorSpec>(
@@ -1085,7 +1086,7 @@ namespace PromptUGUI.Application
                     colors[ce.Name] = ParseThemeColor(ce.Value);
                 if (!bySrc.TryGetValue(themeSrc, out var list))
                     bySrc[themeSrc] = list = new();
-                list.Add((theme.Name, theme.BaseName, colors));
+                list.Add((theme.Name, theme.BaseName, colors, theme.Styles));
             }
             foreach (var kv in bySrc)
                 ThemeStore.Instance.ReplaceFromSrc(kv.Key, kv.Value);
@@ -1096,7 +1097,7 @@ namespace PromptUGUI.Application
             {
                 foreach (var list in bySrc.Values)
                 {
-                    foreach (var (themeName, _, _) in list)
+                    foreach (var (themeName, _, _, _) in list)
                     {
                         if (themeName == Theme.Current)
                         {

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -598,7 +598,7 @@ namespace PromptUGUI.Application
 
         public static void LoadDocument(string label, string xml)
         {
-            var raw = UIDocumentParser.Parse(xml);
+            var raw = UIDocumentParser.Parse(xml, label);
             var doc = PromptUGUI.Template.TemplateExpander.Expand(raw);
             foreach (var s in doc.Screens)
             {

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -10,8 +10,8 @@ namespace PromptUGUI.Application
     {
         private static readonly Dictionary<string, ScreenDef> _docs = new();
         private static readonly Dictionary<string, Screen> _open = new();
-        private static readonly System.Collections.Generic.Dictionary<DocumentLoader.TemplateKey, IR.TemplateDef> _commonsPool = new();
-        private static readonly System.Collections.Generic.Dictionary<DocumentLoader.StyleKey, IR.StyleDef> _commonsStyles = new();
+        private static readonly System.Collections.Generic.Dictionary<TemplateKey, IR.TemplateDef> _commonsPool = new();
+        private static readonly System.Collections.Generic.Dictionary<StyleKey, IR.StyleDef> _commonsStyles = new();
         private static readonly DepGraph _depGraph = new();
 
         public static System.Func<string, UnityEngine.Awaitable<string>> SourceResolver { get; set; }
@@ -696,24 +696,24 @@ namespace PromptUGUI.Application
 
             var loaded = await DocumentLoader.LoadAsync(src, SourceResolver, allowScreens: false);
 
-            var staged = new System.Collections.Generic.List<(DocumentLoader.TemplateKey Key, IR.TemplateDef Def)>();
+            var staged = new System.Collections.Generic.List<(TemplateKey Key, IR.TemplateDef Def)>();
             foreach (var kv in loaded.Templates)
             {
                 var rebasedKey = @as == null
                     ? kv.Key
-                    : new DocumentLoader.TemplateKey(@as, kv.Key.Name);
+                    : new TemplateKey(@as, kv.Key.Name);
                 if (_commonsPool.ContainsKey(rebasedKey))
                     throw new PromptUGUI.Template.TemplateException(
                         $"common library conflict: '{rebasedKey}' already in commons pool");
                 staged.Add((rebasedKey, kv.Value));
             }
 
-            var stagedStyles = new System.Collections.Generic.List<(DocumentLoader.StyleKey Key, IR.StyleDef Def)>();
+            var stagedStyles = new System.Collections.Generic.List<(StyleKey Key, IR.StyleDef Def)>();
             foreach (var kv in loaded.Styles)
             {
                 var rebasedKey = @as == null
                     ? kv.Key
-                    : new DocumentLoader.StyleKey(@as, kv.Key.Name);
+                    : new StyleKey(@as, kv.Key.Name);
                 if (_commonsStyles.ContainsKey(rebasedKey))
                     throw new PromptUGUI.Template.TemplateException(
                         $"common library conflict: style '{rebasedKey}' already in commons pool");
@@ -759,13 +759,13 @@ namespace PromptUGUI.Application
 
             // M4 v1 limitation: original `as=` namespace is not preserved across reload.
             var stashed = new System.Collections.Generic.List<
-                System.Collections.Generic.KeyValuePair<DocumentLoader.TemplateKey, IR.TemplateDef>>();
+                System.Collections.Generic.KeyValuePair<TemplateKey, IR.TemplateDef>>();
             foreach (var kv in _commonsPool)
                 if (kv.Value.OriginSrc == src) stashed.Add(kv);
             foreach (var kv in stashed) _commonsPool.Remove(kv.Key);
 
             var stashedStyles = new System.Collections.Generic.List<
-                System.Collections.Generic.KeyValuePair<DocumentLoader.StyleKey, IR.StyleDef>>();
+                System.Collections.Generic.KeyValuePair<StyleKey, IR.StyleDef>>();
             foreach (var kv in _commonsStyles)
                 if (kv.Value.OriginSrc == src) stashedStyles.Add(kv);
             foreach (var kv in stashedStyles) _commonsStyles.Remove(kv.Key);
@@ -1010,7 +1010,7 @@ namespace PromptUGUI.Application
         /// <see cref="LoadCommonLibraryAsync"/> and <see cref="LoadDocumentAsync"/>
         /// so that &lt;Theme&gt; blocks work regardless of which file they live in.
         /// </summary>
-        private static void RegisterThemesAndAutoSet(DocumentLoader.LoadedDoc loaded)
+        private static void RegisterThemesAndAutoSet(LoadedDoc loaded)
         {
             foreach (var (theme, themeSrc) in loaded.Themes)
             {
@@ -1068,7 +1068,7 @@ namespace PromptUGUI.Application
         /// Screens re-color via <see cref="Screen.ReSolve"/>. Theme.Current is
         /// preserved (no AutoSetIfSingleAvailable on reload).
         /// </summary>
-        private static void ReplaceThemesAndNotify(DocumentLoader.LoadedDoc loaded)
+        private static void ReplaceThemesAndNotify(LoadedDoc loaded)
         {
             // Group themes by their originating src so ReplaceFromSrc gets a
             // per-src complete replacement (any theme deleted from the new XML

--- a/Runtime/Controls/Btn.cs
+++ b/Runtime/Controls/Btn.cs
@@ -111,12 +111,15 @@ namespace PromptUGUI.Controls
             _offsetHolder = StateOffsetInstaller.Install(GameObject, _offsetHolder, new StateOffsetSet(_pressedOffset, null));
             var abs = StateColorSet.ResolveAbsolutes(_hoverColor, _pressedColor, null, _disabledColor);
             var mod = StateColorSet.ResolveModulates(_hoverModulate, _pressedModulate, null, StateColorSet.NoneToNull(_disabledModulate));
-            StateTintInstaller.Install(GameObject, _btn, Children, abs, mod);
-            // A pressed/disabled sprite is itself a state visual: drop uGUI's built-in ColorTint so the
-            // swapped image isn't double-darkened. Set-only, matching the state-colour path
-            // (StateTintInstaller flips transition to None when any *Color / *Modulate is present).
-            if (_pressedSprite != null || _disabledSprite != null)
-                _btn.transition = UnityEngine.UI.Selectable.Transition.None;
+            var bgReactor = StateTintInstaller.Install(GameObject, _btn, Children, abs, mod);
+            // A pressed/disabled sprite is itself a state visual: drop uGUI's built-in ColorTint so
+            // the swapped image isn't double-darkened. COMPUTED, not set one-way — clearing the
+            // sprite (a Variant flip, a theme switch) has to hand feedback back to ColorTint, or the
+            // Btn is left with none at all and no attribute can restore it.
+            _btn.transition =
+                bgReactor != null || _pressedSprite != null || _disabledSprite != null
+                    ? UnityEngine.UI.Selectable.Transition.None
+                    : UnityEngine.UI.Selectable.Transition.ColorTint;
             // 默认禁用外观：作者未声明任何 disabled* 时整控件去色。与 transition 无关（ColorTint/None 皆可）。
             if (string.IsNullOrWhiteSpace(_disabledColor)
                 && string.IsNullOrWhiteSpace(_disabledModulate)

--- a/Runtime/Controls/Progress.cs
+++ b/Runtime/Controls/Progress.cs
@@ -20,6 +20,10 @@ namespace PromptUGUI.Controls
 
         // Attribute state.
         private float _value;
+        // Whether a sprite / colour was authored for each layer; ReconcileLayerVisibility turns the
+        // GameObjects on and off from these so the two setters cannot race each other.
+        private bool _bgSprite, _bgColor, _frameSprite, _frameColor;
+
         private string _direction = "horizontal";
         private string _mode = "scale";
 
@@ -95,11 +99,10 @@ namespace PromptUGUI.Controls
         {
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                _bg.sprite = UI.ResolveSprite(value);
-                _bg.gameObject.SetActive(true);
-                ProceduralBuilders.AutoSlice(_bg);
-                ReconcileMaskVisibility();
+                _bgSprite = !(string.IsNullOrEmpty(value) || value == "none");
+                _bg.sprite = _bgSprite ? UI.ResolveSprite(value) : null;
+                if (_bgSprite) ProceduralBuilders.AutoSlice(_bg);
+                ReconcileLayers();
             }
         }
 
@@ -109,8 +112,8 @@ namespace PromptUGUI.Controls
             set
             {
                 Internal.ColorApplier.Apply(_bg, UI.Theme.ResolveSpec(value));
-                _bg.gameObject.SetActive(true);
-                ReconcileMaskVisibility();
+                _bgColor = true;
+                ReconcileLayers();
             }
         }
 
@@ -119,10 +122,10 @@ namespace PromptUGUI.Controls
         {
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                _frame.sprite = UI.ResolveSprite(value);
-                _frame.gameObject.SetActive(true);
-                ProceduralBuilders.AutoSlice(_frame);
+                _frameSprite = !(string.IsNullOrEmpty(value) || value == "none");
+                _frame.sprite = _frameSprite ? UI.ResolveSprite(value) : null;
+                if (_frameSprite) ProceduralBuilders.AutoSlice(_frame);
+                ReconcileLayers();
             }
         }
 
@@ -132,7 +135,8 @@ namespace PromptUGUI.Controls
             set
             {
                 Internal.ColorApplier.Apply(_frame, UI.Theme.ResolveSpec(value));
-                _frame.gameObject.SetActive(true);
+                _frameColor = true;
+                ReconcileLayers();
             }
         }
 
@@ -160,8 +164,27 @@ namespace PromptUGUI.Controls
             ProceduralBuilders.AutoSlice(_bg);
             ProceduralBuilders.AutoSlice(_frame);
             ProceduralBuilders.AutoSlice(_maskGraphic);
-            ReconcileMaskVisibility();
+            ReconcileLayers();
             ReconcileFill();
+        }
+
+        /// <summary>
+        /// A layer is shown when EITHER a sprite or a colour was authored for it.
+        ///
+        /// <para>Derived from those flags rather than switched on inside each setter, for two
+        /// reasons. <c>bg=""</c> has to be able to turn the layer back OFF — it could previously only
+        /// ever be switched on, so a Variant flip or a theme switch left a stale sprite showing. And
+        /// because the answer is computed from BOTH flags, the sprite and colour setters no longer
+        /// race each other within one apply pass, whose attribute order is unspecified.</para>
+        ///
+        /// <para>Called from the setters too, not just <c>OnAfterApply</c>: code that assigns
+        /// <c>progress.Bg</c> at runtime never goes through an apply pass.</para>
+        /// </summary>
+        private void ReconcileLayers()
+        {
+            _bg.gameObject.SetActive(_bgSprite || _bgColor);
+            _frame.gameObject.SetActive(_frameSprite || _frameColor);
+            ReconcileMaskVisibility();
         }
 
         private void ReconcileMaskVisibility()

--- a/Runtime/Controls/Tab.cs
+++ b/Runtime/Controls/Tab.cs
@@ -268,13 +268,14 @@ namespace PromptUGUI.Controls
                 if (string.IsNullOrEmpty(value) || value == "none")
                 {
                     _selectedSprite = null;
+                    ReconcileTransition();
                     ApplySelectedSprite();
                     return;
                 }
                 _selectedSprite = UI.ResolveSprite(value);
                 // Mirror <Btn pressedSprite>: the swapped sprite IS the selected feedback, so take the
                 // bg off uGUI's built-in ColorTint to avoid double-tinting it.
-                _toggle.transition = Selectable.Transition.None;
+                ReconcileTransition();
                 ApplySelectedSprite();
             }
         }
@@ -385,12 +386,27 @@ namespace PromptUGUI.Controls
                 ? (ColorSpec?)null
                 : UI.Theme.ResolveSpec(_selectedColor);
             _bgReactor = StateTintInstaller.Install(GameObject, _toggle, Children, abs, mod, selectedBase, IsOn);
-            if (_selectedSprite != null) _toggle.transition = Selectable.Transition.None;
+            ReconcileTransition();
             ApplySelectedSprite();
             // 默认禁用外观：作者未声明任何 disabled* 时整控件去色。
             if (string.IsNullOrWhiteSpace(_disabledColor) && string.IsNullOrWhiteSpace(_disabledModulate))
                 DisabledGrayscaleInstaller.Install(GameObject, _toggle, Children);
         }
+
+        /// <summary>
+        /// uGUI's ColorTint and our own state visuals are mutually exclusive owners of the bg: a
+        /// selected sprite or an installed <see cref="StateTintReactor"/> IS the feedback, so the
+        /// built-in tint would double it.
+        ///
+        /// <para>Computed rather than set one-way. Clearing <c>selectedSprite</c> — a Variant flip, a
+        /// theme switch — used to leave the Tab on <c>Transition.None</c> with nothing replacing it,
+        /// i.e. no hover or press feedback at all and no attribute the author could write to get it
+        /// back.</para>
+        /// </summary>
+        private void ReconcileTransition() =>
+            _toggle.transition = _bgReactor != null || _selectedSprite != null
+                ? Selectable.Transition.None
+                : Selectable.Transition.ColorTint;
 
         public override void Dispose()
         {

--- a/Runtime/Core/IR/DocumentKeys.cs
+++ b/Runtime/Core/IR/DocumentKeys.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace PromptUGUI.IR
+{
+    /// <summary>
+    /// Identity of a <c>&lt;Template&gt;</c> after Import merging: the declaring library's
+    /// <c>as=</c> namespace plus the template name. Authors write the namespaced form with a dot
+    /// (<c>&lt;ui.TitledPanel/&gt;</c>) because it occupies a tag position.
+    /// </summary>
+    internal readonly struct TemplateKey : IEquatable<TemplateKey>
+    {
+        public readonly string Namespace;
+        public readonly string Name;
+        public TemplateKey(string ns, string name) { Namespace = ns; Name = name; }
+        public bool Equals(TemplateKey o) => Namespace == o.Namespace && Name == o.Name;
+        public override bool Equals(object o) => o is TemplateKey k && Equals(k);
+        public override int GetHashCode() =>
+            (Namespace?.GetHashCode() ?? 0) * 397 ^ (Name?.GetHashCode() ?? 0);
+        public override string ToString() =>
+            Namespace == null ? Name : $"{Namespace}.{Name}";
+    }
+
+    /// <summary>
+    /// Mirrors <see cref="TemplateKey"/> for <c>&lt;Style&gt;</c>. Namespaced references are
+    /// written <c>class="ui:card"</c> — a colon, not the dot templates use for tags, matching
+    /// the <c>Set:Name</c> form authors already write for sprite / icon references.
+    /// </summary>
+    internal readonly struct StyleKey : IEquatable<StyleKey>
+    {
+        public const char NamespaceSeparator = ':';
+
+        public readonly string Namespace;
+        public readonly string Name;
+        public StyleKey(string ns, string name) { Namespace = ns; Name = name; }
+        public bool Equals(StyleKey o) => Namespace == o.Namespace && Name == o.Name;
+        public override bool Equals(object o) => o is StyleKey k && Equals(k);
+        public override int GetHashCode() =>
+            (Namespace?.GetHashCode() ?? 0) * 397 ^ (Name?.GetHashCode() ?? 0);
+        public override string ToString() =>
+            Namespace == null ? Name : $"{Namespace}{NamespaceSeparator}{Name}";
+
+        /// <summary>Splits an author-written <c>class</c> entry into (namespace, name).</summary>
+        public static StyleKey ParseReference(string reference)
+        {
+            var sep = reference.IndexOf(NamespaceSeparator);
+            return sep < 0
+                ? new StyleKey(null, reference)
+                : new StyleKey(reference.Substring(0, sep), reference.Substring(sep + 1));
+        }
+    }
+}

--- a/Runtime/Core/IR/DocumentKeys.cs.meta
+++ b/Runtime/Core/IR/DocumentKeys.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2b2e746d936b438eba993513cee28b34

--- a/Runtime/Core/IR/ElementNode.cs
+++ b/Runtime/Core/IR/ElementNode.cs
@@ -12,6 +12,15 @@ namespace PromptUGUI.IR
         public List<ElementNode> Children { get; }
 
         /// <summary>
+        /// The src this node's markup was written in, stamped by <c>UIDocumentParser.Parse(xml, src)</c>
+        /// and carried through every expansion copy. Lint reports against it so a finding inside an
+        /// imported Template body names the file the author has to open, not the entry document that
+        /// merely invoked it. Null when the caller parsed without a src (the caller's own path is
+        /// then the only sensible attribution).
+        /// </summary>
+        public string OriginSrc { get; set; }
+
+        /// <summary>
         /// Pre-substitution textContent. Filled by parser AND TemplateExpander preserves it through
         /// to expanded nodes (parser fills raw, expander leaves it alone but updates TextArgs).
         /// Only Text/Btn-shaped controls consume this; other tags ignore.

--- a/Runtime/Core/IR/ElementNode.cs
+++ b/Runtime/Core/IR/ElementNode.cs
@@ -12,6 +12,18 @@ namespace PromptUGUI.IR
         public List<ElementNode> Children { get; }
 
         /// <summary>
+        /// Which attribute names the <c>class=</c> pack contributed at the last merge. Non-null iff
+        /// the node's class has been resolved (an empty set is a real answer: every packed name was
+        /// already spelled out inline).
+        ///
+        /// <para>This is what makes a theme switch re-computable: dropping exactly these names
+        /// leaves inline attributes — and the common attributes a template invocation merged onto an
+        /// instance root AFTER the style pack — untouched, so the new pack can be laid down over a
+        /// clean slate without a separate snapshot of the author's own values.</para>
+        /// </summary>
+        public System.Collections.Generic.HashSet<string> StyleAttrNames { get; set; }
+
+        /// <summary>
         /// The src this node's markup was written in, stamped by <c>UIDocumentParser.Parse(xml, src)</c>
         /// and carried through every expansion copy. Lint reports against it so a finding inside an
         /// imported Template body names the file the author has to open, not the entry document that

--- a/Runtime/Core/IR/LoadedDoc.cs
+++ b/Runtime/Core/IR/LoadedDoc.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace PromptUGUI.IR
+{
+    /// <summary>
+    /// One entry document with its whole <c>&lt;Import&gt;</c> closure merged in: every Screen,
+    /// Template, Style and Theme reachable from it, keyed so namespaced references resolve.
+    /// Produced by <c>DocumentLoader</c> (which owns the async source fetching) and consumed by
+    /// <see cref="Template.TemplateExpander"/>.
+    ///
+    /// <para>Lives in Core/IR rather than next to its producer so the expansion layer stays free of
+    /// <c>PromptUGUI.Application</c> — that is what lets the UIXmlLint CLI compile
+    /// <c>Core/Template</c> and lint the EXPANDED tree, the same one ScreenInstantiator sees.
+    /// See the 2026-08-26 theme-driven-style spec §9.</para>
+    /// </summary>
+    internal sealed class LoadedDoc
+    {
+        public string EntrySrc;
+        public HashSet<string> AllSrcs = new();
+        public List<ScreenDef> Screens = new();
+        public Dictionary<TemplateKey, TemplateDef> Templates = new();
+        public Dictionary<StyleKey, StyleDef> Styles = new();
+        // Each entry carries the original src so cross-doc duplicate detection
+        // can name both conflicting files in the error message.
+        public List<(ThemeBlock Theme, string Src)> Themes = new();
+    }
+}

--- a/Runtime/Core/IR/LoadedDoc.cs.meta
+++ b/Runtime/Core/IR/LoadedDoc.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b56030aac58ebc7ef8ba8fa423325b8c

--- a/Runtime/Core/IR/ScreenDef.cs
+++ b/Runtime/Core/IR/ScreenDef.cs
@@ -16,6 +16,14 @@ namespace PromptUGUI.IR
         /// </summary>
         public Dictionary<string, TemplateDef> Templates { get; } = new();
 
+        /// <summary>
+        /// The document's global <c>&lt;Style&gt;</c> table, attached by
+        /// <c>TemplateExpander.Expand</c> for the same reason <see cref="Templates"/> is: the runtime
+        /// needs it after the LoadedDoc is gone. A theme switch folds its packs over this table and
+        /// re-merges every <c>class=</c> node in the Screen.
+        /// </summary>
+        internal Dictionary<StyleKey, StyleDef> Styles { get; } = new();
+
         /// <summary>该 Screen 声明的 &lt;FocusCursor&gt; 节点（解析时从 Root.Children 抽出）；null = 未声明，
         /// 运行时回退全局默认光标（spec §5.2）。</summary>
         public ElementNode FocusCursor { get; set; }

--- a/Runtime/Core/IR/ThemeBlock.cs
+++ b/Runtime/Core/IR/ThemeBlock.cs
@@ -8,5 +8,14 @@ namespace PromptUGUI.IR
         public string Name;
         public string BaseName;     // null if no base=
         public List<ColorEntry> Colors = new List<ColorEntry>();
+
+        /// <summary>
+        /// Theme-scoped <c>&lt;Style&gt;</c> packs, keyed by style name. Because <c>class=</c> is an
+        /// attribute macro rather than a style engine, these give a theme the whole attribute surface
+        /// — sprite, radius, font size, padding — not just colour tokens. Folded over the global
+        /// <c>&lt;Style&gt;</c> of the same name (which acts as the implicit root of every theme
+        /// chain), so a theme only spells out what differs. See the 2026-08-26 spec §3–§4.
+        /// </summary>
+        public Dictionary<string, StyleDef> Styles = new Dictionary<string, StyleDef>();
     }
 }

--- a/Runtime/Core/Lint/DocumentLinter.cs
+++ b/Runtime/Core/Lint/DocumentLinter.cs
@@ -54,32 +54,128 @@ namespace PromptUGUI.Lint
 
             // Expansion throws instead of collecting, and C# forbids `yield return` inside a catch,
             // so stage the outcome first and emit it below.
-            UIDocument expanded = null;
-            LintIssue? expansionFailure = null;
+            LoadedDoc loaded = null;
+            LintIssue? failure = null;
             try
             {
-                var loaded = DocumentAssembler.Assemble(
+                loaded = DocumentAssembler.Assemble(
                     entrySrc,
                     s => s == entrySrc ? doc : imports?.Invoke(s),
                     allowScreens: true);
+            }
+            catch (Exception ex) when (ex is TemplateException || ex is ParseException)
+            {
+                failure = new LintIssue(ExpansionCode, null, null, ex.Message);
+            }
+            if (failure.HasValue)
+            {
+                yield return failure.Value;
+                yield break;
+            }
+
+            // Theme rules run BEFORE expansion is attempted: the most common thing they diagnose —
+            // a theme style with no global baseline — is itself what makes expansion throw, and
+            // reporting only "unknown style 'card'" would send the author looking in the wrong place.
+            var themes = ThemesByName(loaded);
+
+            foreach (var issue in ThemeStyleRules.CheckBaselines(loaded.Styles, themes))
+                if (seen.Add(KeyOf(issue)))
+                    yield return issue;
+
+            foreach (var issue in ThemeStyleRules.CheckShape(loaded.Styles, themes))
+                if (seen.Add(KeyOf(issue)))
+                    yield return issue;
+
+            foreach (var issue in CheckInvocationsAcross(loaded, themes))
+                if (seen.Add(KeyOf(issue)))
+                    yield return issue;
+
+            UIDocument expanded = null;
+            try
+            {
                 expanded = TemplateExpander.Expand(loaded);
             }
             catch (Exception ex) when (ex is TemplateException || ex is ParseException)
             {
                 // Reaching UI.Open() to learn that a template or style name does not resolve is the
                 // slowest feedback loop there is; surfacing it at write time is the point of a CLI.
-                expansionFailure = new LintIssue(ExpansionCode, null, null, ex.Message);
+                failure = new LintIssue(ExpansionCode, null, null, ex.Message);
             }
-
-            if (expansionFailure.HasValue)
+            if (failure.HasValue)
             {
-                yield return expansionFailure.Value;
+                yield return failure.Value;
                 yield break;
             }
 
             foreach (var issue in IRWalker.Walk(expanded))
                 if (seen.Add(KeyOf(issue)))
                     yield return issue;
+
+            // Rules that reason about a node's resolved configuration (GlassRules above all) can only
+            // answer for ONE skin at a time. Re-derive the tree under each theme and walk again;
+            // dedup means a theme that changes nothing relevant costs nothing but the walk. No flag
+            // to remember: the themes a document can reach are already declared in it.
+            foreach (var themeName in SortedKeys(themes))
+            {
+                ThemeStyleApplierForLint(expanded, loaded.Styles, themes, themeName);
+                foreach (var issue in IRWalker.Walk(expanded))
+                    if (seen.Add(KeyOf(issue)))
+                        yield return issue;
+            }
+        }
+
+        private static Dictionary<string, ThemeBlock> ThemesByName(LoadedDoc loaded)
+        {
+            var themes = new Dictionary<string, ThemeBlock>();
+            foreach (var (theme, _) in loaded.Themes)
+                themes[theme.Name] = theme;   // a cross-file duplicate already threw in Assemble
+            return themes;
+        }
+
+        private static IEnumerable<LintIssue> CheckInvocationsAcross(
+            LoadedDoc loaded, Dictionary<string, ThemeBlock> themes)
+        {
+            var themeStyleNames = new HashSet<string>();
+            foreach (var theme in themes.Values)
+                foreach (var name in theme.Styles.Keys)
+                    themeStyleNames.Add(name);
+            if (themeStyleNames.Count == 0) yield break;
+
+            var tags = new List<string>();
+            foreach (var key in loaded.Templates.Keys) tags.Add(key.ToString());
+
+            // Invocations only exist BEFORE expansion, so this walks the assembled-but-raw screens.
+            foreach (var screen in loaded.Screens)
+            {
+                foreach (var issue in ThemeStyleRules.CheckInvocations(screen.Root, tags, themeStyleNames))
+                    yield return issue;
+                foreach (var block in screen.Variants)
+                    foreach (var add in block.Adds)
+                        foreach (var child in add.Children)
+                            foreach (var issue in ThemeStyleRules.CheckInvocations(child, tags, themeStyleNames))
+                                yield return issue;
+            }
+            foreach (var tpl in loaded.Templates.Values)
+                foreach (var issue in ThemeStyleRules.CheckInvocations(tpl.Body, tags, themeStyleNames))
+                    yield return issue;
+        }
+
+        private static void ThemeStyleApplierForLint(
+            UIDocument expanded,
+            IReadOnlyDictionary<StyleKey, StyleDef> globalStyles,
+            IReadOnlyDictionary<string, ThemeBlock> themes,
+            string themeName)
+        {
+            var effective = ThemeStyleResolver.Resolve(globalStyles, themes, themeName);
+            foreach (var screen in expanded.Screens)
+                ThemeStyleApplier.Apply(screen, effective);
+        }
+
+        private static List<string> SortedKeys(Dictionary<string, ThemeBlock> themes)
+        {
+            var names = new List<string>(themes.Keys);
+            names.Sort(System.StringComparer.Ordinal);
+            return names;
         }
 
         // Identical message => same finding, whichever pass produced it. Code/Tag/Id alone would

--- a/Runtime/Core/Lint/DocumentLinter.cs
+++ b/Runtime/Core/Lint/DocumentLinter.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using PromptUGUI.IR;
+using PromptUGUI.Parser;
+using PromptUGUI.Template;
+
+namespace PromptUGUI.Lint
+{
+    /// <summary>
+    /// Runs <see cref="IRWalker"/> over BOTH the document as written and the document as expanded,
+    /// deduplicated. Neither view is a superset of the other:
+    ///
+    /// <list type="bullet">
+    /// <item><b>raw</b> — reaches code the expander drops: subtrees behind <c>if="false"</c>,
+    /// templates nobody invokes. Author mistakes there are still author mistakes.</item>
+    /// <item><b>expanded</b> — the tree <c>ScreenInstantiator</c> actually builds. Reaches what the
+    /// raw view structurally cannot: a template invocation's real parent/child context, attributes
+    /// arriving through <c>class=</c>, and the resolved configuration a rule needs before it will
+    /// speak at all (<see cref="GlassRules"/>, <see cref="PureContainerVisualAttrRules"/>,
+    /// <c>PUI-TAB-PARENT</c>).</item>
+    /// </list>
+    ///
+    /// <para>Lives here rather than in the CLI's <c>Program.cs</c> so it is reachable from
+    /// <c>PromptUGUI.Tests.EditMode</c> — the CLI has no test assembly of its own, and this is the
+    /// layer where a miscount silently turns a failing lint into exit code 0.</para>
+    ///
+    /// <para>See the 2026-08-26 theme-driven-style spec §9.</para>
+    /// </summary>
+    public static class DocumentLinter
+    {
+        /// <summary>Expansion itself failed — an unknown template / style name, or an Import cycle.</summary>
+        public const string ExpansionCode = "PUI-EXPAND";
+
+        /// <summary>
+        /// <paramref name="imports"/> resolves an <c>&lt;Import src&gt;</c> to its parsed document.
+        /// Pass <c>null</c> when the caller cannot produce the closure — a project may serve its
+        /// commons from Addressables or a custom resolver with no filesystem shape at all, and
+        /// failing a today-clean document over that would cost more than the missed coverage. The
+        /// expanded pass is then skipped and the raw rules still apply, exactly as before.
+        /// </summary>
+        public static IEnumerable<LintIssue> Walk(
+            UIDocument doc, string entrySrc = "<entry>", Func<string, UIDocument> imports = null)
+        {
+            if (doc == null) yield break;
+
+            var seen = new HashSet<string>();
+
+            foreach (var issue in IRWalker.Walk(doc))
+                if (seen.Add(KeyOf(issue)))
+                    yield return issue;
+
+            if (imports == null && doc.Imports.Count > 0)
+                yield break;
+
+            // Expansion throws instead of collecting, and C# forbids `yield return` inside a catch,
+            // so stage the outcome first and emit it below.
+            UIDocument expanded = null;
+            LintIssue? expansionFailure = null;
+            try
+            {
+                var loaded = DocumentAssembler.Assemble(
+                    entrySrc,
+                    s => s == entrySrc ? doc : imports?.Invoke(s),
+                    allowScreens: true);
+                expanded = TemplateExpander.Expand(loaded);
+            }
+            catch (Exception ex) when (ex is TemplateException || ex is ParseException)
+            {
+                // Reaching UI.Open() to learn that a template or style name does not resolve is the
+                // slowest feedback loop there is; surfacing it at write time is the point of a CLI.
+                expansionFailure = new LintIssue(ExpansionCode, null, null, ex.Message);
+            }
+
+            if (expansionFailure.HasValue)
+            {
+                yield return expansionFailure.Value;
+                yield break;
+            }
+
+            foreach (var issue in IRWalker.Walk(expanded))
+                if (seen.Add(KeyOf(issue)))
+                    yield return issue;
+        }
+
+        // Identical message => same finding, whichever pass produced it. Code/Tag/Id alone would
+        // collapse two genuinely different problems on one node.
+        private static string KeyOf(LintIssue i) => $"{i.Code}|{i.Tag}|{i.Id}|{i.Message}";
+    }
+}

--- a/Runtime/Core/Lint/DocumentLinter.cs.meta
+++ b/Runtime/Core/Lint/DocumentLinter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fae9740bd600efbdb94e8b53b1a5fc20

--- a/Runtime/Core/Lint/IRWalker.cs
+++ b/Runtime/Core/Lint/IRWalker.cs
@@ -104,6 +104,9 @@ namespace PromptUGUI.Lint
                 foreach (var issue in ImageFitRules.CheckGeometry(node))
                     yield return issue;
             }
+            else if (node.Tag == "RawImage")
+                foreach (var issue in MaskAttributeRules.CheckRawImage(node))
+                    yield return issue;
             else if (node.Tag == "Progress")
                 foreach (var issue in ProgressAttributeRules.CheckProgress(node))
                     yield return issue;

--- a/Runtime/Core/Lint/IRWalker.cs
+++ b/Runtime/Core/Lint/IRWalker.cs
@@ -38,7 +38,7 @@ namespace PromptUGUI.Lint
             // they get their own pass so a bad radius in a style is caught where it's written.
             foreach (var style in doc.Styles.Values)
                 foreach (var issue in StyleRules.CheckStyle(style))
-                    yield return issue;
+                    yield return issue.WithOrigin(style.OriginSrc);
 
             foreach (var template in doc.Templates.Values)
             {
@@ -74,7 +74,21 @@ namespace PromptUGUI.Lint
                 CollectIds(child, ids);
         }
 
+        /// <summary>
+        /// Attributes every finding to the file its node was written in. Doing it here means a rule
+        /// never has to think about it, and a finding raised inside an imported Template body names
+        /// that library rather than the entry document that merely invoked it.
+        ///
+        /// <para>Issues that already carry an origin come from the recursive call below — a child
+        /// stamps itself, so this must not overwrite them.</para>
+        /// </summary>
         private static IEnumerable<LintIssue> WalkNode(ElementNode node, bool inTemplateBody, bool hasStateSourceAncestor, bool parentIsLayoutGroup, bool isTemplateBodyRoot, HashSet<string> screenIds, StyleAttributeView styles)
+        {
+            foreach (var issue in WalkNodeCore(node, inTemplateBody, hasStateSourceAncestor, parentIsLayoutGroup, isTemplateBodyRoot, screenIds, styles))
+                yield return issue.Origin == null ? issue.WithOrigin(node.OriginSrc) : issue;
+        }
+
+        private static IEnumerable<LintIssue> WalkNodeCore(ElementNode node, bool inTemplateBody, bool hasStateSourceAncestor, bool parentIsLayoutGroup, bool isTemplateBodyRoot, HashSet<string> screenIds, StyleAttributeView styles)
         {
             // Per-tag self-checks (mirror of ScreenInstantiator dispatch; CLI errors).
             // Self-relative — about the node itself, unlike parent-relative LayoutGroupChildRules.
@@ -173,22 +187,22 @@ namespace PromptUGUI.Lint
             {
                 if (isLayoutGroup)
                     foreach (var issue in LayoutGroupChildRules.CheckChild(child))
-                        yield return issue;
+                        yield return issue.WithOrigin(child.OriginSrc);
                 else
                     // 'flow' under a non-layout-group parent is inert — flag it. Dispatched
                     // from the child loop only (parent tag truly known): template-body roots,
                     // <Add> roots and screen roots are exempt automatically — their real
                     // parent is resolved at invocation/runtime and may well be an HStack.
                     foreach (var issue in LayoutGroupChildRules.CheckNonLayoutChild(child))
-                        yield return issue;
+                        yield return issue.WithOrigin(child.OriginSrc);
                 if (node.Tag == "Carousel")
                     foreach (var issue in CarouselRules.CheckCard(node, child))
-                        yield return issue;
+                        yield return issue.WithOrigin(child.OriginSrc);
                 // CLI-only: a direct <Grid> child's own size/width/height is overridden by cellSize.
                 // Grid-specific (V/HStack children's size IS meaningful), so gated on the parent tag here.
                 if (node.Tag == "Grid")
                     foreach (var issue in LayoutGroupChildRules.CheckGridChild(child))
-                        yield return issue;
+                        yield return issue.WithOrigin(child.OriginSrc);
                 // Exempt Template-instance roots and bodies: <Tab> wrapped in a
                 // Template (e.g. <Template name='FileTab'><Frame><Tab/>...) is
                 // intentional — TabBar.CollectStaticTabs walks wrappers via FindTabIn.
@@ -199,7 +213,8 @@ namespace PromptUGUI.Lint
                     yield return new LintIssue(
                         TabRules.TabParentCode, child.Tag, child.Id,
                         $"<Tab id='{child.Id}'>: must be a direct child of <TabBar>; current parent is <{node.Tag}>. " +
-                        "Mutual exclusion and shared visuals will not apply.");
+                        "Mutual exclusion and shared visuals will not apply.",
+                        child.OriginSrc);
                 foreach (var issue in WalkNode(child, inTemplateBody, childHasStateSourceAncestor, parentIsLayoutGroup: isLayoutGroup, isTemplateBodyRoot: false, screenIds: screenIds, styles: styles))
                     yield return issue;
             }

--- a/Runtime/Core/Lint/LintIssue.cs
+++ b/Runtime/Core/Lint/LintIssue.cs
@@ -7,12 +7,24 @@ namespace PromptUGUI.Lint
         public string Id { get; }
         public string Message { get; }
 
-        public LintIssue(string code, string tag, string id, string message)
+        /// <summary>
+        /// The src the offending node was written in (<see cref="IR.ElementNode.OriginSrc"/>), or
+        /// null when unknown. Rules never set it — <see cref="IRWalker"/> stamps it centrally, so a
+        /// new rule gets correct file attribution for free.
+        /// </summary>
+        public string Origin { get; }
+
+        public LintIssue(string code, string tag, string id, string message, string origin = null)
         {
             Code = code;
             Tag = tag;
             Id = id;
             Message = message;
+            Origin = origin;
         }
+
+        /// <summary>Same finding, attributed to <paramref name="origin"/>.</summary>
+        public LintIssue WithOrigin(string origin) =>
+            new LintIssue(Code, Tag, Id, Message, origin);
     }
 }

--- a/Runtime/Core/Lint/MaskAttributeRules.cs
+++ b/Runtime/Core/Lint/MaskAttributeRules.cs
@@ -95,6 +95,49 @@ namespace PromptUGUI.Lint
             }
         }
 
+        /// <summary>
+        /// <c>&lt;RawImage&gt;</c> exposes the same mask family as <c>&lt;Image&gt;</c> with the same
+        /// add-only implementation, but its image source is a <c>Texture</c> assigned from C# — there
+        /// is no <c>sprite=</c>, so <see cref="SelfNoSpriteCode"/> cannot apply and the two cannot
+        /// share <see cref="CheckImage"/>.
+        ///
+        /// <para>Without this it fell through BOTH guards: <c>IRWalker</c> dispatched the mask rules
+        /// only for Frame and Image, while <c>VariantBaseRules</c> skips the mask family outright on
+        /// the grounds that <see cref="VariantCode"/> "owns it in ALL cases".</para>
+        /// </summary>
+        public static IEnumerable<LintIssue> CheckRawImage(ElementNode n)
+        {
+            foreach (var issue in CheckVariantOverrides(n)) yield return issue;
+
+            n.Attributes.TryGetValue("mask", out var mask);
+
+            if (!string.IsNullOrEmpty(mask) && mask != "rect" && mask != "self")
+            {
+                yield return new LintIssue(
+                    ValueCode, n.Tag, n.Id,
+                    $"<RawImage id='{n.Id}'>: mask=\"{mask}\" is invalid. " +
+                    "RawImage allows mask=\"rect\" or mask=\"self\".");
+            }
+
+            if (n.Attributes.ContainsKey("maskPadding") && mask != "rect")
+            {
+                yield return new LintIssue(
+                    PaddingNoRectCode, n.Tag, n.Id,
+                    $"<RawImage id='{n.Id}'>: maskPadding only takes effect with mask=\"rect\" " +
+                    "(RectMask2D); stencil Mask (mask=\"self\") has no padding concept. " +
+                    "Add mask=\"rect\" or remove maskPadding.");
+            }
+
+            if (n.Attributes.ContainsKey("showMask") && mask != "self")
+            {
+                yield return new LintIssue(
+                    ShowMaskNoSelfCode, n.Tag, n.Id,
+                    $"<RawImage id='{n.Id}'>: showMask only takes effect with mask=\"self\" " +
+                    "(stencil Mask). RectMask2D has no graphic to show/hide. " +
+                    "Add mask=\"self\" or remove showMask.");
+            }
+        }
+
         private static IEnumerable<LintIssue> CheckVariantOverrides(ElementNode n)
         {
             if (n.VariantOverrides.ContainsKey("mask")

--- a/Runtime/Core/Lint/StyleAttributeView.cs
+++ b/Runtime/Core/Lint/StyleAttributeView.cs
@@ -41,6 +41,11 @@ namespace PromptUGUI.Lint
         public bool IsUncertain(ElementNode n)
         {
             if (n == null) return false;
+            // An expanded node keeps its class= (a theme switch re-merges from it), but its pack is
+            // already folded into Attributes — nothing about it is unknown, whatever this document
+            // happens to declare. Without this the expanded lint pass would go quiet again exactly
+            // where following <Import> made it able to speak.
+            if (n.StyleAttrNames != null) return false;
             if (!n.Attributes.TryGetValue(StyleClassAttr, out var value)) return false;
             if (value == null) return false;
             if (value.Contains("{{")) return true;

--- a/Runtime/Core/Lint/ThemeStyleRules.cs
+++ b/Runtime/Core/Lint/ThemeStyleRules.cs
@@ -1,0 +1,203 @@
+using System.Collections.Generic;
+using PromptUGUI.IR;
+using PromptUGUI.Template;
+
+namespace PromptUGUI.Lint
+{
+    /// <summary>
+    /// Rules for theme-scoped <c>&lt;Style&gt;</c> packs (2026-08-26 spec §6.1, §7). Both catch
+    /// mistakes whose only runtime symptom is "some attribute silently keeps the previous theme's
+    /// value", which is close to undebuggable from the outside — the reason the spec makes them
+    /// static constraints rather than documentation.
+    /// </summary>
+    /// <remarks>
+    /// Internal, unlike the other rule classes: <see cref="StyleKey"/> is internal, and widening it
+    /// to the public API just to type one lint parameter would be the tail wagging the dog. The only
+    /// consumers are <see cref="DocumentLinter"/> and the tests, both of which see internals.
+    /// </remarks>
+    internal static class ThemeStyleRules
+    {
+        public const string ShapeCode = "PUI-THEME-STYLE-SHAPE";
+        public const string OnInvocationCode = "PUI-THEME-STYLE-ON-INVOCATION";
+        public const string NoBaselineCode = "PUI-THEME-STYLE-NO-BASELINE";
+
+        /// <summary>
+        /// §4.2. Expansion resolves <c>class=</c> against the GLOBAL style pool; the theme layer only
+        /// re-derives values afterwards. A style that exists solely inside a <c>&lt;Theme&gt;</c> is
+        /// therefore unreferenceable — <c>class="pixel-only"</c> throws "unknown style" at expansion,
+        /// with a message that cannot mention the theme it was actually written in.
+        ///
+        /// <para>Reported even when nothing references it, because both readings are worth knowing:
+        /// unreferenced means dead, referenced means broken. The fix is the same either way and is
+        /// the discipline §6.1 rests on — declare the global <c>&lt;Style&gt;</c> as the baseline and
+        /// let each theme override values on top of it.</para>
+        /// </summary>
+        public static IEnumerable<LintIssue> CheckBaselines(
+            IReadOnlyDictionary<StyleKey, StyleDef> globalStyles,
+            IReadOnlyDictionary<string, ThemeBlock> themes)
+        {
+            if (themes == null) yield break;
+
+            var reported = new HashSet<string>();
+            foreach (var themeName in Sorted(themes.Keys))
+            {
+                foreach (var styleName in Sorted(themes[themeName].Styles.Keys))
+                {
+                    if (globalStyles != null && globalStyles.ContainsKey(new StyleKey(null, styleName)))
+                        continue;
+                    if (!reported.Add(styleName)) continue;
+
+                    yield return new LintIssue(
+                        NoBaselineCode, "Theme", styleName,
+                        $"<Theme name='{themeName}'> declares <Style name='{styleName}'> but there is " +
+                        "no global <Style> of that name. class= resolves against the global pool at " +
+                        "expansion, so this pack can never be reached. Declare the global " +
+                        $"<Style name='{styleName}'> with the full attribute set and let each theme " +
+                        "override the few values that differ.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// §6.1. Every theme must resolve the same attribute-NAME set for a given style, because
+        /// <c>ControlAttributeApplier</c> only replays attributes that resolve to a value: a name
+        /// present under theme A and absent under theme B is never reset when you switch to B, so the
+        /// control silently keeps A's value.
+        ///
+        /// <para>Only compared ACROSS themes. The global <c>&lt;Style&gt;</c> is the implicit root of
+        /// every chain, so each theme's set already contains it; and with fewer than two themes there
+        /// is no switch to go wrong.</para>
+        /// </summary>
+        public static IEnumerable<LintIssue> CheckShape(
+            IReadOnlyDictionary<StyleKey, StyleDef> globalStyles,
+            IReadOnlyDictionary<string, ThemeBlock> themes)
+        {
+            if (themes == null || themes.Count < 2) yield break;
+
+            var touched = new HashSet<string>();
+            foreach (var theme in themes.Values)
+                foreach (var name in theme.Styles.Keys)
+                    touched.Add(name);
+            if (touched.Count == 0) yield break;
+
+            // theme name -> its resolved table, computed once each.
+            var resolved = new Dictionary<string, IReadOnlyDictionary<StyleKey, StyleDef>>(themes.Count);
+            foreach (var themeName in themes.Keys)
+                resolved[themeName] = ThemeStyleResolver.Resolve(globalStyles, themes, themeName);
+
+            foreach (var styleName in Sorted(touched))
+            {
+                var key = new StyleKey(null, styleName);
+                string referenceTheme = null;
+                HashSet<string> referenceNames = null;
+
+                foreach (var themeName in Sorted(resolved.Keys))
+                {
+                    var names = NamesOf(resolved[themeName], key);
+                    if (referenceNames == null)
+                    {
+                        referenceTheme = themeName;
+                        referenceNames = names;
+                        continue;
+                    }
+                    if (referenceNames.SetEquals(names)) continue;
+
+                    var onlyA = Missing(referenceNames, names);
+                    var onlyB = Missing(names, referenceNames);
+                    yield return new LintIssue(
+                        ShapeCode, "Theme", styleName,
+                        $"<Style name='{styleName}'> resolves to different attributes under " +
+                        $"'{referenceTheme}' and '{themeName}': " +
+                        Describe(referenceTheme, onlyA) + Describe(themeName, onlyB) +
+                        "An attribute one theme sets and the other does not is never reset on a " +
+                        "switch — the control keeps the old value. Give it a baseline in the global " +
+                        $"<Style name='{styleName}'>, or declare it in every theme.");
+                    break;   // one report per style name is enough to act on
+                }
+            }
+        }
+
+        /// <summary>
+        /// §7. A theme-scoped style on a Template INVOCATION does not follow the theme. Half of the
+        /// pack becomes <c>&lt;Param&gt;</c> values, which <c>Substitution</c> bakes into the body's
+        /// attribute strings at expansion; the other half is merged onto the instance root, and the
+        /// invocation node itself no longer exists afterwards, so there is nothing left to re-derive
+        /// from. The author gets a skin that silently refuses to change.
+        ///
+        /// <para>The fix is to move the <c>class=</c> down onto a node inside the template body,
+        /// where it is an ordinary node attribute and re-merges like any other.</para>
+        /// </summary>
+        public static IEnumerable<LintIssue> CheckInvocations(
+            ElementNode root,
+            IReadOnlyCollection<string> templateTags,
+            IReadOnlyCollection<string> themeStyleNames)
+        {
+            if (root == null || templateTags == null || templateTags.Count == 0
+                || themeStyleNames == null || themeStyleNames.Count == 0)
+                yield break;
+
+            var tags = new HashSet<string>(templateTags);
+            var themed = new HashSet<string>(themeStyleNames);
+            foreach (var issue in Walk(root, tags, themed)) yield return issue;
+        }
+
+        private static IEnumerable<LintIssue> Walk(
+            ElementNode node, HashSet<string> tags, HashSet<string> themed)
+        {
+            var tag = new TemplateKey(node.Namespace, node.Tag).ToString();
+            if (tags.Contains(tag)
+                && node.Attributes.TryGetValue(StyleMerger.ClassAttr, out var classValue)
+                && classValue != null)
+            {
+                foreach (var reference in classValue.Split(
+                             new[] { ' ', '\t', '\n', '\r' }, System.StringSplitOptions.RemoveEmptyEntries))
+                {
+                    var key = StyleKey.ParseReference(reference);
+                    // Theme styles address the un-namespaced pool only (spec §4.3), so ui:card can
+                    // never be themed and is not what this rule is about.
+                    if (key.Namespace != null || !themed.Contains(key.Name)) continue;
+
+                    yield return new LintIssue(
+                        OnInvocationCode, node.Tag, node.Id,
+                        $"<{tag}> is a Template invocation, and class=\"{reference}\" names a style " +
+                        "some <Theme> overrides — but a pack applied here is baked in at expansion " +
+                        "and will NOT follow a theme switch. Move class= onto a node inside " +
+                        $"<Template name='{node.Tag}'>, or use a style no theme overrides.");
+                    break;
+                }
+            }
+
+            foreach (var child in node.Children)
+                foreach (var issue in Walk(child, tags, themed))
+                    yield return issue;
+        }
+
+        private static HashSet<string> NamesOf(
+            IReadOnlyDictionary<StyleKey, StyleDef> table, StyleKey key)
+        {
+            var names = new HashSet<string>();
+            if (table != null && table.TryGetValue(key, out var style))
+                foreach (var name in style.DeclaredNames) names.Add(name);
+            return names;
+        }
+
+        private static List<string> Missing(HashSet<string> from, HashSet<string> other)
+        {
+            var only = new List<string>();
+            foreach (var name in from)
+                if (!other.Contains(name)) only.Add(name);
+            only.Sort(System.StringComparer.Ordinal);
+            return only;
+        }
+
+        private static string Describe(string themeName, List<string> only) =>
+            only.Count == 0 ? "" : $"only '{themeName}' sets {string.Join(", ", only)}. ";
+
+        private static List<string> Sorted(IEnumerable<string> names)
+        {
+            var list = new List<string>(names);
+            list.Sort(System.StringComparer.Ordinal);
+            return list;
+        }
+    }
+}

--- a/Runtime/Core/Lint/ThemeStyleRules.cs.meta
+++ b/Runtime/Core/Lint/ThemeStyleRules.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 501cc1e3cad5ab5dd8a5a7ea05f08838

--- a/Runtime/Core/Parser/UIDocumentParser.cs
+++ b/Runtime/Core/Parser/UIDocumentParser.cs
@@ -9,7 +9,46 @@ namespace PromptUGUI.Parser
         private static readonly Regex KebabRx =
             new Regex("^[a-z0-9]+(-[a-z0-9]+)*$", RegexOptions.Compiled);
 
-        public static UIDocument Parse(string xml)
+        /// <summary>
+        /// <paramref name="src"/> is the resolver key / path this xml came from. Supplying it stamps
+        /// every produced <see cref="ElementNode"/> with <see cref="ElementNode.OriginSrc"/> so lint
+        /// findings can name the file the markup was written in — which is not the entry document
+        /// once <c>&lt;Import&gt;</c> and Template inlining are in play. Omitting it is fine and
+        /// leaves the origins null.
+        /// </summary>
+        public static UIDocument Parse(string xml, string src = null)
+        {
+            var doc = ParseCore(xml);
+            if (src != null) StampOrigin(doc, src);
+            return doc;
+        }
+
+        // Every ElementNode the document owns. Stamping here — one walk after parsing — keeps `src`
+        // out of the dozen private parse methods that would otherwise have to thread it through.
+        private static void StampOrigin(UIDocument doc, string src)
+        {
+            foreach (var screen in doc.Screens)
+            {
+                StampSubtree(screen.Root, src);
+                StampSubtree(screen.FocusCursor, src);
+                foreach (var variant in screen.Variants)
+                    foreach (var add in variant.Adds)
+                        foreach (var child in add.Children)
+                            StampSubtree(child, src);
+            }
+            foreach (var template in doc.Templates.Values)
+                StampSubtree(template.Body, src);
+        }
+
+        private static void StampSubtree(ElementNode node, string src)
+        {
+            if (node == null) return;
+            node.OriginSrc = src;
+            foreach (var child in node.Children)
+                StampSubtree(child, src);
+        }
+
+        private static UIDocument ParseCore(string xml)
         {
             var xdoc = new XmlDocument();
             xdoc.LoadXml(xml);

--- a/Runtime/Core/Parser/UIDocumentParser.cs
+++ b/Runtime/Core/Parser/UIDocumentParser.cs
@@ -38,6 +38,14 @@ namespace PromptUGUI.Parser
             }
             foreach (var template in doc.Templates.Values)
                 StampSubtree(template.Body, src);
+
+            // <Style> is not an ElementNode but IS a lint target (StyleRules.CheckStyle), and
+            // IRWalker attributes those findings via StyleDef.OriginSrc.
+            foreach (var style in doc.Styles.Values)
+                style.OriginSrc = src;
+            foreach (var theme in doc.Themes)
+                foreach (var style in theme.Styles.Values)
+                    style.OriginSrc = src;
         }
 
         private static void StampSubtree(ElementNode node, string src)
@@ -141,10 +149,24 @@ namespace PromptUGUI.Parser
             foreach (XmlNode c in el.ChildNodes)
             {
                 if (c is not XmlElement child) continue;
+
+                if (child.Name == "Style")
+                {
+                    // A theme's style pack overrides the global <Style> of the same name rather than
+                    // replacing it, so a theme spells out only what differs (spec §4.2).
+                    var themeStyle = ParseStylePack(
+                        child, $"<Theme name=\"{name}\"> ", ThemeStyleForbiddenAttrs);
+                    if (block.Styles.ContainsKey(themeStyle.Name))
+                        throw new ParseException(
+                            $"<Theme name=\"{name}\"> declares <Style name=\"{themeStyle.Name}\"> twice");
+                    block.Styles[themeStyle.Name] = themeStyle;
+                    continue;
+                }
+
                 if (child.Name != "Color")
                     throw new ParseException(
                         $"<Theme name=\"{name}\">: unexpected child <{child.Name}> " +
-                        $"(only <Color> allowed)");
+                        $"(only <Color> and <Style> allowed)");
                 var cn = child.GetAttribute("name");
                 var hasValue = child.HasAttribute("value");
                 var cv = child.GetAttribute("value");
@@ -362,22 +384,60 @@ namespace PromptUGUI.Parser
         /// </summary>
         private static readonly string[] StyleForbiddenAttrs = { "id", "if", "class", "bind" };
 
+        /// <summary>
+        /// A theme-scoped <c>&lt;Style&gt;</c> rejects everything a global one does, plus two groups
+        /// that only become a problem once a pack can change while a Screen is open. See spec §6.3.
+        /// </summary>
+        private static readonly string[] ThemeStyleForbiddenAttrs =
+        {
+            "id", "if", "class", "bind",
+            "text", "isOn", "value", "current",
+            "mask", "showMask", "maskPadding",
+        };
+
+        private static string ForbiddenAttrReason(string name) => name switch
+        {
+            "id" or "if" or "class" or "bind" =>
+                "identifies a node, and a style is shared by many nodes",
+            "text" or "isOn" or "value" or "current" =>
+                "is runtime-owned state - ControlAttributeApplier stops replaying it once code has "
+                + "taken it over, so a theme's value would be swallowed some of the time, which is "
+                + "worse than never applying",
+            "mask" or "showMask" or "maskPadding" =>
+                "switches mask mode, which PUI-MASK-VARIANT already declares unsupported in v1 "
+                + "(it would need AddComponent / Destroy while the Screen is open); a theme must not "
+                + "become a second door into the same unsupported operation",
+            _ => "is not allowed here",
+        };
+
         private static void ParseStyle(XmlElement el, UIDocument doc)
+        {
+            var style = ParseStylePack(el, ownerPrefix: "", StyleForbiddenAttrs);
+            if (doc.Styles.ContainsKey(style.Name))
+                throw new ParseException($"duplicate <Style name=\"{style.Name}\"> within document");
+            doc.Styles[style.Name] = style;
+        }
+
+        /// <summary>
+        /// The <c>&lt;Style&gt;</c> attribute-pack grammar, shared by the top-level element and the
+        /// theme-scoped one. <paramref name="ownerPrefix"/> is prepended to every diagnostic so a
+        /// theme-nested style names its theme; <paramref name="forbidden"/> is the only other thing
+        /// that differs between the two (see <see cref="ThemeStyleForbiddenAttrs"/>).
+        /// </summary>
+        private static StyleDef ParseStylePack(XmlElement el, string ownerPrefix, string[] forbidden)
         {
             var name = el.GetAttribute("name");
             if (string.IsNullOrEmpty(name))
-                throw new ParseException("<Style>: missing required attribute 'name'");
+                throw new ParseException($"{ownerPrefix}<Style>: missing required attribute 'name'");
             if (!KebabRx.IsMatch(name))
                 throw new ParseException(
-                    $"<Style name=\"{name}\">: style name must be kebab-case [a-z0-9-]");
-            if (doc.Styles.ContainsKey(name))
-                throw new ParseException($"duplicate <Style name=\"{name}\"> within document");
+                    $"{ownerPrefix}<Style name=\"{name}\">: style name must be kebab-case [a-z0-9-]");
 
             foreach (XmlNode c in el.ChildNodes)
             {
                 if (c is XmlElement child)
                     throw new ParseException(
-                        $"<Style name=\"{name}\">: unexpected child <{child.Name}> " +
+                        $"{ownerPrefix}<Style name=\"{name}\">: unexpected child <{child.Name}> " +
                         "(a style is an attribute pack and takes no children)");
             }
 
@@ -390,12 +450,12 @@ namespace PromptUGUI.Parser
                 var attrDot = attr.Name.IndexOf('.');
                 var baseName = attrDot < 0 ? attr.Name : attr.Name.Substring(0, attrDot);
 
-                foreach (var forbidden in StyleForbiddenAttrs)
+                foreach (var banned in forbidden)
                 {
-                    if (baseName != forbidden) continue;
+                    if (baseName != banned) continue;
                     throw new ParseException(
-                        $"<Style name=\"{name}\">: '{attr.Name}' is not a style attribute — " +
-                        $"'{forbidden}' identifies a node, and a style is shared by many nodes");
+                        $"{ownerPrefix}<Style name=\"{name}\">: '{attr.Name}' is not a style " +
+                        $"attribute — '{banned}' {ForbiddenAttrReason(banned)}");
                 }
 
                 if (attrDot < 0)
@@ -406,14 +466,14 @@ namespace PromptUGUI.Parser
 
                 if (attrDot == 0 || attrDot == attr.Name.Length - 1)
                     throw new ParseException(
-                        $"<Style name=\"{name}\">: malformed attribute '{attr.Name}' " +
+                        $"{ownerPrefix}<Style name=\"{name}\">: malformed attribute '{attr.Name}' " +
                         "(variant suffix must be 'name.variant')");
 
                 var variant = attr.Name.Substring(attrDot + 1);
                 if (variant.Contains('.'))
                     throw new ParseException(
-                        $"<Style name=\"{name}\">: attribute '{attr.Name}' has '.' inside the variant " +
-                        "name (use '-' for compound names like 'mobile-portrait')");
+                        $"{ownerPrefix}<Style name=\"{name}\">: attribute '{attr.Name}' has '.' inside " +
+                        "the variant name (use '-' for compound names like 'mobile-portrait')");
 
                 if (!style.VariantOverrides.TryGetValue(baseName, out var list))
                 {
@@ -425,9 +485,9 @@ namespace PromptUGUI.Parser
 
             if (style.Attributes.Count == 0 && style.VariantOverrides.Count == 0)
                 throw new ParseException(
-                    $"<Style name=\"{name}\">: declares no attributes");
+                    $"{ownerPrefix}<Style name=\"{name}\">: declares no attributes");
 
-            doc.Styles[name] = style;
+            return style;
         }
 
         private static void ParseVariantBlock(XmlElement el, ScreenDef screen,

--- a/Runtime/Core/Template/DocumentAssembler.cs
+++ b/Runtime/Core/Template/DocumentAssembler.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using PromptUGUI.IR;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Template
+{
+    /// <summary>
+    /// The <c>&lt;Import&gt;</c> merge algorithm, with the fetching taken out: given a way to look
+    /// up an already-parsed <see cref="UIDocument"/> by src, it walks the import closure and folds
+    /// everything into one <see cref="LoadedDoc"/> — namespace application (<c>as=</c>), cycle
+    /// detection, cross-file duplicate detection, and the "imports may not declare
+    /// <c>&lt;Screen&gt;</c>" rule.
+    ///
+    /// <para><b>Why the split.</b> Fetching is the only asynchronous part, and <c>Awaitable</c> is a
+    /// Unity type. Keeping the merge SEMANTICS here — pure C#, no Unity — is what lets the UIXmlLint
+    /// CLI follow <c>&lt;Import&gt;</c> and lint the same expanded tree ScreenInstantiator sees,
+    /// instead of guessing at what an unseen commons library declares. Single source of truth: the
+    /// Unity path (<c>DocumentLoader</c>, async prefetch) and the CLI path (filesystem prefetch)
+    /// both land here. See the 2026-08-26 theme-driven-style spec §9.</para>
+    ///
+    /// <para><b>Namespace note.</b> This lives in <c>PromptUGUI.Template</c> — next to the expander
+    /// it feeds — rather than in a <c>PromptUGUI.Loading</c> of its own: that name would shadow the
+    /// public <c>PromptUGUI.Application.Modals.Loading</c> API for every file inside a
+    /// <c>PromptUGUI.*</c> namespace, since C# resolves the bare identifier outward.</para>
+    /// </summary>
+    internal static class DocumentAssembler
+    {
+        /// <summary>
+        /// <paramref name="lookup"/> must answer for <paramref name="entrySrc"/> and every src
+        /// reachable from it by <c>&lt;Import&gt;</c>; returning null is reported as a hard error
+        /// rather than silently producing a half-merged document.
+        /// </summary>
+        public static LoadedDoc Assemble(
+            string entrySrc, Func<string, UIDocument> lookup, bool allowScreens)
+        {
+            var loaded = new LoadedDoc { EntrySrc = entrySrc };
+            MergeInto(entrySrc, lookup, allowScreens, loaded, new Stack<string>(),
+                      applyNamespace: null);
+            return loaded;
+        }
+
+        /// <summary>
+        /// Folds the commons pool onto an already-assembled document. A name declared on both sides
+        /// is a hard conflict — commons are meant to be the shared baseline, so silently letting the
+        /// entry document shadow one would make the same markup mean different things per screen.
+        /// </summary>
+        public static void MergeCommons(
+            LoadedDoc loaded,
+            IReadOnlyDictionary<TemplateKey, TemplateDef> commonsPool,
+            IReadOnlyDictionary<StyleKey, StyleDef> commonsStyles = null)
+        {
+            if (commonsPool != null)
+            {
+                foreach (var kv in commonsPool)
+                {
+                    if (loaded.Templates.ContainsKey(kv.Key))
+                        throw new TemplateException(
+                            $"template '{kv.Key}' conflicts with commons pool");
+                    loaded.Templates[kv.Key] = kv.Value;
+                }
+            }
+            if (commonsStyles != null)
+            {
+                foreach (var kv in commonsStyles)
+                {
+                    if (loaded.Styles.ContainsKey(kv.Key))
+                        throw new TemplateException(
+                            $"style '{kv.Key}' conflicts with commons pool");
+                    loaded.Styles[kv.Key] = kv.Value;
+                }
+            }
+        }
+
+        private static void MergeInto(
+            string src,
+            Func<string, UIDocument> lookup,
+            bool allowScreens,
+            LoadedDoc agg,
+            Stack<string> visiting,
+            string applyNamespace)
+        {
+            if (visiting.Contains(src))
+            {
+                var chain = string.Join(" → ", visiting);
+                throw new ParseException(
+                    $"cyclic Import detected: {chain} → {src}");
+            }
+            if (!agg.AllSrcs.Add(src)) return;
+
+            var doc = lookup(src)
+                ?? throw new ParseException(
+                    $"no parsed document available for src='{src}' (the caller must supply every " +
+                    "src reachable through <Import> before assembling)");
+
+            if (!allowScreens && doc.Screens.Count > 0)
+                throw new ParseException(
+                    $"src='{src}' is loaded as common library / nested import; <Screen> not allowed");
+
+            if (allowScreens)
+            {
+                foreach (var s in doc.Screens) agg.Screens.Add(s);
+            }
+
+            foreach (var kv in doc.Templates)
+            {
+                var key = new TemplateKey(applyNamespace, kv.Key);
+                if (agg.Templates.ContainsKey(key))
+                    throw new TemplateException(
+                        $"duplicate template '{key}' (loaded from src='{src}')");
+                agg.Templates[key] = kv.Value;
+            }
+
+            foreach (var kv in doc.Styles)
+            {
+                var key = new StyleKey(applyNamespace, kv.Key);
+                if (agg.Styles.ContainsKey(key))
+                    throw new TemplateException(
+                        $"duplicate style '{key}' (loaded from src='{src}')");
+                agg.Styles[key] = kv.Value;
+            }
+
+            foreach (var theme in doc.Themes)
+                agg.Themes.Add((theme, src));
+
+            visiting.Push(src);
+            try
+            {
+                foreach (var imp in doc.Imports)
+                {
+                    var childNs = imp.Namespace ?? applyNamespace;
+                    MergeInto(imp.Src, lookup, allowScreens: false, agg, visiting, childNs);
+                }
+            }
+            finally { visiting.Pop(); }
+        }
+    }
+}

--- a/Runtime/Core/Template/DocumentAssembler.cs.meta
+++ b/Runtime/Core/Template/DocumentAssembler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b4131927fb45e1ef2b76afe1de83b75e

--- a/Runtime/Core/Template/StyleMerger.cs
+++ b/Runtime/Core/Template/StyleMerger.cs
@@ -9,8 +9,9 @@ namespace PromptUGUI.Template
     /// tree walk, and (because it only ever writes to the copy) a shared commons template body can
     /// never be polluted in place.
     ///
-    /// The expanded tree carries no <c>class</c> attribute, so ScreenInstantiator and everything
-    /// downstream stay unaware that styles exist. That is what makes this feature free at runtime.
+    /// The expanded tree keeps <c>class</c> so a theme switch can re-derive the pack
+    /// (<see cref="ReMerge"/>), but the VALUES are already folded into Attributes — ScreenInstantiator
+    /// and everything downstream still read plain attributes and stay unaware that styles exist.
     /// </summary>
     internal static class StyleMerger
     {
@@ -20,7 +21,8 @@ namespace PromptUGUI.Template
 
         /// <summary>
         /// Returns <paramref name="src"/> unchanged when it carries no <c>class</c> (the common
-        /// case, zero allocation); otherwise a copy with the pack merged in and <c>class</c> removed.
+        /// case, zero allocation); otherwise a copy with the pack merged in, <c>class</c> kept, and
+        /// <see cref="ElementNode.StyleAttrNames"/> recording what the pack contributed.
         /// </summary>
         /// <param name="invocationTarget">
         /// Non-null when <paramref name="src"/> invokes a Template. A style is broadcast, so instead
@@ -36,41 +38,17 @@ namespace PromptUGUI.Template
             if (src == null || !src.Attributes.TryGetValue(ClassAttr, out var classValue))
                 return src;
 
-            var names = classValue == null
-                ? System.Array.Empty<string>()
-                : classValue.Split(ClassSeparators, System.StringSplitOptions.RemoveEmptyEntries);
+            ComputePack(classValue, styles, src, out var packAttrs, out var packVariants);
 
-            if (names.Length == 0)
-                throw new TemplateException(
-                    $"<{src.Tag}>: class=\"{classValue}\" names no style " +
-                    "(write class=\"some-style\" or drop the attribute)");
-
-            // Fold left→right: a later class fully masks an earlier one for any attribute NAME it
-            // declares, in either base or .variant form (same atomic rule inline attributes get).
-            var packAttrs = new Dictionary<string, string>();
-            var packVariants = new Dictionary<string, List<(string Variant, string Value)>>();
-
-            foreach (var reference in names)
-            {
-                var style = Lookup(reference, styles, src);
-                foreach (var name in style.DeclaredNames)
-                {
-                    packAttrs.Remove(name);
-                    packVariants.Remove(name);
-                }
-                foreach (var kv in style.Attributes)
-                    packAttrs[kv.Key] = kv.Value;
-                foreach (var kv in style.VariantOverrides)
-                    packVariants[kv.Key] = new List<(string, string)>(kv.Value);
-            }
-
-            var dst = CloneWithoutClass(src);
+            var dst = CloneForMerge(src);
+            var contributed = new HashSet<string>();
 
             foreach (var kv in packAttrs)
             {
                 if (NodeDeclares(src, kv.Key)) continue;
                 if (invocationTarget != null && !AcceptsBase(kv.Key, invocationTarget)) continue;
                 dst.Attributes[kv.Key] = kv.Value;
+                contributed.Add(kv.Key);
             }
 
             foreach (var kv in packVariants)
@@ -81,9 +59,99 @@ namespace PromptUGUI.Template
                 // broadcast style from turning into that error on an unrelated node.
                 if (invocationTarget != null && !TemplateExpander.CommonAttrs.Contains(kv.Key)) continue;
                 dst.VariantOverrides[kv.Key] = kv.Value;
+                contributed.Add(kv.Key);
             }
 
+            dst.StyleAttrNames = contributed;
             return dst;
+        }
+
+        /// <summary>
+        /// Recomputes an already-expanded node's pack against a different style table — what a theme
+        /// switch runs. Idempotent, and safe to call on a node whose class was never merged.
+        ///
+        /// <para>Correctness rests on <see cref="ElementNode.StyleAttrNames"/>: dropping exactly the
+        /// names the previous pack contributed leaves everything else in place — the author's inline
+        /// attributes, and the common attributes a template invocation merged onto an instance root
+        /// after the style pack was applied. Rebuilding from a snapshot of the inline values instead
+        /// would silently lose that second group.</para>
+        /// </summary>
+        public static void ReMerge(
+            ElementNode node, IReadOnlyDictionary<StyleKey, StyleDef> styles)
+        {
+            if (node == null) return;
+            if (!node.Attributes.TryGetValue(ClassAttr, out var classValue)) return;
+
+            if (node.StyleAttrNames != null)
+            {
+                foreach (var name in node.StyleAttrNames)
+                {
+                    node.Attributes.Remove(name);
+                    node.VariantOverrides.Remove(name);
+                }
+            }
+
+            ComputePack(classValue, styles, node, out var packAttrs, out var packVariants);
+
+            // Snapshot what the NODE declares before laying the pack down. Testing the live node
+            // instead would let the pack's own base value mask its matching .variant entry — Apply
+            // avoids this for free by testing the pre-merge source node.
+            var selfDeclared = new HashSet<string>(node.Attributes.Keys);
+            foreach (var name in node.VariantOverrides.Keys) selfDeclared.Add(name);
+
+            var contributed = new HashSet<string>();
+            foreach (var kv in packAttrs)
+            {
+                if (selfDeclared.Contains(kv.Key)) continue;
+                node.Attributes[kv.Key] = kv.Value;
+                contributed.Add(kv.Key);
+            }
+            foreach (var kv in packVariants)
+            {
+                if (selfDeclared.Contains(kv.Key)) continue;
+                node.VariantOverrides[kv.Key] = kv.Value;
+                contributed.Add(kv.Key);
+            }
+            node.StyleAttrNames = contributed;
+        }
+
+        /// <summary>
+        /// Folds <c>class="a b"</c> left to right. A later class fully masks an earlier one for any
+        /// attribute NAME it declares, in either base or <c>.variant</c> form — the same atomic rule
+        /// inline attributes get.
+        /// </summary>
+        private static void ComputePack(
+            string classValue,
+            IReadOnlyDictionary<StyleKey, StyleDef> styles,
+            ElementNode context,
+            out Dictionary<string, string> packAttrs,
+            out Dictionary<string, List<(string Variant, string Value)>> packVariants)
+        {
+            var names = classValue == null
+                ? System.Array.Empty<string>()
+                : classValue.Split(ClassSeparators, System.StringSplitOptions.RemoveEmptyEntries);
+
+            if (names.Length == 0)
+                throw new TemplateException(
+                    $"<{context.Tag}>: class=\"{classValue}\" names no style " +
+                    "(write class=\"some-style\" or drop the attribute)");
+
+            packAttrs = new Dictionary<string, string>();
+            packVariants = new Dictionary<string, List<(string Variant, string Value)>>();
+
+            foreach (var reference in names)
+            {
+                var style = Lookup(reference, styles, context);
+                foreach (var name in style.DeclaredNames)
+                {
+                    packAttrs.Remove(name);
+                    packVariants.Remove(name);
+                }
+                foreach (var kv in style.Attributes)
+                    packAttrs[kv.Key] = kv.Value;
+                foreach (var kv in style.VariantOverrides)
+                    packVariants[kv.Key] = new List<(string, string)>(kv.Value);
+            }
         }
 
         private static StyleDef Lookup(
@@ -119,21 +187,24 @@ namespace PromptUGUI.Template
             return false;
         }
 
-        private static ElementNode CloneWithoutClass(ElementNode src)
+        /// <summary>
+        /// <c>class=</c> is deliberately KEPT on the copy: a theme switch re-derives the pack from
+        /// it (<see cref="ReMerge"/>). No control declares an attribute by that name, so
+        /// <c>ControlAttributeApplier</c> skips it like any other unknown one.
+        /// </summary>
+        private static ElementNode CloneForMerge(ElementNode src)
         {
             var dst = new ElementNode(src.Tag, src.Namespace)
             {
                 OriginSrc = src.OriginSrc,
+                StyleAttrNames = src.StyleAttrNames,
                 Id = src.Id,
                 TextContent = src.TextContent,
                 TextContentRaw = src.TextContentRaw,
                 IsTemplateInstanceRoot = src.IsTemplateInstanceRoot,
             };
             foreach (var kv in src.Attributes)
-            {
-                if (kv.Key == ClassAttr) continue;
                 dst.Attributes[kv.Key] = kv.Value;
-            }
             foreach (var kv in src.AttributesRaw)
                 dst.AttributesRaw[kv.Key] = kv.Value;
             foreach (var kv in src.VariantOverrides)

--- a/Runtime/Core/Template/StyleMerger.cs
+++ b/Runtime/Core/Template/StyleMerger.cs
@@ -30,7 +30,7 @@ namespace PromptUGUI.Template
         /// </param>
         public static ElementNode Apply(
             ElementNode src,
-            IReadOnlyDictionary<Application.DocumentLoader.StyleKey, StyleDef> styles,
+            IReadOnlyDictionary<StyleKey, StyleDef> styles,
             TemplateDef invocationTarget)
         {
             if (src == null || !src.Attributes.TryGetValue(ClassAttr, out var classValue))
@@ -88,10 +88,10 @@ namespace PromptUGUI.Template
 
         private static StyleDef Lookup(
             string reference,
-            IReadOnlyDictionary<Application.DocumentLoader.StyleKey, StyleDef> styles,
+            IReadOnlyDictionary<StyleKey, StyleDef> styles,
             ElementNode context)
         {
-            var key = Application.DocumentLoader.StyleKey.ParseReference(reference);
+            var key = StyleKey.ParseReference(reference);
             if (styles != null && styles.TryGetValue(key, out var style)) return style;
 
             var known = new List<string>();

--- a/Runtime/Core/Template/StyleMerger.cs
+++ b/Runtime/Core/Template/StyleMerger.cs
@@ -123,6 +123,7 @@ namespace PromptUGUI.Template
         {
             var dst = new ElementNode(src.Tag, src.Namespace)
             {
+                OriginSrc = src.OriginSrc,
                 Id = src.Id,
                 TextContent = src.TextContent,
                 TextContentRaw = src.TextContentRaw,

--- a/Runtime/Core/Template/TemplateExpander.cs
+++ b/Runtime/Core/Template/TemplateExpander.cs
@@ -62,6 +62,9 @@ namespace PromptUGUI.Template
                 // 把全局 Template 表附到本 Screen，供 ScrollList 等运行时控件按 tag 反查。
                 foreach (var kv in loaded.Templates)
                     newScreen.Templates[kv.Key.ToString()] = kv.Value;
+                // 同理附上样式表：切主题时要把主题 pack 折在它之上重算 class=。
+                foreach (var kv in styles)
+                    newScreen.Styles[kv.Key] = kv.Value;
                 foreach (var block in s.Variants)
                 {
                     var newBlock = new VariantBlock(block.When);
@@ -150,6 +153,7 @@ namespace PromptUGUI.Template
             var dst = new ElementNode(merged.Tag, merged.Namespace)
             {
                 OriginSrc = merged.OriginSrc,
+                StyleAttrNames = merged.StyleAttrNames,
                 Id = merged.Id,
                 TextContent = merged.TextContent,
                 TextContentRaw = merged.TextContentRaw ?? merged.TextContent,
@@ -200,6 +204,9 @@ namespace PromptUGUI.Template
                 {
                     if (CommonAttrs.Contains(kv.Key)) continue;
                     if (args.ContainsKey(kv.Key)) continue;
+                    // StyleMerger has already consumed class= into args / CommonAttrs above and
+                    // leaves the attribute in place so a theme switch can re-derive the pack.
+                    if (kv.Key == StyleMerger.ClassAttr) continue;
                     throw new TemplateException(
                         $"<{tpl.Name}>: unknown attribute '{kv.Key}'");
                 }
@@ -279,6 +286,7 @@ namespace PromptUGUI.Template
             var dst = new ElementNode(prepared.Tag, prepared.Namespace)
             {
                 OriginSrc = prepared.OriginSrc,
+                StyleAttrNames = prepared.StyleAttrNames,
                 Id = prepared.Id,
                 TextContent = Substitution.Apply(prepared.TextContent, args),
                 TextContentRaw = src.TextContentRaw ?? src.TextContent,
@@ -314,6 +322,7 @@ namespace PromptUGUI.Template
             var dst = new ElementNode(src.Tag, src.Namespace)
             {
                 OriginSrc = src.OriginSrc,
+                StyleAttrNames = src.StyleAttrNames,
                 Id = src.Id,
                 TextContent = src.TextContent,
             };
@@ -346,6 +355,7 @@ namespace PromptUGUI.Template
             var dst = new ElementNode(src.Tag, src.Namespace)
             {
                 OriginSrc = src.OriginSrc,
+                StyleAttrNames = src.StyleAttrNames,
                 Id = src.Id,
                 TextContent = src.TextContent,
                 TextContentRaw = src.TextContentRaw ?? src.TextContent,

--- a/Runtime/Core/Template/TemplateExpander.cs
+++ b/Runtime/Core/Template/TemplateExpander.cs
@@ -32,7 +32,10 @@ namespace PromptUGUI.Template
 
             foreach (var s in loaded.Screens)
             {
-                var newRoot = new ElementNode(s.Root.Tag, s.Root.Namespace);
+                var newRoot = new ElementNode(s.Root.Tag, s.Root.Namespace)
+                {
+                    OriginSrc = s.Root.OriginSrc,
+                };
                 // Screen-level attributes (e.g. reference=, reference.<variant>=) live on
                 // ScreenDef.Root and must survive expansion so runtime VariantResolver can read them.
                 foreach (var kv in s.Root.Attributes)
@@ -146,6 +149,7 @@ namespace PromptUGUI.Template
             var merged = StyleMerger.Apply(src, styles, null);
             var dst = new ElementNode(merged.Tag, merged.Namespace)
             {
+                OriginSrc = merged.OriginSrc,
                 Id = merged.Id,
                 TextContent = merged.TextContent,
                 TextContentRaw = merged.TextContentRaw ?? merged.TextContent,
@@ -274,6 +278,7 @@ namespace PromptUGUI.Template
 
             var dst = new ElementNode(prepared.Tag, prepared.Namespace)
             {
+                OriginSrc = prepared.OriginSrc,
                 Id = prepared.Id,
                 TextContent = Substitution.Apply(prepared.TextContent, args),
                 TextContentRaw = src.TextContentRaw ?? src.TextContent,
@@ -308,6 +313,7 @@ namespace PromptUGUI.Template
         {
             var dst = new ElementNode(src.Tag, src.Namespace)
             {
+                OriginSrc = src.OriginSrc,
                 Id = src.Id,
                 TextContent = src.TextContent,
             };
@@ -339,6 +345,7 @@ namespace PromptUGUI.Template
         {
             var dst = new ElementNode(src.Tag, src.Namespace)
             {
+                OriginSrc = src.OriginSrc,
                 Id = src.Id,
                 TextContent = src.TextContent,
                 TextContentRaw = src.TextContentRaw ?? src.TextContent,

--- a/Runtime/Core/Template/TemplateExpander.cs
+++ b/Runtime/Core/Template/TemplateExpander.cs
@@ -18,7 +18,7 @@ namespace PromptUGUI.Template
         /// Real entry point — takes the merged LoadedDoc produced by DocumentLoader.
         /// Uses (Namespace, Name) keyed lookup for template resolution.
         /// </summary>
-        internal static UIDocument Expand(PromptUGUI.Application.DocumentLoader.LoadedDoc loaded)
+        internal static UIDocument Expand(LoadedDoc loaded)
         {
             foreach (var t in loaded.Templates.Values) ValidateSlotCount(t);
 
@@ -44,7 +44,7 @@ namespace PromptUGUI.Template
                 {
                     EnsureNoSlot(c, $"Screen '{s.Name}'");
                     var ec = ExpandTree(c, loaded.Templates, styles,
-                                        new HashSet<PromptUGUI.Application.DocumentLoader.TemplateKey>());
+                                        new HashSet<TemplateKey>());
                     if (ec != null) newRoot.Children.Add(ec);
                 }
                 var newScreen = new ScreenDef(s.Name, newRoot)
@@ -54,7 +54,7 @@ namespace PromptUGUI.Template
                     // forwarded here; otherwise SetupFocusCursor receives null and no overlay is built.
                     FocusCursor = s.FocusCursor == null ? null
                         : ExpandTree(s.FocusCursor, loaded.Templates, styles,
-                                     new HashSet<PromptUGUI.Application.DocumentLoader.TemplateKey>()),
+                                     new HashSet<TemplateKey>()),
                 };
                 // 把全局 Template 表附到本 Screen，供 ScrollList 等运行时控件按 tag 反查。
                 foreach (var kv in loaded.Templates)
@@ -73,7 +73,7 @@ namespace PromptUGUI.Template
                         {
                             EnsureNoSlot(ch, $"<Variant when='{block.When}'> in Screen '{s.Name}'");
                             var ec = ExpandTree(ch, loaded.Templates, styles,
-                                                new HashSet<PromptUGUI.Application.DocumentLoader.TemplateKey>());
+                                                new HashSet<TemplateKey>());
                             if (ec != null) newAdd.Children.Add(ec);
                         }
                         newBlock.Adds.Add(newAdd);
@@ -91,15 +91,15 @@ namespace PromptUGUI.Template
         /// </summary>
         public static UIDocument Expand(UIDocument doc)
         {
-            var loaded = new PromptUGUI.Application.DocumentLoader.LoadedDoc
+            var loaded = new LoadedDoc
             {
                 EntrySrc = "<inline>",
             };
             foreach (var s in doc.Screens) loaded.Screens.Add(s);
             foreach (var kv in doc.Templates)
-                loaded.Templates[new PromptUGUI.Application.DocumentLoader.TemplateKey(null, kv.Key)] = kv.Value;
+                loaded.Templates[new TemplateKey(null, kv.Key)] = kv.Value;
             foreach (var kv in doc.Styles)
-                loaded.Styles[new PromptUGUI.Application.DocumentLoader.StyleKey(null, kv.Key)] = kv.Value;
+                loaded.Styles[new StyleKey(null, kv.Key)] = kv.Value;
             return Expand(loaded);
         }
 
@@ -128,12 +128,12 @@ namespace PromptUGUI.Template
 
         private static ElementNode ExpandTree(
             ElementNode src,
-            IReadOnlyDictionary<PromptUGUI.Application.DocumentLoader.TemplateKey, TemplateDef> templates,
-            IReadOnlyDictionary<PromptUGUI.Application.DocumentLoader.StyleKey, StyleDef> styles,
-            HashSet<PromptUGUI.Application.DocumentLoader.TemplateKey> visiting)
+            IReadOnlyDictionary<TemplateKey, TemplateDef> templates,
+            IReadOnlyDictionary<StyleKey, StyleDef> styles,
+            HashSet<TemplateKey> visiting)
         {
 
-            var key = new PromptUGUI.Application.DocumentLoader.TemplateKey(src.Namespace, src.Tag);
+            var key = new TemplateKey(src.Namespace, src.Tag);
             if (templates.TryGetValue(key, out var tpl))
                 return ExpandInvocation(StyleMerger.Apply(src, styles, tpl), tpl, key,
                                         templates, styles, visiting);
@@ -167,10 +167,10 @@ namespace PromptUGUI.Template
         private static ElementNode ExpandInvocation(
             ElementNode invocation,
             TemplateDef tpl,
-            PromptUGUI.Application.DocumentLoader.TemplateKey key,
-            IReadOnlyDictionary<PromptUGUI.Application.DocumentLoader.TemplateKey, TemplateDef> templates,
-            IReadOnlyDictionary<PromptUGUI.Application.DocumentLoader.StyleKey, StyleDef> styles,
-            HashSet<PromptUGUI.Application.DocumentLoader.TemplateKey> visiting)
+            TemplateKey key,
+            IReadOnlyDictionary<TemplateKey, TemplateDef> templates,
+            IReadOnlyDictionary<StyleKey, StyleDef> styles,
+            HashSet<TemplateKey> visiting)
         {
 
             // Cycle tracking uses (Namespace, Name) key to allow same-named templates across different namespaces
@@ -252,9 +252,9 @@ namespace PromptUGUI.Template
             ElementNode src,
             IReadOnlyDictionary<string, string> args,
             IReadOnlyList<ElementNode> slotContent,
-            IReadOnlyDictionary<PromptUGUI.Application.DocumentLoader.TemplateKey, TemplateDef> templates,
-            IReadOnlyDictionary<PromptUGUI.Application.DocumentLoader.StyleKey, StyleDef> styles,
-            HashSet<PromptUGUI.Application.DocumentLoader.TemplateKey> visiting)
+            IReadOnlyDictionary<TemplateKey, TemplateDef> templates,
+            IReadOnlyDictionary<StyleKey, StyleDef> styles,
+            HashSet<TemplateKey> visiting)
         {
 
             if (src.Attributes.TryGetValue("if", out var rawIf))
@@ -265,7 +265,7 @@ namespace PromptUGUI.Template
 
             ElementNode prepared = SubstituteAttrs(src, args);
 
-            var key2 = new PromptUGUI.Application.DocumentLoader.TemplateKey(prepared.Namespace, prepared.Tag);
+            var key2 = new TemplateKey(prepared.Namespace, prepared.Tag);
             if (templates.ContainsKey(key2))
                 return ExpandTree(prepared, templates, styles, visiting);
 

--- a/Runtime/Core/Template/ThemeStyleApplier.cs
+++ b/Runtime/Core/Template/ThemeStyleApplier.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using PromptUGUI.IR;
+
+namespace PromptUGUI.Template
+{
+    /// <summary>
+    /// Re-derives every <c>class=</c> node in an already-expanded Screen against a different style
+    /// table — what a theme switch runs (2026-08-26 spec §5).
+    ///
+    /// <para><b>Why this and not a second expansion.</b> Re-expanding would rebuild the IR and force
+    /// <c>ScreenInstantiator</c> to rebuild GameObjects, destroying references and R3 subscriptions.
+    /// Attributes, however, are already re-applied wholesale on every <c>Screen.ReSolve</c> — the
+    /// same path a resize or a Variant flip takes — so re-deriving the attribute VALUES in place and
+    /// letting ReSolve replay them costs one extra pass over the classed nodes and nothing else.</para>
+    ///
+    /// <para>Idempotent: running it twice with the same table is a no-op, which is what lets it sit
+    /// unconditionally at the head of both <c>Open</c> and <c>ReSolve</c> rather than needing a
+    /// theme-changed hook of its own.</para>
+    /// </summary>
+    internal static class ThemeStyleApplier
+    {
+        public static void Apply(ScreenDef def, IReadOnlyDictionary<StyleKey, StyleDef> styles)
+        {
+            if (def == null) return;
+
+            ApplySubtree(def.Root, styles);
+            ApplySubtree(def.FocusCursor, styles);
+
+            // Add-block subtrees are instantiated lazily but live in the same declaration space, and
+            // Screen.ReSolve walks them too — an inactive block must come back with the current skin.
+            foreach (var block in def.Variants)
+                foreach (var add in block.Adds)
+                    foreach (var child in add.Children)
+                        ApplySubtree(child, styles);
+        }
+
+        private static void ApplySubtree(ElementNode node, IReadOnlyDictionary<StyleKey, StyleDef> styles)
+        {
+            if (node == null) return;
+            StyleMerger.ReMerge(node, styles);
+            foreach (var child in node.Children)
+                ApplySubtree(child, styles);
+        }
+    }
+}

--- a/Runtime/Core/Template/ThemeStyleApplier.cs.meta
+++ b/Runtime/Core/Template/ThemeStyleApplier.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cd3fc0a6afc194e2e9164c2acbcedfec

--- a/Runtime/Core/Template/ThemeStyleResolver.cs
+++ b/Runtime/Core/Template/ThemeStyleResolver.cs
@@ -1,0 +1,115 @@
+using System.Collections.Generic;
+using PromptUGUI.IR;
+
+namespace PromptUGUI.Template
+{
+    /// <summary>
+    /// Folds theme-scoped <c>&lt;Style&gt;</c> packs over the global ones to produce the style table
+    /// that <see cref="StyleMerger"/> should see for a given active theme (2026-08-26 spec §4.2).
+    ///
+    /// <para><b>The global style is the implicit root of every theme chain.</b> Folding order is
+    /// global → the chain's most distant <c>base=</c> → … → the active theme. Three things follow,
+    /// and they are the reason for this shape:</para>
+    /// <list type="number">
+    /// <item>A project that declares no theme styles gets <paramref name="globalStyles"/> back
+    /// unchanged — byte-for-byte today's behaviour, no cost.</item>
+    /// <item>The residue problem (spec §6.1) mostly dissolves: the global pack supplies the baseline
+    /// attribute-name set, so a theme that omits <c>radius</c> falls back to the global value rather
+    /// than leaving the control stuck at the previous theme's.</item>
+    /// <item>Authors get a simple model — the global <c>&lt;Style&gt;</c> says what a component IS,
+    /// a theme's says which few parameters differ under that skin.</item>
+    /// </list>
+    ///
+    /// <para>Folding is <b>atomic per attribute name</b>, the same rule the multi-class fold in
+    /// <see cref="StyleMerger"/> uses: an override declaring <c>radius.mobile</c> masks a lower
+    /// layer's <c>radius</c> too, because a name is claimed as a whole or not at all.</para>
+    /// </summary>
+    internal static class ThemeStyleResolver
+    {
+        /// <summary>
+        /// Returns <paramref name="globalStyles"/> itself (no allocation) when there is nothing to
+        /// fold: no active theme, no themes at all, or a chain that declares no styles.
+        /// </summary>
+        public static IReadOnlyDictionary<StyleKey, StyleDef> Resolve(
+            IReadOnlyDictionary<StyleKey, StyleDef> globalStyles,
+            IReadOnlyDictionary<string, ThemeBlock> themes,
+            string activeTheme)
+        {
+            if (string.IsNullOrEmpty(activeTheme) || themes == null || themes.Count == 0)
+                return globalStyles;
+
+            var chain = ChainRootFirst(themes, activeTheme);
+            if (chain == null) return globalStyles;
+
+            Dictionary<StyleKey, StyleDef> folded = null;
+            foreach (var theme in chain)
+            {
+                foreach (var kv in theme.Styles)
+                {
+                    folded ??= globalStyles == null
+                        ? new Dictionary<StyleKey, StyleDef>()
+                        : new Dictionary<StyleKey, StyleDef>(globalStyles);
+
+                    // Theme styles address the un-namespaced pool. A commons library imported with
+                    // as="ui" keys its styles StyleKey("ui", name) and class="ui:card" reaches them
+                    // directly; a theme has no namespace of its own to match that with, so themed
+                    // overrides of a namespaced style are simply not a thing yet. See spec §4.3.
+                    var key = new StyleKey(null, kv.Key);
+                    folded[key] = folded.TryGetValue(key, out var lower)
+                        ? FoldOver(lower, kv.Value)
+                        : kv.Value;
+                }
+            }
+            return folded ?? globalStyles;
+        }
+
+        /// <summary>
+        /// The <c>base=</c> chain from the most distant ancestor down to <paramref name="leaf"/>, so
+        /// callers can fold in precedence order. Null when the leaf is unknown. Cycle- and
+        /// missing-base-tolerant on purpose: <c>ThemeStore.ResolveBases</c> already reports both with
+        /// a good message at registration time, and the lint CLI must not crash on markup it is
+        /// being asked to diagnose.
+        /// </summary>
+        private static List<ThemeBlock> ChainRootFirst(
+            IReadOnlyDictionary<string, ThemeBlock> themes, string leaf)
+        {
+            if (!themes.TryGetValue(leaf, out var block)) return null;
+
+            var chain = new List<ThemeBlock>();
+            var seen = new HashSet<string>();
+            for (var cur = block; cur != null && seen.Add(cur.Name);)
+            {
+                chain.Add(cur);
+                cur = string.IsNullOrEmpty(cur.BaseName) || !themes.TryGetValue(cur.BaseName, out var b)
+                    ? null
+                    : b;
+            }
+            chain.Reverse();
+            return chain;
+        }
+
+        private static StyleDef FoldOver(StyleDef lower, StyleDef upper)
+        {
+            var merged = new StyleDef(lower.Name) { OriginSrc = upper.OriginSrc ?? lower.OriginSrc };
+
+            foreach (var kv in lower.Attributes)
+                merged.Attributes[kv.Key] = kv.Value;
+            foreach (var kv in lower.VariantOverrides)
+                merged.VariantOverrides[kv.Key] = new List<(string, string)>(kv.Value);
+
+            // Atomic per name: declaring radius.mobile claims the whole `radius` slot.
+            foreach (var name in upper.DeclaredNames)
+            {
+                merged.Attributes.Remove(name);
+                merged.VariantOverrides.Remove(name);
+            }
+
+            foreach (var kv in upper.Attributes)
+                merged.Attributes[kv.Key] = kv.Value;
+            foreach (var kv in upper.VariantOverrides)
+                merged.VariantOverrides[kv.Key] = new List<(string, string)>(kv.Value);
+
+            return merged;
+        }
+    }
+}

--- a/Runtime/Core/Template/ThemeStyleResolver.cs.meta
+++ b/Runtime/Core/Template/ThemeStyleResolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ba4a322b486134356935bdf35421ee95

--- a/Tests/EditMode/Application/ThemeHotReloadTests.cs
+++ b/Tests/EditMode/Application/ThemeHotReloadTests.cs
@@ -38,9 +38,10 @@ namespace PromptUGUI.Tests.Application
             UI.Theme.Changed += n => fired = n;
 
             ThemeStore.Instance.ReplaceFromSrc("themes/main",
-                new List<(string, string, IReadOnlyDictionary<string, ColorSpec>)>
+                new List<(string, string, IReadOnlyDictionary<string, ColorSpec>,
+                          IReadOnlyDictionary<string, PromptUGUI.IR.StyleDef>)>
                 {
-                    ("light", null, v2)
+                    ("light", null, v2, null)
                 });
             UI.Theme.RaiseChangedIfCurrent("light");
 

--- a/Tests/EditMode/Application/ThemeStyleSwitchTests.cs
+++ b/Tests/EditMode/Application/ThemeStyleSwitchTests.cs
@@ -1,0 +1,178 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using UnityEngine;
+using PromptScreen = PromptUGUI.Application.Screen;
+using UnityImage = UnityEngine.UI.Image;
+
+namespace PromptUGUI.Tests.EditMode.Application
+{
+    /// <summary>
+    /// End-to-end theme-driven styling (2026-08-26 spec §5): switching <c>UI.Theme.Current</c> must
+    /// re-derive every <c>class=</c> node's attributes and let the existing ReSolve replay them —
+    /// without rebuilding a single GameObject.
+    ///
+    /// <para>Themes register through the async load path (<c>RegisterThemesAndAutoSet</c>); the sync
+    /// <c>LoadDocument(label, xml)</c> overload deliberately bypasses it, so these use the fake-files
+    /// resolver pattern.</para>
+    /// </summary>
+    public class ThemeStyleSwitchTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static void UseFiles(Dictionary<string, string> files) =>
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+
+        private static PromptScreen Load(string body, string screenName = "S")
+        {
+            UseFiles(new Dictionary<string, string>
+            {
+                ["main"] = "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>" + body + "</PromptUGUI>",
+            });
+            UI.LoadDocumentAsync("main").GetAwaiter().GetResult();
+            return UI.Open(screenName);
+        }
+
+        private static string ColorOf(PromptScreen screen, string id)
+        {
+            var go = ((Control)(object)screen.Get<Control>(id)).GameObject;
+            return ColorUtility.ToHtmlStringRGB(go.GetComponent<UnityImage>().color);
+        }
+
+        private const string TwoThemes = @"
+            <Style name='card' color='#112233' type='sliced'/>
+            <Theme name='modern'><Color name='ink' value='#000'/></Theme>
+            <Theme name='pixel'>
+              <Color name='ink' value='#111'/>
+              <Style name='card' color='#445566'/>
+            </Theme>
+            <Screen name='S'><Image id='c' class='card'/></Screen>";
+
+        [Test]
+        public void SwitchingTheme_ReDerivesTheClassPack()
+        {
+            var screen = Load(TwoThemes);
+            UI.Theme.Set("modern");
+            Assume.That(ColorOf(screen, "c"), Is.EqualTo("112233"),
+                "guard: 'modern' declares no card pack, so the global one stands");
+
+            UI.Theme.Set("pixel");
+
+            Assert.AreEqual("445566", ColorOf(screen, "c"));
+        }
+
+        // §4.2: the global <Style> is the implicit root of every theme chain, so an attribute the
+        // theme does not mention keeps the global value instead of going unresolved.
+        [Test]
+        public void AttributeTheThemeOmits_FallsBackToTheGlobalPack()
+        {
+            var screen = Load(TwoThemes);
+            UI.Theme.Set("pixel");
+
+            var img = ((Control)(object)screen.Get<Control>("c")).GameObject.GetComponent<UnityImage>();
+            Assert.AreEqual(UnityImage.Type.Sliced, img.type,
+                "'type' comes from the global pack; the pixel theme only overrode 'color'");
+        }
+
+        // §6.1's positive case: with the global pack supplying a baseline, a round trip returns to
+        // where it started rather than leaving the previous theme's value stuck.
+        [Test]
+        public void ThemeRoundTrip_ReturnsToTheGlobalValue()
+        {
+            var screen = Load(TwoThemes);
+            UI.Theme.Set("modern");
+            var before = ColorOf(screen, "c");
+
+            UI.Theme.Set("pixel");
+            Assume.That(ColorOf(screen, "c"), Is.Not.EqualTo(before), "guard: the switch did something");
+
+            UI.Theme.Set("modern");
+
+            Assert.AreEqual(before, ColorOf(screen, "c"));
+        }
+
+        [Test]
+        public void SwitchingTheme_DoesNotRebuildGameObjects()
+        {
+            var screen = Load(TwoThemes);
+            UI.Theme.Set("modern");
+            var go = ((Control)(object)screen.Get<Control>("c")).GameObject;
+
+            UI.Theme.Set("pixel");
+
+            Assert.AreSame(go, ((Control)(object)screen.Get<Control>("c")).GameObject,
+                "references and R3 subscriptions must survive a re-skin — this is attribute replay, "
+                + "not a rebuild");
+        }
+
+        [Test]
+        public void InlineAttribute_StillBeatsTheThemePack()
+        {
+            var screen = Load(@"
+                <Style name='card' color='#112233'/>
+                <Theme name='pixel'><Style name='card' color='#445566'/></Theme>
+                <Screen name='S'><Image id='c' class='card' color='#aabbcc'/></Screen>");
+
+            UI.Theme.Set("pixel");
+
+            Assert.AreEqual("AABBCC", ColorOf(screen, "c"),
+                "what the author spelled out on the node outranks any pack, themed or not");
+        }
+
+        [Test]
+        public void ThemeStyle_AppliesOnFirstOpen_NotOnlyOnSwitch()
+        {
+            UseFiles(new Dictionary<string, string>
+            {
+                ["main"] = @"<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>
+                    <Style name='card' color='#112233'/>
+                    <Theme name='pixel'><Style name='card' color='#445566'/></Theme>
+                    <Screen name='S'><Image id='c' class='card'/></Screen></PromptUGUI>",
+            });
+            UI.Theme.Set("pixel");                 // active BEFORE the document is loaded
+            UI.LoadDocumentAsync("main").GetAwaiter().GetResult();
+
+            Assert.AreEqual("445566", ColorOf(UI.Open("S"), "c"),
+                "Open re-derives too; a Screen must not have to be switched away and back to get "
+                + "the active skin");
+        }
+
+        // A theme's pack must compose with Variant resolution, not replace it.
+        [Test]
+        public void ThemePack_VariantEntries_ResolveThroughTheNormalMachinery()
+        {
+            var screen = Load(@"
+                <Style name='card' color='#112233'/>
+                <Theme name='pixel'><Style name='card' color='#445566' color.mobile='#778899'/></Theme>
+                <Screen name='S'><Image id='c' class='card'/></Screen>");
+
+            UI.Theme.Set("pixel");
+            Assert.AreEqual("445566", ColorOf(screen, "c"), "base value of the themed pack");
+
+            UI.Variants.Set("mobile", true);
+            Assert.AreEqual("778899", ColorOf(screen, "c"), "the pack's .variant entry wins when active");
+
+            UI.Variants.Set("mobile", false);
+            Assert.AreEqual("445566", ColorOf(screen, "c"), "and reverts to the pack's base");
+        }
+
+        // Every project written before this feature: styles but no theme styles. Nothing may change.
+        [Test]
+        public void ColourOnlyThemes_LeaveClassBehaviourUntouched()
+        {
+            var screen = Load(@"
+                <Style name='card' color='#112233'/>
+                <Theme name='light'><Color name='ink' value='#000'/></Theme>
+                <Theme name='dark'><Color name='ink' value='#fff'/></Theme>
+                <Screen name='S'><Image id='c' class='card'/></Screen>");
+
+            UI.Theme.Set("light");
+            Assert.AreEqual("112233", ColorOf(screen, "c"));
+            UI.Theme.Set("dark");
+            Assert.AreEqual("112233", ColorOf(screen, "c"));
+        }
+    }
+}

--- a/Tests/EditMode/Application/ThemeStyleSwitchTests.cs.meta
+++ b/Tests/EditMode/Application/ThemeStyleSwitchTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e4f8473f57e786f4ab3d06d0aa861379

--- a/Tests/EditMode/Controls/AttributeReversibilityTests.cs
+++ b/Tests/EditMode/Controls/AttributeReversibilityTests.cs
@@ -21,9 +21,10 @@ namespace PromptUGUI.Tests.EditMode.Controls
     /// (spec §5) every theme switch walks the same path, which is why these are pinned before that
     /// feature lands.</para>
     ///
-    /// <para><b>The <c>[Ignore]</c>d tests assert the DESIRED behaviour and currently FAIL.</b> The
-    /// fixes are a separate PR (spec §14 M0) — un-ignore each one as its fix lands. They are ignored
-    /// rather than left red so a full-suite run stays a meaningful regression signal.</para>
+    /// <para>These were written first as ignored red tests (spec §14 M0) and un-ignored with the
+    /// fixes. Each defect they pin was one-way state: a setter that could switch a visual ON but had
+    /// no path back, so the control kept the previous value forever. The fixes all take the same
+    /// shape — COMPUTE the state from what is currently authored instead of setting it one way.</para>
     ///
     /// <para>Deliberately NOT here: the <c>mask</c> family. <c>PUI-MASK-VARIANT</c> /
     /// <c>PUI-PROG-MASK-VARIANT</c> already declare per-variant mask switching unsupported in v1 for
@@ -72,7 +73,6 @@ namespace PromptUGUI.Tests.EditMode.Controls
         // ------------------------------------------------------------------
 
         [Test]
-        [Ignore("Red: spec 2026-08-26 §8 — Tab.selectedSprite does not restore Selectable.transition. Un-ignore with the fix.")]
         public void TabSelectedSprite_FlippedToNone_RestoresTransition_LikeFreshBuild()
         {
             StubSprites();
@@ -93,6 +93,46 @@ namespace PromptUGUI.Tests.EditMode.Controls
                 + "left with no hover/press feedback at all, and no attribute the author can write brings it back");
         }
 
+        // Btn has the same shape as Tab: a pressed/disabled sprite takes it off ColorTint so the
+        // swapped image is not double-darkened. It was set one-way too — fixed alongside, since
+        // leaving the sibling control broken would have been arbitrary.
+        [Test]
+        public void BtnPressedSprite_FlippedToNone_RestoresTransition_LikeFreshBuild()
+        {
+            StubSprites();
+
+            var reference = OpenScreen("ref", "R", "<Btn id='b' pressedSprite='none'/>").Get<Btn>("b");
+            var expected = reference.GameObject.GetComponent<Selectable>().transition;
+            Assume.That(expected, Is.EqualTo(Selectable.Transition.ColorTint));
+
+            var btn = OpenScreen("t", "S",
+                    $"<Btn id='b' pressedSprite='ui:down' pressedSprite.{VariantName}='none'/>")
+                .Get<Btn>("b");
+            var selectable = btn.GameObject.GetComponent<Selectable>();
+            Assume.That(selectable.transition, Is.EqualTo(Selectable.Transition.None));
+
+            UI.Variants.Set(VariantName, true);
+
+            Assert.AreEqual(expected, selectable.transition,
+                "clearing pressedSprite must hand feedback back to uGUI's ColorTint");
+        }
+
+        // A state colour keeps the reactors in charge, so clearing the sprite must NOT hand the
+        // visual back to ColorTint — that would double-tint on top of the reactor.
+        [Test]
+        public void ClearingSelectedSprite_KeepsTransitionNone_WhenAStateColourIsStillInPlay()
+        {
+            StubSprites();
+
+            var tab = OpenTab("t", "S",
+                $"selectedColor='#076DD7' selectedSprite='ui:sel' selectedSprite.{VariantName}='none'");
+
+            UI.Variants.Set(VariantName, true);
+
+            Assert.AreEqual(Selectable.Transition.None, TransitionOf(tab),
+                "selectedColor installs a StateTintReactor, which owns the bg visual");
+        }
+
         // ------------------------------------------------------------------
         // Progress.bg / Progress.frame — Progress.cs:94 / :118 do SetActive(true)
         // and early-return on an empty value, so the layer can be switched on but
@@ -101,7 +141,6 @@ namespace PromptUGUI.Tests.EditMode.Controls
         // ------------------------------------------------------------------
 
         [Test]
-        [Ignore("Red: spec 2026-08-26 §8 — Progress.bg cannot be turned off once set. Un-ignore with the fix.")]
         public void ProgressBg_FlippedToEmpty_HidesLayer_LikeFreshBuild()
         {
             StubSprites();
@@ -120,7 +159,6 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
-        [Ignore("Red: spec 2026-08-26 §8 — Progress.frame cannot be turned off once set. Un-ignore with the fix.")]
         public void ProgressFrame_FlippedToEmpty_HidesLayer_LikeFreshBuild()
         {
             StubSprites();

--- a/Tests/EditMode/Controls/AttributeReversibilityTests.cs
+++ b/Tests/EditMode/Controls/AttributeReversibilityTests.cs
@@ -1,0 +1,168 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using UnityEngine;
+using UnityEngine.UI;
+using PromptScreen = PromptUGUI.Application.Screen;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    /// <summary>
+    /// M0 of <c>docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md</c> §8.
+    ///
+    /// <para><b>The property under test</b>: flipping an attribute A→B must leave the control in the
+    /// same state as building it with B in the first place. <c>ControlAttributeApplier</c> re-applies
+    /// every declared attribute on each <c>ReSolve</c>, but a setter that only ever ADDS state leaves
+    /// the previous value's side effects behind when the value changes — so "re-applied" is not the
+    /// same as "reverted". Each test therefore compares a **flipped** control against a **freshly
+    /// built** reference rather than against a hardcoded expectation.</para>
+    ///
+    /// <para>Today this is reachable with a plain <c>.variant</c> flip. Under theme-driven styles
+    /// (spec §5) every theme switch walks the same path, which is why these are pinned before that
+    /// feature lands.</para>
+    ///
+    /// <para><b>The <c>[Ignore]</c>d tests assert the DESIRED behaviour and currently FAIL.</b> The
+    /// fixes are a separate PR (spec §14 M0) — un-ignore each one as its fix lands. They are ignored
+    /// rather than left red so a full-suite run stays a meaningful regression signal.</para>
+    ///
+    /// <para>Deliberately NOT here: the <c>mask</c> family. <c>PUI-MASK-VARIANT</c> /
+    /// <c>PUI-PROG-MASK-VARIANT</c> already declare per-variant mask switching unsupported in v1 for
+    /// exactly this reason, so its irreversibility is a documented non-feature, not a defect — see
+    /// the characterization test at the bottom.</para>
+    /// </summary>
+    public class AttributeReversibilityTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private const string VariantName = "alt";
+
+        private static void StubSprites()
+        {
+            var stub = Sprite.Create(Texture2D.whiteTexture, new Rect(0, 0, 1, 1), Vector2.zero);
+            UI.SpriteResolver = _ => stub;
+        }
+
+        private static PromptScreen OpenScreen(string label, string screenName, string body)
+        {
+            UI.LoadDocument(label,
+                "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>" +
+                $"<Screen name='{screenName}'>{body}</Screen></PromptUGUI>");
+            return UI.Open(screenName);
+        }
+
+        private static Tab OpenTab(string label, string screenName, string tabAttrs)
+            => OpenScreen(label, screenName,
+                    $"<TabBar id='bar'><Tab id='t' {tabAttrs}/></TabBar>")
+               .Get<Tab>("bar/t");
+
+        private static Selectable.Transition TransitionOf(Tab tab)
+            => tab.GameObject.GetComponent<Selectable>().transition;
+
+        private static Progress OpenProgress(string label, string screenName, string progressAttrs)
+            => OpenScreen(label, screenName, $"<Progress id='p' {progressAttrs}/>").Get<Progress>("p");
+
+        private static bool ChildActive(Progress p, string path)
+            => p.GameObject.transform.Find(path).gameObject.activeSelf;
+
+        // ------------------------------------------------------------------
+        // Tab.selectedSprite — Tab.cs:277 sets transition=None when a sprite is
+        // supplied (the swapped sprite IS the selection feedback, so uGUI's ColorTint
+        // must not double-tint it). Clearing the sprite restores neither.
+        // ------------------------------------------------------------------
+
+        [Test]
+        [Ignore("Red: spec 2026-08-26 §8 — Tab.selectedSprite does not restore Selectable.transition. Un-ignore with the fix.")]
+        public void TabSelectedSprite_FlippedToNone_RestoresTransition_LikeFreshBuild()
+        {
+            StubSprites();
+
+            var reference = OpenTab("ref", "R", "selectedSprite='none'");
+            var expected = TransitionOf(reference);
+            Assume.That(expected, Is.EqualTo(Selectable.Transition.ColorTint),
+                "guard: a Tab built without a selected sprite keeps uGUI's ColorTint");
+
+            var tab = OpenTab("t", "S", $"selectedSprite='ui:sel' selectedSprite.{VariantName}='none'");
+            Assume.That(TransitionOf(tab), Is.EqualTo(Selectable.Transition.None),
+                "guard: the authored selected sprite takes the Tab off ColorTint");
+
+            UI.Variants.Set(VariantName, true);
+
+            Assert.AreEqual(expected, TransitionOf(tab),
+                "clearing selectedSprite must put the Tab back on ColorTint — otherwise the tab is "
+                + "left with no hover/press feedback at all, and no attribute the author can write brings it back");
+        }
+
+        // ------------------------------------------------------------------
+        // Progress.bg / Progress.frame — Progress.cs:94 / :118 do SetActive(true)
+        // and early-return on an empty value, so the layer can be switched on but
+        // never off. Note PUI-PROG-MASK-VARIANT's message currently advertises
+        // `bg` as variant-safe (ProgressAttributeRules.cs:72) — see the lint test below.
+        // ------------------------------------------------------------------
+
+        [Test]
+        [Ignore("Red: spec 2026-08-26 §8 — Progress.bg cannot be turned off once set. Un-ignore with the fix.")]
+        public void ProgressBg_FlippedToEmpty_HidesLayer_LikeFreshBuild()
+        {
+            StubSprites();
+
+            var reference = OpenProgress("ref", "R", "bg=''");
+            var expected = ChildActive(reference, "MaskWrapper/Bg");
+            Assume.That(expected, Is.False, "guard: a Progress built with no bg keeps its Bg layer disabled");
+
+            var p = OpenProgress("t", "S", $"bg='ui:track' bg.{VariantName}=''");
+            Assume.That(ChildActive(p, "MaskWrapper/Bg"), Is.True, "guard: the authored bg enables the layer");
+
+            UI.Variants.Set(VariantName, true);
+
+            Assert.AreEqual(expected, ChildActive(p, "MaskWrapper/Bg"),
+                "clearing bg must hide the Bg layer — it currently stays visible with a stale sprite");
+        }
+
+        [Test]
+        [Ignore("Red: spec 2026-08-26 §8 — Progress.frame cannot be turned off once set. Un-ignore with the fix.")]
+        public void ProgressFrame_FlippedToEmpty_HidesLayer_LikeFreshBuild()
+        {
+            StubSprites();
+
+            var reference = OpenProgress("ref", "R", "frame=''");
+            var expected = ChildActive(reference, "Frame");
+            Assume.That(expected, Is.False, "guard: a Progress built with no frame keeps its Frame layer disabled");
+
+            var p = OpenProgress("t", "S", $"frame='ui:fr' frame.{VariantName}=''");
+            Assume.That(ChildActive(p, "Frame"), Is.True, "guard: the authored frame enables the layer");
+
+            UI.Variants.Set(VariantName, true);
+
+            Assert.AreEqual(expected, ChildActive(p, "Frame"),
+                "clearing frame must hide the Frame layer — it currently stays visible with a stale sprite");
+        }
+
+        // ------------------------------------------------------------------
+        // Characterization (GREEN, on purpose): the mask family is irreversible by
+        // DESIGN, not by accident — PUI-MASK-VARIANT (MaskAttributeRules.cs) rejects
+        // per-variant mask switching outright because it "requires AddComponent /
+        // Destroy which has performance / lifetime issues".
+        //
+        // This test exists so that whoever eventually makes mask reversible sees it
+        // fail and knows the lint rule must be retired in the same change, rather than
+        // silently leaving authors barred from a feature that now works.
+        // ------------------------------------------------------------------
+
+        [Test]
+        public void FrameMask_FlippedToNone_KeepsRectMask2D_DocumentedNonFeature()
+        {
+            var screen = OpenScreen("t", "S",
+                $"<Frame id='f' mask='rect' mask.{VariantName}='none'/>");
+            var frame = screen.Get<Frame>("f");
+            Assume.That(frame.GameObject.GetComponent<RectMask2D>(), Is.Not.Null,
+                "guard: mask='rect' installs the clipper");
+
+            UI.Variants.Set(VariantName, true);
+
+            Assert.IsNotNull(frame.GameObject.GetComponent<RectMask2D>(),
+                "mask is add-only at runtime; this is why PUI-MASK-VARIANT rejects the markup that "
+                + "reaches here. If this assertion starts failing, retire that lint rule in the same change.");
+        }
+    }
+}

--- a/Tests/EditMode/Controls/AttributeReversibilityTests.cs.meta
+++ b/Tests/EditMode/Controls/AttributeReversibilityTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e22012b95b12d587d9c38ace80c9adc6

--- a/Tests/EditMode/Lint/DocumentLinterTests.cs
+++ b/Tests/EditMode/Lint/DocumentLinterTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.IR;
+using PromptUGUI.Lint;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.EditMode.Lint
+{
+    /// <summary>
+    /// <see cref="DocumentLinter"/> is the two-pass (raw + expanded) walk the UIXmlLint CLI runs.
+    /// See the 2026-08-26 theme-driven-style spec §9: the runtime warning path has always seen the
+    /// EXPANDED tree while the CLI only ever saw the raw IR, which is why rules that reason about a
+    /// node's resolved configuration had to stay quiet whenever <c>class=</c> or a template was
+    /// involved.
+    /// </summary>
+    public class DocumentLinterTests
+    {
+        private static UIDocument Parse(string body) =>
+            UIDocumentParser.Parse(
+                "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>" + body + "</PromptUGUI>");
+
+        private static List<LintIssue> Walk(string body) =>
+            DocumentLinter.Walk(Parse(body)).ToList();
+
+        // A rule that reads the node's written attributes is unaffected by the second pass — and
+        // must not start reporting twice now that the tree is walked twice.
+        [Test]
+        public void RawIssue_IsReportedExactlyOnce_ThoughBothPassesSeeIt()
+        {
+            var issues = Walk("<Screen name='S'><Frame id='f' mask='self'/></Screen>");
+
+            Assert.AreEqual(1, issues.Count(i => i.Code == MaskAttributeRules.FrameSelfCode),
+                "mask='self' survives expansion verbatim, so both passes find it — dedup must collapse them");
+        }
+
+        // The motivating case. PureContainerVisualAttrRules reads n.Attributes; before expansion the
+        // sprite lives in a <Style> the node merely references, so the raw pass is blind to it.
+        [Test]
+        public void ClassSuppliedAttribute_IsOnlyVisibleAfterExpansion()
+        {
+            const string body = @"
+                <Style name='boxed' sprite='ui:panel'/>
+                <Screen name='S'><VStack id='v' class='boxed' anchor='stretch'/></Screen>";
+
+            var rawOnly = IRWalker.Walk(Parse(body)).ToList();
+            Assert.IsFalse(rawOnly.Any(i => i.Code == PureContainerVisualAttrRules.VisualAttrCode),
+                "guard: the raw walk cannot see an attribute that arrives through class=");
+
+            var both = Walk(body);
+            Assert.IsTrue(both.Any(i => i.Code == PureContainerVisualAttrRules.VisualAttrCode && i.Id == "v"),
+                "the expanded pass merges the style pack onto the node, making 'sprite' on a pure "
+                + "container visible");
+        }
+
+        [Test]
+        public void UnknownStyleName_IsReportedAsAnExpansionFailure()
+        {
+            var issues = Walk("<Screen name='S'><Frame id='f' class='does-not-exist'/></Screen>");
+
+            var expansion = issues.SingleOrDefault(i => i.Code == DocumentLinter.ExpansionCode);
+            Assert.IsNotNull(expansion.Message, "an unresolvable class name must not wait until UI.Open()");
+            StringAssert.Contains("does-not-exist", expansion.Message);
+        }
+
+        [Test]
+        public void ImportedStyle_IsResolvedThroughTheLookup()
+        {
+            var lib = Parse("<Style name='boxed' sprite='ui:panel'/>");
+            var entry = Parse(@"
+                <Import src='skin.ui'/>
+                <Screen name='S'><VStack id='v' class='boxed' anchor='stretch'/></Screen>");
+
+            var issues = DocumentLinter
+                .Walk(entry, "main.ui", src => src == "skin.ui" ? lib : null)
+                .ToList();
+
+            Assert.IsTrue(issues.Any(i => i.Code == PureContainerVisualAttrRules.VisualAttrCode && i.Id == "v"),
+                "following <Import> is what retires StyleAttributeView.IsUncertain's silence");
+        }
+
+        // A project whose commons come from Addressables has no filesystem closure to hand over.
+        // That must cost coverage, never turn a clean document into a failure.
+        [Test]
+        public void UnresolvableImports_SkipExpandedPass_ButKeepRawRules()
+        {
+            var entry = Parse(@"
+                <Import src='skin.ui'/>
+                <Screen name='S'>
+                  <Frame id='f' mask='self'/>
+                  <VStack id='v' class='boxed' anchor='stretch'/>
+                </Screen>");
+
+            var issues = DocumentLinter.Walk(entry, "main.ui", imports: null).ToList();
+
+            Assert.IsTrue(issues.Any(i => i.Code == MaskAttributeRules.FrameSelfCode),
+                "raw rules still apply when the closure is unavailable");
+            Assert.IsFalse(issues.Any(i => i.Code == DocumentLinter.ExpansionCode),
+                "class='boxed' names a style only the unseen library declares — reporting it as an "
+                + "expansion failure would fail every Addressables-backed project");
+        }
+
+        // Guards the accumulation bug this class was written for: an expanded-only finding used to
+        // be printed but not counted, so the CLI exited 0 on a failing document.
+        [Test]
+        public void ExpandedOnlyFindings_AreEnumerated_NotJustPrinted()
+        {
+            var issues = Walk(@"
+                <Style name='boxed' sprite='ui:panel'/>
+                <Screen name='S'><VStack id='v' class='boxed' anchor='stretch'/></Screen>");
+
+            Assert.AreEqual(1, issues.Count,
+                "the caller counts what it enumerates; an expanded-only issue must be in the sequence");
+        }
+    }
+}

--- a/Tests/EditMode/Lint/DocumentLinterTests.cs.meta
+++ b/Tests/EditMode/Lint/DocumentLinterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b0e01fe80da8725a39c3b4753ebac2f2

--- a/Tests/EditMode/Lint/IRWalkerMaskTests.cs
+++ b/Tests/EditMode/Lint/IRWalkerMaskTests.cs
@@ -43,7 +43,7 @@ namespace PromptUGUI.Tests.EditMode.Lint
         public void Walk_NonFrameNonImageTags_NoMaskIssue()
         {
             // <VStack mask="rect"> 不该触发 mask rule（VStack 是纯容器，没有 mask 属性）。
-            // 注意：暴露 mask 的不止 Frame/Image —— RawImage / Progress 也有，见下面的覆盖缺口测试。
+            // 暴露 mask 的是 Frame / Image / RawImage / Progress，各有自己的 Check* 分发。
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S'>
@@ -71,7 +71,6 @@ namespace PromptUGUI.Tests.EditMode.Lint
         /// same, since PUI-PROG-MASK-VARIANT only covers <c>mask</c>).</para>
         /// </summary>
         [Test]
-        [Ignore("Red: spec 2026-08-26 §8 — RawImage mask variants reach neither PUI-MASK-VARIANT nor PUI-VARIANT-NO-BASE. Un-ignore with the fix.")]
         public void Walk_RawImageMaskInVariantOverride_VariantIssue()
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>

--- a/Tests/EditMode/Lint/IRWalkerMaskTests.cs
+++ b/Tests/EditMode/Lint/IRWalkerMaskTests.cs
@@ -42,7 +42,8 @@ namespace PromptUGUI.Tests.EditMode.Lint
         [Test]
         public void Walk_NonFrameNonImageTags_NoMaskIssue()
         {
-            // <VStack mask="rect"> 不该触发 mask rule（mask 只 Frame/Image 暴露）
+            // <VStack mask="rect"> 不该触发 mask rule（VStack 是纯容器，没有 mask 属性）。
+            // 注意：暴露 mask 的不止 Frame/Image —— RawImage / Progress 也有，见下面的覆盖缺口测试。
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
   <Screen name='S'>
@@ -53,6 +54,37 @@ namespace PromptUGUI.Tests.EditMode.Lint
             var issues = IRWalker.Walk(doc).Where(i =>
                 i.Code.StartsWith("PUI-MASK-")).ToList();
             Assert.IsEmpty(issues);
+        }
+
+        /// <summary>
+        /// M0 of docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md §8.
+        ///
+        /// <para><c>&lt;RawImage&gt;</c> exposes the whole mask family (RawImage.cs:101 / :121 / :133)
+        /// with the same add-only <c>AddComponent</c> implementation Frame and Image have — but it
+        /// falls through BOTH guards: <c>IRWalker</c> dispatches <c>MaskAttributeRules</c> only for
+        /// <c>Frame</c> and <c>Image</c>, and <c>VariantBaseRules</c> deliberately skips the mask
+        /// family because <c>PUI-MASK-VARIANT</c> is supposed to own it "in ALL cases". So a
+        /// per-variant mask switch on a RawImage is silently accepted and silently broken.</para>
+        ///
+        /// <para>Ignored red test: the fix is to dispatch the mask rules for <c>RawImage</c> too
+        /// (and to decide whether <c>Progress</c>'s <c>showMask</c> / <c>maskPadding</c> need the
+        /// same, since PUI-PROG-MASK-VARIANT only covers <c>mask</c>).</para>
+        /// </summary>
+        [Test]
+        [Ignore("Red: spec 2026-08-26 §8 — RawImage mask variants reach neither PUI-MASK-VARIANT nor PUI-VARIANT-NO-BASE. Un-ignore with the fix.")]
+        public void Walk_RawImageMaskInVariantOverride_VariantIssue()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <RawImage id='r' mask='rect' mask.alt='self'/>
+  </Screen>
+</PromptUGUI>";
+            var doc = UIDocumentParser.Parse(xml);
+            var issues = IRWalker.Walk(doc).ToList();
+            Assert.IsTrue(issues.Any(i => i.Code == MaskAttributeRules.VariantCode && i.Id == "r"),
+                "switching a RawImage's mask mode per Variant is as unsupported as it is on Frame/Image, "
+                + "but no rule currently reports it");
         }
     }
 }

--- a/Tests/EditMode/Lint/LintOriginTests.cs
+++ b/Tests/EditMode/Lint/LintOriginTests.cs
@@ -1,0 +1,131 @@
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.IR;
+using PromptUGUI.Lint;
+using PromptUGUI.Parser;
+using PromptUGUI.Template;
+
+namespace PromptUGUI.Tests.EditMode.Lint
+{
+    /// <summary>
+    /// File attribution for lint findings. Once the CLI follows <c>&lt;Import&gt;</c> and walks the
+    /// EXPANDED tree, the node a rule complains about is frequently NOT in the document that was
+    /// linted — it was written in an imported library and inlined here. Reporting all of it against
+    /// the entry file sends the author to the wrong place, so every node carries the src its markup
+    /// came from. See the 2026-08-26 theme-driven-style spec §9.5.
+    /// </summary>
+    public class LintOriginTests
+    {
+        private static UIDocument Parse(string body, string src = null) =>
+            UIDocumentParser.Parse(
+                "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>" + body + "</PromptUGUI>",
+                src);
+
+        private static ElementNode FindById(ElementNode node, string id)
+        {
+            if (node == null) return null;
+            if (node.Id == id) return node;
+            foreach (var child in node.Children)
+            {
+                var hit = FindById(child, id);
+                if (hit != null) return hit;
+            }
+            return null;
+        }
+
+        [Test]
+        public void Parse_StampsEveryNode_IncludingTemplateBodiesAndAddBlocks()
+        {
+            var doc = Parse(@"
+                <Template name='Card'><Frame id='card-root'><Text id='deep'>x</Text></Frame></Template>
+                <Screen name='S'>
+                  <Frame id='top'/>
+                  <Variant when='mobile'><Add into='#top'><Frame id='added'/></Add></Variant>
+                </Screen>", "lib.ui");
+
+            var screen = doc.Screens.Single();
+            Assert.AreEqual("lib.ui", screen.Root.OriginSrc, "screen root");
+            Assert.AreEqual("lib.ui", FindById(screen.Root, "top")?.OriginSrc, "screen descendant");
+            Assert.AreEqual("lib.ui", FindById(doc.Templates["Card"].Body, "deep")?.OriginSrc,
+                "template body descendant");
+            Assert.AreEqual("lib.ui",
+                screen.Variants.Single().Adds.Single().Children.Single().OriginSrc, "<Add> child");
+        }
+
+        [Test]
+        public void Parse_WithoutSrc_LeavesOriginNull()
+        {
+            var doc = Parse("<Screen name='S'><Frame id='f'/></Screen>");
+            Assert.IsNull(FindById(doc.Screens.Single().Root, "f").OriginSrc,
+                "callers that have no src must keep working; their own path is the attribution");
+        }
+
+        [Test]
+        public void Expansion_CarriesOrigin_FromTheDeclaringLibrary()
+        {
+            var lib = Parse("<Template name='Card'><Frame id='card'/></Template>", "skin.ui");
+            var entry = Parse(@"
+                <Import src='skin.ui'/>
+                <Screen name='S'><Card/></Screen>", "main.ui");
+
+            var loaded = DocumentAssembler.Assemble(
+                "main.ui", src => src == "main.ui" ? entry : lib, allowScreens: true);
+            var expanded = TemplateExpander.Expand(loaded);
+
+            var inlined = FindById(expanded.Screens.Single().Root, "card");
+            Assert.IsNotNull(inlined, "guard: the template was inlined");
+            Assert.AreEqual("skin.ui", inlined.OriginSrc,
+                "the node was written in skin.ui; main.ui only invoked it");
+        }
+
+        // The bug this whole class exists for.
+        [Test]
+        public void ExpandedFinding_IsAttributedToTheLibrary_NotTheEntryDocument()
+        {
+            // mask='self' on a <Frame> has no Image to mask with -> PUI-MASK-FRAME-SELF.
+            // It sits inside a Template declared in skin.ui and is invoked from main.ui, so the raw
+            // walk of main.ui cannot see it at all - only the expanded pass finds it.
+            var lib = Parse("<Template name='Card'><Frame id='card' mask='self'/></Template>", "skin.ui");
+            var entry = Parse(@"
+                <Import src='skin.ui'/>
+                <Screen name='S'><Card/></Screen>", "main.ui");
+
+            var issue = DocumentLinter
+                .Walk(entry, "main.ui", src => src == "skin.ui" ? lib : null)
+                .Single(i => i.Code == MaskAttributeRules.FrameSelfCode);
+
+            Assert.AreEqual("skin.ui", issue.Origin,
+                "sending the author to main.ui would be sending them to a file that does not contain "
+                + "the mistake");
+        }
+
+        [Test]
+        public void EntryDocumentFinding_KeepsTheEntryOrigin()
+        {
+            var issue = DocumentLinter
+                .Walk(Parse("<Screen name='S'><Frame id='f' mask='self'/></Screen>", "main.ui"), "main.ui")
+                .Single(i => i.Code == MaskAttributeRules.FrameSelfCode);
+
+            Assert.AreEqual("main.ui", issue.Origin);
+        }
+
+        // Parent-frame rules (LayoutGroupChildRules and friends) run while walking the PARENT but
+        // complain about the CHILD, so they must not inherit the parent's origin.
+        [Test]
+        public void ChildTargetedRule_IsAttributedToTheChild_NotItsParent()
+        {
+            var lib = Parse(
+                "<Template name='Row'><Frame id='row-child' anchor='top-left'/></Template>", "skin.ui");
+            var entry = Parse(@"
+                <Import src='skin.ui'/>
+                <Screen name='S'><VStack id='stack' anchor='stretch'><Row/></VStack></Screen>", "main.ui");
+
+            var issue = DocumentLinter
+                .Walk(entry, "main.ui", src => src == "skin.ui" ? lib : null)
+                .Single(i => i.Id == "row-child" && i.Code == LayoutGroupChildRules.AnchorCode);
+
+            Assert.AreEqual("skin.ui", issue.Origin,
+                "the <VStack> is in main.ui but the offending anchor= was written in skin.ui");
+        }
+    }
+}

--- a/Tests/EditMode/Lint/LintOriginTests.cs.meta
+++ b/Tests/EditMode/Lint/LintOriginTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eef6e5bace9fbdd79960bdb78ac4f29c

--- a/Tests/EditMode/Lint/ThemeStyleRulesTests.cs
+++ b/Tests/EditMode/Lint/ThemeStyleRulesTests.cs
@@ -1,0 +1,204 @@
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.IR;
+using PromptUGUI.Lint;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.EditMode.Lint
+{
+    /// <summary>
+    /// The two static constraints theme-driven styling rests on (2026-08-26 spec §6.1, §7). Both
+    /// guard against the same runtime symptom — an attribute silently keeping the previous theme's
+    /// value — which is why they have to be caught at write time rather than documented.
+    /// </summary>
+    public class ThemeStyleRulesTests
+    {
+        private static UIDocument Parse(string body) =>
+            UIDocumentParser.Parse(
+                "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>" + body + "</PromptUGUI>");
+
+        private static System.Collections.Generic.List<LintIssue> Lint(string body) =>
+            DocumentLinter.Walk(Parse(body)).ToList();
+
+        // --- PUI-THEME-STYLE-SHAPE (§6.1) ---
+
+        [Test]
+        public void ThemesAgreeingOnTheAttributeSet_AreClean()
+        {
+            var issues = Lint(@"
+                <Style name='card' color='#112233' radius='16'/>
+                <Theme name='light'><Style name='card' color='#fff'/></Theme>
+                <Theme name='dark'><Style name='card' color='#000' radius='0'/></Theme>
+                <Screen name='S'><Image id='c' class='card'/></Screen>");
+
+            Assert.IsEmpty(issues.Where(i => i.Code == ThemeStyleRules.ShapeCode),
+                "both resolve to {color, radius} — the global pack supplies whatever a theme omits");
+        }
+
+        [Test]
+        public void AttributeOnlyOneThemeSets_IsReported()
+        {
+            var issues = Lint(@"
+                <Style name='card' color='#112233'/>
+                <Theme name='light'><Style name='card' color='#fff'/></Theme>
+                <Theme name='dark'><Style name='card' color='#000' glow='8'/></Theme>
+                <Screen name='S'><Image id='c' class='card'/></Screen>");
+
+            var issue = issues.Single(i => i.Code == ThemeStyleRules.ShapeCode);
+            StringAssert.Contains("glow", issue.Message);
+            StringAssert.Contains("card", issue.Message);
+        }
+
+        [Test]
+        public void StyleOnlyOneThemeDeclares_IsReported()
+        {
+            var issues = Lint(@"
+                <Style name='card' color='#112233'/>
+                <Style name='chip' color='#112233'/>
+                <Theme name='light'><Style name='card' color='#fff'/><Style name='chip' glow='4'/></Theme>
+                <Theme name='dark'><Style name='card' color='#000'/></Theme>
+                <Screen name='S'><Image id='c' class='chip'/></Screen>");
+
+            var issue = issues.Single(i => i.Code == ThemeStyleRules.ShapeCode);
+            StringAssert.Contains("chip", issue.Message);
+            StringAssert.Contains("glow", issue.Message);
+            Assert.IsFalse(issue.Message.Contains("card"),
+                "'card' resolves to {color} under both themes — the global baseline covers 'dark'");
+        }
+
+        // --- PUI-THEME-STYLE-NO-BASELINE (§4.2) ---
+
+        // Expansion resolves class= against the GLOBAL pool and the theme layer only re-derives
+        // values afterwards, so a theme-only style is unreferenceable. The bare runtime error says
+        // "unknown style 'card'" and cannot mention the theme it was really written in.
+        [Test]
+        public void ThemeStyleWithNoGlobalCounterpart_IsReported_BeforeExpansionEvenRuns()
+        {
+            var issues = Lint(@"
+                <Theme name='light'><Style name='card' color='#fff'/></Theme>
+                <Theme name='dark'><Style name='card' color='#000'/></Theme>
+                <Screen name='S'><Image id='c' class='card'/></Screen>");
+
+            var issue = issues.Single(i => i.Code == ThemeStyleRules.NoBaselineCode);
+            StringAssert.Contains("card", issue.Message);
+            StringAssert.Contains("global <Style>", issue.Message);
+
+            Assert.IsNotEmpty(issues.Where(i => i.Code == DocumentLinter.ExpansionCode),
+                "the reference genuinely cannot resolve, so the expansion failure is reported too — "
+                + "but no longer as the only clue");
+        }
+
+        [Test]
+        public void ThemeStyleWithAGlobalCounterpart_IsNotReported()
+        {
+            var issues = Lint(@"
+                <Style name='card' color='#112233'/>
+                <Theme name='light'><Style name='card' color='#fff'/></Theme>
+                <Screen name='S'><Image id='c' class='card'/></Screen>");
+
+            Assert.IsEmpty(issues.Where(i => i.Code == ThemeStyleRules.NoBaselineCode));
+        }
+
+        [Test]
+        public void SingleTheme_IsNeverReported()
+        {
+            var issues = Lint(@"
+                <Theme name='only'><Style name='card' color='#fff' glow='8'/></Theme>
+                <Screen name='S'><Image id='c' class='card'/></Screen>");
+
+            Assert.IsEmpty(issues.Where(i => i.Code == ThemeStyleRules.ShapeCode),
+                "with one theme there is no switch that could go wrong");
+        }
+
+        [Test]
+        public void VariantSuffix_CountsAsTheSameName()
+        {
+            var issues = Lint(@"
+                <Style name='card' radius='16'/>
+                <Theme name='light'><Style name='card' radius='8'/></Theme>
+                <Theme name='dark'><Style name='card' radius.mobile='0'/></Theme>
+                <Screen name='S'><Image id='c' class='card'/></Screen>");
+
+            Assert.IsEmpty(issues.Where(i => i.Code == ThemeStyleRules.ShapeCode),
+                "both claim the whole 'radius' slot, so both resolve to the same name set");
+        }
+
+        // --- PUI-THEME-STYLE-ON-INVOCATION (§7) ---
+
+        [Test]
+        public void ThemedClassOnTemplateInvocation_IsReported()
+        {
+            var issues = Lint(@"
+                <Style name='card' color='#112233'/>
+                <Theme name='light'><Style name='card' color='#fff'/></Theme>
+                <Theme name='dark'><Style name='card' color='#000'/></Theme>
+                <Template name='Panel'><Frame id='body'/></Template>
+                <Screen name='S'><Panel id='p' class='card'/></Screen>");
+
+            var issue = issues.Single(i => i.Code == ThemeStyleRules.OnInvocationCode);
+            StringAssert.Contains("Panel", issue.Message);
+            StringAssert.Contains("will NOT follow a theme switch", issue.Message);
+        }
+
+        [Test]
+        public void ThemedClassInsideTemplateBody_IsFine()
+        {
+            var issues = Lint(@"
+                <Style name='card' color='#112233'/>
+                <Theme name='light'><Style name='card' color='#fff'/></Theme>
+                <Theme name='dark'><Style name='card' color='#000'/></Theme>
+                <Template name='Panel'><Frame id='body' class='card'/></Template>
+                <Screen name='S'><Panel id='p'/></Screen>");
+
+            Assert.IsEmpty(issues.Where(i => i.Code == ThemeStyleRules.OnInvocationCode),
+                "inside the body it is an ordinary node attribute and re-merges like any other — "
+                + "this is exactly the fix the rule tells authors to make");
+        }
+
+        [Test]
+        public void UnthemedClassOnTemplateInvocation_IsFine()
+        {
+            var issues = Lint(@"
+                <Style name='plain' color='#112233'/>
+                <Theme name='light'><Style name='card' color='#fff'/></Theme>
+                <Theme name='dark'><Style name='card' color='#000'/></Theme>
+                <Template name='Panel'><Param name='color' default='#000'/><Frame id='body' color='{{color}}'/></Template>
+                <Screen name='S'><Panel id='p' class='plain'/></Screen>");
+
+            Assert.IsEmpty(issues.Where(i => i.Code == ThemeStyleRules.OnInvocationCode),
+                "no theme overrides 'plain', so baking it in at expansion loses nothing");
+        }
+
+        [Test]
+        public void NoThemeStylesAtAll_ReportsNeitherRule()
+        {
+            var issues = Lint(@"
+                <Style name='card' color='#112233'/>
+                <Theme name='light'><Color name='ink' value='#000'/></Theme>
+                <Theme name='dark'><Color name='ink' value='#fff'/></Theme>
+                <Template name='Panel'><Frame id='body'/></Template>
+                <Screen name='S'><Panel id='p' class='card'/></Screen>");
+
+            Assert.IsEmpty(issues.Where(i =>
+                i.Code == ThemeStyleRules.ShapeCode || i.Code == ThemeStyleRules.OnInvocationCode),
+                "colour-only themes are every project written before this feature");
+        }
+
+        // Rules that need the resolved configuration can only answer for one skin at a time, so the
+        // linter re-derives the tree under each declared theme and walks again.
+        [Test]
+        public void ProblemVisibleOnlyUnderOneTheme_IsStillFound()
+        {
+            var issues = Lint(@"
+                <Style name='boxed' color='#112233'/>
+                <Theme name='plain'><Style name='boxed' color='#fff'/></Theme>
+                <Theme name='sprited'><Style name='boxed' color='#fff' sprite='ui:panel'/></Theme>
+                <Screen name='S'><VStack id='v' class='boxed' anchor='stretch'/></Screen>");
+
+            Assert.IsNotEmpty(
+                issues.Where(i => i.Code == PureContainerVisualAttrRules.VisualAttrCode && i.Id == "v"),
+                "'sprite' on a pure container only exists under the 'sprited' skin; walking just one "
+                + "resolved state would miss it entirely");
+        }
+    }
+}

--- a/Tests/EditMode/Lint/ThemeStyleRulesTests.cs.meta
+++ b/Tests/EditMode/Lint/ThemeStyleRulesTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dc2e44b5433841c598614c02e8f65f3e

--- a/Tests/EditMode/Parser/ThemeStyleParsingTests.cs
+++ b/Tests/EditMode/Parser/ThemeStyleParsingTests.cs
@@ -1,0 +1,162 @@
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.IR;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.EditMode.Parser
+{
+    /// <summary>
+    /// <c>&lt;Theme&gt;</c> gains <c>&lt;Style&gt;</c> children — the declaration half of theme-driven
+    /// styles (2026-08-26 spec §3, §4.1, §6.3). Because <c>class=</c> is an attribute macro rather
+    /// than a style engine, letting a theme carry one lifts theming from "swap colours" to "swap the
+    /// whole skin": sprite, radius, font size, padding, glass parameters.
+    /// </summary>
+    public class ThemeStyleParsingTests
+    {
+        private static UIDocument Parse(string body) =>
+            UIDocumentParser.Parse(
+                "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>" + body + "</PromptUGUI>");
+
+        private static ParseException ParseFails(string body) =>
+            Assert.Throws<ParseException>(() => Parse(body));
+
+        private static ThemeBlock Theme(string body, string name = "pixel") =>
+            Parse(body).Themes.Single(t => t.Name == name);
+
+        [Test]
+        public void ThemeStyle_LandsInThemeBlock_NotTheGlobalPool()
+        {
+            var doc = Parse(@"
+                <Style name='card' sprite='ui:panel' radius='16'/>
+                <Theme name='pixel'>
+                  <Color name='surface' value='#e8d8b0'/>
+                  <Style name='card' sprite='px:panel' radius='0'/>
+                </Theme>");
+
+            Assert.AreEqual("ui:panel", doc.Styles["card"].Attributes["sprite"],
+                "the global <Style> must be untouched — a theme overrides, it does not replace in place");
+
+            var themed = doc.Themes.Single().Styles["card"];
+            Assert.AreEqual("px:panel", themed.Attributes["sprite"]);
+            Assert.AreEqual("0", themed.Attributes["radius"]);
+            Assert.AreEqual(1, doc.Themes.Single().Colors.Count, "<Color> siblings still parse");
+        }
+
+        [Test]
+        public void ThemeStyle_AcceptsVariantSuffixes()
+        {
+            var style = Theme("<Theme name='pixel'><Style name='card' radius='8' radius.mobile='4'/></Theme>")
+                .Styles["card"];
+
+            Assert.AreEqual("8", style.Attributes["radius"]);
+            CollectionAssert.AreEqual(
+                new[] { ("mobile", "4") }, style.VariantOverrides["radius"]);
+        }
+
+        // §6.3: the same four names a top-level <Style> rejects.
+        [TestCase("id")]
+        [TestCase("if")]
+        [TestCase("class")]
+        [TestCase("bind")]
+        public void ThemeStyle_RejectsNodeIdentityAttributes(string attr)
+        {
+            var ex = ParseFails($"<Theme name='pixel'><Style name='card' {attr}='x'/></Theme>");
+            StringAssert.Contains("is not a style attribute", ex.Message);
+        }
+
+        // §6.3: runtime-owned state. ControlAttributeApplier skips re-applying these once code has
+        // taken them over, so a theme's value would be silently swallowed some of the time — worse
+        // than never applying at all.
+        [TestCase("text")]
+        [TestCase("isOn")]
+        [TestCase("value")]
+        [TestCase("current")]
+        public void ThemeStyle_RejectsRuntimeOwnedState(string attr)
+        {
+            var ex = ParseFails($"<Theme name='pixel'><Style name='card' {attr}='x'/></Theme>");
+            StringAssert.Contains("runtime", ex.Message.ToLowerInvariant());
+        }
+
+        // §6.3: PUI-MASK-VARIANT already declares per-state mask switching unsupported in v1.
+        // A theme must not become a second door into the same unsupported operation.
+        [TestCase("mask")]
+        [TestCase("showMask")]
+        [TestCase("maskPadding")]
+        public void ThemeStyle_RejectsMaskFamily_PointingAtTheExistingRule(string attr)
+        {
+            var ex = ParseFails($"<Theme name='pixel'><Style name='card' {attr}='rect'/></Theme>");
+            StringAssert.Contains("PUI-MASK-VARIANT", ex.Message);
+        }
+
+        // The blacklist is theme-scoped. A global <Style> may still carry these — nothing about
+        // them is newly broken there.
+        [TestCase("text")]
+        [TestCase("mask")]
+        public void GlobalStyle_StillAcceptsWhatOnlyThemeStylesReject(string attr)
+        {
+            var doc = Parse($"<Style name='card' {attr}='x'/>");
+            Assert.IsTrue(doc.Styles["card"].Attributes.ContainsKey(attr));
+        }
+
+        [Test]
+        public void ThemeStyle_DuplicateNameWithinOneTheme_IsAnError()
+        {
+            var ex = ParseFails(
+                "<Theme name='pixel'><Style name='card' radius='0'/><Style name='card' radius='4'/></Theme>");
+            StringAssert.Contains("card", ex.Message);
+        }
+
+        [Test]
+        public void SameStyleName_InTwoDifferentThemes_IsFine()
+        {
+            var doc = Parse(@"
+                <Theme name='modern'><Style name='card' radius='16'/></Theme>
+                <Theme name='pixel'><Style name='card' radius='0'/></Theme>");
+
+            Assert.AreEqual("16", doc.Themes.Single(t => t.Name == "modern").Styles["card"].Attributes["radius"]);
+            Assert.AreEqual("0", doc.Themes.Single(t => t.Name == "pixel").Styles["card"].Attributes["radius"]);
+        }
+
+        [Test]
+        public void ThemeStyle_WithChildren_IsAnError()
+        {
+            var ex = ParseFails(
+                "<Theme name='pixel'><Style name='card' radius='0'><Frame/></Style></Theme>");
+            StringAssert.Contains("attribute pack", ex.Message);
+        }
+
+        [Test]
+        public void ThemeStyle_NonKebabName_IsAnError()
+        {
+            var ex = ParseFails("<Theme name='pixel'><Style name='Card' radius='0'/></Theme>");
+            StringAssert.Contains("kebab-case", ex.Message);
+        }
+
+        [Test]
+        public void ThemeStyle_WithNoAttributes_IsAnError()
+        {
+            var ex = ParseFails("<Theme name='pixel'><Style name='card'/></Theme>");
+            StringAssert.Contains("declares no attributes", ex.Message);
+        }
+
+        [Test]
+        public void Theme_UnknownChild_NamesBothAllowedElements()
+        {
+            var ex = ParseFails("<Theme name='pixel'><Frame/></Theme>");
+            StringAssert.Contains("Color", ex.Message);
+            StringAssert.Contains("Style", ex.Message);
+        }
+
+        [Test]
+        public void ThemeStyle_CarriesOriginSrc_LikeAGlobalOne()
+        {
+            var doc = UIDocumentParser.Parse(
+                "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>"
+                + "<Theme name='pixel'><Style name='card' radius='0'/></Theme></PromptUGUI>",
+                "skin.ui");
+
+            Assert.AreEqual("skin.ui", doc.Themes.Single().Styles["card"].OriginSrc,
+                "lint attributes a bad value in a theme style to the file it was written in");
+        }
+    }
+}

--- a/Tests/EditMode/Parser/ThemeStyleParsingTests.cs.meta
+++ b/Tests/EditMode/Parser/ThemeStyleParsingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d239bbdf0122ae9e59a6c78172c77125

--- a/Tests/EditMode/Template/NamespaceLookupTests.cs
+++ b/Tests/EditMode/Template/NamespaceLookupTests.cs
@@ -9,11 +9,11 @@ namespace PromptUGUI.Tests.Template
     public class NamespaceLookupTests
     {
 
-        private DocumentLoader.LoadedDoc Make(
+        private LoadedDoc Make(
             ElementNode rootChild,
             (string ns, string name, ElementNode body)[] templates)
         {
-            var l = new DocumentLoader.LoadedDoc
+            var l = new LoadedDoc
             {
                 EntrySrc = "test",
             };
@@ -23,7 +23,7 @@ namespace PromptUGUI.Tests.Template
             foreach (var (ns, name, body) in templates)
             {
                 var t = new TemplateDef(name) { Body = body };
-                l.Templates[new DocumentLoader.TemplateKey(ns, name)] = t;
+                l.Templates[new TemplateKey(ns, name)] = t;
             }
             return l;
         }
@@ -68,7 +68,7 @@ namespace PromptUGUI.Tests.Template
         {
             var bodyA = new ElementNode("Frame");
             var bodyB = new ElementNode("Image");
-            var l = new DocumentLoader.LoadedDoc
+            var l = new LoadedDoc
             {
                 EntrySrc = "test",
             };
@@ -76,9 +76,9 @@ namespace PromptUGUI.Tests.Template
             screen.Root.Children.Add(new ElementNode("Foo", "a"));
             screen.Root.Children.Add(new ElementNode("Foo", "b"));
             l.Screens.Add(screen);
-            l.Templates[new DocumentLoader.TemplateKey("a", "Foo")] =
+            l.Templates[new TemplateKey("a", "Foo")] =
                 new TemplateDef("Foo") { Body = bodyA };
-            l.Templates[new DocumentLoader.TemplateKey("b", "Foo")] =
+            l.Templates[new TemplateKey("b", "Foo")] =
                 new TemplateDef("Foo") { Body = bodyB };
 
             var expanded = TemplateExpander.Expand(l);

--- a/Tests/EditMode/Template/StyleMergeTests.cs
+++ b/Tests/EditMode/Template/StyleMergeTests.cs
@@ -38,14 +38,23 @@ namespace PromptUGUI.Tests.EditMode.Template
             Assert.AreEqual("220", f.Attributes["height"], "inline attributes survive untouched");
         }
 
+        // Contract change (2026-08-26 spec §5): the expanded tree KEEPS class=, because a theme
+        // switch has to re-derive the pack from it. What still holds — and is what actually made the
+        // feature free — is that the VALUES are folded into plain attributes, so no control and no
+        // part of ScreenInstantiator knows styles exist. StyleAttrNames records what the pack put
+        // there, which is how a re-merge knows exactly what to take back out.
         [Test]
-        public void Class_IsConsumed_NotPresentInExpandedTree()
+        public void Class_IsFoldedIntoAttributes_AndKeptForReMerging()
         {
             var doc = Expand(@"
                 <Style name='card' color='#222'/>
                 <Screen name='S'><Frame id='f' class='card'/></Screen>");
-            Assert.IsFalse(FirstChild(doc).Attributes.ContainsKey("class"),
-                "the runtime must never see class= — that is what makes the feature free");
+            var frame = FirstChild(doc);
+
+            Assert.AreEqual("#222", frame.Attributes["color"], "the pack's value is a plain attribute");
+            Assert.AreEqual("card", frame.Attributes["class"], "kept so a theme switch can re-derive");
+            CollectionAssert.AreEquivalent(new[] { "color" }, frame.StyleAttrNames,
+                "exactly what the pack contributed — 'class' itself is not part of the pack");
         }
 
         [Test]
@@ -146,7 +155,7 @@ namespace PromptUGUI.Tests.EditMode.Template
                 <Screen name='S'><Panel id='p'/></Screen>");
             var inner = FirstChild(doc);
             Assert.AreEqual("#222", inner.Attributes["color"]);
-            Assert.IsFalse(inner.Attributes.ContainsKey("class"));
+            CollectionAssert.AreEquivalent(new[] { "color" }, inner.StyleAttrNames);
         }
 
         [Test]
@@ -176,7 +185,7 @@ namespace PromptUGUI.Tests.EditMode.Template
                 </Screen>");
             var added = doc.Screens[0].Variants[0].Adds[0].Children[0];
             Assert.AreEqual("#222", added.Attributes["color"]);
-            Assert.IsFalse(added.Attributes.ContainsKey("class"));
+            CollectionAssert.AreEquivalent(new[] { "color" }, added.StyleAttrNames);
         }
 
         [Test]

--- a/Tests/EditMode/Template/ThemeStyleResolverTests.cs
+++ b/Tests/EditMode/Template/ThemeStyleResolverTests.cs
@@ -1,0 +1,176 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.IR;
+using PromptUGUI.Parser;
+using PromptUGUI.Template;
+
+namespace PromptUGUI.Tests.EditMode.Template
+{
+    /// <summary>
+    /// Folding theme <c>&lt;Style&gt;</c> packs over the global ones (2026-08-26 spec §4.2). The
+    /// global style acts as the implicit root of every theme chain, which is what makes a
+    /// theme-less project cost nothing and lets a theme spell out only what differs.
+    /// </summary>
+    public class ThemeStyleResolverTests
+    {
+        private static UIDocument Parse(string body) =>
+            UIDocumentParser.Parse(
+                "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>" + body + "</PromptUGUI>");
+
+        private static IReadOnlyDictionary<StyleKey, StyleDef> Global(UIDocument doc) =>
+            doc.Styles.ToDictionary(kv => new StyleKey(null, kv.Key), kv => kv.Value);
+
+        private static IReadOnlyDictionary<string, ThemeBlock> Themes(UIDocument doc) =>
+            doc.Themes.ToDictionary(t => t.Name);
+
+        private static StyleDef Fold(string body, string activeTheme, string styleName = "card")
+        {
+            var doc = Parse(body);
+            var resolved = ThemeStyleResolver.Resolve(Global(doc), Themes(doc), activeTheme);
+            return resolved[new StyleKey(null, styleName)];
+        }
+
+        [Test]
+        public void NoActiveTheme_ReturnsTheGlobalTableItself()
+        {
+            var doc = Parse("<Style name='card' radius='16'/><Theme name='pixel'><Style name='card' radius='0'/></Theme>");
+            var global = Global(doc);
+
+            Assert.AreSame(global, ThemeStyleResolver.Resolve(global, Themes(doc), null),
+                "no active theme must not even allocate — this is the path every theme-less project takes");
+        }
+
+        [Test]
+        public void ThemeWithNoStyles_ReturnsTheGlobalTableItself()
+        {
+            var doc = Parse("<Style name='card' radius='16'/><Theme name='pixel'><Color name='surface' value='#fff'/></Theme>");
+            var global = Global(doc);
+
+            Assert.AreSame(global, ThemeStyleResolver.Resolve(global, Themes(doc), "pixel"));
+        }
+
+        [Test]
+        public void ThemeOverridesOnlyWhatItDeclares_GlobalSuppliesTheRest()
+        {
+            var card = Fold(@"
+                <Style name='card' sprite='ui:panel' radius='16' borderWidth='1'/>
+                <Theme name='pixel'><Style name='card' sprite='px:panel' radius='0'/></Theme>", "pixel");
+
+            Assert.AreEqual("px:panel", card.Attributes["sprite"], "overridden");
+            Assert.AreEqual("0", card.Attributes["radius"], "overridden");
+            Assert.AreEqual("1", card.Attributes["borderWidth"],
+                "not declared by the theme -> falls back to the global baseline, which is what keeps "
+                + "a theme switch from leaving a stale value behind");
+        }
+
+        [Test]
+        public void StyleTheThemeNeverMentions_IsUntouched()
+        {
+            var doc = Parse(@"
+                <Style name='card' radius='16'/>
+                <Style name='chip' radius='4'/>
+                <Theme name='pixel'><Style name='card' radius='0'/></Theme>");
+
+            var resolved = ThemeStyleResolver.Resolve(Global(doc), Themes(doc), "pixel");
+            Assert.AreEqual("4", resolved[new StyleKey(null, "chip")].Attributes["radius"]);
+        }
+
+        [Test]
+        public void ThemeStyleWithNoGlobalCounterpart_IsAddedOutright()
+        {
+            var doc = Parse("<Theme name='pixel'><Style name='pixel-only' radius='0'/></Theme>");
+            var resolved = ThemeStyleResolver.Resolve(Global(doc), Themes(doc), "pixel");
+
+            Assert.AreEqual("0", resolved[new StyleKey(null, "pixel-only")].Attributes["radius"]);
+        }
+
+        [Test]
+        public void BaseChain_FoldsRootFirst_SoTheActiveThemeWins()
+        {
+            var card = Fold(@"
+                <Style name='card' sprite='ui:panel' radius='16' borderWidth='1'/>
+                <Theme name='modern'><Style name='card' radius='12' borderWidth='2'/></Theme>
+                <Theme name='pixel' base='modern'><Style name='card' radius='0'/></Theme>", "pixel");
+
+            Assert.AreEqual("0", card.Attributes["radius"], "leaf beats base");
+            Assert.AreEqual("2", card.Attributes["borderWidth"], "base beats global");
+            Assert.AreEqual("ui:panel", card.Attributes["sprite"], "global survives both");
+        }
+
+        // Same atomic rule the multi-class fold uses: a name is claimed whole, in either form.
+        [Test]
+        public void VariantOnlyOverride_MasksTheLowerLayersBaseValue()
+        {
+            var card = Fold(@"
+                <Style name='card' radius='16'/>
+                <Theme name='pixel'><Style name='card' radius.mobile='4'/></Theme>", "pixel");
+
+            Assert.IsFalse(card.Attributes.ContainsKey("radius"),
+                "declaring radius.mobile claims the whole 'radius' slot — the global base must not "
+                + "sneak in beside it");
+            CollectionAssert.AreEqual(new[] { ("mobile", "4") }, card.VariantOverrides["radius"]);
+        }
+
+        [Test]
+        public void BaseValueOverride_MasksTheLowerLayersVariantEntries()
+        {
+            var card = Fold(@"
+                <Style name='card' radius='16' radius.mobile='8'/>
+                <Theme name='pixel'><Style name='card' radius='0'/></Theme>", "pixel");
+
+            Assert.AreEqual("0", card.Attributes["radius"]);
+            Assert.IsFalse(card.VariantOverrides.ContainsKey("radius"),
+                "the theme claimed 'radius'; the global radius.mobile goes with it");
+        }
+
+        [Test]
+        public void Folding_DoesNotMutateTheGlobalPack()
+        {
+            var doc = Parse(@"
+                <Style name='card' radius='16'/>
+                <Theme name='pixel'><Style name='card' radius='0'/></Theme>");
+
+            ThemeStyleResolver.Resolve(Global(doc), Themes(doc), "pixel");
+
+            Assert.AreEqual("16", doc.Styles["card"].Attributes["radius"],
+                "the global pack is shared by every theme — folding must copy, never write through");
+        }
+
+        [Test]
+        public void UnknownActiveThemeName_FallsBackToTheGlobalTable()
+        {
+            var doc = Parse("<Style name='card' radius='16'/><Theme name='pixel'><Style name='card' radius='0'/></Theme>");
+            var global = Global(doc);
+
+            Assert.AreSame(global, ThemeStyleResolver.Resolve(global, Themes(doc), "typo"),
+                "an unregistered name already warns elsewhere; the fold must not throw on it");
+        }
+
+        // ThemeStore.ResolveBases reports cycles properly at registration; this layer is also reached
+        // by the lint CLI, which must survive the very markup it is diagnosing.
+        [Test]
+        public void BaseCycle_TerminatesInsteadOfHanging()
+        {
+            var a = new ThemeBlock { Name = "a", BaseName = "b" };
+            var b = new ThemeBlock { Name = "b", BaseName = "a" };
+            a.Styles["card"] = StyleWith("radius", "1");
+            b.Styles["card"] = StyleWith("radius", "2");
+
+            var resolved = ThemeStyleResolver.Resolve(
+                new Dictionary<StyleKey, StyleDef>(),
+                new Dictionary<string, ThemeBlock> { ["a"] = a, ["b"] = b },
+                "a");
+
+            Assert.AreEqual("1", resolved[new StyleKey(null, "card")].Attributes["radius"],
+                "walking a -> b stops when 'a' repeats, and 'a' is still the leaf so it wins");
+        }
+
+        private static StyleDef StyleWith(string attr, string value)
+        {
+            var s = new StyleDef("card");
+            s.Attributes[attr] = value;
+            return s;
+        }
+    }
+}

--- a/Tests/EditMode/Template/ThemeStyleResolverTests.cs.meta
+++ b/Tests/EditMode/Template/ThemeStyleResolverTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f23e746f55c3bfdbf9f89585be2cc017

--- a/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
+++ b/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
@@ -460,3 +460,27 @@ tmpl.ui.xml: [PUI-MASK-FRAME-SELF] <Frame id='card'>: mask="self" requires ...
 验证：EditMode 2295 → 2291 passed / 0 failed / 4 skipped；`dotnet format` 无输出；UIXmlLint 13 个文件零 issue。
 
 **剩余**：M2.3（保留 `class` + inline 快照、`ThemeStyleApplier` 重合并、接 Open 与 `Theme.Changed`）、M2.4（三条 lint 规则 + `--theme` + SKILL）。
+
+### M2.3（分支 `test/attr-reversibility-red`）
+
+运行时重合并落地。**实现方式与 §5.1 设计的不同**：设计里是给节点存一份「作者内联属性快照」，重合并时用「快照 ∪ 新 pack」重建。实现时发现那样会**丢掉模板调用点合并到实例根上的公共属性** —— `ExpandInvocation` 在 `StyleMerger` 之后才把 invocation 的 CommonAttrs 写进 `instanceRoot.Attributes`，它们既不在快照里也不在 pack 里。
+
+改为记 `ElementNode.StyleAttrNames`：**上一次 pack 贡献了哪些属性名**。重合并 = 删掉这些名字 → 快照当前剩下的（内联 + invocation 公共属性）→ 铺新 pack。不需要额外的快照字典，一个名字集合就够，而且天然幂等。
+
+其余落地要点：
+
+- **展开产物保留 `class=`**（原来是合并后删掉）。契约变了，`StyleMergeTests` 里三条断言「展开后不含 class」的测试相应改写 —— 真正让这个特性零成本的从来不是删掉 `class`，而是**值已经折成普通属性**，控件与 `ScreenInstantiator` 依旧不知道样式存在。
+- `ExpandInvocation` 要跳过保留下来的 `class`，否则报「unknown attribute 'class'」。
+- **`StyleAttributeView.IsUncertain` 对已合并节点直接返回 false**。否则展开遍看到 `class=` 又会噤声，把 M1 刚拿到的覆盖还回去。实测确认 fixture 里的报错仍然照常触发。
+- 重合并挂在 `Screen.Open` 与 `Screen.ReSolve` 的**开头**，而不是单独的 theme-changed 钩子：它幂等，而 ReSolve 本来就是切主题触发的（`_themeHandler`），一个调用点同时覆盖 resize / Variant / Theme / 首次构建。
+- 两道早退让不用主题样式的工程**一分钱不花**：文档没有 `<Style>`；以及 —— 真正重要的那条 —— `ThemeStore.AnyThemeStyles` 为 false，也就是此特性之前的每一个工程。
+
+实现期抓到的 bug（测试抓的）：`ReMerge` 里判断「节点自己声明过」时查的是**正在被改写**的节点，于是 pack 刚写进去的 base `color` 会让同名的 `color.mobile` 被跳过。`Apply` 查的是合并前的 `src` 所以没这问题。改为先快照 `selfDeclared` 再铺 pack。
+
+**与 §7 的偏离**：设计说调用点 class 的「公共属性那半」可以跟随主题。实现下来**两半都不跟随** —— invocation 节点本身在展开后就不存在了，它的 `class` 无处安放；把它挪到实例根又会和模板体根自己的 `class` 撞车。M2.4 的 `PUI-THEME-STYLE-TEMPLATE-PARAM` 因此要覆盖整个「调用点用 theme-scoped style」的情况，而不只是 Param 那半。
+
+**顺带发现的既有缺口**（与主题无关，未修）：`itemTemplate` 走的是 `InstantiateNode(tpl.Body, ...)`，即**未展开**的模板体 —— 所以 `<Template>` 体内的 `class=` 在被当作 itemTemplate 使用时**从来就没生效过**。重合并没有捎带修它：那些 body 是 `loaded.Templates`（可能就是 commons 池）里共享的原始 IR，就地改写会跨文档泄漏。
+
+产出：`ElementNode.StyleAttrNames`、`StyleMerger.ReMerge` / `ComputePack` / `CloneForMerge`、`Core/Template/ThemeStyleApplier`、`ScreenDef.Styles`、`ThemeStore.AnyThemeStyles` / `ResolveStyles`、`Screen.ReMergeThemeStyles`，加 `Tests/EditMode/Application/ThemeStyleSwitchTests.cs`（8 条）。
+
+验证：EditMode 2303 → 2299 passed / 0 failed / 4 skipped；EditorOnly 308/308；`dotnet format` 无输出；UIXmlLint 仓库 13 个文件仍零 issue，fixture 的跨 import / class 供给报错全部照常。

--- a/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
+++ b/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
@@ -1,0 +1,398 @@
+# 主题驱动样式：`<Theme>` 承载 style pack + 运行时重合并
+
+**日期**：2026-08-26
+**状态**：设计中，未实施。
+**作用域**：把 `<Style>` 属性包纳入 `<Theme>` 的管辖范围——`<Theme>` 从"只有颜色 token"扩展为"颜色 token + 命名属性包"。因为 class 是**属性宏**（对任何控件的任何属性生效），主题的表达力随之从"换配色"跃迁到"换皮肤"：sprite、圆角、描边、字号、内边距、玻璃参数都能整套替换。代价是 class→属性的合并必须从"展开期一次性"变成"主题切换时可重跑"。
+**关联**：`<Style>` / `class=` 机制与合并优先级见 [procedural-style](2026-08-23-procedural-style-design.md) §3–§4，本设计不改那套语义，只加一层作用域；颜色 token 与 `base=` 链见 [color-tokens](2026-05-28-color-tokens-design.md)；主题切换触发 `Screen.ReSolve` 的既有链路见 `Runtime/Application/Screen.cs:207`。本设计**依赖** §9 的 lint 改造才能安全落地（两条新约束是静态约束，运行时查不出来）。
+
+---
+
+## 1. 背景与目标
+
+今天 `<Theme>` 只管颜色：
+
+```xml
+<Theme name="dark" base="light">
+  <Color name="surface" value="#111318"/>
+</Theme>
+```
+
+换主题只能改颜色值。但界面的"皮肤感"大部分不在颜色上——像素 9-slice 的底图、圆角半径、描边粗细、字号、玻璃磨砂度，这些今天只能靠作者手写 Variant 或者干脆做两套 XML。
+
+而 `<Style>` 已经是一个**对任何属性生效**的属性包。把它接进 `<Theme>`，主题就自动获得了整个属性面的表达力，不需要为每种视觉维度单独发明 theme token 类型：
+
+```xml
+<Style name="card" sprite="ui:panel" color="surface/0.85" radius="16" borderWidth="1"/>
+
+<Theme name="pixel">
+  <Style name="card" sprite="px:panel" radius="0" borderWidth="2"/>
+</Theme>
+```
+
+`<Frame class="card">` 在 `pixel` 主题下自动换成像素底图、直角、粗描边。
+
+**设计约束**：
+
+1. **不改 `<Style>` / `class=` 的既有语义**。合并优先级（inline > 右 class > 左 class、按属性名原子）、"不适用即忽略"、commons 共享 / `as` 命名空间 / 热重载——全部原样。本设计只在查找 `StyleDef` 时多插一层主题作用域。
+2. **不新增 ReSolve**。主题切换今天就已经触发全量 `Screen.ReSolve`；本设计只在那次 ReSolve 之前插一步"重算属性字典"。
+3. **零成本回归**。不写 `<Style>` 进 `<Theme>` 的工程，代码路径与今天等价（没有 theme-scoped pack → 没有重合并）。
+4. **静默的错等于没有错**。主题切换后"某个角变不回去"这类残留是无法 debug 的，所以本设计的两条约束（§6.1 / §6.2）必须由 lint 静态拦截，而不是文档口头约定。
+
+## 2. 现状盘点（含实测基线）
+
+三层机制今天各自的形态：
+
+| 层 | 今天在哪跑 | 主题切换时 |
+|---|---|---|
+| 颜色 token | 属性 apply 期解析（`ColorSpec` → `ThemeStore.LookupChained`） | ✅ 随 ReSolve 重解析 |
+| `class=` 合并 | 展开期一次性（`TemplateExpander` → `StyleMerger.Apply`），展开产物**不含 `class`** | ❌ 已经烘死 |
+| 属性 apply | `ControlAttributeApplier.Apply`，初次实例化与 ReSolve 共用 | ✅ 全量重放 |
+
+**实测基线**（host 工程 EditMode / Mono，200 个 `class="card"` 的 `<Frame>`）：
+
+| 项目 | 耗时 |
+|---|---|
+| `class` 合并开销（有 class vs 同等属性内联，展开产物相同） | **0.449 ms**（≈2.2 μs/节点） |
+| 一次 `Screen.ReSolve()`（VStack 内） | **31.5 ms** |
+| 一次 `Screen.ReSolve()`（无 LayoutGroup） | **1.97 ms** |
+| 合并占一次 ReSolve | **1.47 %**（LayoutGroup 内）／ **23 %**（无 LayoutGroup，绝对值仍 <0.5 ms） |
+
+0.449 ms 是**上界**：现在的 `StyleMerger.Apply` 每节点都 `CloneWithoutClass`（新建 ElementNode + 拷贝全部字典）；运行时重合并不需要克隆。
+
+**顺带记录**（不在本 spec 范围，另开 issue）：ReSolve 在 LayoutGroup 内是 O(N²)——100/200/400 节点分别 8.7/31.5/118.2 ms；同样节点数换成普通 `<Frame>` 父节点是 1.1/2.0/4.3 ms，完全线性。二次项来自 LayoutGroup 的重复 rebuild，与程序化属性无关（裸 Frame 也一样二次）。
+
+## 3. 语法：`<Theme>` 内嵌 `<Style>`
+
+`<Theme>` 的子元素从「只能是 `<Color>`」放宽为「`<Color>` 或 `<Style>`」。语法与顶层 `<Style>` 完全一致（属性包、无子节点、name kebab-case）：
+
+```xml
+<!-- 全局基线：定义完整属性集合 -->
+<Style name="card"    sprite="ui:panel" color="surface/0.85" radius="16" borderWidth="1" borderColor="stroke/0.15"/>
+<Style name="btn-cta" sprite="ui:btn"   pressedSprite="ui:btn-down" fontSize="15" radius="8"/>
+
+<Theme name="modern">
+  <Color name="surface" value="#f7f8fa"/>
+  <Color name="stroke"  value="#1b1e28"/>
+</Theme>
+
+<Theme name="pixel" base="modern">
+  <Color name="surface" value="#e8d8b0"/>
+  <Style name="card"    sprite="px:panel" radius="0" borderWidth="2"/>
+  <Style name="btn-cta" sprite="px:btn" pressedSprite="px:btn-down" fontSize="12" radius="0"/>
+</Theme>
+```
+
+`class="card"` 的写法不变。`<Screen>` 依然不接受 `class`。
+
+**为什么内嵌而不是 `<Style theme="pixel">`**：`<Theme>` 已经是一个作用域块，`<Color>` 就在里面；`base=` 链、`ThemeStore` 的注册 / 热重载 / 跨文件重名检测全都按块走。内嵌复用这一整套，`<Style theme=...>` 则要为样式单独造一遍。
+
+## 4. 解析与查找
+
+### 4.1 IR
+
+`ThemeBlock` 增一个字段，与 `Colors` 并列：
+
+```csharp
+public sealed class ThemeBlock
+{
+    public string Name;
+    public string BaseName;
+    public List<ColorEntry> Colors = new();
+    public Dictionary<string, StyleDef> Styles = new();   // 新增
+}
+```
+
+`ParseTheme` 的子节点分支从 `if (child.Name != "Color") throw` 改为 `Color` / `Style` 双分支，`Style` 分支直接复用现有 `ParseStyle` 的属性解析（抽成一个 `ParseStyleAttributes(el, name, forbidden)` helper，顶层 `<Style>` 与主题内 `<Style>` 共用，只是禁用名单不同——见 §6.3）。
+
+`ThemeStore.Entry` 同步增 `Styles`，`Register` / `ReplaceFromSrc` 一并搬运。
+
+### 4.2 有效 pack：全局样式是每条主题链的隐式根
+
+查一个 `class="card"` 时，有效属性包 = **从根到叶依次折叠**：
+
+```
+全局 <Style name="card">  →  base 链最上游主题的 card  →  ...  →  当前主题的 card
+```
+
+折叠用**与 `StyleMerger` 多 class 折叠完全相同的原子规则**：后来者声明的每个属性名（`radius` 与 `radius.mobile` 视为同一个名字）整体屏蔽先前的同名声明，然后写入自己的值。实现上直接复用 `StyleDef.DeclaredNames` + 现有折叠循环，不新写一份。
+
+这个"全局样式当隐式根"的决定有三个直接好处：
+
+1. **零成本回归**。不写主题内 `<Style>` 的工程，链只有一环，结果与今天逐字节相同。
+2. **§6.1 的残留问题基本自动消失**。全局样式提供了完整的属性名基线，主题只覆盖值；某个主题漏写 `radius` 时会回落到全局值，而不是"没有值"。
+3. **作者心智模型简单**：全局 `<Style>` 是"这个组件长什么样"，主题内 `<Style>` 是"在这套皮肤下哪几个参数不一样"。
+
+查不到任何一环 → 沿用现有的 `unknown style` 硬错误。
+
+### 4.3 共享 / 命名空间 / 热重载
+
+全部沿用 `<Theme>` 现有语义：主题跟着 `<Import>` 走、进 commons、跨文件同名硬冲突、`ReplaceFromSrc` 热重载。主题内 `<Style>` 不参与 `as=` 命名空间——它按主题名寻址，`class` 引用的是**样式名**，`ui:card` 这种带命名空间的引用查的仍然是全局 / commons 池。
+
+## 5. 运行时重合并
+
+### 5.1 展开期改动
+
+`StyleMerger.Apply` 今天做两件事：合并 pack、删掉 `class`。改为：
+
+- **保留** `class` 属性到展开产物（下游只有本机制读它，`ControlAttributeApplier` 已经会跳过不认识的属性名，无副作用）；
+- 在节点上额外记录**作者内联写的属性名与值**：`ElementNode.InlineAttributes` / `InlineVariantOverrides`（仅带 class 的节点分配，其余为 null）。
+
+`Attributes` / `VariantOverrides` 的最终内容不变，所以 `ScreenInstantiator` 与 `ControlAttributeApplier` **一行都不用改**。
+
+### 5.2 重合并点
+
+```
+UI.Theme.Current = "pixel"
+        │
+        ├─ 遍历 UI._docs 的展开树：对每个带 class 的节点
+        │     Attributes      = InlineAttributes      ∪ EffectivePack(class, newTheme)
+        │     VariantOverrides = InlineVariantOverrides ∪ pack 的 .variant 部分
+        │     （inline 优先，按属性名原子——与 StyleMerger 同一段代码）
+        │
+        └─ Theme.Changed → 每个 open Screen 的 ReSolve()（既有链路，不改）
+```
+
+在**文档级**而非 Screen 级重合并：同一份展开树可能被多个同时打开的 Screen 共享（`_nodeMap` 的 key 是共享的 ElementNode），主题又是全局的，所以按文档走一遍即可，不会重复劳动。
+
+`ScreenInstantiator` 为 `BindItems` 克隆出来的动态子树（`_dynamicSubtrees`）不在 `_docs` 里，需要一并遍历——ReSolve 已经有这个遍历（`ApplyScalesTo`），复用同一份子树列表。
+
+### 5.3 代价
+
+按 §2 的实测：一次主题切换从 31.5 ms 变成约 32 ms（200 节点，LayoutGroup 内）。稳态与 `UI.Open` 路径零新增开销。**性能不是这个特性的成本项**，成本在下面三条约束和 §9 的 lint 改造。
+
+## 6. 三条约束
+
+### 6.1 属性名集合一致（残留问题）
+
+`ControlAttributeApplier.cs:58-70` 遍历的是 `node.Attributes.Keys ∪ node.VariantOverrides.Keys`，解析不出值就 `continue`。**属性在新状态下"没有值"时 ReSolve 根本不碰它，控件保留旧值。**
+
+今天用 Variant 就能复现（与主题无关的既有行为）：
+
+```xml
+<Image id='v' color.alt='#445566'/>                   <!-- 只在 variant 里声明 -->
+<Image id='b' color='#112233' color.alt='#445566'/>   <!-- 有基础值 -->
+```
+```
+alt=false (初始)   v=#FFFFFF   b=#112233
+alt=true           v=#445566   b=#445566
+alt=false (回来)   v=#445566   b=#112233   ← v 卡住
+```
+
+同形的还有 `Control.cs:357` 的 `if (hidden.HasValue) Hidden = ...`，以及 `Btn.cs:233` 的 `_pressedSpriteAuthored = true` 闩锁（一旦某主题写过 `pressedSprite`，之后省略它的主题拿不回内置按下效果）。
+
+**约束**：对任意样式名 `s`，所有可能激活的主题解析出的 `EffectivePack(s, T)` 必须有**相同的属性名集合**。
+
+§4.2 的"全局样式当隐式根"让绝大多数情况自动满足；剩下的漏网之鱼（某属性只在部分主题的 pack 里出现、全局样式没有基线值）由新 lint 规则 `PUI-THEME-STYLE-SHAPE` 拦截，报错信息直指"把 `radius` 加进全局 `<Style name='card'>` 作为基线，或在每个主题里都声明"。
+
+**不采用**的替代方案：让 ReSolve 对"消失的属性"回放控件默认值。那需要 237 个 `[UIAttr]` setter 各自定义"复位语义"，是本设计 10 倍的工作量，而且很多属性（`mask` / `type` / `fit`）根本没有干净的"默认"。
+
+### 6.2 theme-scoped style 不参与 `if=`
+
+`TemplateExpander.cs:259` 在**展开期**求值 `if=`，false 的节点 `return null`，展开产物里根本不存在。主题要让它重新出现只能重新展开 + 重建 GameObject。
+
+**约束**：theme-scoped style 不得（直接或经由模板 Param）驱动 `if=`。
+
+分两处拦截：
+
+- 节点自身：`<Frame class="skin" if="...">` —— `if` 已经在 `StyleForbiddenAttrs` 里，pack 里带不了 `if`，无需新增。
+- 经由 Param：`<ui.Card class="skin">` 且 `skin` 提供的 Param 被模板体的 `if="{{p}}"` 消费 → 新 lint 规则 `PUI-THEME-STYLE-IF-PARAM`。
+
+现状勘察：项目里现有 `.ui.xml` **零处**使用 `if="{{...}}"`（两种引号都查过），所以这条约束现在不损失任何东西。
+
+### 6.3 theme-style 专用黑名单
+
+顶层 `<Style>` 的禁用名单是 `{ id, if, class, bind }`（`UIDocumentParser.cs:324`）。主题内 `<Style>` 在此之上再禁两组：
+
+```csharp
+private static readonly string[] ThemeStyleForbiddenAttrs =
+{
+    "id", "if", "class", "bind",                    // 与顶层 <Style> 相同
+    "text", "isOn", "value", "current",             // 运行时独占状态
+    "mask", "showMask", "maskPadding",              // 已声明不支持按状态切换
+};
+```
+
+**运行时独占状态**（`text` / `isOn` / `value` / `current`）：`ControlAttributeApplier` 的 `DefaultTextLockedByRuntime` / `RuntimeStateLockedByRuntime` 会在"运行期被代码改过"时**跳过重放**，所以主题写进去的新值大概率被静默吞掉——比不生效更糟的是不确定地生效。这四个名字来自 `BuiltinPrimitives.Register` 的 `defaultTextAttr` / `runtimeStateAttr` 声明。
+
+**mask 家族**：`PUI-MASK-VARIANT`（`MaskAttributeRules.CheckVariantOverrides`）与 `PUI-PROG-MASK-VARIANT` 已经把"按 Variant 切换 mask 模式"整体判为 v1 不支持，理由正是"requires AddComponent / Destroy which has performance / lifetime issues"。主题切换走的是同一条重放路径，所以是同一件不支持的事换了个入口，必须一并挡住——否则作者会绕过一条已有的 lint 规则。
+
+自定义控件若注册了名单外的 `runtimeStateAttr`，`ControlRegistry.Register` 增一条 `Debug.LogWarning`，提示该属性不应经由主题样式提供。（不做成硬错误：Core 层的 parser 不该反向依赖 Registry。）
+
+## 7. 模板边界
+
+`class=` 出现在三个位置，主题跟随能力不同：
+
+| 位置 | 展开期行为 | 跟随主题 |
+|---|---|---|
+| 模板**体内**的节点 | `TemplateExpander.cs:273` → `StyleMerger.Apply(prepared, styles, null)`，**不过滤**，与普通节点同一行代码 | ✅ 完全一样 |
+| 调用节点的 class → **公共属性**那半 | `ExpandInvocation` 拷到实例根的 `Attributes`（`TemplateExpander.cs:229-231`） | ✅ |
+| 调用节点的 class → **Param** 那半 | `Substitution.Apply` 做字符串替换，烘进模板体的属性值 | ⚠️ 见下 |
+
+Param 那半**技术上可解**：`ElementNode.AttributesRaw` 已经存了任何含 `{{...}}` 的属性的替换前原文（`UIDocumentParser.cs:497-502`），`ElementNode.TextArgs` 存了整份实参（`TemplateExpander.cs:288`），i18n 的 locale 切换正是拿这两样重新替换的（`ControlAttributeApplier.cs:76`）。主题重替换可以走同一条路。
+
+**M1 不做**：调用节点上使用 theme-scoped style 且该 style 提供了 Param → lint 报 `PUI-THEME-STYLE-TEMPLATE-PARAM`，引导作者把 class 下沉到模板体内，或改用全局 `<Style>`（全局样式在调用点照常工作，只是不跟随主题）。M2 再打开（§14）。
+
+安全性记录：`id` **不参与替换**（`SubstituteAttrs` 里是 `Id = src.Id`，只有 `Attributes` / `VariantOverrides` 过 `Substitution.Apply`；`id` 在 parser 阶段就 `continue` 掉、从不进 `Attributes`）。所以主题永远改不到 id，`_byId` / `Get<T>` 的路径不受影响。
+
+## 8. Setter 可逆性（既有缺陷，本 spec 只钉 Red test）
+
+§6.1 是"属性没有值"的问题；这一节是"属性有新值但 setter 不还原旧值"的问题。
+
+对 `Runtime/Controls/` 下全部 **237 个 `[UIAttr]` 属性**做了逐个审计，不可逆的有 6 处，但要分成两类——**只有第一类是缺陷**：
+
+**A. 真缺陷（无任何规则覆盖，作者写出来既不报错也不工作）**
+
+| 属性 | 问题 | 位置 |
+|---|---|---|
+| `Tab.selectedSprite` | 给 sprite 时把 `transition` 设成 `None`，改回 `none` 不恢复 `ColorTint` —— 该 Tab 从此没有任何 hover/press 反馈，且没有任何属性能救回来 | Tab.cs:277 / 388 |
+| `Progress.bg` / `Progress.frame` | `SetActive(true)` 无反向路径，`""` 直接 early-return | Progress.cs:94 / 118 |
+
+**B. 已声明的不支持（不是缺陷）**：`Frame.mask` / `Image.mask` / `RawImage.mask` / `Progress.mask` 的 `AddComponent` 只加不减是真的，但 `PUI-MASK-VARIANT` 与 `PUI-PROG-MASK-VARIANT` 已经把按状态切换 mask 整体判为 v1 不支持，理由与我们发现的完全一致。所以它们不该"修"，而该**保持不支持并堵住新入口**——见 §6.3 把 mask 家族加进主题黑名单。
+
+**C. 顺带发现的两处覆盖缺口（M0 一并钉住）**
+
+| 缺口 | 说明 |
+|---|---|
+| `RawImage` 的 mask 家族无人管 | `IRWalker` 只为 `Frame` / `Image` 分发 `MaskAttributeRules`；而 `VariantBaseRules` 又把 mask 家族整体排除（注释写"Owned by PUI-MASK-VARIANT in ALL cases"）。于是 `<RawImage mask='rect' mask.alt='self'/>` **两道闸门都漏**，静默接受、静默损坏 |
+| `PUI-PROG-MASK-VARIANT` 的文案有误 | 消息明说 "other attrs (value / fill / **bg** / mode / direction) are safe in variants"（`ProgressAttributeRules.cs:72`），但 A 类已证明 `bg` 不安全。修 `Progress.bg` 时必须同步改这句 |
+
+实测确认（今天的代码，纯 Variant，不需要任何新特性）：
+
+```
+<Frame mask='rect' mask.alt='none'>  →  翻转后 RectMask2D 仍在
+<Image mask='self' mask.alt='rect'>  →  翻转后 RectMask2D + Mask 双份
+<Image color=…     color.alt=…>      →  翻转后正常（对照组）
+```
+
+误报、实际可逆的：`Frame.weld`（`weld<=0` 会 `SetWeld(0)`，源码注释明写是为 Variant 准备的）、`Icon.name`、`Btn.text` / `Tab.text`、`Tab.sprite`、`Toggle.group`、`Markdown.*Color`、`Image.showMask`——空值都有明确复位分支。
+
+**A / C 两类都是既有 bug，两行 XML 用 `.variant` 就能复现，不记在本特性账上。** 本 spec 的动作是：**先写 Red test 钉住正确行为**，修复另开 PR。这样主题特性上线时，这批用例要么已绿、要么明确挂着可见，不会变成"主题一换就有人报奇怪的 bug 但没人知道根因"。
+
+Red test 的写法：每条都拿**翻转后的控件**对比**用目标值全新构建的控件**，而不是对比硬编码期望值——因为要断言的性质正是"A→B 之后必须等同于一开始就用 B 构建"，这也正是主题切换的正确性定义。B 类另配一条**绿色的特征化测试**，把"mask 就是不可逆"钉成显式契约，将来谁真把它做可逆了会看到这条测试失败，从而知道要一并撤掉 `PUI-MASK-VARIANT`。
+
+## 9. Lint：让 CLI 追平 runtime（本设计的前置依赖）
+
+### 9.1 现状
+
+`IRWalker.Walk` 走的是**解析后、展开前**的原始 IR。因此：
+
+- **模板体**被检查了，但以"声明空间"身份，且为此**主动关掉了 5 组规则**：`NavTargetRules.CheckNavTarget`（无 screen id 集合）、`StateTriggerRules.CheckStateSource`（可点击祖先在调用点才定）、`<Tab>` 父节点检查、`LayoutGroupChildRules.CheckNonLayoutChild`（模板体根的真实父节点在调用点才定）、`VariantBaseRules`（实例根可能从调用点拿到 CommonAttr 基线）。
+- **模板调用点从来没被检查过**：tag 不匹配任何 per-tag 规则，Param 值不验证，Slot 子节点按"未知父节点"判。
+- **style** 靠 `StyleAttributeView` 在原始 IR 上模拟一次 merge；查不到的 style 名（几乎必然来自 `<Import>` 的 commons 库，单文件 CLI 看不见）→ `IsUncertain` → 规则闭嘴。
+
+而 `ScreenInstantiator` 走的是 `TemplateExpander.Expand` **之后**的树，7 组规则（`LayoutGroupChildRules` / `MaskAttributeRules` / `ImageFitRules` / `ProgressAttributeRules` / `TabRules` / `CarouselRules` / `NavTargetRules.CheckNav`）已经作用于展开后的值。
+
+**结论：runtime 查展开后，CLI 查展开前。** 把 CLI 挪到展开后，模板检查是顺带白拿的，`IsUncertain` 的沉默模式基本可以退休——主题样式让 lint 变弱的问题因此自然消失，不需要单独想办法。
+
+### 9.2 挡路的是依赖，不是规则
+
+`.lint/UIXmlLint/UIXmlLint.csproj` 的注释已经写明：Template/Variants 被排除是因为它们 type-reference `PromptUGUI.Application`，"even though the algorithm is pure"。实查：
+
+```
+Runtime/Core/Template/StyleMerger.cs      -> Application.DocumentLoader.StyleKey
+Runtime/Core/Template/TemplateExpander.cs -> Application.DocumentLoader.{LoadedDoc, StyleKey, TemplateKey}
+```
+
+零个 `UnityEngine` 引用。`DocumentLoader` 本身除了 `Awaitable` 异步管道，整个 body 就是 `UIDocumentParser.Parse` + 字典合并 + 冲突检测，纯 C#。
+
+### 9.3 三步
+
+1. **搬三个类型**：`LoadedDoc` / `TemplateKey` / `StyleKey` → `Core/IR/`。搬完 `Core/Template/**` 整个目录进 CLI 编译集。`VariantResolver` 不动——展开产物保留 `VariantOverrides`，variant 本来就是运行时解析。
+2. **把 load/merge 算法从 IO 里剥出来**：`LoadInternalAsync` 现在把「递归 + resolver + 合并 + 查重」揉在一起。抽成 resolver 泛型的同步核心放 `Core/`，`DocumentLoader` 退化成 async 薄壳。**这是真正的工作量**，同时也是 `IsUncertain` 存在的根本原因。
+3. **CLI 加文件系统 resolver**（相对路径解析 `src`），然后 `IRWalker.Walk(expandedDoc)`。
+
+### 9.4 主题维度
+
+CLI 能展开之后，`--theme <name>` / `--theme all` 按每个主题各展开一遍交叉验证。这是唯一能真正保住 `GlassRules` / `PureContainerVisualAttrRules` 的做法——否则一个节点在主题 A 下进 glass 模式、B 下不进，静态永远说不清。
+
+新增三条规则：
+
+| 代码 | 检查 |
+|---|---|
+| `PUI-THEME-STYLE-SHAPE` | §6.1：同一样式名在不同主题下解析出的属性名集合不一致 |
+| `PUI-THEME-STYLE-IF-PARAM` | §6.2：theme-scoped style 提供的 Param 被 `if=` 消费 |
+| `PUI-THEME-STYLE-TEMPLATE-PARAM` | §7：theme-scoped style 用在模板调用节点上且提供了 Param |
+
+### 9.5 两遍都跑
+
+展开后的树里 `if="false"` 的节点已不存在、`<Variant>` 的 Add 块也已分离。展开前那一遍能查作者写的死代码，展开后那一遍查真正会实例化的东西。保留两遍、按 `(Code, Id, Message)` 去重——CLI 不在热路径上。
+
+**报错溯源**：`LintIssue` 现在是 `(Code, Tag, Id, Message)`，CLI 输出 `{path}: [{code}] {message}`，**本来就没有行号**，所以不存在"展开后行号错位"的损失。但跟进 `<Import>` 之后 issue 可能来自 commons 文件而非入口文件，需要在 `ElementNode` 上带 origin src + 模板调用链（`StyleDef.OriginSrc` 已是这个先例）。
+
+## 10. 明确不支持（错误，非静默降级）
+
+- 主题内 `<Style>` 携带 `id` / `if` / `class` / `bind`、运行时独占状态（`text` / `isOn` / `value` / `current`）、或 mask 家族（`mask` / `showMask` / `maskPadding`）→ parse error（§6.3）。
+- 主题内 `<Style>` 带子节点、name 非 kebab-case、同主题内重名 → parse error，消息与顶层 `<Style>` 对齐。
+- 同一样式名在不同主题下属性名集合不一致 → lint error（§6.1）。
+- theme-scoped style 驱动 `if=`，或用在模板调用节点上提供 Param → lint error（§6.2 / §7）。
+- `<Screen class=...>` → 沿用现有 parse error。
+
+## 11. 不做的事（YAGNI 记录）
+
+- **不做选择器 / 级联 / 继承树**。`<Style>` 依然是属性宏，主题只是给它加了一层作用域。
+- **不做 setter 复位语义**。§6.1 用属性名集合约束绕开，而不是给 237 个 setter 定义"默认值"。
+- **不做主题切换的 GameObject 重建**。`if=` 驱动的树形变化明确不支持，而不是"重建子树来支持它"。
+- **不做主题内 `<Template>`**。模板是结构，主题是皮肤；结构随主题变是另一个量级的特性，没有需求前不开这个口子。
+- **不做过渡动画**。主题切换是瞬时的属性重放；跨主题的补间需要属性级插值语义，另开 spec。
+
+## 12. 测试（Red 先行）
+
+EditMode（`UI.ResetForTests` 约定）：
+
+1. **解析**：`<Theme>` 内 `<Style>` 进 `ThemeBlock.Styles`；§10 全部 parse error；`ThemeStyleForbiddenAttrs` 八个名字逐个报错。
+2. **有效 pack 折叠**：全局样式当隐式根；`base=` 链上游→下游覆盖；原子性（主题声明 `radius.mobile` 屏蔽全局 `radius`）；主题不声明该样式时回落全局；三处都查不到时报 `unknown style`。
+3. **运行时重合并**：`<Frame class="card">` 切主题后材质参数变化且 **GameObject 未重建**（对象引用比对）；inline 属性在切主题后仍然压过主题 pack；带 `.variant` 的 pack 在切主题 + 切 variant 的四种组合下取值正确。
+4. **残留回归**（§6.1 的正面用例）：全局样式提供基线时，主题 A→B→A 往返后属性值回到初始。
+5. **模板**：模板体内 class 跟随主题（正面）；调用点 class 的 CommonAttrs 半跟随主题（正面）；调用点 class 提供 Param 时 lint 报错（`PUI-THEME-STYLE-TEMPLATE-PARAM`）。
+6. **commons / 热重载**：主题内 `<Style>` 入 commons 池、跨文件同名冲突、`ReloadCommonLibraryAsync` 换池后已打开 Screen 的视觉跟随变化。
+7. **可逆性 Red test**（§8，M0 已交付，见 §15）：A 类三条 `.variant` 往返——`Tab.selectedSprite` 归零后 `transition` 回 `ColorTint`、`Progress.bg` / `frame` 置空后子节点 `activeSelf == false`；C 类一条 `<RawImage mask.alt=...>` 应报 `PUI-MASK-VARIANT`；B 类一条绿色特征化钉住 mask 的不可逆契约。全部以"翻转后 == 用目标值全新构建"的形式断言。
+8. **主题黑名单**：§6.3 三组名字逐个 parse error；mask 家族被拒时的消息要指向 `PUI-MASK-VARIANT` 而不是只说"不允许"。
+9. **Lint**（`PromptUGUI.Tests.EditMode`，规则是纯 C#）：三条新规则各正反用例；展开后 walk 与展开前 walk 的去重；跟 `<Import>` 后的 origin 归属。
+10. **XSD**：`<Theme>` 允许 `<Style>` 子元素，substring 断言。
+
+PlayMode：一条端到端冒烟——两个主题各带 `<Style name="card">`（不同 sprite + radius），`UI.Theme.Current` 来回切两次，断言材质参数与 sprite 引用跟随、GameObject 实例未变、无 console error。
+
+性能守门：200 节点 `class` 树的主题切换耗时相对切换前基线不劣化超过 5%（用 §2 的测法）。
+
+## 13. SKILL 更新（同 PR，英文）
+
+- `authoring-promptugui-xml/SKILL.md`
+  - **Style & class** 一节：加"theme-scoped style"小节——语法、全局样式当隐式根的折叠顺序、属性名集合一致约束、八项禁用属性、模板调用点的限制。
+  - **Color Tokens** 一节：`<Theme>` 的子元素描述从"only `<Color>`"改为"`<Color>` / `<Style>`"，主表第 68 行同步。
+  - 顶层元素表 `<Theme>` 行、`<Style>` 行同步。
+  - 速查区（1181 行起）的 `STYLE/CLASS` 与 `STYLE LINT` 段补三条新规则代码。
+- `scripting-promptugui-csharp/SKILL.md`：`UI.Theme.Current` 的描述从"重新解析颜色"改为"重新解析颜色**与样式包**"，并说明切换成本量级（§5.3）。
+- `.lint/UIXmlLint/README.md`：展开后 lint、`--theme` 参数、两遍去重。
+- 若 §7 的 M2 落地，再补模板 Param 跟随主题的说明。
+
+## 14. 里程碑拆分
+
+| | 内容 | 依赖 |
+|---|---|---|
+| **M0 Red test** | §8 的 A 类 3 条 + C 类 1 条 red test（`Ignore` 挂起），B 类 1 条绿色特征化测试。纯测试，可先合 | 无 |
+| **M1 Lint 展开化** | §9.1–§9.3：搬三个类型、剥离 load/merge、CLI 文件 resolver、`IRWalker` 走展开树、两遍去重 | 无（与主题特性正交，独立有价值） |
+| **M2 主题样式** | §3–§7：IR / parser / ThemeStore / 有效 pack 折叠 / 运行时重合并 / 三条约束 | M1（§9.4 的三条规则要 CLI 能展开） |
+| **M3 模板 Param 跟随** | §7 的 raw + args 重替换，去掉 `PUI-THEME-STYLE-TEMPLATE-PARAM` | M2 |
+
+M0 与 M1 都不依赖主题特性、都能独立合入主干。M1 是 M2 的硬前置：没有它，§6.1 / §6.2 两条约束只能靠文档口头约定，而它们的违规表现是"换主题后某个属性静默不还原"——正是最难 debug 的那一类。
+
+## 15. 实施记录
+
+### M0（分支 `test/attr-reversibility-red`）
+
+审计期把"6 处不可逆"当成 6 个待修 bug 写进了 §8 的第一版；动手时才发现其中 4 处（mask 家族）早已有 `PUI-MASK-VARIANT` / `PUI-PROG-MASK-VARIANT` 把它判为 v1 不支持，理由与审计结论逐字一致。**为它们写"应该可逆"的 red test 会直接推翻一条既有设计决定**，所以改成：B 类保持不支持、加一条绿色特征化测试钉住契约，同时把 mask 家族补进 §6.3 的主题黑名单（同一件不支持的事，不能让主题成为新入口）。
+
+顺带查出两处覆盖缺口（§8 C 类）：`RawImage` 的 mask 家族同时漏出 `MaskAttributeRules` 的分发与 `VariantBaseRules` 的豁免；`PUI-PROG-MASK-VARIANT` 的文案把 `bg` 宣传成 variant-safe。
+
+产出：
+
+| 文件 | 内容 |
+|---|---|
+| `Tests/EditMode/Controls/AttributeReversibilityTests.cs` | A 类 3 条 red（`Ignore`）+ B 类 1 条绿色特征化 |
+| `Tests/EditMode/Lint/IRWalkerMaskTests.cs` | C 类 RawImage 覆盖缺口 1 条 red（`Ignore`）；顺手订正 `Walk_NonFrameNonImageTags_NoMaskIssue` 里"mask 只 Frame/Image 暴露"的过期注释 |
+
+验证：临时摘掉 `[Ignore]` 跑过一遍，4 条全部失败且失败原因正确（`Assume` 守卫全过，证明失败来自缺陷本身而非 setup）；恢复 `[Ignore]` 后全量 EditMode 2250 条 **2246 passed / 0 failed / 4 skipped**。
+
+`[Ignore]` 而非留红：全量跑必须保持是有效的回归信号。修复 PR 逐条摘 `Ignore` 即可。
+
+**本机环境缺口**：没有安装 dotnet SDK，`dotnet format` 与 `UIXmlLint` / `PxlPreview` CLI 在此机器上跑不了。本次改动只有测试文件，已人工核对缩进 / 行尾空白 / 文件结尾换行与同目录既有测试一致。

--- a/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
+++ b/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
@@ -503,11 +503,37 @@ lint 规则 + SKILL。三处与设计不同：
 
 ---
 
+### M2.5 —— §8 的可逆性修复（`[Ignore]` 全部摘掉）
+
+三处 A 类缺陷与 C 类覆盖缺口一并修完，四条 red test 转绿。**三个修复是同一个形状**：把「一次性设置」改成「从当前声明**算出来**」。
+
+| 处 | 改法 |
+|---|---|
+| `Tab.selectedSprite` | 新增 `ReconcileTransition()`：`transition = (reactor 存在 ‖ selectedSprite 存在) ? None : ColorTint`，由 setter 与 `OnAfterApply` 共用 |
+| `Btn.pressedSprite` / `disabledSprite` | 同形。**不在 red test 覆盖范围内，但一起修了** —— 一模一样的缺陷（原注释自己写着 "Set-only"），只修 Tab 没有道理 |
+| `Progress.bg` / `frame` | 新增 `_bgSprite/_bgColor/_frameSprite/_frameColor` 四个标志，图层显隐由 `ReconcileLayers()` 从标志算出 |
+| `RawImage` mask 家族 | 新增 `MaskAttributeRules.CheckRawImage` + `IRWalker` 分发（不能复用 `CheckImage`：RawImage 没有 `sprite=`，`PUI-MASK-SELF-NO-SPRITE` 不适用） |
+
+`Progress` 的改法顺带修掉一个**没人注意到的既有 bug**：`bg` 与 `bgColor` 两个 setter 都在 `SetActive(true)`，而 `ControlAttributeApplier` 遍历属性的顺序来自 `HashSet`，**未定义**。改成从两个标志一起算之后，谁先谁后都一样。
+
+`PUI-PROG-MASK-VARIANT` 的文案说 "other attrs (value / fill / **bg** / mode / direction) are safe in variants" —— 修完 `bg` 之后这句**变成真的了**，不用改。
+
+测试抓到一次回归：可见性搬进 `OnAfterApply` 之后，运行时从 C# 直接赋值 `progress.Bg` 不再触发它。因为答案是从标志算出来的，setter 里直接调 `ReconcileLayers()` 就行 —— 顺序无关，这正是这种写法的好处。
+
+另加两条测试：`Btn` 的对应用例，以及一条守卫 —— **有 `selectedColor` 时清掉 `selectedSprite` 必须保持 `None`**（reactor 仍然在管 bg，交还 ColorTint 会双重着色）。
+
+SKILL：`reference/states.md` 补「ColorTint 的切换是算出来的，可逆」；`reference/controls-progress.md` 新增「bg / frame 图层的显隐」一节。
+
+验证：EditMode **2317/2317**、PlayMode **171/171**、EditorOnly **308/308**，全部 0 failed **0 skipped**；`dotnet format` 无输出；UIXmlLint 13 个文件零 issue。
+
+---
+
 ## 16. 现状小结
 
-M0 / M1 / M2 全部落地。§9.4 的 `--theme` 以「自动逐主题走查」代替，§6.2 的规则取消（见 M2.4）。仍然开着的：
+M0 / M1 / M2 全部落地，§8 的可逆性缺陷全部修完，测试套件无 skipped。§9.4 的 `--theme` 以「自动逐主题走查」代替，§6.2 的规则取消（见 M2.4）。
 
-- **§8 A 类三处 setter 可逆性**：red test 挂着 `[Ignore]`，修复未做。
+仍然开着的：
+
 - **`itemTemplate` 的 `class=` 从来没生效过**（M2.3 发现的既有缺口，与主题无关）。
 - **lint 无行号**；同一模板多次调用时不可区分是哪一次（M1 记录）。
 - **带命名空间的样式不能被主题覆盖**（M2.2 的 §4.3 收紧）。

--- a/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
+++ b/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
@@ -420,4 +420,23 @@ M0 与 M1 都不依赖主题特性、都能独立合入主干。M1 是 M2 的硬
 
 验证：EditMode 2256 → 2252 passed / 0 failed / 4 skipped（4 skipped 是 M0 的 red）；EditorOnly 308/308；`dotnet format --verify-no-changes --severity warn` 无输出；CLI 对仓库全部 13 个 `.ui.xml` 仍然零 issue（无回归），对专门造的 fixture 正确报出 3 条并 exit 1。新测试的有效性用「临时摘掉展开遍」验证过：6 条里 4 条转红，另 2 条（去重、无法解析时降级）本就该两边成立。
 
-**尚未做**：§9.4 的 `--theme` 与三条主题规则属于 M2；§9.5 提到的 origin 溯源（issue 来自 commons 文件时的归属）也还没做 —— 现在展开遍报出的 issue 一律挂在入口文件路径下，跨文件时会指错文件。M2 之前应补。
+**尚未做**：§9.4 的 `--theme` 与三条主题规则属于 M2。
+
+### M1 追加：origin 溯源（§9.5）
+
+`ElementNode.OriginSrc` 由 `UIDocumentParser.Parse(xml, src)` 一次性打戳（解析后遍历整份文档，避免把 `src` 穿过十几个私有解析方法），并在展开期的全部 6 个 clone 点逐层传递（`TemplateExpander` ×5 + `StyleMerger.CloneWithoutClass`）。`LintIssue` 增 `Origin`，由 `IRWalker` **集中**打戳 —— 规则一行不用改，新规则自动获得正确归属。
+
+一个不显然的点：`LayoutGroupChildRules` 这类规则在**父节点的帧**里运行却是在说**子节点**，所以不能继承父节点的 origin，那 5 处显式用 `child.OriginSrc`（`LintOriginTests.ChildTargetedRule_IsAttributedToTheChild_NotItsParent` 钉住）。`<Style>` 不是 ElementNode，用它自己已有的 `StyleDef.OriginSrc`。
+
+CLI 端给 import 打戳时用的是**解析出来的磁盘路径**而非 `imp.Src`：`src` 是 resolver key，作者打不开；lookup 键仍用 `imp.Src` 不变。
+
+效果：
+
+```
+$ UIXmlLint uses-tmpl.ui.xml
+tmpl.ui.xml: [PUI-MASK-FRAME-SELF] <Frame id='card'>: mask="self" requires ...
+```
+
+**行号仍然没有**，本次也没做：`LintIssue` 从来就没有行号，`XmlDocument` 的节点默认不实现 `IXmlLineInfo`，要拿到得换一套读取方式。同一个模板被调用多次时，"哪一次调用"也仍不可区分（需要模板调用链，`TextArgs` 有原料但没接）。这两条都留给需要时再说。
+
+验证：EditMode 2262 → 2258 passed / 0 failed / 4 skipped；EditorOnly 308/308；`dotnet format` 无输出；CLI 对仓库 13 个文件仍零 issue；跨文件 fixture 正确指向库文件。有效性用「摘掉模板内联时的 origin 传递」验证：6 条里 3 条转红，失败信息正是这个 bug 本身（`Expected: "skin.ui" But was: "main.ui"`）。

--- a/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
+++ b/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
@@ -484,3 +484,30 @@ tmpl.ui.xml: [PUI-MASK-FRAME-SELF] <Frame id='card'>: mask="self" requires ...
 产出：`ElementNode.StyleAttrNames`、`StyleMerger.ReMerge` / `ComputePack` / `CloneForMerge`、`Core/Template/ThemeStyleApplier`、`ScreenDef.Styles`、`ThemeStore.AnyThemeStyles` / `ResolveStyles`、`Screen.ReMergeThemeStyles`，加 `Tests/EditMode/Application/ThemeStyleSwitchTests.cs`（8 条）。
 
 验证：EditMode 2303 → 2299 passed / 0 failed / 4 skipped；EditorOnly 308/308；`dotnet format` 无输出；UIXmlLint 仓库 13 个文件仍零 issue，fixture 的跨 import / class 供给报错全部照常。
+
+### M2.4（分支 `test/attr-reversibility-red`）
+
+lint 规则 + SKILL。三处与设计不同：
+
+**1. `PUI-THEME-STYLE-IF-PARAM` 取消。** M2.3 之后它**永远不可能触发**：`if` 在样式黑名单里（普通节点走不通），而唯一的 Param 通道是模板调用点 —— 那已经被 `PUI-THEME-STYLE-ON-INVOCATION` 整个盖住（M2.3 的偏离让这条规则从「只管 Param 那半」扩到了「调用点上的 theme-scoped class 一律不跟随」）。写一条永远不响的规则是负债，不写。
+
+**2. `--theme` 不做成 flag。** 既然主题层是「展开后重合并」，CLI 直接**对文档声明的每个主题各走一遍展开树并去重** —— 不用作者记参数，主题改不动的东西也不会多出输出。`ThemeStyleRulesTests.ProblemVisibleOnlyUnderOneTheme_IsStillFound` 钉住：只在某一个皮肤下才成立的 `sprite` on `<VStack>`，单看一个状态会整个漏掉。
+
+**3. 新增第三条规则 `PUI-THEME-STYLE-NO-BASELINE`。** 写测试时才发现设计没想清楚的一个点：**只在主题里声明、没有全局对应的样式，`class=` 根本引用不到** —— 展开期只认全局池，会抛 unknown style，而那条信息没法提到它其实写在哪个 `<Theme>` 里。这个行为本身是对的（全局样式当基线正是 §6.1 成立的前提），缺的是可操作的诊断。顺带把主题规则移到了**尝试展开之前**，否则展开失败会把它们整个短路掉。
+
+规则位置：`ThemeStyleRules` 是 `internal`（其余规则类都是 public）—— `StyleKey` 是 internal，为了给一个 lint 参数标类型就把它提到公共 API 是本末倒置；消费者只有 `DocumentLinter` 和测试。
+
+产出：`Runtime/Core/Lint/ThemeStyleRules.cs`（三条规则）、`DocumentLinter` 接入 + 逐主题走查、`Tests/EditMode/Lint/ThemeStyleRulesTests.cs`（12 条）、`authoring-promptugui-xml/SKILL.md` 新增 **Theme-scoped styles** 一节 + 顶层元素表 + lint 速查、`scripting-promptugui-csharp/SKILL.md` 的 `UI.Theme.Set` 说明。
+
+验证：EditMode 2315 → 2311 passed / 0 failed / 4 skipped；`dotnet format` 无输出；UIXmlLint 仓库 13 个文件仍零 issue，themed fixture 上 SHAPE 与 ON-INVOCATION 两条都正确触发。
+
+---
+
+## 16. 现状小结
+
+M0 / M1 / M2 全部落地。§9.4 的 `--theme` 以「自动逐主题走查」代替，§6.2 的规则取消（见 M2.4）。仍然开着的：
+
+- **§8 A 类三处 setter 可逆性**：red test 挂着 `[Ignore]`，修复未做。
+- **`itemTemplate` 的 `class=` 从来没生效过**（M2.3 发现的既有缺口，与主题无关）。
+- **lint 无行号**；同一模板多次调用时不可区分是哪一次（M1 记录）。
+- **带命名空间的样式不能被主题覆盖**（M2.2 的 §4.3 收紧）。

--- a/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
+++ b/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
@@ -396,3 +396,28 @@ M0 与 M1 都不依赖主题特性、都能独立合入主干。M1 是 M2 的硬
 `[Ignore]` 而非留红：全量跑必须保持是有效的回归信号。修复 PR 逐条摘 `Ignore` 即可。
 
 **本机环境缺口**：没有安装 dotnet SDK，`dotnet format` 与 `UIXmlLint` / `PxlPreview` CLI 在此机器上跑不了。本次改动只有测试文件，已人工核对缩进 / 行尾空白 / 文件结尾换行与同目录既有测试一致。
+
+### M1（分支 `test/attr-reversibility-red`，两个 commit）
+
+§9.3 的三步全部落地，实测行为与设计一致。三处值得记的偏离 / 发现：
+
+**1. `DocumentAssembler` 没有自立命名空间。** 设计里没写它住哪；第一版放 `PromptUGUI.Loading`，编译炸 30 处 —— 那个名字会**遮蔽公共 API `PromptUGUI.Application.Modals.Loading`**（C# 从内往外解析裸标识符，任何 `PromptUGUI.*` 里的 `Loading` 都先命中命名空间）。改放 `PromptUGUI.Template`（它产出的 `LoadedDoc` 正是 `TemplateExpander` 的输入），理由写进了文件头注释。
+
+**2. 两遍走查下沉到 `Core/Lint/DocumentLinter`，而不是留在 `Program.cs`。** 起因是一个实打实的 bug：`count += WalkExpanded(path, doc, Report)` 会先读 `count`（0），再执行右侧（闭包里 `Report` 把 `count` 加到 1），最后 `0 + 0` 把增量覆盖掉 —— 打印了 3 条却汇总成 1 条，**「只有展开遍报错」的文档 exit code 会是 0**。CLI 没有自己的测试工程，这类错误没人挡得住。把逻辑搬进 Core 之后 `PromptUGUI.Tests.EditMode` 能直接测（`DocumentLinterTests`，6 条），`Program.cs` 只剩 I/O 与 src→path 猜测。
+
+**3. 「解析不到的 import 不算错误」是新增的设计决定。** 设计里没考虑：Addressables / 自定义 resolver 的工程根本没有磁盘形态。若按缺失即报错处理，会把今天干净的文件变成构建失败。改为：整条闭包全部解析成功才跑展开遍，否则只跑 raw 并在 stdout 留一行说明。`DocumentLinterTests.UnresolvableImports_SkipExpandedPass_ButKeepRawRules` 钉住这条。
+
+产出：
+
+| 文件 | 内容 |
+|---|---|
+| `Runtime/Core/IR/DocumentKeys.cs` · `LoadedDoc.cs` | 从 `Application.DocumentLoader` 搬出的三个类型 |
+| `Runtime/Core/Template/DocumentAssembler.cs` | Import 闭包合并语义（纯 C#） |
+| `Runtime/Application/DocumentLoader.cs` | 缩成异步预取壳（151 行 → 80 行） |
+| `Runtime/Core/Lint/DocumentLinter.cs` | raw + expanded 两遍 + 去重 + `PUI-EXPAND` |
+| `.lint/UIXmlLint/{UIXmlLint.csproj,Program.cs,README.md}` | 编译集加 `Core/Template`；文件系统 resolver |
+| `Tests/EditMode/Lint/DocumentLinterTests.cs` | 6 条 |
+
+验证：EditMode 2256 → 2252 passed / 0 failed / 4 skipped（4 skipped 是 M0 的 red）；EditorOnly 308/308；`dotnet format --verify-no-changes --severity warn` 无输出；CLI 对仓库全部 13 个 `.ui.xml` 仍然零 issue（无回归），对专门造的 fixture 正确报出 3 条并 exit 1。新测试的有效性用「临时摘掉展开遍」验证过：6 条里 4 条转红，另 2 条（去重、无法解析时降级）本就该两边成立。
+
+**尚未做**：§9.4 的 `--theme` 与三条主题规则属于 M2；§9.5 提到的 origin 溯源（issue 来自 commons 文件时的归属）也还没做 —— 现在展开遍报出的 issue 一律挂在入口文件路径下，跨文件时会指错文件。M2 之前应补。

--- a/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
+++ b/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
@@ -440,3 +440,23 @@ tmpl.ui.xml: [PUI-MASK-FRAME-SELF] <Frame id='card'>: mask="self" requires ...
 **行号仍然没有**，本次也没做：`LintIssue` 从来就没有行号，`XmlDocument` 的节点默认不实现 `IXmlLineInfo`，要拿到得换一套读取方式。同一个模板被调用多次时，"哪一次调用"也仍不可区分（需要模板调用链，`TextArgs` 有原料但没接）。这两条都留给需要时再说。
 
 验证：EditMode 2262 → 2258 passed / 0 failed / 4 skipped；EditorOnly 308/308；`dotnet format` 无输出；CLI 对仓库 13 个文件仍零 issue；跨文件 fixture 正确指向库文件。有效性用「摘掉模板内联时的 origin 传递」验证：6 条里 3 条转红，失败信息正是这个 bug 本身（`Expected: "skin.ui" But was: "main.ui"`）。
+
+### M2.1 / M2.2（分支 `test/attr-reversibility-red`）
+
+**路线调整（§4.2 / §5 的实现顺序）**：设计里主题 pack 是在**展开期**折进 `class=` 的，M2.3 的运行时重合并再负责后续切换。实现时发现这会有两条路径做同一件事，而且展开期那条拿不到 commons 主题 —— `LoadCommonLibraryAsync` 注册的主题在 `ThemeStore` 里，不在后续某次 `LoadedDoc.Themes` 中。改为：**展开期照旧只合全局 pack，主题层完全由重合并那一步负责**（它本来就要在 Open 时跑一次）。一条路径，`ThemeStore` 是唯一真相源，M2.4 的 `--theme` 也复用同一个函数。
+
+**§4.3 收紧为明确规则**：设计里"主题内 `<Style>` 不参与 `as=` 命名空间"写得含糊。落实为：**主题样式只对 `StyleKey(null, name)` 生效** —— `as="ui"` 导入的 commons 库其样式键是 `StyleKey("ui", name)`，主题没有自己的命名空间去匹配，所以「给带命名空间的样式换肤」目前不支持。写进了 `ThemeStyleResolver` 的注释与测试。要支持得先给 `<Theme>` 一个命名空间概念，另议。
+
+产出：
+
+| 文件 | 内容 |
+|---|---|
+| `Runtime/Core/IR/ThemeBlock.cs` | `Styles` 字段 |
+| `Runtime/Core/Parser/UIDocumentParser.cs` | `ParseStylePack` 抽取共用；`<Theme>` 接受 `<Style>`；`ThemeStyleForbiddenAttrs` + 分组理由文案；`StampOrigin` 顺带给 `StyleDef` 打戳 |
+| `Runtime/Application/ThemeStore.cs` · `UI.cs` | 携带主题样式；`Register` 加只有颜色的兼容重载（既有 ~20 处调用点不动） |
+| `Runtime/Core/Template/ThemeStyleResolver.cs` | 有效 pack 折叠：全局当隐式根 → base 链 root-first → 激活主题；按属性名原子；无主题/无主题样式时原样返回不分配 |
+| `Tests/EditMode/Parser/ThemeStyleParsingTests.cs` · `Template/ThemeStyleResolverTests.cs` | 22 + 11 条 |
+
+验证：EditMode 2295 → 2291 passed / 0 failed / 4 skipped；`dotnet format` 无输出；UIXmlLint 13 个文件零 issue。
+
+**剩余**：M2.3（保留 `class` + inline 快照、`ThemeStyleApplier` 重合并、接 Open 与 `Theme.Changed`）、M2.4（三条 lint 规则 + `--theme` + SKILL）。


### PR DESCRIPTION
`docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md` 的 M0 / M1 / M2 全部里程碑，外加 §8 的可逆性修复。分支名 `test/attr-reversibility-red` 只反映最初的 M0，实际范围长成了整条链。

## 起因

`<Style>` 是**属性宏**，对任何控件的任何属性生效。把它接进 `<Theme>`，主题的表达力就从「换配色」跃迁到「换皮肤」—— sprite、圆角、描边、字号、玻璃参数。代价是 `class=` → 属性的合并必须从「展开期一次性」变成「切主题时可重跑」。

动手前先量了基线：`class` 合并 0.449 ms / 200 节点，一次 `Screen.ReSolve` 31.5 ms —— **合并只占 1.47%，性能不是成本项**。真正的成本在下面几条约束。

## 提交

| | 内容 |
|---|---|
| `e514d97` | **M0** 属性可逆性 red test（对 237 个 `[UIAttr]` 逐个审计） |
| `5f75546` | **M1.1** 合并语义下沉到 Core，`DocumentLoader` 缩成异步预取壳 |
| `e87810d` | **M1.2** lint 走展开后的树，CLI 追平 runtime |
| `008203c` | **M1+** origin 溯源，报错归属到问题真正所在的文件 |
| `f627667` | **M2.1** `<Theme>` 内嵌 `<Style>` 声明层 |
| `c16c41a` | **M2.2** 有效 pack 折叠（全局样式当隐式根） |
| `d870afc` | **M2.3** 切主题在运行时重算 `class=` |
| `d09c50a` | **M2.4** 三条 lint 规则 + SKILL |
| `732dc19` | **M2.5** 可逆性修复，四条 red test 转绿摘掉 `[Ignore]` |

## 三个值得看的设计点

**全局 `<Style>` 是每条主题链的隐式根。** 折叠顺序 `全局 → base 链 → 激活主题`，按属性名原子。带来三件事：不写主题样式的工程逐字节等于今天（`AreSame`，不分配）；主题漏写某属性会回落到全局值而不是「没有值」，残留问题基本消解；作者心智简单 —— 全局说组件是什么，主题只写哪几个参数不一样。

**重合并靠「上次 pack 贡献了哪些属性名」，不靠内联快照。** 设计原本是存一份作者内联属性的快照，实现时发现那样会丢掉模板调用点合并到实例根上的公共属性。改记 `StyleAttrNames`：删掉这些名字，剩下的自然就是内联 + invocation 公共属性，再铺新 pack。一个名字集合就够，天然幂等。

**可逆性的三个修复是同一个形状**：把「一次性设置」改成「从当前声明算出来」。`Tab`/`Btn` 的 `transition`、`Progress` 的图层显隐都是如此。

## 实现期改掉的设计判断

都记在 spec §15：

- **mask 家族不是要修的 bug，是已声明的不支持。** 审计把 6 处不可逆当成 6 个待修项写进了 §8；动手才发现其中 4 处早有 `PUI-MASK-VARIANT` 判为 v1 不支持，理由与审计结论逐字一致。改为保持不支持 + 一条绿色特征化测试钉住契约，同时把 mask 家族补进主题黑名单 —— 同一件不支持的事，不能让主题成为新入口。
- **`PUI-THEME-STYLE-IF-PARAM` 取消**：M2.3 之后它永远不可能触发。
- **`--theme` 不做成 flag**：CLI 自动对每个声明的主题各走一遍展开树并去重。
- **新增 `PUI-THEME-STYLE-NO-BASELINE`**：写测试时才发现只在主题里声明的样式根本引用不到。
- **解析不到的 `<Import>` 不算错误**：Addressables / 自定义 resolver 的工程没有磁盘形态，按缺失即报错会把今天干净的文件变成构建失败。

## 顺手修掉的既有缺陷

- `Btn.pressedSprite` / `disabledSprite` 与 Tab 同形（原注释写着 "Set-only"），一起修。
- `Progress` 的 `bg` 与 `bgColor` 两个 setter 都在 `SetActive(true)`，而属性遍历顺序来自 `HashSet`、**未定义**。改成从两个标志一起算之后顺序无关。
- `RawImage` 的 mask 家族同时漏出 `IRWalker` 的分发与 `VariantBaseRules` 的豁免，两道闸门都不管。
- `Walk_NonFrameNonImageTags_NoMaskIssue` 里「mask 只 Frame/Image 暴露」的过期注释。

## 验证

- EditMode **2317 / 2317**、PlayMode **171 / 171**、EditorOnly **308 / 308** —— 0 failed，**0 skipped**
- `dotnet format --verify-no-changes --severity warn` 无输出
- UIXmlLint 对仓库全部 13 个 `.ui.xml` **零 issue**（无回归）
- 新测试的有效性都用「临时摘掉实现再跑」验证过，确认转红且原因正确

## 已知仍开着

- `itemTemplate` 的 `class=` 从来没生效过（M2.3 发现的既有缺口，与主题无关）
- lint 无行号；同一模板多次调用时不可区分是哪一次
- 带命名空间的样式（`class="ui:card"`）不能被主题覆盖

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhZySsbMocJuC1kULMtpf4