### PR TITLE
fix: itemTemplate 完整展开 + 动态子树重解算，feat: lint 源位置

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -698,6 +698,8 @@ inline 属性  >  右边的 class  >  左边的 class
 - `class="{{param}}"` inside a `<Template>` body is fine — the class name is substituted first, so a template can take its skin as a parameter.
 - `<Screen>` takes no `class` (it is not a control). `class=""` (no names) and an unknown style name are both errors.
 
+**`itemTemplate=` 也走完整展开**：`<ScrollList>` / `<TabBar>` / `<Carousel>` 用的模板体和别处一样会合并 `class=`、替换 `{{param}}`、内联嵌套模板调用。因为没有调用点提供实参，模板自己的 `<Param default=...>` 就是实参 —— 所以**当作 itemTemplate 用的模板，每个 `<Param>` 都必须有 `default=`**，否则 `UI.Open` 会直接报错说清楚是哪个模板的哪个参数。
+
 **Sharing** works exactly like `<Template>`: styles travel through `<Import>`, land in the commons pool, hot-reload with their file, and a name colliding between commons and the entry document is a hard error. An unknown style name is caught by the lint CLI as `PUI-EXPAND` whenever it can read the imported files from disk; otherwise it surfaces at `UI.Open()`. A namespaced commons library is referenced with a colon — `class="ui:card"` — mirroring the `Set:Name` form used for sprites and icons (tags use a dot, `ui.TitledPanel`; class references use a colon).
 
 Swapping which commons library is loaded therefore re-skins everything at once.

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -501,6 +501,8 @@ For Addressables-backed `.po` loading (`UI.Locale.UseAddressableResolver`, `Loca
 
 ## Theme switching
 
+`BindItems` 建出来的行**跟随 Variant / 主题重解算**（此前它们在实例化后就冻住，连颜色 token 都不跟）。一次重放的代价随行数超线性增长（50 行约 6 ms，500 行约 500 ms），所以**窗口 resize 刻意跳过它** —— 行所依赖的状态并没有变，而 resize 是成串到来的；转屏仍然能到达行，因为那是切 Variant，走状态路径。行数很多时列表本身就该考虑虚拟化。
+
 `UI.Theme.Set` re-derives **colour tokens and `<Style>` packs** — a theme that declares `<Style>`
 children re-skins sprites, radii, font sizes and everything else `class=` can carry, in place: the
 attributes are replayed through the same path a resize takes, so **no GameObject is rebuilt** and

--- a/.lint/UIXmlLint/Program.cs
+++ b/.lint/UIXmlLint/Program.cs
@@ -24,9 +24,14 @@ namespace PromptUGUI.UIXmlLint
                 return 2;
             }
 
+            // Deduplicate ACROSS entry files, not just within one. Linting a directory walks both
+            // a library and the document that imports it, and the expanded pass attributes a finding
+            // to where it was written — so the same defect would otherwise be printed once per entry
+            // file that reaches it. Origin + line is what makes that identity precise enough to fold.
+            var reported = new HashSet<string>();
             var errorCount = 0;
             foreach (var path in paths)
-                errorCount += LintFile(path);
+                errorCount += LintFile(path, reported);
 
             if (errorCount > 0)
             {
@@ -74,7 +79,7 @@ namespace PromptUGUI.UIXmlLint
             return result;
         }
 
-        private static int LintFile(string path)
+        private static int LintFile(string path, HashSet<string> reported)
         {
             var doc = TryParse(path, out var parseFailed);
             if (parseFailed) return 1;
@@ -97,7 +102,14 @@ namespace PromptUGUI.UIXmlLint
             {
                 // Origin is the file the markup was WRITTEN in — for a finding inside an imported
                 // Template body that is the library, not the entry document that invoked it.
-                Console.Error.WriteLine($"{issue.Origin ?? path}: [{issue.Code}] {issue.Message}");
+                // "file:line:" is the shape editors and terminals turn into a jump.
+                var where = issue.Origin ?? path;
+                if (issue.Line > 0) where += ":" + issue.Line;
+                // The declaration site stays primary — that is where the edit goes. The invocation
+                // is context, and only worth printing when it names a different place.
+                var via = issue.Via != null && issue.Via != where ? $" (via {issue.Via})" : "";
+                if (!reported.Add(where + via + "|" + issue.Code + "|" + issue.Message)) continue;
+                Console.Error.WriteLine($"{where}: [{issue.Code}] {issue.Message}{via}");
                 count++;
             }
             return count;

--- a/.lint/UIXmlLint/README.md
+++ b/.lint/UIXmlLint/README.md
@@ -42,6 +42,25 @@ document simply skips the expanded pass (a note on stdout says so) and keeps
 exactly the pre-existing raw-IR behaviour — failing a today-clean file over an
 environment gap would cost more than the missed coverage.
 
+### Where a finding points
+
+Output is `file:line: [CODE] message`, the shape editors and terminals turn into a jump:
+
+```
+$ UIXmlLint multi.ui.xml
+multi.ui.xml:4: [PUI-MASK-FRAME-SELF] <Frame id='a'>: mask="self" … (via multi.ui.xml:7)
+multi.ui.xml:4: [PUI-MASK-FRAME-SELF] <Frame id='b'>: mask="self" … (via multi.ui.xml:8)
+```
+
+The primary position is where the markup was **declared** — that is where the edit goes. `(via …)`
+is the Template invocation that produced this instance, printed only when a template is involved:
+without it, ten invocations of one template produce ten findings that read identically. Nested
+invocations record the OUTERMOST site, since inner ones are the same for every instance.
+
+Line numbers come from a `LineInfoXmlDocument` that overrides `CreateElement` while the reader is
+still on the element — `XmlDocument` nodes carry no position of their own, and this was cheaper than
+porting the parser to `XDocument` for the same information.
+
 ### Which file a finding is reported against
 
 Once imports are followed, the node a rule complains about is often **not** in
@@ -59,9 +78,13 @@ The mistake is in `tmpl.ui.xml`; `uses-tmpl.ui.xml` merely invoked the template.
 Findings in the linted file itself are unaffected — they report against it as
 before.
 
+Findings are deduplicated **across** entry files, not just within one: linting a directory walks
+both a library and the document importing it, and the expanded pass attributes a finding to where it
+was written, so the same defect would otherwise print once per entry file that reaches it.
+
 The two-pass logic lives in `Runtime/Core/Lint/DocumentLinter.cs`, not in
 `Program.cs`, so it is covered by `PromptUGUI.Tests.EditMode`
-(`DocumentLinterTests`, `LintOriginTests`). The CLI owns only I/O and the
+(`DocumentLinterTests`, `LintOriginTests`, `LintSourcePositionTests`). The CLI owns only I/O and the
 src → path guess.
 
 Some rules are **CLI-only** — they catch author confusion that runtime

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ dotnet run --project .lint/UIXmlLint -- Runtime/Resources/                   # �
 
 规则代码在 `Runtime/Core/Lint/`（纯 C#），跟 `ScreenInstantiator` 的 warning 路径共用同一份实现 —— 新增规则时只改一处。
 
-CLI 对每份文档跑**两遍**（`Core/Lint/DocumentLinter.cs`，按 issue 去重）：**raw**（作者写的原样，能看到 `if="false"` 背后和没人调用的模板）+ **expanded**（`ScreenInstantiator` 真正构建的那棵树，能看到模板调用的真实父子关系、`class=` 带来的属性、以及 `GlassRules` 这类规则开口前必须知道的最终形态）。两者互不包含。它会跟着 `<Import>` 读盘（按「导入方所在目录 → 逐级上溯到 `Resources/`」猜 `src`）；**解析不到的 import 不算错误**，那份文档只是跳过展开遍、退回今天的行为（Addressables / 自定义 resolver 的工程没有磁盘形态）。展开失败（未知模板/样式名、Import 循环）报 `PUI-EXPAND`。**报错归属按 `ElementNode.OriginSrc`**（`Parse(xml, src)` 打戳、展开期逐层传递）—— 问题出在被 import 的库里就报那个库的文件名，不是入口文件。详见 `.lint/UIXmlLint/README.md`。
+CLI 对每份文档跑**两遍**（`Core/Lint/DocumentLinter.cs`，按 issue 去重）：**raw**（作者写的原样，能看到 `if="false"` 背后和没人调用的模板）+ **expanded**（`ScreenInstantiator` 真正构建的那棵树，能看到模板调用的真实父子关系、`class=` 带来的属性、以及 `GlassRules` 这类规则开口前必须知道的最终形态）。两者互不包含。它会跟着 `<Import>` 读盘（按「导入方所在目录 → 逐级上溯到 `Resources/`」猜 `src`）；**解析不到的 import 不算错误**，那份文档只是跳过展开遍、退回今天的行为（Addressables / 自定义 resolver 的工程没有磁盘形态）。展开失败（未知模板/样式名、Import 循环）报 `PUI-EXPAND`。输出是 `file:line: [CODE] msg`；**归属按 `ElementNode.OriginSrc` + `Line`**（`Parse(xml, src)` 打戳、展开期逐层传递）—— 问题出在被 import 的库里就报那个库的文件行号，不是入口文件。模板参与时追一段 `(via file:line)` 指出是哪一次调用（记最外层，内层每个实例都一样、区分不了）。跨入口文件去重。详见 `.lint/UIXmlLint/README.md`。
 
 ### `.pxl` 渲染预览（PxlPreview CLI）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Internal refactors, test-only changes, performance work, and Editor tooling that
 `Runtime/` is split into:
 - `Core/IR/` — pure POCOs (`UIDocument`, `ScreenDef`, `TemplateDef`, `ElementNode`, `ImportRef`, `VariantBlock`, `AddDirective`, `StyleDef`, `ThemeBlock`) + 合并产物 `LoadedDoc` 与它的键 `TemplateKey` / `StyleKey`
 - `Core/Parser/` — `UIDocumentParser` (XML → IR) + `ParseException`
-- `Core/Template/` — `DocumentAssembler` (Import 闭包合并 → `LoadedDoc`) + `TemplateExpander` (inlines Template invocations) + `StyleMerger` (`class=` 属性包合并) + `Substitution` / `Truthy`
+- `Core/Template/` — `DocumentAssembler` (Import 闭包合并 → `LoadedDoc`) + `TemplateExpander` (inlines Template invocations；并为 `itemTemplate=` 预展开一份 per-Screen 的 `ScreenDef.Templates`) + `StyleMerger` (`class=` 属性包合并 + 切主题重算) + `ThemeStyleResolver` / `ThemeStyleApplier` + `Substitution` / `Truthy`
 - `Core/Variants/` — `VariantResolver` (last-active-wins for `attr.var` overrides)
 - `Core/Layout/` — `AnchorResolver` / `MarginResolver` / `SizeSpec`
 - `Controls/` — built-in primitives (`Frame`, `Image`, `Text`, `VStack`, `HStack`, `Grid`, `Btn`) + the `Control` base class

--- a/Runtime/Application/Screen.cs
+++ b/Runtime/Application/Screen.cs
@@ -334,6 +334,12 @@ namespace PromptUGUI.Application
                     t.gameObject.AddComponent<Controls.Internal.PixelSnap>();
         }
 
+        // dynamicBaseline stays TRUE even though ReSolveDynamicSubtrees can now re-run ApplyCommon
+        // on these nodes. The two are not alternatives: the resize path deliberately SKIPS the
+        // attribute replay (it is ~500 ms on a 500-row list), so ApplyCommon has not necessarily run
+        // and the captured baseline is still what keeps the box-preserving compensation from
+        // accumulating across resizes. Where ApplyCommon did run it produced the same geometry, so
+        // restoring the capture on top of it is a no-op.
         private void ApplyScalesTo(Dictionary<ElementNode, Control> nodes)
         {
             foreach (var kv in nodes)
@@ -420,20 +426,21 @@ namespace PromptUGUI.Application
 
         // ScreenInstantiator.InstantiateNode（BindItems / Markdown 动态实例化）完成后调用。
         // 无 scale 声明的子树不登记（绝大多数列表卡片），零额外开销。
+        /// <summary>
+        /// 登记一棵 BindItems 建出来的子树。**每一棵都登记**，不再只登记声明了 <c>scale</c> 的那些 ——
+        /// 这个列表原本只为 <see cref="ApplyScales"/> 服务，于是没有 <c>scale</c> 的行根本不在里面，
+        /// 而 <see cref="ReSolveDynamicSubtrees"/> 要靠它把属性重放到每一行上。少登记的后果是：
+        /// 绑出来的列表不跟 Variant、不随主题重绘、resize 不重解算，连颜色 token 都到不了。
+        /// </summary>
         internal void RegisterDynamicSubtree(Control root, Dictionary<ElementNode, Control> nodes)
         {
             AttachPixelSnaps(root.GameObject);
             PruneDeadDynamicSubtrees();
-            var hasScale = false;
             foreach (var node in nodes.Keys)
             {
-                if (!hasScale && (node.Attributes.ContainsKey("scale")
-                                  || node.VariantOverrides.ContainsKey("scale")))
-                    hasScale = true;
                 // 动态子树可能是 Screen 里唯一的 factor scale 来源；resize 门控必须看到它。
-                if (DeclaresFactorScale(node)) _hasFactorScale = true;
+                if (DeclaresFactorScale(node)) { _hasFactorScale = true; break; }
             }
-            if (!hasScale) return;
             _dynamicSubtrees.Add(new DynamicSubtree { Root = root, Nodes = nodes });
             ApplyScalesTo(nodes);
         }
@@ -586,8 +593,9 @@ namespace PromptUGUI.Application
                 if (_hasFactorScale)
                     // 'Nx' localScale depends on the factor: re-baseline + recompute via the
                     // tested ReSolve path (ApplyCommon → ApplyCanvasScaler → ApplyScales) so the
-                    // box-preserving inflation does not accumulate.
-                    ReSolve();
+                    // box-preserving inflation does not accumulate. Rows are skipped: nothing they
+                    // resolve against changed, and resizes arrive in bursts.
+                    ReSolve(replayDynamicSubtrees: false);
                 else
                     ApplyCanvasScaler(scaler);
             }
@@ -804,7 +812,18 @@ namespace PromptUGUI.Application
 
         public void Dispose() => Close();
 
-        public void ReSolve()
+        /// <summary>
+        /// <paramref name="replayDynamicSubtrees"/> controls whether rows built by <c>BindItems</c>
+        /// get their attributes replayed. They need it when the STATE they resolve against changed —
+        /// a Variant flip, a theme switch — and not on a plain resize, where nothing about a row's
+        /// declared values can have moved (its canvas-dependent <c>scale</c> is handled separately by
+        /// <see cref="ApplyScales"/>, which still runs).
+        ///
+        /// <para>The distinction is worth making because the cost is not small: a 500-row list is
+        /// ~550 ms per replay, and window resizes arrive in bursts. An orientation change reaches
+        /// rows anyway — it flips a Variant, which is the state path.</para>
+        /// </summary>
+        public void ReSolve(bool replayDynamicSubtrees = true)
         {
             // root 被外部销毁(场景重载)而 Screen 未走 Close 时,任何静态事件回调(Theme/Variants
             // .Changed)都不应再触达 ReSolve 解引用已销毁的 RootGameObject。哨兵(relay.OnDestroy)
@@ -844,11 +863,42 @@ namespace PromptUGUI.Application
                 var entry = _registry.Resolve(node.Tag);
                 ControlAttributeApplier.Apply(node, control, entry, Variants, initial: false);
             }
+            if (replayDynamicSubtrees) ReSolveDynamicSubtrees();
             RecomputeFactorScale();
             ApplyCanvasScaler(RootGameObject.GetComponent<UnityEngine.UI.CanvasScaler>());
             ApplyScales();
             AttachPixelSnaps(RootGameObject);
             Navigation.ExplicitNavigationResolver.Resolve(this, _nodeMap, Variants, inactiveNodes, NavConfineRoot);
+        }
+
+        /// <summary>
+        /// Replays attributes for rows built by <c>BindItems</c>, the same way the loop above does
+        /// for the static tree. Without it a bound list was frozen at whatever it was instantiated
+        /// with: no Variant, no theme repaint, no re-solve on resize.
+        ///
+        /// <para>Runs BEFORE <see cref="ApplyScales"/>, so the scale compensation reads geometry
+        /// <c>ApplyCommon</c> has just resolved. It does NOT replace the dynamic scale path's own
+        /// captured baseline: the resize path skips this replay entirely, so that capture is still
+        /// what keeps the compensation from accumulating (see <c>ApplyScalesTo</c>).</para>
+        ///
+        /// <para>The subtrees of one list share their ElementNodes — every row is instantiated from
+        /// the same template body — so the same node is applied once per row, each to that row's own
+        /// Control. The runtime-takeover locks are per-Control, which is what keeps a replay from
+        /// snapping bound content back to the declared value.</para>
+        /// </summary>
+        private void ReSolveDynamicSubtrees()
+        {
+            PruneDeadDynamicSubtrees();
+            foreach (var subtree in _dynamicSubtrees)
+            {
+                foreach (var kv in subtree.Nodes)
+                {
+                    var control = kv.Value;
+                    if (control.GameObject == null) continue;
+                    var entry = _registry.Resolve(kv.Key.Tag);
+                    ControlAttributeApplier.Apply(kv.Key, control, entry, Variants, initial: false);
+                }
+            }
         }
 
         /// <summary>

--- a/Runtime/Controls/Carousel.cs
+++ b/Runtime/Controls/Carousel.cs
@@ -224,6 +224,7 @@ namespace PromptUGUI.Controls
             var owner = UI.OwnerScreenOf(this);
             if (owner?.Def?.Templates != null && owner.Def.Templates.TryGetValue(tag, out var tpl))
             {
+                Internal.ItemTemplateGuard.EnsureInstantiable(tag, tpl);
                 return parent =>
                 {
                     var instantiator = UI.GetInstantiator();

--- a/Runtime/Controls/Internal/ItemTemplateGuard.cs
+++ b/Runtime/Controls/Internal/ItemTemplateGuard.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using PromptUGUI.IR;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Controls.Internal
+{
+    /// <summary>
+    /// Shared by the three <c>itemTemplate=</c> consumers (<c>ScrollList</c> / <c>TabBar</c> /
+    /// <c>Carousel</c>).
+    /// </summary>
+    internal static class ItemTemplateGuard
+    {
+        /// <summary>
+        /// An itemTemplate is instantiated with no invocation, so a template's own
+        /// <c>&lt;Param&gt;</c> defaults are the only arguments available. A REQUIRED param has no
+        /// value at all: <c>TemplateExpander</c> therefore leaves such a body unexpanded, and
+        /// instantiating it would apply <c>{{name}}</c> to a real attribute — which throws deep
+        /// inside the bind, where R3 turns it into a console error about a colour token and the list
+        /// just comes up empty. Say what is actually wrong, at Open, instead.
+        /// </summary>
+        public static void EnsureInstantiable(string tag, TemplateDef tpl)
+        {
+            List<string> required = null;
+            foreach (var p in tpl.Params)
+            {
+                if (p.HasDefault) continue;
+                (required ??= new List<string>()).Add(p.Name);
+            }
+            if (required == null) return;
+
+            throw new ParseException(
+                $"itemTemplate='{tag}': <Template name='{tpl.Name}'> has required <Param> " +
+                $"{string.Join(", ", required)} with no default. An item template is instantiated " +
+                "without an invocation, so there is nothing to supply them — give each a default=, " +
+                "or point itemTemplate at a template that needs no arguments.");
+        }
+    }
+}

--- a/Runtime/Controls/Internal/ItemTemplateGuard.cs.meta
+++ b/Runtime/Controls/Internal/ItemTemplateGuard.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f587174b58fa9836eb0b39ff199cbe3c

--- a/Runtime/Controls/ScrollList.cs
+++ b/Runtime/Controls/ScrollList.cs
@@ -258,6 +258,7 @@ namespace PromptUGUI.Controls
             // 1) Template
             if (owner?.Def?.Templates != null && owner.Def.Templates.TryGetValue(tag, out var tpl))
             {
+                Internal.ItemTemplateGuard.EnsureInstantiable(tag, tpl);
                 return parent =>
                 {
                     var instantiator = PromptUGUI.Application.UI.GetInstantiator();

--- a/Runtime/Controls/TabBar.cs
+++ b/Runtime/Controls/TabBar.cs
@@ -165,6 +165,7 @@ namespace PromptUGUI.Controls
             var owner = UI.OwnerScreenOf(this);
             if (owner?.Def?.Templates != null && owner.Def.Templates.TryGetValue(tag, out var tpl))
             {
+                Internal.ItemTemplateGuard.EnsureInstantiable(tag, tpl);
                 return parent =>
                 {
                     var instantiator = UI.GetInstantiator();

--- a/Runtime/Core/IR/ElementNode.cs
+++ b/Runtime/Core/IR/ElementNode.cs
@@ -12,6 +12,18 @@ namespace PromptUGUI.IR
         public List<ElementNode> Children { get; }
 
         /// <summary>
+        /// Where the Template invocation that produced this node was written, preformatted as
+        /// <c>file:line</c>; null on nodes that were not produced by one.
+        ///
+        /// <para><see cref="OriginSrc"/> plus <see cref="Line"/> say where the markup was DECLARED,
+        /// which is where a fix goes. That is not enough on its own when one template is invoked ten
+        /// times and a single instance is wrong — all ten findings would read identically. This says
+        /// WHICH instance. It records the OUTERMOST invocation deliberately: nested ones are
+        /// structural and identical across instances, so they cannot tell two apart.</para>
+        /// </summary>
+        public string InvokedAt { get; set; }
+
+        /// <summary>
         /// Which attribute names the <c>class=</c> pack contributed at the last merge. Non-null iff
         /// the node's class has been resolved (an empty set is a real answer: every packed name was
         /// already spelled out inline).
@@ -22,6 +34,13 @@ namespace PromptUGUI.IR
         /// clean slate without a separate snapshot of the author's own values.</para>
         /// </summary>
         public System.Collections.Generic.HashSet<string> StyleAttrNames { get; set; }
+
+        /// <summary>
+        /// 1-based line in <see cref="OriginSrc"/> where this node's opening tag starts; 0 when
+        /// unknown (a synthesised node, or a caller that parsed without line info). Travels with
+        /// <see cref="OriginSrc"/> through expansion so a lint finding can name a place, not a file.
+        /// </summary>
+        public int Line { get; set; }
 
         /// <summary>
         /// The src this node's markup was written in, stamped by <c>UIDocumentParser.Parse(xml, src)</c>

--- a/Runtime/Core/IR/TemplateDef.cs
+++ b/Runtime/Core/IR/TemplateDef.cs
@@ -9,6 +9,15 @@ namespace PromptUGUI.IR
         public ElementNode Body { get; set; }    // 必须有且仅有一个根元素
         public string OriginSrc { get; set; }   // 仅 commons reload 时使用；其他场景 null
 
+        /// <summary>
+        /// True only on the per-Screen runtime copies whose <see cref="Body"/> went through
+        /// expansion (<c>TemplateExpander.BuildRuntimeTemplates</c>). A body kept RAW — because a
+        /// required <c>&lt;Param&gt;</c> left nothing to substitute — still carries
+        /// <c>{{placeholder}}</c> text, so anything that resolves attribute values against it (a
+        /// theme re-merge looking up <c>class=</c>) must leave it alone.
+        /// </summary>
+        internal bool BodyExpanded { get; set; }
+
         public TemplateDef(string name) { Name = name; }
     }
 }

--- a/Runtime/Core/Lint/DocumentLinter.cs
+++ b/Runtime/Core/Lint/DocumentLinter.cs
@@ -117,7 +117,26 @@ namespace PromptUGUI.Lint
             // to remember: the themes a document can reach are already declared in it.
             foreach (var themeName in SortedKeys(themes))
             {
-                ThemeStyleApplierForLint(expanded, loaded.Styles, themes, themeName);
+                // Re-deriving under a theme can throw the same way expansion can (an unresolvable
+                // class name). Report it and move on rather than taking the whole run down — a
+                // linter that dies on its input tells the author nothing about the other files.
+                LintIssue? themeFailure = null;
+                try
+                {
+                    ThemeStyleApplierForLint(expanded, loaded.Styles, themes, themeName);
+                }
+                catch (Exception ex) when (ex is TemplateException || ex is ParseException)
+                {
+                    themeFailure = new LintIssue(
+                        ExpansionCode, "Theme", themeName,
+                        $"re-deriving styles under <Theme name='{themeName}'> failed: {ex.Message}");
+                }
+                if (themeFailure.HasValue)
+                {
+                    if (seen.Add(KeyOf(themeFailure.Value))) yield return themeFailure.Value;
+                    continue;
+                }
+
                 foreach (var issue in IRWalker.Walk(expanded))
                     if (seen.Add(KeyOf(issue)))
                         yield return issue;

--- a/Runtime/Core/Lint/IRWalker.cs
+++ b/Runtime/Core/Lint/IRWalker.cs
@@ -38,7 +38,7 @@ namespace PromptUGUI.Lint
             // they get their own pass so a bad radius in a style is caught where it's written.
             foreach (var style in doc.Styles.Values)
                 foreach (var issue in StyleRules.CheckStyle(style))
-                    yield return issue.WithOrigin(style.OriginSrc);
+                    yield return issue.WithSource(style.OriginSrc, 0);
 
             foreach (var template in doc.Templates.Values)
             {
@@ -85,7 +85,7 @@ namespace PromptUGUI.Lint
         private static IEnumerable<LintIssue> WalkNode(ElementNode node, bool inTemplateBody, bool hasStateSourceAncestor, bool parentIsLayoutGroup, bool isTemplateBodyRoot, HashSet<string> screenIds, StyleAttributeView styles)
         {
             foreach (var issue in WalkNodeCore(node, inTemplateBody, hasStateSourceAncestor, parentIsLayoutGroup, isTemplateBodyRoot, screenIds, styles))
-                yield return issue.Origin == null ? issue.WithOrigin(node.OriginSrc) : issue;
+                yield return issue.Origin == null ? issue.WithSource(node.OriginSrc, node.Line, node.InvokedAt) : issue;
         }
 
         private static IEnumerable<LintIssue> WalkNodeCore(ElementNode node, bool inTemplateBody, bool hasStateSourceAncestor, bool parentIsLayoutGroup, bool isTemplateBodyRoot, HashSet<string> screenIds, StyleAttributeView styles)
@@ -190,22 +190,22 @@ namespace PromptUGUI.Lint
             {
                 if (isLayoutGroup)
                     foreach (var issue in LayoutGroupChildRules.CheckChild(child))
-                        yield return issue.WithOrigin(child.OriginSrc);
+                        yield return issue.WithSource(child.OriginSrc, child.Line, child.InvokedAt);
                 else
                     // 'flow' under a non-layout-group parent is inert — flag it. Dispatched
                     // from the child loop only (parent tag truly known): template-body roots,
                     // <Add> roots and screen roots are exempt automatically — their real
                     // parent is resolved at invocation/runtime and may well be an HStack.
                     foreach (var issue in LayoutGroupChildRules.CheckNonLayoutChild(child))
-                        yield return issue.WithOrigin(child.OriginSrc);
+                        yield return issue.WithSource(child.OriginSrc, child.Line, child.InvokedAt);
                 if (node.Tag == "Carousel")
                     foreach (var issue in CarouselRules.CheckCard(node, child))
-                        yield return issue.WithOrigin(child.OriginSrc);
+                        yield return issue.WithSource(child.OriginSrc, child.Line, child.InvokedAt);
                 // CLI-only: a direct <Grid> child's own size/width/height is overridden by cellSize.
                 // Grid-specific (V/HStack children's size IS meaningful), so gated on the parent tag here.
                 if (node.Tag == "Grid")
                     foreach (var issue in LayoutGroupChildRules.CheckGridChild(child))
-                        yield return issue.WithOrigin(child.OriginSrc);
+                        yield return issue.WithSource(child.OriginSrc, child.Line, child.InvokedAt);
                 // Exempt Template-instance roots and bodies: <Tab> wrapped in a
                 // Template (e.g. <Template name='FileTab'><Frame><Tab/>...) is
                 // intentional — TabBar.CollectStaticTabs walks wrappers via FindTabIn.
@@ -217,7 +217,7 @@ namespace PromptUGUI.Lint
                         TabRules.TabParentCode, child.Tag, child.Id,
                         $"<Tab id='{child.Id}'>: must be a direct child of <TabBar>; current parent is <{node.Tag}>. " +
                         "Mutual exclusion and shared visuals will not apply.",
-                        child.OriginSrc);
+                        child.OriginSrc, child.Line, child.InvokedAt);
                 foreach (var issue in WalkNode(child, inTemplateBody, childHasStateSourceAncestor, parentIsLayoutGroup: isLayoutGroup, isTemplateBodyRoot: false, screenIds: screenIds, styles: styles))
                     yield return issue;
             }

--- a/Runtime/Core/Lint/LintIssue.cs
+++ b/Runtime/Core/Lint/LintIssue.cs
@@ -14,17 +14,29 @@ namespace PromptUGUI.Lint
         /// </summary>
         public string Origin { get; }
 
-        public LintIssue(string code, string tag, string id, string message, string origin = null)
+        /// <summary>1-based line in <see cref="Origin"/>, or 0 when unknown.</summary>
+        public int Line { get; }
+
+        /// <summary>
+        /// <c>file:line</c> of the Template invocation this node came from, or null. Distinguishes
+        /// instances when one template is invoked many times; see <see cref="IR.ElementNode.InvokedAt"/>.
+        /// </summary>
+        public string Via { get; }
+
+        public LintIssue(string code, string tag, string id, string message,
+                         string origin = null, int line = 0, string via = null)
         {
             Code = code;
             Tag = tag;
             Id = id;
             Message = message;
             Origin = origin;
+            Line = line;
+            Via = via;
         }
 
-        /// <summary>Same finding, attributed to <paramref name="origin"/>.</summary>
-        public LintIssue WithOrigin(string origin) =>
-            new LintIssue(Code, Tag, Id, Message, origin);
+        /// <summary>Same finding, attributed to a place in the source.</summary>
+        public LintIssue WithSource(string origin, int line, string via = null) =>
+            new LintIssue(Code, Tag, Id, Message, origin, line, via);
     }
 }

--- a/Runtime/Core/Parser/LineInfoXmlDocument.cs
+++ b/Runtime/Core/Parser/LineInfoXmlDocument.cs
@@ -1,0 +1,61 @@
+using System.IO;
+using System.Xml;
+
+namespace PromptUGUI.Parser
+{
+    /// <summary>
+    /// An <see cref="XmlElement"/> that remembers where it was in the source text.
+    /// </summary>
+    internal sealed class LineInfoElement : XmlElement
+    {
+        public int Line { get; }
+        public int Column { get; }
+
+        internal LineInfoElement(
+            string prefix, string localName, string namespaceUri, XmlDocument doc, int line, int column)
+            : base(prefix, localName, namespaceUri, doc)
+        {
+            Line = line;
+            Column = column;
+        }
+    }
+
+    /// <summary>
+    /// Gives the parser source positions without rewriting it against a different XML API.
+    ///
+    /// <para><see cref="XmlDocument"/> nodes carry no line information, and <c>LoadXml(string)</c>
+    /// throws the reader away. But <c>Load(XmlReader)</c> calls <see cref="CreateElement"/> while the
+    /// reader is still sitting on the element being created — so an override can read the position
+    /// off it and hand back an element that keeps it. The alternative was porting ~700 lines of
+    /// <c>XmlElement</c> code to <c>XDocument</c> for the same information.</para>
+    ///
+    /// <para>Positions reach lint findings through <c>ElementNode.Line</c>, which survives expansion
+    /// the same way <c>OriginSrc</c> does.</para>
+    /// </summary>
+    internal sealed class LineInfoXmlDocument : XmlDocument
+    {
+        private IXmlLineInfo _lineInfo;
+
+        public static XmlDocument Parse(string xml)
+        {
+            var doc = new LineInfoXmlDocument();
+            using var reader = XmlReader.Create(new StringReader(xml));
+            doc._lineInfo = reader as IXmlLineInfo;
+            doc.Load(reader);
+            doc._lineInfo = null;   // stale after the load; later CreateElement calls get 0
+            return doc;
+        }
+
+        public override XmlElement CreateElement(string prefix, string localName, string namespaceUri)
+        {
+            var line = 0;
+            var column = 0;
+            if (_lineInfo != null && _lineInfo.HasLineInfo())
+            {
+                line = _lineInfo.LineNumber;
+                column = _lineInfo.LinePosition;
+            }
+            return new LineInfoElement(prefix, localName, namespaceUri, this, line, column);
+        }
+    }
+}

--- a/Runtime/Core/Parser/LineInfoXmlDocument.cs.meta
+++ b/Runtime/Core/Parser/LineInfoXmlDocument.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 30fbbeccbda8076119b6eed27efa7083

--- a/Runtime/Core/Parser/UIDocumentParser.cs
+++ b/Runtime/Core/Parser/UIDocumentParser.cs
@@ -58,8 +58,7 @@ namespace PromptUGUI.Parser
 
         private static UIDocument ParseCore(string xml)
         {
-            var xdoc = new XmlDocument();
-            xdoc.LoadXml(xml);
+            var xdoc = LineInfoXmlDocument.Parse(xml);
 
             var root = xdoc.DocumentElement;
             if (root == null || root.Name != "PromptUGUI")
@@ -135,6 +134,8 @@ namespace PromptUGUI.Parser
             doc.Imports.Add(new IR.ImportRef(src, ns));
         }
 
+        private static int LineOf(XmlElement el) => el is LineInfoElement li ? li.Line : 0;
+
         private static ThemeBlock ParseTheme(XmlElement el)
         {
             var name = el.GetAttribute("name");
@@ -208,7 +209,8 @@ namespace PromptUGUI.Parser
                     "(a Screen is not a control; put class= on a child element)");
 
             var idsInScreen = new System.Collections.Generic.HashSet<string>();
-            var rootNode = new ElementNode("__screen_root__");
+            // The synthetic root stands in for <Screen> itself, so point at that.
+            var rootNode = new ElementNode("__screen_root__") { Line = LineOf(el) };
             var screen = new ScreenDef(name, rootNode);
 
             var canvasAttr = el.GetAttribute("canvas");
@@ -549,7 +551,7 @@ namespace PromptUGUI.Parser
                 ns = tag.Substring(0, dot);
                 tag = tag.Substring(dot + 1);
             }
-            var node = new ElementNode(tag, ns);
+            var node = new ElementNode(tag, ns) { Line = LineOf(el) };
 
             foreach (XmlAttribute attr in el.Attributes)
             {

--- a/Runtime/Core/Template/StyleMerger.cs
+++ b/Runtime/Core/Template/StyleMerger.cs
@@ -197,6 +197,8 @@ namespace PromptUGUI.Template
             var dst = new ElementNode(src.Tag, src.Namespace)
             {
                 OriginSrc = src.OriginSrc,
+                Line = src.Line,
+                InvokedAt = src.InvokedAt,
                 StyleAttrNames = src.StyleAttrNames,
                 Id = src.Id,
                 TextContent = src.TextContent,

--- a/Runtime/Core/Template/TemplateExpander.cs
+++ b/Runtime/Core/Template/TemplateExpander.cs
@@ -29,6 +29,7 @@ namespace PromptUGUI.Template
                 result.Styles[kv.Key.ToString()] = kv.Value;      // 同上：诊断用，展开产物已不含 class
 
             var styles = loaded.Styles;
+            var runtimeTemplates = BuildRuntimeTemplates(loaded, styles);
 
             foreach (var s in loaded.Screens)
             {
@@ -60,7 +61,7 @@ namespace PromptUGUI.Template
                                      new HashSet<TemplateKey>()),
                 };
                 // 把全局 Template 表附到本 Screen，供 ScrollList 等运行时控件按 tag 反查。
-                foreach (var kv in loaded.Templates)
+                foreach (var kv in runtimeTemplates)
                     newScreen.Templates[kv.Key.ToString()] = kv.Value;
                 // 同理附上样式表：切主题时要把主题 pack 折在它之上重算 class=。
                 foreach (var kv in styles)
@@ -107,6 +108,63 @@ namespace PromptUGUI.Template
             foreach (var kv in doc.Styles)
                 loaded.Styles[new StyleKey(null, kv.Key)] = kv.Value;
             return Expand(loaded);
+        }
+
+        /// <summary>
+        /// The Template table a Screen carries for RUNTIME instantiation (<c>itemTemplate=</c>).
+        /// <c>ScrollList</c> / <c>TabBar</c> / <c>Carousel</c> hand the body straight to
+        /// <c>ScreenInstantiator</c>, so everything expansion normally does has to have happened
+        /// already — <c>class=</c> merged, <c>{{param}}</c> substituted, nested invocations inlined.
+        /// Handing over the raw body meant the first two silently produced wrong values and the third
+        /// threw <c>unregistered tag</c> inside the bind, where R3 swallows it into a console error
+        /// and leaves the list empty.
+        ///
+        /// <para>With no invocation to supply them, a template's own <c>&lt;Param&gt;</c> defaults ARE
+        /// the arguments. A required Param has no such value, so those templates cannot be expanded
+        /// here — they are kept as a deep copy instead, and rejected by name if actually used as an
+        /// itemTemplate. Expansion failures fall back the same way: a template that is only ever
+        /// invoked normally must not start failing at load.</para>
+        ///
+        /// <para>Every entry is a copy the ScreenDef OWNS, never the shared (possibly commons-pool)
+        /// TemplateDef — that is what lets a theme switch re-merge these bodies in place without
+        /// leaking across documents.</para>
+        /// </summary>
+        private static Dictionary<PromptUGUI.IR.TemplateKey, TemplateDef> BuildRuntimeTemplates(
+            PromptUGUI.IR.LoadedDoc loaded,
+            IReadOnlyDictionary<PromptUGUI.IR.StyleKey, StyleDef> styles)
+        {
+            var result = new Dictionary<PromptUGUI.IR.TemplateKey, TemplateDef>(loaded.Templates.Count);
+            foreach (var kv in loaded.Templates)
+            {
+                var tpl = kv.Value;
+                var copy = new TemplateDef(tpl.Name) { OriginSrc = tpl.OriginSrc };
+                copy.Params.AddRange(tpl.Params);
+
+                var args = new Dictionary<string, string>();
+                var expandable = tpl.Body != null;
+                foreach (var p in tpl.Params)
+                {
+                    if (!p.HasDefault) { expandable = false; break; }
+                    args[p.Name] = p.DefaultValue;
+                }
+
+                ElementNode body = null;
+                if (expandable)
+                {
+                    try
+                    {
+                        body = ExpandNode(tpl.Body, args, slotContent: null, loaded.Templates, styles,
+                                          new HashSet<PromptUGUI.IR.TemplateKey>());
+                    }
+                    catch (TemplateException) { body = null; }
+                    catch (Parser.ParseException) { body = null; }
+                }
+
+                copy.Body = body ?? (tpl.Body == null ? null : DeepClone(tpl.Body));
+                copy.BodyExpanded = body != null;
+                result[kv.Key] = copy;
+            }
+            return result;
         }
 
         private static void ValidateSlotCount(TemplateDef tpl)

--- a/Runtime/Core/Template/TemplateExpander.cs
+++ b/Runtime/Core/Template/TemplateExpander.cs
@@ -36,6 +36,7 @@ namespace PromptUGUI.Template
                 var newRoot = new ElementNode(s.Root.Tag, s.Root.Namespace)
                 {
                     OriginSrc = s.Root.OriginSrc,
+                    Line = s.Root.Line,
                 };
                 // Screen-level attributes (e.g. reference=, reference.<variant>=) live on
                 // ScreenDef.Root and must survive expansion so runtime VariantResolver can read them.
@@ -167,6 +168,13 @@ namespace PromptUGUI.Template
             return result;
         }
 
+        private static void StampInvokedAt(ElementNode node, string site)
+        {
+            node.InvokedAt = site;
+            foreach (var child in node.Children)
+                StampInvokedAt(child, site);
+        }
+
         private static void ValidateSlotCount(TemplateDef tpl)
         {
             var count = 0;
@@ -211,6 +219,8 @@ namespace PromptUGUI.Template
             var dst = new ElementNode(merged.Tag, merged.Namespace)
             {
                 OriginSrc = merged.OriginSrc,
+                Line = merged.Line,
+                InvokedAt = merged.InvokedAt,
                 StyleAttrNames = merged.StyleAttrNames,
                 Id = merged.Id,
                 TextContent = merged.TextContent,
@@ -309,6 +319,12 @@ namespace PromptUGUI.Template
                     list.AddRange(kv.Value);
                 }
 
+                // Overwrite rather than fill-in-if-empty: nested invocations expanded first and
+                // stamped themselves, but an inner site is the same for every instance and so cannot
+                // distinguish them. The outermost one runs last and wins.
+                if (invocation.Line > 0 && invocation.OriginSrc != null)
+                    StampInvokedAt(instanceRoot, $"{invocation.OriginSrc}:{invocation.Line}");
+
                 return instanceRoot;
             }
             finally
@@ -344,6 +360,8 @@ namespace PromptUGUI.Template
             var dst = new ElementNode(prepared.Tag, prepared.Namespace)
             {
                 OriginSrc = prepared.OriginSrc,
+                Line = prepared.Line,
+                InvokedAt = prepared.InvokedAt,
                 StyleAttrNames = prepared.StyleAttrNames,
                 Id = prepared.Id,
                 TextContent = Substitution.Apply(prepared.TextContent, args),
@@ -380,6 +398,8 @@ namespace PromptUGUI.Template
             var dst = new ElementNode(src.Tag, src.Namespace)
             {
                 OriginSrc = src.OriginSrc,
+                Line = src.Line,
+                InvokedAt = src.InvokedAt,
                 StyleAttrNames = src.StyleAttrNames,
                 Id = src.Id,
                 TextContent = src.TextContent,
@@ -413,6 +433,8 @@ namespace PromptUGUI.Template
             var dst = new ElementNode(src.Tag, src.Namespace)
             {
                 OriginSrc = src.OriginSrc,
+                Line = src.Line,
+                InvokedAt = src.InvokedAt,
                 StyleAttrNames = src.StyleAttrNames,
                 Id = src.Id,
                 TextContent = src.TextContent,

--- a/Runtime/Core/Template/ThemeStyleApplier.cs
+++ b/Runtime/Core/Template/ThemeStyleApplier.cs
@@ -32,6 +32,16 @@ namespace PromptUGUI.Template
                 foreach (var add in block.Adds)
                     foreach (var child in add.Children)
                         ApplySubtree(child, styles);
+
+            // itemTemplate bodies too: rows bound AFTER a theme switch are instantiated from these.
+            // Safe to write in place only because BuildRuntimeTemplates gave the ScreenDef its own
+            // copies — the shared (possibly commons-pool) TemplateDefs are never touched.
+            //
+            // BodyExpanded gates it: a body kept raw (required <Param>) can still read
+            // class="{{skin}}", and looking THAT up as a style name throws "unknown style '{{skin}}'".
+            foreach (var tpl in def.Templates.Values)
+                if (tpl.BodyExpanded)
+                    ApplySubtree(tpl.Body, styles);
         }
 
         private static void ApplySubtree(ElementNode node, IReadOnlyDictionary<StyleKey, StyleDef> styles)

--- a/Tests/EditMode/Application/ThemeStyleSwitchTests.cs
+++ b/Tests/EditMode/Application/ThemeStyleSwitchTests.cs
@@ -159,6 +159,25 @@ namespace PromptUGUI.Tests.EditMode.Application
             Assert.AreEqual("445566", ColorOf(screen, "c"), "and reverts to the pack's base");
         }
 
+        // Regression: the theme re-merge walks itemTemplate bodies so rows bound after a switch get
+        // the current skin. A body kept RAW — because a required <Param> left nothing to substitute —
+        // still reads class="{{skin}}", and looking that up as a style name threw
+        // "unknown style '{{skin}}'", taking down UI.Open and the lint CLI alike. This is the shape
+        // of the shipped ProceduralStyle sample, which is how it was caught.
+        [Test]
+        public void RawItemTemplateBody_WithAPlaceholderClass_SurvivesTheThemeReMerge()
+        {
+            Assert.DoesNotThrow(() => Load(@"
+                <Style name='card' color='#112233'/>
+                <Theme name='pixel'><Style name='card' color='#445566'/></Theme>
+                <Template name='Skinned'><Param name='skin'/><Frame id='b' class='{{skin}}'/></Template>
+                <Screen name='S'><Image id='c' class='card'/></Screen>"));
+
+            UI.Theme.Set("pixel");
+            Assert.AreEqual("445566", ColorOf(UI.Open("S"), "c"),
+                "and the rest of the Screen still re-skins normally");
+        }
+
         // Every project written before this feature: styles but no theme styles. Nothing may change.
         [Test]
         public void ColourOnlyThemes_LeaveClassBehaviourUntouched()

--- a/Tests/EditMode/Controls/DynamicSubtreeReSolveTests.cs
+++ b/Tests/EditMode/Controls/DynamicSubtreeReSolveTests.cs
@@ -1,0 +1,176 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using R3;
+using UnityEngine;
+using PromptScreen = PromptUGUI.Application.Screen;
+using UnityImage = UnityEngine.UI.Image;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    /// <summary>
+    /// Rows built by <c>BindItems</c> must re-solve like everything else.
+    ///
+    /// <para><c>Screen.ReSolve</c> replays attributes for every node in <c>_nodeMap</c>, which is how
+    /// a resize, a Variant flip and a theme switch reach the UI. Dynamic subtrees were registered
+    /// only for <c>ApplyScales</c>, so <c>ControlAttributeApplier</c> ran on them exactly once, at
+    /// instantiation — a bound list did not follow a Variant, did not repaint on a theme switch, and
+    /// did not re-solve on resize. Not even colour tokens reached it.</para>
+    /// </summary>
+    public class DynamicSubtreeReSolveTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static void UseFiles(Dictionary<string, string> files) =>
+            UI.SourceResolver = src =>
+                AwaitableHelpers.Completed(files.TryGetValue(src, out var v) ? v : null);
+
+        private static PromptScreen LoadAsync(string body)
+        {
+            UseFiles(new Dictionary<string, string>
+            {
+                ["main"] = "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>" + body
+                           + "</PromptUGUI>",
+            });
+            UI.LoadDocumentAsync("main").GetAwaiter().GetResult();
+            return UI.Open("S");
+        }
+
+        private static IControl BindOne(ScrollList list)
+        {
+            IControl captured = null;
+            list.BindItems(
+                Observable.Return<IReadOnlyList<string>>(new[] { "a" }),
+                (IControl slot, string s) => captured = slot);
+            Assert.AreEqual(1, list.SlotCount, "guard: one row was built");
+            return captured;
+        }
+
+        private static string ColorOf(IControl row, string id) =>
+            ColorUtility.ToHtmlStringRGB(
+                ((Control)row.Get<IControl>(id)).GameObject.GetComponent<UnityImage>().color);
+
+        [Test]
+        public void BoundRow_FollowsAVariantFlip()
+        {
+            UI.LoadDocument("test", @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Row'><HStack><Image id='bg' color='#112233' color.alt='#445566'/></HStack></Template>
+  <Screen name='S'><ScrollList id='list' itemTemplate='Row'/></Screen>
+</PromptUGUI>");
+            var row = BindOne(UI.Open("S").Get<ScrollList>("list"));
+            Assume.That(ColorOf(row, "bg"), Is.EqualTo("112233"));
+
+            UI.Variants.Set("alt", true);
+
+            Assert.AreEqual("445566", ColorOf(row, "bg"),
+                "a Variant override on an item template is markup the author wrote; it has to mean "
+                + "something");
+        }
+
+        [Test]
+        public void BoundRow_RepaintsOnAThemeSwitch()
+        {
+            var screen = LoadAsync(@"
+                <Style name='card' color='#112233'/>
+                <Theme name='modern'><Color name='ink' value='#000'/></Theme>
+                <Theme name='pixel'><Style name='card' color='#445566'/></Theme>
+                <Template name='Row'><HStack><Image id='bg' class='card'/></HStack></Template>
+                <Screen name='S'><ScrollList id='list' itemTemplate='Row'/></Screen>");
+
+            UI.Theme.Set("modern");
+            var row = BindOne(screen.Get<ScrollList>("list"));
+            Assume.That(ColorOf(row, "bg"), Is.EqualTo("112233"));
+
+            UI.Theme.Set("pixel");
+
+            Assert.AreEqual("445566", ColorOf(row, "bg"),
+                "rows already on screen when the skin changes must change with it");
+        }
+
+        // The runtime-takeover locks still have to win: BindItems is code setting a value, and a
+        // ReSolve must not snap it back to whatever the XML declared.
+        [Test]
+        public void BoundText_SurvivesReSolve()
+        {
+            UI.LoadDocument("test", @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Row'><HStack><Text id='label'>placeholder</Text></HStack></Template>
+  <Screen name='S'><ScrollList id='list' itemTemplate='Row'/></Screen>
+</PromptUGUI>");
+            var screen = UI.Open("S");
+            var list = screen.Get<ScrollList>("list");
+
+            IControl row = null;
+            list.BindItems(
+                Observable.Return<IReadOnlyList<string>>(new[] { "bound" }),
+                (IControl slot, string s) => { row = slot; slot.Get<Text>("label").TextValue = s; });
+            Assume.That(list.SlotCount, Is.EqualTo(1));
+
+            screen.ReSolve();
+
+            // TextValue is write-only; read the TMP component the control drives.
+            var tmp = ((Control)row.Get<IControl>("label")).GameObject
+                .GetComponent<TMPro.TMP_Text>();
+            Assert.AreEqual("bound", tmp.text,
+                "the DefaultText lock is what keeps a replay from clobbering bound content");
+        }
+
+        // The replay is not free — a 500-row list measures ~500 ms — so a plain resize opts out:
+        // nothing a row resolves against changed, and resizes arrive in bursts. An orientation change
+        // still reaches rows, because it flips a Variant, which is the state path.
+        [Test]
+        public void ResizePathReSolve_SkipsRows()
+        {
+            UI.LoadDocument("test", @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Row'><HStack><Image id='bg' color='#112233' color.alt='#445566'/></HStack></Template>
+  <Screen name='S'><ScrollList id='list' itemTemplate='Row'/></Screen>
+</PromptUGUI>");
+            var screen = UI.Open("S");
+            var row = BindOne(screen.Get<ScrollList>("list"));
+
+            UI.Variants.Set("alt", true);
+            Assume.That(ColorOf(row, "bg"), Is.EqualTo("445566"), "guard: the state path did reach it");
+
+            UI.Variants.Set("alt", false);
+            Assume.That(ColorOf(row, "bg"), Is.EqualTo("112233"));
+
+            // Simulate the resize path directly: it must leave rows exactly as they are.
+            UI.Variants.Set("alt", true);
+            screen.ReSolve(replayDynamicSubtrees: false);
+            var afterResizeOnly = ColorOf(row, "bg");
+
+            screen.ReSolve();
+            Assert.AreEqual("445566", ColorOf(row, "bg"), "the state path still replays");
+            Assert.AreEqual("445566", afterResizeOnly,
+                "…and the variant had already been applied by Set, so the resize-path call simply "
+                + "left it alone rather than reverting anything");
+        }
+
+        // Rows are torn down and rebuilt on every data change; a stale subtree must not resurrect.
+        [Test]
+        public void ReSolveAfterARebuild_TouchesOnlyLiveRows()
+        {
+            UI.LoadDocument("test", @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Row'><HStack><Image id='bg' color='#112233' color.alt='#445566'/></HStack></Template>
+  <Screen name='S'><ScrollList id='list' itemTemplate='Row'/></Screen>
+</PromptUGUI>");
+            var screen = UI.Open("S");
+            var list = screen.Get<ScrollList>("list");
+
+            var src = new ReactiveProperty<IReadOnlyList<string>>(new[] { "a", "b" });
+            IControl last = null;
+            list.BindItems(src, (IControl slot, string s) => last = slot);
+            src.Value = new[] { "x" };                    // destroys the first two rows
+            Assume.That(list.SlotCount, Is.EqualTo(1));
+
+            Assert.DoesNotThrow(() => UI.Variants.Set("alt", true),
+                "the replay must skip subtrees whose GameObjects are gone");
+            Assert.AreEqual("445566", ColorOf(last, "bg"));
+        }
+    }
+}

--- a/Tests/EditMode/Controls/DynamicSubtreeReSolveTests.cs.meta
+++ b/Tests/EditMode/Controls/DynamicSubtreeReSolveTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e80ee48454beb24248b1c86635be14ad

--- a/Tests/EditMode/Controls/ItemTemplateExpansionTests.cs
+++ b/Tests/EditMode/Controls/ItemTemplateExpansionTests.cs
@@ -1,0 +1,118 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using R3;
+using UnityEngine;
+using UnityImage = UnityEngine.UI.Image;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    /// <summary>
+    /// <c>itemTemplate</c> bodies must go through the same expansion every other node does.
+    ///
+    /// <para><c>ScreenDef.Templates</c> used to carry the RAW <c>&lt;Template&gt;</c> bodies straight
+    /// from the loaded document, and <c>ScrollList</c> / <c>TabBar</c> / <c>Carousel</c> instantiate
+    /// from them directly. Nothing expansion normally does had happened to them: <c>class=</c> was
+    /// never merged, <c>{{param}}</c> was never substituted, nested Template invocations were never
+    /// inlined.</para>
+    ///
+    /// <para>The last two threw inside the bind — <c>unregistered tag 'Inner'</c>, <c>unknown color
+    /// token "{{tint}}"</c> — but R3 routes that to its unhandled-exception handler, so the call
+    /// returned normally and the author got an EMPTY list plus a console error that names neither
+    /// the list nor the template. Hence the slot-count assertions below: an empty list is the
+    /// symptom, not an incidental detail.</para>
+    /// </summary>
+    public class ItemTemplateExpansionTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static ScrollList OpenList(string declarations)
+        {
+            UI.LoadDocument("test",
+                "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>" + declarations +
+                "<Screen name='S'><ScrollList id='list' itemTemplate='Row'/></Screen></PromptUGUI>");
+            return UI.Open("S").Get<ScrollList>("list");
+        }
+
+        // ScrollList exposes slots only through the bind callback; catch the one row there.
+        private static IControl BindOne(ScrollList list)
+        {
+            IControl captured = null;
+            list.BindItems(
+                Observable.Return<IReadOnlyList<string>>(new[] { "a" }),
+                (IControl slot, string s) => captured = slot);
+            Assert.AreEqual(1, list.SlotCount,
+                "instantiating the row must succeed; a body that throws leaves the list empty and "
+                + "only logs, so an empty list IS the defect");
+            return captured;
+        }
+
+        private static string ColorOf(IControl control, string id) =>
+            ColorUtility.ToHtmlStringRGB(
+                ((Control)control.Get<IControl>(id)).GameObject.GetComponent<UnityImage>().color);
+
+        [Test]
+        public void ClassOnAnItemTemplateNode_IsMerged()
+        {
+            var list = OpenList(
+                "<Style name='card' color='#112233'/>" +
+                "<Template name='Row'><HStack><Image id='bg' class='card'/></HStack></Template>");
+
+            Assert.AreEqual("112233", ColorOf(BindOne(list), "bg"),
+                "a style pack has to reach an item template like it reaches any other node");
+        }
+
+        [Test]
+        public void TemplateParamDefault_IsSubstitutedInAnItemTemplate()
+        {
+            var list = OpenList(
+                "<Template name='Row'><Param name='tint' default='#445566'/>" +
+                "<HStack><Image id='bg' color='{{tint}}'/></HStack></Template>");
+
+            Assert.AreEqual("445566", ColorOf(BindOne(list), "bg"),
+                "with no invocation to supply arguments, the declared defaults are the arguments");
+        }
+
+        // The loudest symptom: not a wrong colour but a hard throw out of the control registry.
+        [Test]
+        public void NestedTemplateInvocation_InAnItemTemplate_IsInlined()
+        {
+            var list = OpenList(
+                "<Template name='Inner'><Image id='bg' color='#778899'/></Template>" +
+                "<Template name='Row'><HStack><Inner/></HStack></Template>");
+
+            Assert.AreEqual("778899", ColorOf(BindOne(list), "bg"));
+        }
+
+        // Guard against the obvious way to get this wrong: expanding every template eagerly at load
+        // would throw for any template with a required <Param>, breaking documents that only ever
+        // invoke it normally — where the arguments do exist.
+        [Test]
+        public void TemplateWithRequiredParam_StillLoadsAndInvokesNormally()
+        {
+            UI.LoadDocument("test", @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Needs'><Param name='tint'/><Image id='bg' color='{{tint}}'/></Template>
+  <Screen name='S'><Needs id='n' tint='#aabbcc'/></Screen>
+</PromptUGUI>");
+
+            var screen = UI.Open("S");
+            Assert.AreEqual("AABBCC", ColorUtility.ToHtmlStringRGB(
+                ((Control)(object)screen.Get<Control>("n")).GameObject.GetComponent<UnityImage>().color));
+        }
+
+        // ...and when such a template IS named as an itemTemplate, say so plainly instead of
+        // instantiating a body whose {{tint}} was never substituted.
+        [Test]
+        public void TemplateWithRequiredParam_AsItemTemplate_ThrowsWithAnActionableMessage()
+        {
+            var ex = Assert.Throws<PromptUGUI.Parser.ParseException>(() => OpenList(
+                "<Template name='Row'><Param name='tint'/><Image id='bg' color='{{tint}}'/></Template>"));
+
+            StringAssert.Contains("tint", ex.Message);
+            StringAssert.Contains("Row", ex.Message);
+        }
+    }
+}

--- a/Tests/EditMode/Controls/ItemTemplateExpansionTests.cs.meta
+++ b/Tests/EditMode/Controls/ItemTemplateExpansionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5253b4d65f3161804b98568b1fb3f5dc

--- a/Tests/EditMode/Lint/LintSourcePositionTests.cs
+++ b/Tests/EditMode/Lint/LintSourcePositionTests.cs
@@ -1,0 +1,140 @@
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.IR;
+using PromptUGUI.Lint;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.EditMode.Lint
+{
+    /// <summary>
+    /// Source positions on lint findings. <see cref="LintOriginTests"/> pins WHICH FILE; this pins
+    /// where in it, and which Template instance when one template is invoked more than once.
+    ///
+    /// <para>Together those are what turns a finding into somewhere to go. A file name alone is not
+    /// enough for a 300-line document, and a declaration site alone is not enough when ten instances
+    /// of the same template produce ten identical-looking findings.</para>
+    /// </summary>
+    public class LintSourcePositionTests
+    {
+        private static UIDocument Parse(string body, string src = "main.ui") =>
+            UIDocumentParser.Parse(body, src);
+
+        private static ElementNode FindById(ElementNode node, string id)
+        {
+            if (node == null) return null;
+            if (node.Id == id) return node;
+            foreach (var child in node.Children)
+            {
+                var hit = FindById(child, id);
+                if (hit != null) return hit;
+            }
+            return null;
+        }
+
+        [Test]
+        public void Parse_RecordsTheLineEachNodeStartsOn()
+        {
+            var doc = Parse(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <Frame id='first'/>
+    <Frame id='second'/>
+  </Screen>
+</PromptUGUI>");
+
+            var root = doc.Screens.Single().Root;
+            Assert.AreEqual(4, FindById(root, "first").Line);
+            Assert.AreEqual(5, FindById(root, "second").Line);
+        }
+
+        [Test]
+        public void ParseWithoutLineInfoIsStillFine_LineIsZero()
+        {
+            // A synthesised node — nothing read it out of a file, so there is no line to give.
+            Assert.AreEqual(0, new ElementNode("Frame").Line);
+        }
+
+        [Test]
+        public void Expansion_CarriesTheDeclarationLine_ThroughTemplateInlining()
+        {
+            var doc = Parse(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Card'>
+    <Frame id='card' mask='self'/>
+  </Template>
+  <Screen name='S'>
+    <Card id='a'/>
+  </Screen>
+</PromptUGUI>");
+
+            var issue = DocumentLinter.Walk(doc, "main.ui")
+                .Single(i => i.Code == MaskAttributeRules.FrameSelfCode && i.Id == "a");
+
+            Assert.AreEqual(4, issue.Line,
+                "the fix goes where the markup was written, not where the template was invoked");
+        }
+
+        [Test]
+        public void TwoInvocationsOfOneTemplate_AreToldApartByTheirInvocationSite()
+        {
+            var doc = Parse(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Card'>
+    <Frame id='card' mask='self'/>
+  </Template>
+  <Screen name='S'>
+    <Card id='a'/>
+    <Card id='b'/>
+  </Screen>
+</PromptUGUI>");
+
+            var issues = DocumentLinter.Walk(doc, "main.ui")
+                .Where(i => i.Code == MaskAttributeRules.FrameSelfCode)
+                .ToList();
+
+            Assert.AreEqual("main.ui:7", issues.Single(i => i.Id == "a").Via);
+            Assert.AreEqual("main.ui:8", issues.Single(i => i.Id == "b").Via);
+        }
+
+        [Test]
+        public void NodeNotProducedByAnInvocation_HasNoVia()
+        {
+            var doc = Parse(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S'>
+    <Frame id='plain' mask='self'/>
+  </Screen>
+</PromptUGUI>");
+
+            var issue = DocumentLinter.Walk(doc, "main.ui")
+                .First(i => i.Code == MaskAttributeRules.FrameSelfCode);
+
+            Assert.IsNull(issue.Via, "nothing invoked it; saying 'via' anything would be noise");
+        }
+
+        // A template invoked from inside another template: the OUTER site is the one that can tell
+        // two instances apart, so that is the one recorded.
+        [Test]
+        public void NestedInvocation_RecordsTheOutermostSite()
+        {
+            var doc = Parse(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Inner'>
+    <Frame id='deep' mask='self'/>
+  </Template>
+  <Template name='Outer'>
+    <Inner/>
+  </Template>
+  <Screen name='S'>
+    <Outer id='x'/>
+  </Screen>
+</PromptUGUI>");
+
+            var issue = DocumentLinter.Walk(doc, "main.ui")
+                .Single(i => i.Code == MaskAttributeRules.FrameSelfCode && i.Id == "x");
+
+            Assert.AreEqual("main.ui:10", issue.Via,
+                "line 7's <Inner/> is identical for every <Outer>, so it cannot distinguish instances");
+        }
+    }
+}

--- a/Tests/EditMode/Lint/LintSourcePositionTests.cs.meta
+++ b/Tests/EditMode/Lint/LintSourcePositionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 34c1589aafd713b3ea92fd5656ac2a06

--- a/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
+++ b/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
@@ -534,7 +534,6 @@ M0 / M1 / M2 全部落地，§8 的可逆性缺陷全部修完，测试套件无
 
 仍然开着的：
 
-- **动态子树不参与 ReSolve 的属性重放**（见下，修 `itemTemplate` 时查实的）。
 - **带命名空间的样式不能被主题覆盖**（M2.2 的 §4.3 收紧）。
 
 ### 追加：`itemTemplate` 走完整展开
@@ -571,3 +570,27 @@ multi.ui.xml:4: [PUI-MASK-FRAME-SELF] <Frame id='b'>: mask="self" … (via multi
 **顺带**：有了精确的 `origin:line` 身份，CLI 改成**跨入口文件去重**。之前 lint 一个目录时，库和 import 它的文档各作为入口跑一次，同一个缺陷会打两遍（实测 7 → 6）。
 
 验证：EditMode 2329/2329、EditorOnly 308/308，0 failed 0 skipped；`dotnet format` 无输出；UIXmlLint 仓库 13 个文件零 issue。
+
+### 追加：动态子树参与 ReSolve 的属性重放
+
+修 `itemTemplate` 时查实的那条：`BindItems` 建出来的行在实例化后就冻住，不跟 Variant、不随主题重绘、resize 不重解算。
+
+**根因不是 ReSolve 漏了它们，是它们压根没进那张表。** `RegisterDynamicSubtree` 有一句 `if (!hasScale) return;` —— `_dynamicSubtrees` 当初只为 `ApplyScales` 服务，所以**只登记声明了 `scale` 的子树**。典型的列表行一个都不在里面。把列表语义从「需要重算 scale 的子树」拓宽成「所有活着的动态子树」，再加 `ReSolveDynamicSubtrees()`。
+
+**代价是实打实的，测了：**
+
+| 行数 | resize 路径 | 状态路径（Variant / 主题） |
+|---|---|---|
+| 50 | 0.02 ms | 6.1 ms |
+| 200 | 0.08 ms | 86.3 ms |
+| 500 | 0.16 ms | 506.2 ms |
+
+超线性，还是 LayoutGroup 那个 O(N²)（行都在 ScrollList content 的 VerticalLayoutGroup 里）。500 行单次重放半秒，不能无条件跑。
+
+**所以 `ReSolve(bool replayDynamicSubtrees = true)` 按原因分流**：窗口 resize 传 `false` —— 行所依赖的状态并没有变（它对画布尺寸的依赖只有 `scale="Nx"` / `<r>r`，那由 `ApplyScales` 单独处理且照常跑），而 resize 是成串到来的。转屏仍然能到达行，因为那是切 Variant，走状态路径。resize 因此从「将要 554 ms」变成 **0.16 ms**。
+
+**一个反直觉的交互，测试抓的**：`ApplyScalesTo` 的 `dynamicBaseline` 我一开始改成了 `false`（理由是 `ApplyCommon` 现在会重跑）。`BindItems_card_box_preserving_does_not_accumulate_across_resizes` 立刻红了（-0.5 → -2.5，补偿累积 5 次）—— 因为 **resize 路径恰恰跳过了重放**，`ApplyCommon` 并没有跑，那份捕获基线仍然是让 resize 幂等的唯一依靠。退回 `true`：真跑过 `ApplyCommon` 的地方，基线是同一个几何，还原上去是 no-op。
+
+**遗留**：500 行的列表切一次 Variant 仍要半秒。`ScrollList` 不做虚拟化（一条数据一个 slot），这种规模本身就有别的问题；真正的解法是 LayoutGroup 的 O(N²)，独立一条。
+
+验证：EditMode 2334/2334、PlayMode 171/171、EditorOnly 308/308，0 failed 0 skipped；`dotnet format` 无输出；UIXmlLint 13 个文件零 issue。

--- a/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
+++ b/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
@@ -534,7 +534,6 @@ M0 / M1 / M2 全部落地，§8 的可逆性缺陷全部修完，测试套件无
 
 仍然开着的：
 
-- **lint 无行号**；同一模板多次调用时不可区分是哪一次（M1 记录）。
 - **动态子树不参与 ReSolve 的属性重放**（见下，修 `itemTemplate` 时查实的）。
 - **带命名空间的样式不能被主题覆盖**（M2.2 的 §4.3 收紧）。
 
@@ -555,3 +554,20 @@ M0 / M1 / M2 全部落地，§8 的可逆性缺陷全部修完，测试套件无
 **顺带查实、未修**：`_dynamicSubtrees` 在 `Screen` 里只被 `ApplyScalesTo` 和 `HasFactorScaleNode` 用到，`ControlAttributeApplier.Apply` 只在实例化时对它们跑过一次 —— 也就是说 **`BindItems` 出来的行，切主题 / 切 Variant / resize 都不会重放属性**，连颜色 token 都不跟随。这在今天就成立，是比 `class=` 更大的一条，独立于本次修复（原分析里的 1-B）。本次修复让**之后新绑的行**拿到当前皮肤，已绑的行仍需要 1-B。
 
 验证：EditMode 2323/2323、PlayMode 171/171、EditorOnly 308/308，0 failed 0 skipped；`dotnet format` 无输出；UIXmlLint 13 个文件零 issue、exit 0。
+
+### 追加：lint 的源位置（行号 + 调用点）
+
+M1 里我判断「要拿到行号得换一套读取方式」，那个结论偏保守 —— 确实不用重写 parser。`XmlDocument.Load(XmlReader)` 在读到元素时才调 `CreateElement`，此刻 reader 正停在该元素上，所以一个 `XmlDocument` 子类 + 一个记住位置的 `XmlElement` 子类就够，**零参数穿透**（`ParseElement` 本来就拿着那个 `XmlElement`）。把 700 行 `XmlElement` 代码搬到 `XDocument` 换同样的信息是不划算的。
+
+`ElementNode.Line` 跟着 `OriginSrc` 走同样的展开传递路径。输出变成 `file:line: [CODE] msg`。
+
+**第二半：同一模板多次调用。** `ElementNode.InvokedAt` 记「产生这个节点的模板调用点」，`ExpandInvocation` 在实例根子树上打戳。关键决定是**覆盖而非填空**：嵌套调用先展开、先打了戳，但内层调用点对每个实例都一样、区分不了；最外层最后跑，覆盖后正好是能区分实例的那个。输出里声明点仍是主位（改代码去那儿），调用点作为 `(via file:line)` 补在后面。
+
+```
+multi.ui.xml:4: [PUI-MASK-FRAME-SELF] <Frame id='a'>: mask="self" … (via multi.ui.xml:7)
+multi.ui.xml:4: [PUI-MASK-FRAME-SELF] <Frame id='b'>: mask="self" … (via multi.ui.xml:8)
+```
+
+**顺带**：有了精确的 `origin:line` 身份，CLI 改成**跨入口文件去重**。之前 lint 一个目录时，库和 import 它的文档各作为入口跑一次，同一个缺陷会打两遍（实测 7 → 6）。
+
+验证：EditMode 2329/2329、EditorOnly 308/308，0 failed 0 skipped；`dotnet format` 无输出；UIXmlLint 仓库 13 个文件零 issue。

--- a/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
+++ b/docs~/superpowers/specs/2026-08-26-theme-driven-style-design.md
@@ -534,6 +534,24 @@ M0 / M1 / M2 全部落地，§8 的可逆性缺陷全部修完，测试套件无
 
 仍然开着的：
 
-- **`itemTemplate` 的 `class=` 从来没生效过**（M2.3 发现的既有缺口，与主题无关）。
 - **lint 无行号**；同一模板多次调用时不可区分是哪一次（M1 记录）。
+- **动态子树不参与 ReSolve 的属性重放**（见下，修 `itemTemplate` 时查实的）。
 - **带命名空间的样式不能被主题覆盖**（M2.2 的 §4.3 收紧）。
+
+### 追加：`itemTemplate` 走完整展开
+
+`ScreenDef.Templates` 原本存的是 `loaded.Templates` 的**原始 body**，而 `ScrollList` / `TabBar` / `Carousel` 直接拿它实例化。展开该做的事一件都没做：`class=` 没合并、`{{param}}` 没替换、嵌套模板调用没内联。
+
+**症状比记录的严重，也和记录的不同。** 实测（`slots=0` + 控制台）：后两者会在 bind 内部抛（`unregistered tag 'Inner'`、`unknown color token "{{tint}}"`），但 R3 把异常路由给未处理异常处理器 —— 调用方**正常返回，列表是空的**，控制台那条错误既不提列表也不提模板。不是「静默不生效」，是「空列表 + 一条指不到现场的日志」。
+
+改法：`TemplateExpander` 增 `BuildRuntimeTemplates`，用模板自己的 `<Param>` 默认值当实参预展开一份，存进 `ScreenDef.Templates`。
+
+三个必须做对的点：
+
+1. **有必填 `<Param>` 的模板不能急切展开** —— 它们可能只作普通调用用、从不当 itemTemplate，展开会把今天能跑的工程炸掉。这类保留 body 原样；真被用作 itemTemplate 时由 `ItemTemplateGuard` 在 `Open` 处报错说清楚是哪个模板的哪个参数。展开抛异常（如循环引用）同样回退，保证**不新增任何 load 期失败**。
+2. **每个条目都是 ScreenDef 自己拥有的副本**（必填 Param 那类走 `DeepClone`），不是共享的（可能来自 commons 池的）`TemplateDef`。这正是让切主题能就地重算这些 body 而不跨文档泄漏的前提 —— M2.3 当时拒绝碰它们的理由随之消失，`ThemeStyleApplier` 现在也走 `def.Templates`。
+3. **`BodyExpanded` 标志**：保留原样的 body 里 `class="{{skin}}"` 还是占位符，拿它查样式会抛 `unknown style '{{skin}}'`。这个是**回归跑 CLI 时崩出来的**（exit 134，正好是自带 ProceduralStyle 样例的形状），运行时同一条路也会崩。顺带给 `DocumentLinter` 的逐主题重算加了 try/catch —— lint 工具不该被它正要诊断的 markup 弄死。
+
+**顺带查实、未修**：`_dynamicSubtrees` 在 `Screen` 里只被 `ApplyScalesTo` 和 `HasFactorScaleNode` 用到，`ControlAttributeApplier.Apply` 只在实例化时对它们跑过一次 —— 也就是说 **`BindItems` 出来的行，切主题 / 切 Variant / resize 都不会重放属性**，连颜色 token 都不跟随。这在今天就成立，是比 `class=` 更大的一条，独立于本次修复（原分析里的 1-B）。本次修复让**之后新绑的行**拿到当前皮肤，已绑的行仍需要 1-B。
+
+验证：EditMode 2323/2323、PlayMode 171/171、EditorOnly 308/308，0 failed 0 skipped；`dotnet format` 无输出；UIXmlLint 13 个文件零 issue、exit 0。


### PR DESCRIPTION
接 #101，收掉 spec §16 里剩下的三条中的两条半。三个 commit 各自独立可读、都跑过全量验证。

## 1. `itemTemplate` 走完整展开 (`4767b2f`)

`ScreenDef.Templates` 存的是 `loaded.Templates` 的**原始 body**，而 `ScrollList` / `TabBar` / `Carousel` 直接拿它实例化。展开该做的事一件都没做：`class=` 没合并、`{{param}}` 没替换、嵌套模板调用没内联。

**症状和我最初以为的不一样。** 实测（`slots=0` + 控制台）：后两者会在 bind 内部抛（`unregistered tag 'Inner'`、`unknown color token \"{{tint}}\"`），但 R3 把异常路由给未处理异常处理器 —— 调用方**正常返回，列表是空的**，控制台那条错误既不提列表也不提模板。不是「静默不生效」，是「空列表 + 一条指不到现场的日志」。

| | 修复前 | 修复后 |
|---|---|---|
| `<Param default>` | `slots=0` | `slots=1  color=#445566` |
| 嵌套模板调用 | `slots=0` | `slots=1  color=#778899` |
| `class=` | `slots=1  color=#FFFFFF` | `slots=1  color=#112233` |
| 必填 `<Param>` | `slots=0` + 一条无关日志 | `ParseException`，点名哪个模板哪个参数 |

三个必须做对的点：

1. **有必填 `<Param>` 的模板不能急切展开** —— 它们可能只作普通调用用，展开会把今天能跑的工程炸掉。这类保留原样，真被用作 itemTemplate 时由 `ItemTemplateGuard` 在 `Open` 报错。展开抛异常（如循环引用）同样回退，**不新增任何 load 期失败**。
2. **每个条目都是 ScreenDef 自己拥有的副本**。这正好消除了 M2.3 当时拒绝碰它们的理由（共享 IR 跨文档泄漏），所以 `ThemeStyleApplier` 现在也走 `def.Templates`。
3. **`BodyExpanded` 标志 —— 回归跑 CLI 时崩出来的**（exit 134，正是自带 ProceduralStyle 样例的形状）：保留原样的 body 里 `class=\"{{skin}}\"` 还是占位符，拿它查样式会抛。运行时同一条路也会崩。顺带给 `DocumentLinter` 的逐主题重算加了 try/catch —— lint 工具不该被它正要诊断的 markup 弄死。

## 2. lint 的源位置：行号 + 是哪一次调用 (`16d087f`)

M1 里我判断「要拿到行号得换一套读取方式」，那个结论**偏保守**：`XmlDocument.Load(XmlReader)` 在读到元素时才调 `CreateElement`，此刻 reader 正停在该元素上，所以一个 `XmlDocument` 子类 + 一个记住位置的 `XmlElement` 子类就够，**零参数穿透**。把 700 行 `XmlElement` 代码搬到 `XDocument` 换同样的信息不划算。

第二半（同一模板多次调用不可区分）的关键决定是**覆盖而非填空**：嵌套调用先展开、先打了戳，但内层调用点对每个实例都一样、区分不了；最外层最后跑，覆盖后正好是能区分实例的那个。

```
multi.ui.xml:4: [PUI-MASK-FRAME-SELF] <Frame id='a'>: … (via multi.ui.xml:7)
multi.ui.xml:4: [PUI-MASK-FRAME-SELF] <Frame id='b'>: … (via multi.ui.xml:8)
```

声明点是主位（改代码去那儿），调用点作为 `(via …)` 补在后面。顺带：有了精确的 `origin:line` 身份，CLI 改成**跨入口文件去重**（实测 7 → 6）。

## 3. `BindItems` 的行参与 ReSolve 的属性重放 (`fc5a20b`)

**根因不是 ReSolve 漏了它们，是它们压根没进那张表。** `RegisterDynamicSubtree` 有一句 `if (!hasScale) return;` —— `_dynamicSubtrees` 当初只为 `ApplyScales` 服务，只登记声明了 `scale` 的子树，典型列表行一个都不在里面。

**代价是实打实的，测了**（行都在 `ScrollList` content 的 `VerticalLayoutGroup` 里，又是那个 O(N²)）：

| 行数 | resize 路径 | 状态路径（Variant / 主题） |
|---|---|---|
| 50 | 0.02 ms | 6.1 ms |
| 200 | 0.08 ms | 86.3 ms |
| 500 | 0.16 ms | **506.2 ms** |

所以 `ReSolve(bool replayDynamicSubtrees = true)` **按原因分流**：窗口 resize 传 `false` —— 行所依赖的状态并没有变（它对画布尺寸的依赖只有 `scale=\"Nx\"` / `<r>r`，那由 `ApplyScales` 单独处理且照常跑），而 resize 是成串到来的。转屏仍然到得了行（那是切 Variant，走状态路径）。resize 因此从「将要 554 ms」变成 **0.16 ms**。

**测试抓到一个反直觉的交互**：`ApplyScalesTo` 的 `dynamicBaseline` 我一开始改成 `false`（理由是 `ApplyCommon` 现在会重跑），`BindItems_card_box_preserving_does_not_accumulate_across_resizes` 立刻红了（-0.5 → -2.5，补偿累积 5 次）—— 因为 **resize 路径恰恰跳过了重放**，`ApplyCommon` 并没有跑，那份捕获基线仍是让 resize 幂等的唯一依靠。

## 验证

- EditMode **2334 / 2334**、PlayMode **171 / 171**、EditorOnly **308 / 308** —— 0 failed，0 skipped
- `dotnet format --verify-no-changes --severity warn` 无输出
- UIXmlLint 对仓库全部 13 个 `.ui.xml` 零 issue、exit 0
- 每条修复的前后行为都用 Unity 内实测探针对照过，不只是靠测试断言

## 已知仍开着

- **500 行的列表切一次 Variant 仍要半秒**。`ScrollList` 不做虚拟化（一条数据一个 slot），这种规模本身就有别的问题；真正的解法是 **LayoutGroup 的 O(N²)** —— 本 PR 的 resize 分流是绕过它而不是解决它，优先级因此被抬高了。
- 带命名空间的样式（`class=\"ui:card\"`）不能被主题覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhZySsbMocJuC1kULMtpf4