### PR TITLE
fix: 主题一个人就能换皮 —— 让 SHAPE 规则认得程序化表面的自愈

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -791,16 +791,55 @@ node and replays the attributes; **no GameObject is rebuilt**, so references and
 </Theme>
 ```
 
+That baseline `radius="16"` is correct here because `card` lands on a `<Frame>`, which has no sprite
+to lose. On an Image-backed control it would be wrong — see the shape exception below.
+
 **The global `<Style>` is the implicit root of every theme chain.** Folding order is
 `global → base= chain → active theme`, atomic per attribute name (same rule multiple classes get).
 Three consequences worth internalising:
 
 - A theme spells out only what differs; everything else comes from the global pack.
-- **Always declare the global `<Style>` with the full attribute set.** An attribute one theme sets
-  and another doesn't is never reset on a switch — the control keeps the old value. `PUI-THEME-STYLE-SHAPE`
-  catches this; `PUI-THEME-STYLE-NO-BASELINE` catches a style that exists only inside a theme
-  (unreachable — `class=` resolves against the global pool).
+- **Always declare the global `<Style>` with the full attribute set** — with one exception, below.
+  An attribute one theme sets and another doesn't is never reset on a switch — the control keeps the
+  old value. `PUI-THEME-STYLE-SHAPE` catches this; `PUI-THEME-STYLE-NO-BASELINE` catches a style that
+  exists only inside a theme (unreachable — `class=` resolves against the global pool).
 - A project with no theme styles costs exactly nothing; this is all opt-in.
+
+**Exception: never give a shape attribute a baseline on an Image-backed control.** On the controls listed
+under 程序化表面 (`<Btn>` `<Tab>` `<Toggle>` `<Slider>` `<Dropdown>` `<InputField>` `<ScrollList>`
+`<Progress>`), `radius` / `glass` / `border*` / `glow*` / the glass parameters /
+`<layer>Radius` are **switches, not values**: writing one at all attaches the
+SDF face and retires the Image, whatever the value. So `radius=""` as a "baseline" does not mean
+"no radius", it means "this control is procedural in every theme" — and the bitmap skin loses its
+sprite (`PUI-PROC-SPRITE-CONFLICT` then reports the sprite as the contradiction it now is).
+
+Write the whole shape group in the theme that wants it, and **not one attribute of it** in the others:
+
+```xml
+<Style name="btn" sprite="px:btn" color="#E8D2A8"/>          <!-- pixel skin: shape IS the sprite -->
+
+<Theme name="pixel"><Style name="btn" color="#E8D2A8"/></Theme>
+<Theme name="glass">
+  <Style name="btn" sprite="none" color="white/0.22"
+         radius="10" glass="true" borderWidth="1" borderColor="white/0.55"/>
+</Theme>
+```
+
+`PUI-THEME-STYLE-SHAPE` exempts exactly this: `ProceduralSurface` recomputes the mode every pass, so
+a theme that omits the group turns the surface off and hands the Image back, sprite and alpha
+included — it reverts on its own. The exemption is **all-or-nothing**: a theme holding *half* the
+group pins the mode on, its missing half really does stick, and the rule reports the style again.
+`sprite` and `color` are deliberately NOT exempt — leave one of those to the control's built-in
+default in one theme and set it in another and you get a genuine residue.
+
+Two limits worth knowing:
+
+- **`<Frame>` does not self-heal.** It attaches its panel directly and never reconciles the mode per
+  pass, so a shape attribute one theme sets and another omits stays put. `PUI-THEME-STYLE-SHAPE`
+  cannot see which tag a `class=` lands on and will not warn you. On a Frame, declare the shape in
+  every theme (a global baseline is fine there — a Frame has no sprite to lose).
+- The controls' `<layer>Radius` attributes (`fillRadius`, `handleRadius`, `frameRadius`,
+  `maskRadius`) follow the same rule as the outer group: each drives one inner surface wholesale.
 
 **Rejected inside a `<Theme>`'s `<Style>`** (all parse errors; a global `<Style>` still accepts the
 last two groups):
@@ -1411,6 +1450,8 @@ STYLE LINT    PUI-CLASS-EMPTY                  class="" / whitespace-only — na
                the CLI skips that check and the name stays a runtime error)
               PUI-THEME-STYLE-NO-BASELINE      <Style> declared only inside a <Theme> — unreachable
               PUI-THEME-STYLE-SHAPE            two themes resolve a style to different attribute sets
+                                               (shape attrs are exempt when one side has NONE of them
+                                                — that surface toggles wholesale and reverts itself)
               PUI-THEME-STYLE-ON-INVOCATION    themed class= on a Template invocation won't re-skin
 ```
 

--- a/.claude/skills/authoring-promptugui-xml/reference/glass.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/glass.md
@@ -134,6 +134,35 @@ Two placements do **not** work, both silently, so both are lint errors:
   welding, so a mask there would clip every child away (`PUI-MASK-WELD-SELF`). Put `mask="self"` on
   a member, or wrap the group in a plain rounded `<Frame mask="self">`.
 
+## One theme glass, another bitmap
+
+The common skin-swap: the same `<Btn>` is a 9-sliced pixel sprite under one theme and a frosted pane
+under another. Put the **whole** shape group in the glass theme and **none of it** anywhere else —
+including the global `<Style>`:
+
+```xml
+<Style name="btn" sprite="px:btn" color="#E8D2A8"/>          <!-- pixel: the sprite IS the shape -->
+
+<Theme name="pixel"><Style name="btn" color="#E8D2A8"/></Theme>
+<Theme name="glass">
+  <Style name="btn" sprite="none" color="white/0.22"
+         radius="10" glass="true" frost="0.6" depth="5"
+         borderWidth="1" borderColor="white/0.55"/>
+</Theme>
+```
+
+**Do not give the pixel side a baseline** — not `glass="false"`, not `radius=""`. Presence is what
+attaches the surface, so any of those turns the control procedural in *both* themes and the pixel
+skin loses its sprite; `PUI-PROC-SPRITE-CONFLICT` will then report the sprite. `PUI-THEME-STYLE-SHAPE`
+exempts this asymmetry precisely because the surface toggles wholesale and puts the Image back on its
+own. Half a group is not exempt: leave `glass` in one theme and take `radius` out and the rule
+reports it again, correctly.
+
+On a **`<Frame>`** the advice inverts: its panel is attached once and never reconciled per pass, so a
+shape attribute one theme omits stays put. Declare it in every theme there (a global baseline is
+fine — a Frame has no sprite to lose), and note that the shape rule cannot warn you, because it
+cannot see which tag a `class=` lands on.
+
 ## Lint codes
 
 The CLI (`dotnet run --project .lint/UIXmlLint -- <path>`) exits non-zero on any of these. Every one

--- a/Runtime/Controls/Internal/ProceduralSurface.cs
+++ b/Runtime/Controls/Internal/ProceduralSurface.cs
@@ -171,16 +171,48 @@ namespace PromptUGUI.Controls.Internal
             _hostImage.color = new Color(c.r, c.g, c.b, 0f);
         }
 
+        /// <summary>
+        /// Hands the Image back — but only what THIS pass did not already write.
+        ///
+        /// <para>The snapshot <see cref="Retire"/> takes is not "the control's built-in default": it
+        /// runs from <see cref="Reconcile"/>, which is <c>OnAfterApply</c>, so it captures whatever
+        /// the author declared on the pass that first turned the surface on. Restoring it blindly
+        /// clobbers the incoming skin — open under a glass theme, switch to the pixel one, and the
+        /// pass has already written the wood sprite and an opaque colour before this runs.</para>
+        ///
+        /// <para>Both halves therefore ask "did this pass declare one?" rather than tracking a new
+        /// flag per attribute. <c>Retire()</c> nulls the sprite every pass it is on, so a non-null
+        /// sprite here can only have come from a setter that ran this pass; <c>_hasFill</c> already
+        /// carries the same answer for the colour, set by the control's <c>color=</c> setter and
+        /// cleared by <see cref="BeginPass"/>.</para>
+        ///
+        /// <para>What stays out of reach is the ASYMMETRIC declaration — one skin sets
+        /// <c>sprite</c> / <c>color</c> and the other leaves it to the control's own default. The
+        /// snapshot then holds the first skin's value, and no amount of looking at the Image can tell
+        /// it apart from a default. Both spellings are reported statically before they can ever run:
+        /// <c>PUI-THEME-STYLE-SHAPE</c> on the theme side (neither <c>sprite</c> nor <c>color</c> is
+        /// in its procedural exemption, precisely so this stays covered) and
+        /// <c>PUI-VARIANT-NO-BASE</c> on the variant side.</para>
+        /// </summary>
         private void Restore()
         {
             if (!_retired || _hostImage == null) return;
             _retired = false;
-            _hostImage.sprite = _retiredSprite;
-            _hostImage.type = _retiredType;
-            // Alpha only: the rgb may legitimately have moved on (a theme switch, a Variant) while
-            // the surface was drawing, and that newer colour is the right one to come back to.
-            var c = _hostImage.color;
-            _hostImage.color = new Color(c.r, c.g, c.b, _retiredColor.a);
+
+            if (_hostImage.sprite == null)
+            {
+                _hostImage.sprite = _retiredSprite;
+                _hostImage.type = _retiredType;
+            }
+
+            // Alpha only, and only when nothing declared a colour: the rgb may legitimately have
+            // moved on (a theme switch, a Variant) while the surface was drawing, and so may the
+            // alpha — `white/0.22` under one skin and an opaque colour under the next.
+            if (!_hasFill)
+            {
+                var c = _hostImage.color;
+                _hostImage.color = new Color(c.r, c.g, c.b, _retiredColor.a);
+            }
         }
 
         private ProceduralPanel EnsurePanel()

--- a/Runtime/Core/Lint/ThemeStyleRules.cs
+++ b/Runtime/Core/Lint/ThemeStyleRules.cs
@@ -68,6 +68,8 @@ namespace PromptUGUI.Lint
         /// <para>Only compared ACROSS themes. The global <c>&lt;Style&gt;</c> is the implicit root of
         /// every chain, so each theme's set already contains it; and with fewer than two themes there
         /// is no switch to go wrong.</para>
+        ///
+        /// <para>One family is exempt — see <see cref="ShapeOnlyProcedural"/>.</para>
         /// </summary>
         public static IEnumerable<LintIssue> CheckShape(
             IReadOnlyDictionary<StyleKey, StyleDef> globalStyles,
@@ -89,12 +91,20 @@ namespace PromptUGUI.Lint
             foreach (var styleName in Sorted(touched))
             {
                 var key = StyleKey.ParseReference(styleName);
+
+                // Decided across ALL themes before any pair is compared — deliberately not inside
+                // the loop below. That loop measures everything against the first theme in sort
+                // order, so a pairwise test would clear 'plain vs full' and 'plain vs partial'
+                // independently and never notice that 'full' and 'partial' disagree.
+                var exemptProcedural = ProceduralSetIsAllOrNothing(resolved, key);
+
                 string referenceTheme = null;
                 HashSet<string> referenceNames = null;
 
                 foreach (var themeName in Sorted(resolved.Keys))
                 {
                     var names = NamesOf(resolved[themeName], key);
+                    if (exemptProcedural) names.ExceptWith(ShapeOnlyProcedural);
                     if (referenceNames == null)
                     {
                         referenceTheme = themeName;
@@ -170,6 +180,79 @@ namespace PromptUGUI.Lint
             foreach (var child in node.Children)
                 foreach (var issue in Walk(child, tags, themed))
                     yield return issue;
+        }
+
+        /// <summary>
+        /// The attributes that describe a procedural SHAPE, and nothing else. Derived from
+        /// <see cref="ProceduralAttrNames"/> rather than hand-listed, so a new procedural attribute
+        /// lands here the moment it is wired up.
+        ///
+        /// <para><b>Why these are exempt from §6.1.</b> The residue this rule guards against needs an
+        /// attribute that STICKS when a theme stops setting it. These do the opposite:
+        /// <c>ProceduralSurface</c> recomputes the mode every pass from "was the setter called at
+        /// all" (procedural-surface spec §8), so a theme that simply omits them turns the surface off
+        /// and hands the control back to its Image, sprite and alpha included. The twin rule on the
+        /// variant side has said so since procedural surfaces shipped —
+        /// <c>VariantBaseRules.proceduralSelfHeals</c>.</para>
+        ///
+        /// <para>And §6.1's usual advice is actively harmful here: presence, not value, is what
+        /// attaches the surface, so writing <c>radius=""</c> as a "baseline" retires the sprite the
+        /// other theme needs — which <c>PUI-PROC-SPRITE-CONFLICT</c> then reports, correctly.</para>
+        ///
+        /// <para><b>Two deliberate omissions.</b> <c>weld</c> never crosses into a control
+        /// (procedural-surface §13.2), the same reason <c>ProceduralSurfaceRules</c> skips it.
+        /// <c>color</c> is left out even though <c>VariantBaseRules</c> counts it as procedural: on an
+        /// Image-backed control it is an ordinary tint, and the path that would make it self-heal —
+        /// <c>Restore()</c> putting the retired alpha back — is itself the defect the 2026-08-27 spec
+        /// §5 fixes. A theme that stops setting <c>color</c> is a real residue.</para>
+        ///
+        /// <para><b>Known under-report:</b> this rule is style-level and runs before expansion, so it
+        /// cannot see which tag the class lands on. <c>&lt;Frame&gt;</c> attaches its panel directly
+        /// and never reconciles the mode per pass, so it does NOT self-heal — a themed shape on a
+        /// Frame goes unreported. Accepted: <c>VariantBaseRules</c> can exclude Frame only because it
+        /// has a node to look at, and a false positive here would wall off correct XML behind the
+        /// CLI's non-zero exit. See the 2026-08-27 spec §3.3.</para>
+        /// </summary>
+        private static readonly HashSet<string> ShapeOnlyProcedural = BuildShapeOnlyProcedural();
+
+        private static HashSet<string> BuildShapeOnlyProcedural()
+        {
+            var set = new HashSet<string>();
+            foreach (var name in ProceduralAttrNames.NeedsPanel)
+                if (name != "weld") set.Add(name);
+            foreach (var name in ProceduralAttrNames.InnerLayerRadius)
+                set.Add(name);
+            return set;
+        }
+
+        /// <summary>
+        /// Whether every theme's procedural set for this style is either EMPTY or the same one —
+        /// which is what "the surface toggles wholesale" means, and the only shape that self-heals.
+        ///
+        /// <para>A theme holding HALF the set pins the mode on, so the half it omits really is never
+        /// reset; that style goes back to being reported name-for-name. Requiring an empty side too
+        /// is what separates "one skin has a shape, the other has none" from "two skins disagree
+        /// about the shape they both draw".</para>
+        /// </summary>
+        private static bool ProceduralSetIsAllOrNothing(
+            Dictionary<string, IReadOnlyDictionary<StyleKey, StyleDef>> resolved, StyleKey key)
+        {
+            var distinct = new HashSet<string>(System.StringComparer.Ordinal);
+            var sawEmpty = false;
+
+            foreach (var table in resolved.Values)
+            {
+                var shape = new List<string>();
+                foreach (var name in NamesOf(table, key))
+                    if (ShapeOnlyProcedural.Contains(name)) shape.Add(name);
+                shape.Sort(System.StringComparer.Ordinal);
+
+                var canonical = string.Join(",", shape);
+                if (canonical.Length == 0) sawEmpty = true;
+                distinct.Add(canonical);
+            }
+
+            return sawEmpty && distinct.Count <= 2;
         }
 
         private static HashSet<string> NamesOf(

--- a/Samples~/CommonControls/CommonControlsRunner.cs
+++ b/Samples~/CommonControls/CommonControlsRunner.cs
@@ -72,6 +72,9 @@ namespace PromptUGUI.Samples.CommonControls
 
         // 一套皮 = 一个 <Theme>（颜色 token + <Style> 属性包）+ 一个同名 Variant。
         //
+        // 换皮的部分**全在 Theme 里**：颜色、贴图、圆角、玻璃参数，一个属性都没有走 Variant。
+        // 同名 Variant 只为下面这一件事存在。
+        //
         // 为什么要两个开关：scale-mode 写在 <Screen> 上，而 <Screen> 不接受 class= —— 它不是控件，
         // 挂不住属性包，parser 直接报错。玻璃是高清程序化图形，跟 pixel 那种整数倍缩放天生打架
         // （圆角和模糊会被整块放大），所以这一项走 Variant：XML 里 scale-mode="pixel"

--- a/Samples~/CommonControls/Resources/UI/CommonControls.ui.xml
+++ b/Samples~/CommonControls/Resources/UI/CommonControls.ui.xml
@@ -27,7 +27,7 @@
        所以叠两层，让主题用 hidden 决定哪层露出来。hidden 是公共属性，<Style> 能设。 -->
   <Style name="skin-wood"  hidden="false"/>
   <Style name="skin-glass" hidden="true"
-         frost="0.6" depth="5" lightAngle="-25" lightIntensity="0.55"
+         frost="0.6" depth="5" dispersion="0.3" lightAngle="-25" lightIntensity="0.55"
          saturation="1.3" noise="0.03"/>
 
   <!-- 其余控件**原地**换皮，不用叠层。关键是：内置控件的每一个内层都有 XML 钩子
@@ -74,6 +74,9 @@
     <Color name="plaque"        value="#E8B86B"/>
     <Color name="panel"         value="#FFFFFF"/>
     <Color name="accent"        value="#A8D88C"/>
+    <Color name="sky-haze"      value="#DCEFF4"/>
+    <Color name="soil-a"        value="#8B5E3C"/>
+    <Color name="soil-b"        value="#A87E5C"/>
   </Theme>
 
   <!-- 玻璃：磨砂玻璃 UI 浮在同一张农场背景上。木层收起、玻璃层露出，
@@ -123,6 +126,9 @@
     <Color name="plaque"        value="#E8B86B"/>
     <Color name="panel"         value="#FFFFFF"/>
     <Color name="accent"        value="#FFFFFF4D"/>
+    <Color name="sky-haze"      value="#DCEFF4"/>
+    <Color name="soil-a"        value="#8B5E3C"/>
+    <Color name="soil-b"        value="#A87E5C"/>
   </Theme>
 
   <!-- 面板底：两层叠着，主题决定露哪层。class= 写在体内的节点上（见文件头第 3 条）。 -->
@@ -163,18 +169,93 @@
        两块画布各自一个 CanvasScaler，本来就能各走各的。 -->
   <Screen name="Backdrop" canvas="camera" reference="640x360" reference.portrait="360x640"
           scale-mode="pixel">
-    <Image anchor="stretch" color="sky" raycastTarget="false"/>
-    <Image anchor="bottom-stretch" height="56" color="grass" raycastTarget="false"/>
-    <!-- 玻璃底下得有点花纹才看得出模糊，摆一排作物 -->
-    <HStack anchor="bottom-stretch" height="32" margin="_,24,12,24" spacing="28">
-      <Image size="32x32" sprite="farm:carrot" raycastTarget="false"/>
-      <Image size="32x32" sprite="farm:tomato" raycastTarget="false"/>
-      <Image size="32x32" sprite="farm:wheat" raycastTarget="false"/>
-      <Image size="32x32" sprite="farm:sunflower" raycastTarget="false"/>
-      <Image size="32x32" sprite="farm:pumpkin" raycastTarget="false"/>
-      <Image size="32x32" sprite="farm:grape" raycastTarget="false"/>
-      <Frame width="stretch"/>
-    </HStack>
+    <!-- ── 为什么背景要长这样：玻璃是个**采样器**，只能展示它背后有的东西 ──
+         纯色是它的天敌。一片常量色模糊之后还是同一个常量，位移采样也取到同一个颜色，
+         于是 frost / depth / dispersion 三个参数**同时归零**，saturation 也没东西可提 ——
+         面板会退化成「半透明白板 + 一圈高光」，跟普通 <Frame> 长得一样。
+         所以这块背景要在**面板压着的那片区域**同时提供三样东西：
+
+           高频细节 → frost 才有东西可毁          （作物）
+           强边界   → depth/dispersion 才看得出扭曲（田垄之间的高对比横线）
+           饱和色   → saturation 才有东西可提      （crops.pxl 那套饱和配色）
+
+         再加一层缓慢漂移：玻璃底下持续在变，才看得出它是实时采样而不是一张贴图。 -->
+
+    <!-- 天空：竖直渐变。渐变本身对 frost 没用（模糊一条斜坡还是那条斜坡），
+         但它让面板上下缘的折射带取到不同的颜色，边缘立刻有了厚度感。 -->
+    <Image anchor="stretch" color="sky,sky-haze" raycastTarget="false"/>
+
+    <!-- 地平线：玻璃能看到的第一条强边界 -->
+    <Image anchor="top-stretch" margin="94,_,_,_" height="8" color="grass" raycastTarget="false"/>
+
+    <!-- 田垄：深浅交替四条，从地平线一路铺到底 —— 面板 85% 的面积压在这上面。
+         条带**本身**就是 depth 要的强横向边界：一条高对比水平线从面板圆角底下穿过去，
+         折射带会把它扭出一个肉眼可见的弯。作物负责 frost 要毁的高频细节。
+         每条的漂移幅度和时长都不同（越近越快越大）→ 视差。 -->
+    <VStack anchor="stretch" margin="102,0,0,0" margin.portrait="150,0,0,0" spacing="0">
+
+      <Frame width="stretch" height="stretch">
+        <Image anchor="stretch" color="soil-a" raycastTarget="false"/>
+        <Animation anchor="stretch" translate="0,0:10,0" duration="17s" on="loop" easing="in-out-cubic">
+          <HStack anchor="top-stretch" height="22" margin="10,_,_,18" spacing="62" spacing.portrait="34">
+            <Image size="22x22" sprite="farm:wheat" raycastTarget="false"/>
+            <Image size="22x22" sprite="farm:turnip" raycastTarget="false"/>
+            <Image size="22x22" sprite="farm:corn" raycastTarget="false"/>
+            <Image size="22x22" sprite="farm:carrot" raycastTarget="false"/>
+            <Image size="22x22" sprite="farm:wheat" raycastTarget="false"/>
+            <Image size="22x22" sprite="farm:eggplant" raycastTarget="false"/>
+            <Image size="22x22" sprite="farm:corn" raycastTarget="false"/>
+            <Frame width="stretch"/>
+          </HStack>
+        </Animation>
+      </Frame>
+
+      <Frame width="stretch" height="stretch">
+        <Image anchor="stretch" color="soil-b" raycastTarget="false"/>
+        <Animation anchor="stretch" translate="0,0:16,0" duration="14s" on="loop" easing="in-out-cubic">
+          <HStack anchor="top-stretch" height="24" margin="12,_,_,52" spacing="58" spacing.portrait="30">
+            <Image size="24x24" sprite="farm:tomato" raycastTarget="false"/>
+            <Image size="24x24" sprite="farm:sunflower" raycastTarget="false"/>
+            <Image size="24x24" sprite="farm:grape" raycastTarget="false"/>
+            <Image size="24x24" sprite="farm:tomato" raycastTarget="false"/>
+            <Image size="24x24" sprite="farm:apple" raycastTarget="false"/>
+            <Image size="24x24" sprite="farm:sunflower" raycastTarget="false"/>
+            <Frame width="stretch"/>
+          </HStack>
+        </Animation>
+      </Frame>
+
+      <Frame width="stretch" height="stretch">
+        <Image anchor="stretch" color="soil-a" raycastTarget="false"/>
+        <Animation anchor="stretch" translate="0,0:24,0" duration="11s" on="loop" easing="in-out-cubic">
+          <HStack anchor="top-stretch" height="26" margin="14,_,_,24" spacing="54" spacing.portrait="26">
+            <Image size="26x26" sprite="farm:pumpkin" raycastTarget="false"/>
+            <Image size="26x26" sprite="farm:strawberry" raycastTarget="false"/>
+            <Image size="26x26" sprite="farm:watermelon" raycastTarget="false"/>
+            <Image size="26x26" sprite="farm:pumpkin" raycastTarget="false"/>
+            <Image size="26x26" sprite="farm:eggplant" raycastTarget="false"/>
+            <Image size="26x26" sprite="farm:strawberry" raycastTarget="false"/>
+            <Frame width="stretch"/>
+          </HStack>
+        </Animation>
+      </Frame>
+
+      <Frame width="stretch" height="stretch">
+        <Image anchor="stretch" color="soil-b" raycastTarget="false"/>
+        <Animation anchor="stretch" translate="0,0:34,0" duration="9s" on="loop" easing="in-out-cubic">
+          <HStack anchor="top-stretch" height="30" margin="16,_,_,60" spacing="50" spacing.portrait="22">
+            <Image size="30x30" sprite="farm:watermelon" raycastTarget="false"/>
+            <Image size="30x30" sprite="farm:carrot" raycastTarget="false"/>
+            <Image size="30x30" sprite="farm:apple" raycastTarget="false"/>
+            <Image size="30x30" sprite="farm:grape" raycastTarget="false"/>
+            <Image size="30x30" sprite="farm:turnip" raycastTarget="false"/>
+            <Image size="30x30" sprite="farm:tomato" raycastTarget="false"/>
+            <Frame width="stretch"/>
+          </HStack>
+        </Animation>
+      </Frame>
+
+    </VStack>
   </Screen>
 
   <!-- 全文件唯一一处变体，也是主题唯一够不着的东西：scale-mode 挂在 <Screen> 上，而 <Screen>

--- a/Samples~/CommonControls/Resources/UI/CommonControls.ui.xml
+++ b/Samples~/CommonControls/Resources/UI/CommonControls.ui.xml
@@ -6,12 +6,20 @@
        同一棵 XML 树，一套主题渲染成像素木框，另一套渲染成磨砂玻璃，**不重建任何 GameObject**。
        C# 调 UI.Theme.Set("farm"/"glass")，已打开的 Screen 自己 ReSolve。
 
+       换皮这件事**整个由 <Theme> 一个人管**。变体在这份文件里只剩一处，就是 <Screen> 的
+       scale-mode —— 那是主题唯一够不着的东西（见下面 CommonControls 那段注释）。
+
        三条规矩（都有 lint 兜着）：
        1) 全局 <Style> 是**基线**，<Theme> 里的同名 <Style> 只写差异。基线不能省 ——
           class= 在展开期只认全局池，只写在 <Theme> 里的样式根本引用不到
           （lint: PUI-THEME-STYLE-NO-BASELINE）。
        2) 每个主题必须解出**同一套属性名**。某个名字 A 主题有、B 主题没有，切到 B 时它不会被
           重置，控件静默留着 A 的值（lint: PUI-THEME-STYLE-SHAPE）。
+          **例外是形状那一组**（radius / glass / border* / *Radius）：它们不是「值」而是
+          「开关」—— 写了就挂上 SDF 面并把 Image 退休，所以农场侧必须一个都不写，玻璃侧整套
+          写。ProceduralSurface 每一 pass 重算模式，主题不写就等于关掉表面、把贴图还回去，
+          自己会复位。反过来给它们加「基线」才是错的：radius="" 照样挂面，木头 9-slice 当场
+          消失（lint 会用 PUI-PROC-SPRITE-CONFLICT 骂回来）。
        3) class= 要写在**模板体内**的节点上。写在调用点 <Skin class="..."/> 上不跟随主题：
           invocation 节点展开后就不存在了（lint: PUI-THEME-STYLE-ON-INVOCATION）。 -->
 
@@ -28,30 +36,21 @@
        不只是最外面那张底图。只换外层的话，玻璃皮下面会留一堆木头勾选框和木头滑块。
 
        农场侧写的就是**内置默认值**（内置皮肤本来就是像素农场风），玻璃侧把 9-slice 结构层清成
-       none + 半透明白，字形（勾、箭头）留着、只改成墨色。 -->
+       none + 半透明白，字形（勾、箭头）留着、只改成墨色。
+
+       注意这里**一个形状属性都没有** —— radius / glass / border* 全在玻璃那侧（见文件头第 2 条）。
+       农场皮的形状就是那张 9-slice 贴图本身。 -->
   <Style name="btn"      sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round"
-         color="#E8D2A8" hoverColor="#F5E6C8" textColor="#4A3018" pressedOffset="0,-1"
-         radius.glass="10" glass.glass="true"
-         borderWidth.glass="1" borderColor.glass="white/0.55"/>
+         color="#E8D2A8" hoverColor="#F5E6C8" textColor="#4A3018" pressedOffset="0,-1"/>
   <Style name="tab"      sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round"
-         color="#E8D2A8" selectedColor="#CDEBA8" textColor="#4A3018"
-         radius.glass="10,10,0,0" glass.glass="true"
-         borderWidth.glass="1" borderColor.glass="white/0.45"/>
-  <Style name="input"    sprite="PromptUGUI/Defaults/pugui#pugui_9slice_inset" color="white" textColor="#4A3322"
-         radius.glass="8" glass.glass="true"
-         borderWidth.glass="1" borderColor.glass="white/0.5"/>
+         color="#E8D2A8" selectedColor="#CDEBA8" textColor="#4A3018"/>
+  <Style name="input"    sprite="PromptUGUI/Defaults/pugui#pugui_9slice_inset" color="white" textColor="#4A3322"/>
   <Style name="toggle"   sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round" color="white" textColor="#4A3322"
-         checkmark="PromptUGUI/Defaults/pugui#pugui_checkmark" checkmarkColor="white"
-         radius.glass="6" glass.glass="true"
-         borderWidth.glass="1" borderColor.glass="white/0.6"/>
+         checkmark="PromptUGUI/Defaults/pugui#pugui_checkmark" checkmarkColor="white"/>
   <Style name="slider"   sprite="PromptUGUI/Defaults/pugui#pugui_9slice_inset" color="white"
          fill="PromptUGUI/Defaults/pugui#pugui_9slice_round"  fillColor="white"
-         handle="PromptUGUI/Defaults/pugui#pugui_knob"        handleColor="white"
-         radius.glass="pill" glass.glass="true"
-         fillRadius.glass="pill" handleRadius.glass="pill"/>
+         handle="PromptUGUI/Defaults/pugui#pugui_knob"        handleColor="white"/>
   <Style name="dropdown" sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round" color="white" textColor="#4A3322"
-         radius.glass="10" glass.glass="true"
-         borderWidth.glass="1" borderColor.glass="white/0.5"
          arrow="PromptUGUI/Defaults/pugui#pugui_caret"        arrowColor="white"
          popupSprite="PromptUGUI/Defaults/pugui#pugui_9slice_round" popupColor="white"
          itemColor="#F5F5F5" itemTextColor="#4A3322"
@@ -59,14 +58,11 @@
          scrollbar="PromptUGUI/Defaults/pugui#pugui_9slice_inset"      scrollbarColor="white"
          scrollbarHandle="PromptUGUI/Defaults/pugui#pugui_9slice_round" scrollbarHandleColor="white"/>
   <Style name="list"     sprite="PromptUGUI/Defaults/pugui#pugui_9slice_inset" color="white/0.39"
-         radius.glass="12" glass.glass="true"
-         borderWidth.glass="1" borderColor.glass="white/0.4"
          scrollbar="PromptUGUI/Defaults/pugui#pugui_9slice_inset" scrollbarColor="white"
          scrollbarHandle="PromptUGUI/Defaults/pugui#pugui_9slice_round" scrollbarHandleColor="white"/>
   <!-- Progress 的 fill/bg 默认就没有贴图（纯色层），所以这两个包只换颜色 —— 也顺带说明属性包
        并不强求每个控件都交出 sprite。Carousel 的圆点同理。 -->
-  <Style name="progress" fillColor="#58A63C" bgColor="#E8CFA0"
-         radius.glass="pill"/>
+  <Style name="progress" fillColor="#58A63C" bgColor="#E8CFA0"/>
   <Style name="carousel" dotColor="#C8A878" dotSelectedColor="#5A3A20"/>
   <!-- 轮播卡只交出 sprite：卡片底色由 C# BindItems 逐条填（运行时接管），主题不该跟它抢。 -->
   <Style name="card"     sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round"/>
@@ -86,17 +82,25 @@
     <Style name="skin-wood"  hidden="true"/>
     <Style name="skin-glass" hidden="false"/>
     <!-- 每个包只写和农场不一样的那几项，其余从全局基线继承 —— 比如 checkmark 的**贴图**两边
-         一样，只有它的**颜色**换成墨色。 -->
+         一样，只有它的**颜色**换成墨色。
+         每个包的最后一行是**形状**：sprite 清成 none，改由 radius / glass / border* 自绘。
+         这一组只出现在这里，农场那边一个都没有 —— 这正是它能自己复位的原因。 -->
     <Style name="btn"      sprite="none" color="white/0.22" hoverColor="white/0.40"
-           textColor="#1C2B33" pressedOffset="0,0"/>
+           textColor="#1C2B33" pressedOffset="0,0"
+           radius="10" glass="true" borderWidth="1" borderColor="white/0.55"/>
     <Style name="tab"      sprite="none" color="white/0.12" selectedColor="white/0.45"
-           textColor="#1C2B33"/>
-    <Style name="input"    sprite="none" color="white/0.28" textColor="#1C2B33"/>
+           textColor="#1C2B33"
+           radius="10,10,0,0" glass="true" borderWidth="1" borderColor="white/0.45"/>
+    <Style name="input"    sprite="none" color="white/0.28" textColor="#1C2B33"
+           radius="8" glass="true" borderWidth="1" borderColor="white/0.5"/>
     <Style name="toggle"   sprite="none" color="white/0.28" textColor="#1C2B33"
-           checkmarkColor="#1C2B33"/>
+           checkmarkColor="#1C2B33"
+           radius="6" glass="true" borderWidth="1" borderColor="white/0.6"/>
+    <!-- 内层也有自己的形状钩子：fillRadius / handleRadius 各自管一层，跟着一起翻。 -->
     <Style name="slider"   sprite="none" color="white/0.18"
            fill="none"   fillColor="white/0.75"
-           handle="none" handleColor="white"/>
+           handle="none" handleColor="white"
+           radius="pill" glass="true" fillRadius="pill" handleRadius="pill"/>
     <!-- 弹出层不是玻璃（它是普通 Image，飘在玻璃之上），所以给个接近不透明的浅面保可读。 -->
     <Style name="dropdown" sprite="none" color="white/0.28" textColor="#1C2B33"
            arrowColor="#1C2B33"
@@ -104,11 +108,13 @@
            itemColor="#00000000" itemTextColor="#1C2B33"
            checkmarkColor="#1C2B33"
            scrollbar="none"       scrollbarColor="white/0.18"
-           scrollbarHandle="none" scrollbarHandleColor="white/0.55"/>
+           scrollbarHandle="none" scrollbarHandleColor="white/0.55"
+           radius="10" glass="true" borderWidth="1" borderColor="white/0.5"/>
     <Style name="list"     sprite="none" color="white/0.10"
            scrollbar="none" scrollbarColor="white/0.18"
-           scrollbarHandle="none" scrollbarHandleColor="white/0.55"/>
-    <Style name="progress" fillColor="white/0.80" bgColor="white/0.20"/>
+           scrollbarHandle="none" scrollbarHandleColor="white/0.55"
+           radius="12" glass="true" borderWidth="1" borderColor="white/0.4"/>
+    <Style name="progress" fillColor="white/0.80" bgColor="white/0.20" radius="pill"/>
     <Style name="carousel" dotColor="white/0.45" dotSelectedColor="#1C2B33"/>
     <Style name="card"     sprite="none"/>
 
@@ -171,10 +177,11 @@
     </HStack>
   </Screen>
 
-  <!-- scale-mode 只能靠 Variant 换，不能靠 <Theme>：<Screen> 上写 class= 是 parse error
-       （Screen 不是控件，挂不住属性包）。玻璃是高清程序化图形，跟 pixel 的整数倍缩放天生打架
-       —— 圆角和模糊会被整块放大成锯齿。所以 C# 那边切主题时把同名 Variant 一起翻：
-       UI.Variants.Set("glass", …) + UI.Theme.Set(…)。 -->
+  <!-- 全文件唯一一处变体，也是主题唯一够不着的东西：scale-mode 挂在 <Screen> 上，而 <Screen>
+       写 class= 是 parse error（它不是控件，挂不住属性包），所以属性包换不了它。而玻璃是高清
+       程序化图形，跟 pixel 的整数倍缩放天生打架 —— 圆角和模糊会被整块放大成锯齿。
+       于是 C# 那边切主题时把同名 Variant 一起翻：UI.Variants.Set("glass", …) + UI.Theme.Set(…)。
+       两个开关同名，读起来是一件事；上面所有换皮都只走 Theme，不掺 Variant。 -->
   <Screen name="CommonControls" reference="640x360" reference.portrait="360x640"
           scale-mode="pixel" scale-mode.glass="auto">
     <SafeArea>

--- a/Tests/EditMode/Controls/ProceduralSurfaceRestoreTests.cs
+++ b/Tests/EditMode/Controls/ProceduralSurfaceRestoreTests.cs
@@ -1,0 +1,181 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using UnityEngine;
+using UnityImage = UnityEngine.UI.Image;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    /// <summary>
+    /// M0 of the 2026-08-27 spec §5: what <c>ProceduralSurface.Restore()</c> is allowed to put back
+    /// when the surface stands down.
+    ///
+    /// <para><b>The defect.</b> <c>Retire()</c> snapshots the host Image once, on the FIRST retire —
+    /// and it runs from <c>Reconcile()</c>, which is <c>OnAfterApply</c>, i.e. AFTER every setter of
+    /// that pass. So the snapshot is not "the control's built-in default", it is "whatever the
+    /// author declared on the pass that first turned the surface on". <c>Restore()</c> then writes
+    /// that snapshot back unconditionally, on a pass where the author's own <c>sprite=</c> /
+    /// <c>color=</c> setters have ALREADY written the values the new skin wants — and clobbers
+    /// them.</para>
+    ///
+    /// <para>Reachable whenever procedural mode is on for the FIRST apply pass: a persisted skin
+    /// choice means <c>UI.Theme.Set("glass")</c> runs before <c>UI.Open</c>, and switching back to
+    /// the pixel skin then loses its 9-slice and gets the glass alpha. Orthogonal to the lint change
+    /// in §3 — today's <c>attr.glass=</c> spelling hits it just the same, which is why the variant
+    /// fixtures below are the primary ones and the theme fixture is the shipped-sample shape.</para>
+    ///
+    /// <para>Two of these are GUARD tests (green today): the fix must not overshoot into "never
+    /// restore anything", which would strand the control with the null sprite and zero alpha
+    /// <c>Retire()</c> left behind.</para>
+    /// </summary>
+    public class ProceduralSurfaceRestoreTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static Sprite MakeSprite()
+        {
+            var tex = new Texture2D(4, 4);
+            return Sprite.Create(tex, new Rect(0, 0, 4, 4), new Vector2(0.5f, 0.5f));
+        }
+
+        private static Btn LoadBtn(string attrs, string top = "")
+        {
+            UI.UnloadAll();
+            UI.LoadDocument("t", $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>{top}<Screen name='S'>
+  <Btn id='b' anchor='center' size='120x40' {attrs} text='OK'/>
+</Screen></PromptUGUI>");
+            return UI.Open("S").Get<Btn>("b");
+        }
+
+        private static UnityImage BgOf(Btn b) => b.GameObject.GetComponent<UnityImage>();
+
+        // ===== §5.1 the alpha half =====
+
+        /// <summary>
+        /// RED. Opening while the surface is on snapshots the glass alpha (0x38 ≈ 0.22); leaving
+        /// procedural mode then forces it back over the pixel skin's opaque colour, and the button
+        /// comes back see-through. `_hasFill` already carries the signal this needs — the control's
+        /// `color=` setter calls SetFill, and BeginPass clears it every pass.
+        /// </summary>
+        [Test]
+        public void LeavingProceduralMode_KeepsTheAlphaThisPassDeclared()
+        {
+            UI.Variants.Set("mobile", true);
+            var b = LoadBtn("color='#E8D2A8' color.mobile='#FFFFFF38' radius.mobile='10'");
+
+            UI.Variants.Set("mobile", false);
+
+            Assert.AreEqual(1f, BgOf(b).color.a, 0.01f,
+                "the pass that turned the surface off declared color='#E8D2A8', which is opaque — "
+                + "restoring the alpha captured under the glass skin makes the button translucent");
+        }
+
+        /// <summary>
+        /// GUARD (green today). Retire() zeroes the alpha every pass it is on, so when NOTHING
+        /// declares a colour on the way out there is nothing but the snapshot to come back to.
+        /// </summary>
+        [Test]
+        public void LeavingProceduralMode_RestoresTheAlphaWhenNoColourIsDeclared()
+        {
+            var b = LoadBtn("radius.mobile='10'");
+            var opaque = BgOf(b).color.a;
+
+            UI.Variants.Set("mobile", true);
+            UI.Variants.Set("mobile", false);
+
+            Assert.AreEqual(opaque, BgOf(b).color.a, 0.001f,
+                "no color= anywhere, so the Image must come back exactly as it went in — a fix that "
+                + "simply stops restoring would leave it at Retire()'s alpha 0 and invisible");
+        }
+
+        // ===== §5.1 the sprite half =====
+
+        /// <summary>
+        /// RED. Same shape one layer over: the snapshot is taken after `sprite.mobile='none'` has
+        /// already nulled the Image, so leaving procedural mode writes null over the sprite the
+        /// pixel skin just asked for.
+        /// </summary>
+        [Test]
+        public void LeavingProceduralMode_KeepsTheSpriteThisPassDeclared()
+        {
+            var wood = MakeSprite();
+            UI.SpriteResolver = key => key == "s:wood" ? wood : null;
+
+            UI.Variants.Set("mobile", true);
+            var b = LoadBtn("sprite='s:wood' sprite.mobile='none' radius.mobile='10'");
+
+            UI.Variants.Set("mobile", false);
+
+            Assert.AreSame(wood, BgOf(b).sprite,
+                "the pass that turned the surface off declared sprite='s:wood'; Restore must not "
+                + "overwrite it with the null captured while the glass skin was drawing");
+        }
+
+        /// <summary>
+        /// GUARD (green today). With no authored sprite the snapshot IS the built-in 9-slice, and
+        /// restoring it is the whole reason Restore() exists — Retire() nulled it on the way in.
+        /// </summary>
+        [Test]
+        public void LeavingProceduralMode_RestoresTheBuiltinSpriteWhenNoneIsDeclared()
+        {
+            var b = LoadBtn("radius.mobile='10'");
+            var builtin = BgOf(b).sprite;
+            Assert.IsNotNull(builtin, "<Btn> ships with a default 9-sliced sprite");
+
+            UI.Variants.Set("mobile", true);
+            Assert.IsNull(BgOf(b).sprite, "§7: no bitmap under the SDF face");
+
+            UI.Variants.Set("mobile", false);
+
+            Assert.AreSame(builtin, BgOf(b).sprite,
+                "nobody declared a sprite on the way out, so the control's own default has to come "
+                + "back — this is the case the snapshot is for");
+        }
+
+        // ===== the same round trip, driven by <Theme> instead of a variant =====
+
+        /// <summary>
+        /// RED, and the shape the shipped CommonControls sample takes after the §4 rewrite: the skin
+        /// lives entirely in <c>&lt;Theme&gt;</c> packs, with the glass theme adding the shape
+        /// attributes and the pixel theme simply not having them. Pinned separately from the variant
+        /// fixtures because the two reach <c>ControlAttributeApplier</c> by different routes — a
+        /// variant leaves a key that resolves to null, a theme drops the key outright.
+        ///
+        /// <para>Goes through the fake-files resolver rather than <c>LoadDocument(label, xml)</c>:
+        /// only the async path runs <c>RegisterThemesAndAutoSet</c>, and without it the packs never
+        /// reach <c>ThemeStore</c> and the whole fixture passes for the wrong reason. Same note
+        /// <c>ThemeStyleSwitchTests</c> carries.</para>
+        /// </summary>
+        [Test]
+        public void ThemeDrivenRoundTrip_KeepsWhatTheIncomingThemeDeclared()
+        {
+            var wood = MakeSprite();
+            UI.SpriteResolver = key => key == "s:wood" ? wood : null;
+            UI.SourceResolver = _ => AwaitableHelpers.Completed(
+                @"<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>
+                    <Style name='btn' sprite='s:wood' color='#E8D2A8'/>
+                    <Theme name='farm'><Style name='btn' sprite='s:wood' color='#E8D2A8'/></Theme>
+                    <Theme name='glass'><Style name='btn' sprite='none' color='#FFFFFF38'
+                           radius='10' glass='true'/></Theme>
+                    <Screen name='S'>
+                      <Btn id='b' class='btn' anchor='center' size='120x40' text='OK'/>
+                    </Screen>
+                  </PromptUGUI>");
+            UI.LoadDocumentAsync("main").GetAwaiter().GetResult();
+
+            // Before Open, so the FIRST apply pass is the one that retires the Image — the boot
+            // order a persisted skin choice produces, and the only one that captures a snapshot the
+            // other theme cannot live with.
+            UI.Theme.Set("glass");
+            var b = UI.Open("S").Get<Btn>("b");
+            Assume.That(BgOf(b).sprite, Is.Null, "guard: the glass pack really did take the Image");
+
+            UI.Theme.Set("farm");
+
+            Assert.AreSame(wood, BgOf(b).sprite, "the farm pack declares the wood sprite");
+            Assert.AreEqual(1f, BgOf(b).color.a, 0.01f, "…and an opaque colour");
+        }
+    }
+}

--- a/Tests/EditMode/Controls/ProceduralSurfaceRestoreTests.cs.meta
+++ b/Tests/EditMode/Controls/ProceduralSurfaceRestoreTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 17b4d377fca8641d6bbca886850e2f65

--- a/Tests/EditMode/Lint/ThemeStyleRulesTests.cs
+++ b/Tests/EditMode/Lint/ThemeStyleRulesTests.cs
@@ -35,17 +35,21 @@ namespace PromptUGUI.Tests.EditMode.Lint
                 "both resolve to {color, radius} — the global pack supplies whatever a theme omits");
         }
 
+        // Deliberately NOT a procedural attribute: those toggle the whole surface wholesale and
+        // revert on their own, which is why they are exempt below
+        // (ProceduralShapeOnlyOneThemeSets_IsExempt). `fontSize` is an ordinary setter with no
+        // per-pass reconcile — the residue §6.1 describes is real for it.
         [Test]
         public void AttributeOnlyOneThemeSets_IsReported()
         {
             var issues = Lint(@"
                 <Style name='card' color='#112233'/>
                 <Theme name='light'><Style name='card' color='#fff'/></Theme>
-                <Theme name='dark'><Style name='card' color='#000' glow='8'/></Theme>
-                <Screen name='S'><Image id='c' class='card'/></Screen>");
+                <Theme name='dark'><Style name='card' color='#000' fontSize='18'/></Theme>
+                <Screen name='S'><Text id='c' class='card'/></Screen>");
 
             var issue = issues.Single(i => i.Code == ThemeStyleRules.ShapeCode);
-            StringAssert.Contains("glow", issue.Message);
+            StringAssert.Contains("fontSize", issue.Message);
             StringAssert.Contains("card", issue.Message);
         }
 
@@ -55,15 +59,120 @@ namespace PromptUGUI.Tests.EditMode.Lint
             var issues = Lint(@"
                 <Style name='card' color='#112233'/>
                 <Style name='chip' color='#112233'/>
-                <Theme name='light'><Style name='card' color='#fff'/><Style name='chip' glow='4'/></Theme>
+                <Theme name='light'><Style name='card' color='#fff'/><Style name='chip' fontSize='14'/></Theme>
                 <Theme name='dark'><Style name='card' color='#000'/></Theme>
-                <Screen name='S'><Image id='c' class='chip'/></Screen>");
+                <Screen name='S'><Text id='c' class='chip'/></Screen>");
 
             var issue = issues.Single(i => i.Code == ThemeStyleRules.ShapeCode);
             StringAssert.Contains("chip", issue.Message);
-            StringAssert.Contains("glow", issue.Message);
+            StringAssert.Contains("fontSize", issue.Message);
             Assert.IsFalse(issue.Message.Contains("card"),
                 "'card' resolves to {color} under both themes — the global baseline covers 'dark'");
+        }
+
+        // --- PUI-THEME-STYLE-SHAPE: procedural self-heal exemption (2026-08-27 spec §3) ---
+        //
+        // The twin rule on the variant side (VariantBaseRules.cs) has exempted this shape since
+        // procedural surfaces shipped: a control whose surface toggles WHOLESALE reverts on its own,
+        // because ProceduralSurface recomputes the mode every pass from "was the setter called at
+        // all" and Reconcile puts the retired Image back. A theme that simply omits the shape
+        // attributes produces exactly that signal — StyleMerger.ReMerge drops the names outright, so
+        // the setter is never called. §6.1's "give it a baseline in the global <Style>" advice is
+        // actively WRONG here: writing radius="" is what ATTACHES the surface (presence, not value),
+        // which retires the sprite the other theme needs and trips PUI-PROC-SPRITE-CONFLICT.
+
+        [Test]
+        public void ProceduralShapeOnlyOneThemeSets_IsExempt()
+        {
+            var issues = Lint(@"
+                <Style name='btn' sprite='ui:wood' color='#E8D2A8'/>
+                <Theme name='farm'><Style name='btn' color='#E8D2A8'/></Theme>
+                <Theme name='glass'><Style name='btn' sprite='none' color='#FFFFFF38'
+                       radius='10' glass='true' borderWidth='1' borderColor='#FFFFFF8C'/></Theme>
+                <Screen name='S'><Btn id='b' class='btn'/></Screen>");
+
+            Assert.IsEmpty(issues.Where(i => i.Code == ThemeStyleRules.ShapeCode),
+                "'farm' declares no procedural attribute at all, so the surface turns off wholesale "
+                + "and the Image comes back — nothing is left stuck at the glass values");
+        }
+
+        [Test]
+        public void InnerLayerRadius_IsExempt()
+        {
+            var issues = Lint(@"
+                <Style name='slider' sprite='ui:wood' fill='ui:wood' handle='ui:knob'/>
+                <Theme name='farm'><Style name='slider' sprite='ui:wood'/></Theme>
+                <Theme name='glass'><Style name='slider' sprite='none' fill='none' handle='none'
+                       radius='pill' glass='true' fillRadius='pill' handleRadius='pill'/></Theme>
+                <Screen name='S'><Slider id='s' class='slider'/></Screen>");
+
+            Assert.IsEmpty(issues.Where(i => i.Code == ThemeStyleRules.ShapeCode),
+                "one attribute per inner surface, so a base-less <layer>Radius always means "
+                + "'this surface toggles wholesale' — the same reason VariantBaseRules exempts it");
+        }
+
+        /// <summary>
+        /// Green today and must STAY green: the exemption is all-or-nothing across themes, so a
+        /// theme holding HALF the procedural set pins the mode on and its missing half really does
+        /// stick. Also the order-independence guard — 'a-plain' sorts first and is the theme
+        /// CheckShape compares everything against, so an exemption applied pairwise-against-the-
+        /// reference would skip both comparisons and report nothing at all.
+        /// </summary>
+        [Test]
+        public void PartialProceduralSet_IsStillReported()
+        {
+            var issues = Lint(@"
+                <Style name='btn' color='#E8D2A8'/>
+                <Theme name='a-plain'><Style name='btn' color='#E8D2A8'/></Theme>
+                <Theme name='b-full'><Style name='btn' color='#fff' radius='10' glass='true'/></Theme>
+                <Theme name='c-partial'><Style name='btn' color='#fff' radius='10'/></Theme>
+                <Screen name='S'><Btn id='b' class='btn'/></Screen>");
+
+            Assert.IsNotEmpty(issues.Where(i => i.Code == ThemeStyleRules.ShapeCode),
+                "'c-partial' declares radius, which pins the surface on — so the 'glass' it omits "
+                + "is never reset and the button keeps b-full's frosted fill");
+        }
+
+        /// <summary>
+        /// The report itself stays (fontSize is a genuine residue), but the MESSAGE is RED today: it
+        /// currently names radius too, which sends the author straight at the one baseline that
+        /// breaks the other skin. The exemption must eat names in the procedural family without
+        /// swallowing the ordinary setters sitting beside them.
+        /// </summary>
+        [Test]
+        public void NonProceduralAttributeAlongsideProcedural_IsStillReported()
+        {
+            var issues = Lint(@"
+                <Style name='btn' color='#E8D2A8'/>
+                <Theme name='farm'><Style name='btn' color='#E8D2A8'/></Theme>
+                <Theme name='glass'><Style name='btn' color='#fff' radius='10' fontSize='18'/></Theme>
+                <Screen name='S'><Btn id='b' class='btn'/></Screen>");
+
+            var issue = issues.Single(i => i.Code == ThemeStyleRules.ShapeCode);
+            StringAssert.Contains("fontSize", issue.Message);
+            Assert.IsFalse(issue.Message.Contains("radius"),
+                "radius reverts on its own; naming it in the message would send the author to add "
+                + "the one baseline that breaks the other skin");
+        }
+
+        /// <summary>
+        /// Green today and must stay green. `sprite` is NOT in the exempt family, and that is what
+        /// closes the one hole ProceduralSurface.Restore cannot: it snapshots the host Image at the
+        /// first retire, so a theme that clears the sprite while another declares none at all would
+        /// have nothing to come back to. Reported statically instead.
+        /// </summary>
+        [Test]
+        public void SpriteOnlyOneThemeSets_IsStillReported()
+        {
+            var issues = Lint(@"
+                <Style name='btn' color='#E8D2A8'/>
+                <Theme name='farm'><Style name='btn' color='#E8D2A8'/></Theme>
+                <Theme name='glass'><Style name='btn' color='#fff' sprite='none'
+                       radius='10' glass='true'/></Theme>
+                <Screen name='S'><Btn id='b' class='btn'/></Screen>");
+
+            var issue = issues.Single(i => i.Code == ThemeStyleRules.ShapeCode);
+            StringAssert.Contains("sprite", issue.Message);
         }
 
         // --- PUI-THEME-STYLE-NO-BASELINE (§4.2) ---

--- a/docs~/superpowers/specs/2026-08-27-theme-procedural-shape-exemption-design.md
+++ b/docs~/superpowers/specs/2026-08-27-theme-procedural-shape-exemption-design.md
@@ -1,0 +1,254 @@
+# 主题就该管皮肤：让 `PUI-THEME-STYLE-SHAPE` 认得程序化表面的自愈
+
+**日期**：2026-08-27
+**状态**：设计中，未实施。
+**作用域**：两件事，同一个 PR。
+1. 给 `ThemeStyleRules.CheckShape`（`PUI-THEME-STYLE-SHAPE`）加一条**程序化表面自愈豁免**，让「某个主题给控件开程序化形状、别的主题不开」成为合法的纯 `<Theme>` 写法；随后把 `Samples~/CommonControls` 里那 18 行 `attr.glass=` 绕道全部收回 `<Theme name="glass">`。
+2. 顺手钉住一个相邻缺陷：`ProceduralSurface.Restore()` 会用**首次退休时的快照**盖掉本轮 pass 刚写进去的 sprite / alpha。与 1 正交（今天的 `.glass` 写法一样中招），但两者都发生在「主题切换 × 程序化表面」这条线上，一起改一起测。
+
+**关联**：`<Style>` / `class=` 合并语义见 [procedural-style](2026-08-23-procedural-style-design.md) §3–§4；`<Theme>` 承载 style pack 与 §6.1 的残留约束见 [theme-driven-style](2026-08-26-theme-driven-style-design.md)；程序化表面的 per-pass reconcile 见 [procedural-surface](2026-08-26-procedural-surface-design.md) §8。本设计**不改** `<Style>` / `<Theme>` / `ProceduralSurface` 的任何语义，只改 lint 的一条判定，以及 `Restore()` 里两行赋值的条件。
+
+---
+
+## 1. 背景：示例里那 18 行 `.glass` 是绕道，不是设计
+
+`CommonControls` 演示的是「同一棵 XML 树，farm 主题渲染成像素木框，glass 主题渲染成磨砂玻璃」。颜色、sprite、勾选框贴图全部走 `<Theme name="glass">` 里的 `<Style>` 覆盖 —— 干净的纯主题路径。唯独**形状**那一组属性走了另一条路，写在**全局基线**上：
+
+```xml
+<Style name="btn" sprite="PromptUGUI/Defaults/pugui#pugui_9slice_round"
+       color="#E8D2A8" hoverColor="#F5E6C8" textColor="#4A3018" pressedOffset="0,-1"
+       radius.glass="10" glass.glass="true"
+       borderWidth.glass="1" borderColor.glass="white/0.55"/>
+```
+
+`btn` / `tab` / `input` / `toggle` / `slider` / `dropdown` / `list` / `progress` 八个包，18 行，全是这个形状。读起来像「主题和变体是两套并行机制」，实际上不是 —— 作者是被 lint 逼到这条路上的。推导链三步：
+
+**① 对 `ProceduralControl` 来说，「写没写」才是开关，值是什么无所谓。** `Radius` / `Glass` / `BorderWidth` 这些 setter 一被调用就 `Surface.Declare(...)`，挂上 SDF 面并让 Image 退休（`ProceduralSurface.Retire()`：清 sprite + alpha 归零）。所以农场皮**必须一个 procedural 属性都不写** —— 写 `radius=""` 或 `radius="0"` 当基线，木头 9-slice 当场消失。
+
+**② 但 `PUI-THEME-STYLE-SHAPE` 要求「同一样式名在所有主题下解析出同一套属性名」**，报错信息还专门建议「把 `radius` 加进全局 `<Style>` 当基线」—— 正好是 ① 禁止的那件事。
+
+**③ 于是绕道**：把属性**名**留在全局基线上，用 `attr.glass=` 让**值**只在 `glass` 变体激活时落地。SHAPE 看到名字在，闭嘴；farm 下变体没命中 → applier 不调 setter → 表面自己关掉、木头回来。
+
+代价不只是 18 行噪音。它给读者（和 LLM 作者）灌了一个错误的心智模型：「换皮肤要主题和变体配合」。真相是主题一个人就够。
+
+## 2. 现状盘点（实测）
+
+### 2.1 两条路给 applier 的信号完全一样
+
+| | 变体路径 `radius.glass="10"` | 主题路径 `<Theme name="glass"><Style radius="10">` |
+|---|---|---|
+| farm 下 `node.Attributes` 里有 `radius` 吗 | 有键，`VariantResolver` 解出 `null` | **键都没有**（`StyleMerger.ReMerge` 按 `StyleAttrNames` 把上一套 pack 贡献的名字整批删掉，`StyleMerger.cs:115`） |
+| applier 行为 | `ControlAttributeApplier.cs:72` `if (v == null) continue` | 同左（键不在 `allKeys` 里，压根不进循环） |
+| setter 被调用吗 | 否 | 否 |
+| `ProceduralSurface` | `BeginPass()` 清 `_declaredThisPass`（`ProceduralSurface.cs:74`）→ `Reconcile()` 关面板 → `Restore()` 还原 Image | 同左 |
+
+主题路径**更干净**：变体路径留着一个解不出值的键，主题路径连键都不留。运行时早就支持纯 theme。
+
+### 2.2 两种纯 theme 写法各自撞上什么
+
+把 sample 改写成纯 theme 跑 `UIXmlLint`（实测，非推断）：
+
+| 写法 | 结果 |
+|---|---|
+| 属性只写在 `<Theme name="glass">` 的 `<Style>` 里 | **8 条 `PUI-THEME-STYLE-SHAPE`**（btn / tab / input / toggle / slider / dropdown / list / progress），差集全是 `radius` `glass` `borderWidth` `borderColor` `fillRadius` `handleRadius` |
+| 按 SHAPE 的报错建议补基线（`radius="" glass="false" borderWidth="" borderColor=""`） | 8 条 SHAPE 消失，换来 **10 条 `PUI-PROC-SPRITE-CONFLICT`** —— 而且**这条不是误报**，farm 下真会丢贴图 |
+| 今天的 `attr.glass=` 绕道 | 0 issue |
+
+第二行值得展开：`DeclaresProcedural` 判的是 `baseValue != null`，`radius=""` 是非 null，于是「声明了程序化」为真；而 `sprite=` 是真贴图 → 报冲突。这不是 lint 保守，是运行时真的会那样做（setter 被调用 = 挂面 = 退休 Image）。**SHAPE 规则给出的修法建议，在程序化属性上是错的。**
+
+### 2.3 孪生规则已经开过口子
+
+变体侧的同一个问题，`VariantBaseRules.cs:90` 早就豁免了：
+
+```csharp
+// A control whose procedural surface toggles WHOLESALE with the variant reverts on its own,
+// so the base-less form is the correct way to write it — and the idiom a skin wants:
+// `radius.glass="10"` shapes the control under one variant and leaves its sprite alone
+var proceduralSelfHeals = ProceduralSurfaceRules.AppliesTo(n.Tag) && !DeclaresBaseProcedural(n);
+```
+
+`PUI-VARIANT-NO-BASE` 认这个自愈并放行；`PUI-THEME-STYLE-SHAPE`（`ThemeStyleRules.cs:72`）是它的孪生规则，缺这条豁免。两份 spec 同一天写（2026-08-26），theme-driven-style §6.1 落笔时 procedural-surface 的 per-pass reconcile 还不存在 —— **时序遗漏，不是刻意取舍**。本设计补上。
+
+## 3. 设计：CheckShape 的程序化豁免（样式级）
+
+### 3.1 豁免哪些属性名
+
+只豁免**形状类**属性，即 `ProceduralAttrNames.NeedsPanel` 去掉 `weld`，再加上 `InnerLayerRadius`：
+
+```
+radius borderWidth borderColor glow glowColor
+glass frost depth dispersion lightAngle lightIntensity saturation noise
+fillRadius handleRadius frameRadius maskRadius
+```
+
+- **`weld` 排除**：Frame 专属，不跨进控件（procedural-surface spec §13.2），`DeclaresProcedural` 里也是这么跳过的。
+- **`color` 排除**（尽管 `VariantBaseRules.IsProcedural` 把它算进去）。`color` 在 Image-backed 控件上是普通 tint，主题少写一个 `color` 是真残留；而且它的「回退 alpha」路径正是 §5 要修的那个缺陷 —— 不能一边豁免一边指望它自愈。示例的两套主题都写 `color`，不需要这条豁免。
+- **`sprite` 排除**：不在程序化家族里，一个主题写、另一个不写就是真残留。
+
+### 3.2 判定条件：全有或全无
+
+设 `P` = §3.1 的名字集合，`N_T` = 样式 `S` 在主题 `T` 下解析出的属性名集合。
+
+> **豁免条件**：`{N_T ∩ P | T ∈ 所有主题}` 去重后至多两个元素，且其中一个是 `∅`。
+> 满足时，比较 `N_T` 时把 `P` 里的名字整体剔除；不满足时按今天的逻辑原样报。
+
+白话：**程序化那组属性要么整套在、要么整套不在**，才叫「wholesale 切换」，表面才会自己关掉并还原 Image。只要有哪个主题拿了半套（比如 A 写 `{radius, glass}`、B 只写 `{radius}`），B 缺的 `glass` 就真的会卡住 —— 照报。
+
+这个形式是**顺序无关**的，刻意不写成「跟参照主题两两比」。今天的 `CheckShape` 拿排序后的第一个主题当参照、发现不一致就 `break`，三个主题时 `farm(∅) / glass{radius,glass} / neon{radius}` 会因为先跟 `farm` 比而漏掉 `glass` vs `neon` 的真问题。先算全局的「全有或全无」再决定要不要剔除，绕开了这个坑。
+
+### 3.3 精度损失：`<Frame>`（明确接受）
+
+`CheckShape` 是**样式级**规则，跑在展开之前（`DocumentLinter` 有意如此：它诊断的东西正是让展开抛异常的原因），**看不到 tag**。而 `<Frame>` 的面板是直接 `AddComponent` 挂在自己身上、不做 per-pass reconcile（`Frame.cs:24`），**不自愈** —— `VariantBaseRules` 的注释里明确把 Frame 排除在外，它有 node 上下文所以做得到，这里做不到。
+
+于是 `<Frame class="btn">` 这类用法会**漏报**。明确接受，两个理由：
+
+1. 与仓库一贯取向一致 —— `ProceduralSurfaceRules` 的注释原话：「a false positive turns the CLI's non-zero exit into a wall for correct XML」，一直是宁可漏报。
+2. Frame 上「一个主题给 radius、另一个不给」本来就少见：Frame 没有 sprite 可保护，作者没有动机去做 wholesale 切换，直接两个主题都写 `radius` 就行。
+
+在 SKILL 里用一句话标出来（§8）。想彻底闭合得把 shape 检查挪到展开后按节点跑 —— 列进 §6 的 YAGNI。
+
+### 3.4 一处已有测试要改指
+
+`ThemeStyleRulesTests.AttributeOnlyOneThemeSets_IsReported` 现在用 `glow='8'` 当「只有一个主题写的属性」举例，而 `glow` 在 `P` 里 —— 加了豁免它会变绿。把那个例子换成非程序化属性（`fontSize` / `padding`），程序化的情形由新测试覆盖（§7）。**这是改指，不是删测试**：断言的语义没变，只是换了个不撞豁免的载体。
+
+## 4. 示例改造：`CommonControls` 转纯 theme
+
+把 18 行 `attr.glass=` 从全局基线搬进 `<Theme name="glass">` 的同名 `<Style>`，去掉 `.glass` 后缀。改完全局基线就是「农场皮的完整描述」，glass 主题就是「和农场不一样的那些项」—— 正是 spec 说的作者心智模型。
+
+**`glass` 变体不会消失**：`<Screen scale-mode="pixel" scale-mode.glass="auto">` 还得靠它（`<Screen>` 挂不住 `class=`，是 parse error），C# 那边 `UI.Variants.Set("glass", …) + UI.Theme.Set(…)` 照旧成对。但示例的叙事从「主题和变体配合换皮」收敛成 **「皮肤 = theme；变体只管 Screen 级 scale-mode 这一件 theme 干不了的事」**，文件头那段注释也跟着重写。
+
+**影响面**：全仓库只有 `CommonControls.ui.xml` 用了 theme-scoped `<Style>`（`ProceduralStyle` 的两个 skin 文件里 `<Theme>` 只有 `<Color>`）。验收：`dotnet run --project .lint/UIXmlLint -- Samples~/` 零 issue，且在 Unity 里两个主题来回切外观与今天逐像素一致。
+
+## 5. 相邻缺陷：`Restore()` 盖掉本轮写入的 sprite / alpha
+
+### 5.1 两处
+
+```csharp
+private void Restore()                       // ProceduralSurface.cs:174
+{
+    if (!_retired || _hostImage == null) return;
+    _retired = false;
+    _hostImage.sprite = _retiredSprite;      // ← 无条件
+    _hostImage.type = _retiredType;          // ← 无条件
+    var c = _hostImage.color;
+    _hostImage.color = new Color(c.r, c.g, c.b, _retiredColor.a);   // ← 无条件
+}
+```
+
+`_retiredSprite` / `_retiredColor` 是**首次** `Retire()` 时抓的，而 `Retire()` 由 `Reconcile()` 调用、`Reconcile()` 在 `OnAfterApply` 里跑 —— 也就是**在本轮所有 setter 跑完之后**。所以抓到的不是「控件的内置默认」，是「那一轮作者声明的最终值」。
+
+关掉程序化模式的那一轮，作者的 `sprite=` / `color=` setter 已经把新值写进 Image 了，`Restore()` 紧接着用旧快照盖掉。
+
+**触发条件**：首次 `Open` 时程序化模式就是开的。示例里 `UI.Theme.Set("glass")` 发生在 `UI.Open` 之前（比如持久化了上次的皮肤选择），切回 farm 时：木头 sprite 被写成 glass 那轮的 `sprite="none"`（null），alpha 被按回 `white/0.22` 的 0.22。
+
+第二条不依赖启动顺序的路径：程序化模式**保持开着**的同时 sprite 换过（主题 A→B 都是玻璃但贴图不同），之后再关 —— 快照停在 A，还原成 A。
+
+**与 §3 正交**：今天的 `.glass` 写法一模一样中招，改不改 lint 都在。放同一个 PR 是因为两者都在「主题切换 × 程序化表面」这条线上，测试夹具共用。
+
+### 5.2 Red test 先行
+
+三条 EditMode 测试，全部零资产依赖（`UI.SpriteResolver` 是公开可设的 `Func<string, Sprite>`，1×1 纹理 `Sprite.Create` 即可）：
+
+1. **alpha 不该被按回去** —— `<Btn id='b' color='#E8D2A8' color.mobile='white/0.22' radius.mobile='10'/>`，`Variants.Set("mobile", true)` **先于** `Open`，然后置 false，断言 `bg.color.a == 1`。
+2. **本轮写入的 sprite 不该被盖** —— 同形状，`sprite='s:wood' sprite.mobile='none'`，断言退出程序化后 `bg.sprite` 是 wood。
+3. **没人声明 sprite 时，内置默认仍要回来**（守卫，今天就是绿的，防止修法改过头）—— `<Btn id='b' radius.mobile='8'/>` 往返一次，断言 `bg.sprite` 非 null 且等于内置 9-slice。
+
+一并补一条**主题维度**的等价用例（用 `<Theme>` 而非变体驱动同一往返），钉住 §4 改造后的示例形状不会踩回这个坑。
+
+### 5.3 修法
+
+不需要动八个控件的 `Sprite` setter。`Retire()` 每轮都把 sprite 写成 null，所以**关模式那一轮 Image 的 sprite 非 null，只可能是本轮 setter 写的**：
+
+```csharp
+if (_hostImage.sprite == null)                 // 本轮没人声明 sprite → 还原内置默认
+{
+    _hostImage.sprite = _retiredSprite;
+    _hostImage.type = _retiredType;
+}
+if (!_hasFill)                                 // 本轮没人声明 color → 还原退休前的 alpha
+    _hostImage.color = new Color(c.r, c.g, c.b, _retiredColor.a);
+```
+
+alpha 那半用的是**现成的** `_hasFill` —— `SetFill` 由控件的 `color=` setter 调、`BeginPass` 每轮清零，语义正好是「本轮声明过颜色吗」。sprite 那半用 Image 自身的状态当信号，不新增字段。
+
+**残余空洞**（明确记录，不修）：某主题写 `sprite="none"` 而另一主题**完全不写** `sprite=`，快照会是 null，切回去拿不到内置默认。这个形状本身就是 SHAPE 规则要报的（`sprite` 不在 §3.1 的豁免集里），变体侧则由 `PUI-VARIANT-NO-BASE` 报（`sprite` 不在自愈白名单里）—— 两条路都已经有 lint 挡着，运行时不必再兜。
+
+## 6. 不做的事（YAGNI 记录）
+
+- **展开后按节点跑 shape 检查**（能拿到 tag，把 §3.3 的 Frame 漏报闭合）。要把 `CheckShape` 拆成「展开前样式级 + 展开后节点级」两遍，而它现在**故意**跑在展开之前。等真有人被 Frame 那个洞咬到再说。
+- **让 `ReSolve` 对「消失的属性」回放控件默认值**。theme-driven-style §6.1 已经否掉过：237 个 `[UIAttr]` setter 各自定义复位语义，十倍工作量，且 `mask` / `type` / `fit` 根本没有干净的默认。本设计正相反 —— 承认「有些属性天生自愈」，只让 lint 认得这件事。
+- **把 `color` 也纳入 §3.1 的豁免**。见 §3.1 的理由；等 §5 修完、`_hasFill` 路径被测试钉死之后可以重新评估。
+- **给 `<Frame>` 加 per-pass reconcile 让它也自愈**。那是改运行时语义，影响面远超本设计，且 Frame 没有需要保护的 sprite。
+
+## 7. 测试（Red 先行）
+
+**`PromptUGUI.Tests.EditMode` / Lint**（`ThemeStyleRulesTests`）
+
+1. `ProceduralShapeOnlyOneThemeSets_IsExempt` —— 全局 `<Style name='btn' sprite='…'/>` + glass 主题加 `radius glass borderWidth borderColor`，断言无 `ShapeCode`。
+2. `PartialProceduralSet_IsStillReported` —— 三主题，一个 `∅`、一个 `{radius, glass}`、一个 `{radius}`，断言仍报（钉 §3.2 的「全有或全无」与顺序无关性）。
+3. `NonProceduralAttributeAlongsideProcedural_IsStillReported` —— 差集是 `{radius, fontSize}`，断言仍报（豁免只吃 `P` 里的名字）。
+4. `SpriteOnlyOneThemeSets_IsStillReported` —— 钉 `sprite` 不在豁免集里（§5.3 残余空洞的静态兜底）。
+5. `InnerLayerRadius_IsExempt` —— `fillRadius` / `handleRadius`。
+6. `AttributeOnlyOneThemeSets_IsReported` —— 改指到 `fontSize`（§3.4）。
+
+**`PromptUGUI.Tests.EditMode` / Controls**（新建 `ProceduralSurfaceRestoreTests`）
+
+7–10. §5.2 的四条（alpha / sprite / 内置默认守卫 / 主题维度等价）。
+
+**CLI 回归**
+
+11. `dotnet run --project .lint/UIXmlLint -- Runtime/Resources/ Samples~/` 零 issue（今天的基线：13 个文件 0 issue；改造后的示例是这条规则最真实的夹具）。
+12. `ProceduralAttrNamesTests` 照旧 —— §3.1 的名字集合从 `ProceduralAttrNames` 派生，不新开一份手抄清单，drift 由已有测试守着。
+
+## 8. SKILL 更新（同 PR，英文）
+
+- `authoring-promptugui-xml/SKILL.md` 的 **Theme-scoped styles** 一节：「Always declare the global `<Style>` with the full attribute set」这条要加例外 —— 形状类属性（`radius` / `glass` / `border*` / `*Radius`…）**不要**给基线，一个主题整套写、别的主题一个不写才是正确写法；并说明为什么（写了基线 = 打开程序化模式 = 丢 sprite），附 `PUI-PROC-SPRITE-CONFLICT` 的交叉指引。同时点出 §3.3 的 Frame 例外。
+- 那一节现有的示例代码 `<Style name="card" … radius="16"/>` + `<Theme name="pixel"><Style name="card" … radius="0"/></Theme>` 保留 —— Frame-backed 的 card 上它是对的 —— 但要加一句区分「Frame 上写基线 OK，Image-backed 控件上不 OK」。
+- `reference/glass.md`：换皮场景补一段「一个主题玻璃、一个主题贴图」的正确写法。
+- `reference/states.md` / `controls-progress.md`：若引用了 `radius.<variant>` 的旧惯用法，改指主题写法。
+- lint 代码表里 `PUI-THEME-STYLE-SHAPE` 一行补上豁免说明。
+
+## 9. 里程碑拆分
+
+| M | 内容 | 验收 |
+|---|---|---|
+| **M0** | §7 的 1–5 与 7–10 全部写成 Red（含 6 的改指），确认 1/5 与 7/8 真的红 | EditMode 跑通，红的条数与预期一致 |
+| **M1** | `ThemeStyleRules.CheckShape` 豁免落地 | 1–6 转绿；`UIXmlLint` 对今天的 sample 仍零 issue（豁免不改变现状） |
+| **M2** | `ProceduralSurface.Restore()` 两处加条件 | 7–10 转绿；`ProceduralSurfaceRolloutTests` / `ProceduralSurfaceContractTests` 全绿（不许回归） |
+| **M3** | 示例转纯 theme + 文件头注释重写 | 11 零 issue；Unity 里 farm↔glass 往返外观与今天一致 |
+| **M4** | SKILL 更新（§8） | —— |
+
+`dotnet format --verify-no-changes --severity warn` 每个 M 后跑一次。
+
+## 10. 实施记录
+
+### M0（分支 `test/theme-procedural-shape-red`）
+
+Red test 全部落地，**EditMode 2485 passed → 2479 passed / 6 failed**，6 条全是新写的，其余一条没动。
+
+| 测试 | 位置 | 状态 | 实测失败信息 |
+|---|---|---|---|
+| `ProceduralShapeOnlyOneThemeSets_IsExempt` | `ThemeStyleRulesTests` | RED（M1） | `Expected: <empty> But was: <LintIssue>` |
+| `InnerLayerRadius_IsExempt` | 同上 | RED（M1） | 同上 |
+| `NonProceduralAttributeAlongsideProcedural_IsStillReported` | 同上 | **半红**（M1） | 报告本身在（`fontSize` 是真残留），但消息里**还带着 `radius`** —— 正是会把作者引去加那个毁掉另一套皮的基线 |
+| `PartialProceduralSet_IsStillReported` | 同上 | GREEN（守卫） | —— |
+| `SpriteOnlyOneThemeSets_IsStillReported` | 同上 | GREEN（守卫） | —— |
+| `LeavingProceduralMode_KeepsTheAlphaThisPassDeclared` | `ProceduralSurfaceRestoreTests`（新建） | RED（M2） | `Expected: 1.0 But was: 0.2196` —— 正好是 `#FFFFFF38` 的 alpha，玻璃皮的值漏了过来 |
+| `LeavingProceduralMode_KeepsTheSpriteThisPassDeclared` | 同上 | RED（M2） | `Expected: same as <Sprite> But was: null` |
+| `ThemeDrivenRoundTrip_KeepsWhatTheIncomingThemeDeclared` | 同上 | RED（M2） | 同上 |
+| `LeavingProceduralMode_RestoresTheAlphaWhenNoColourIsDeclared` | 同上 | GREEN（守卫） | 防止 M2 修过头变成「什么都不还原」 |
+| `LeavingProceduralMode_RestoresTheBuiltinSpriteWhenNoneIsDeclared` | 同上 | GREEN（守卫） | 同上 |
+
+**§3.4 的改指比预想多一处。** `AttributeOnlyOneThemeSets_IsReported` 之外，`StyleOnlyOneThemeDeclares_IsReported` 也拿 `glow='4'` 当载体，同样会被豁免吃掉。两条一起换成 `fontSize`（载体从 `<Image>` 换成 `<Text>`，让夹具名副其实），断言语义未变。
+
+**一个夹具陷阱，值得写进记录。** `ThemeDrivenRoundTrip_…` 第一版用 `UI.LoadDocument(label, xml)` 建文档，**绿了** —— 不是因为没缺陷，是因为同步重载**有意绕过** `RegisterThemesAndAutoSet`（`ThemeStyleSwitchTests` 的类注释写着这件事），`ThemeStore` 里压根没有 `glass`，`ResolveStyles` 原样返回全局包，玻璃皮从未上身，断言空跑通过。改用 fake-files + `LoadDocumentAsync` 后立刻转红。夹具里补了一条 `Assume.That(BgOf(b).sprite, Is.Null)` 守着这个坑 —— 以后谁再把它退回同步路径，会在 Assume 上就地暴露，而不是伪装成绿色。
+
+`dotnet format --verify-no-changes --severity warn` 无输出。
+
+### M1（待做）
+
+### M2（待做）
+
+### M3（待做）
+
+### M4（待做）

--- a/docs~/superpowers/specs/2026-08-27-theme-procedural-shape-exemption-design.md
+++ b/docs~/superpowers/specs/2026-08-27-theme-procedural-shape-exemption-design.md
@@ -245,10 +245,40 @@ Red test 全部落地，**EditMode 2485 passed → 2479 passed / 6 failed**，6 
 
 `dotnet format --verify-no-changes --severity warn` 无输出。
 
-### M1（待做）
+### M1 —— `CheckShape` 的豁免
 
-### M2（待做）
+按 §3.2 落地，形式与 spec 一致：豁免集从 `ProceduralAttrNames` 派生（`NeedsPanel` 去 `weld` + `InnerLayerRadius`），「全有或全无」跨全部主题算一次再进两两比较。
 
-### M3（待做）
+写代码时确认了 §3.2 那段顺序无关性的推导不是纸上谈兵：`CheckShape` 的循环拿排序第一的主题当参照并在首个不一致处 `break`，所以豁免**只能**在循环外算。放进循环就会分别放过 `plain-vs-full` 与 `plain-vs-partial`，永远发现不了 `full` 与 `partial` 彼此不一致 —— `PartialProceduralSet_IsStillReported` 就是钉这个的（主题名刻意排成 `a-plain` 最先）。
 
-### M4（待做）
+EditMode **2485 → 2482 passed / 3 failed**（只剩 M2 的三条）。`UIXmlLint` 对仓库 13 个文件仍零 issue —— 豁免不改变今天的判定。§2.2 那份纯 theme 草稿：**8 条 SHAPE → 0 issue**。
+
+### M2 —— `Restore()` 只还本轮没写过的
+
+按 §5.3，两处加条件，不新增按属性的标志位。实现时确认了两件 spec 里推断过的事：
+
+- `_hasFill` 的语义确实是「本轮声明过颜色吗」—— 八个控件的 `color=` setter（`Btn.cs:215` 等）都是先 `ColorApplier.Apply(_bg, spec)` 再 `Surface.SetFill(...)`，内层（`Slider.FillSurface` / `Progress.FrameSurface`）各有自己的 `_hasFill`，逐层成立。
+- sprite 那半不需要新信号：`Retire()` 每轮把它清成 null，所以关模式那一轮非 null 只可能是本轮 setter 写的。
+
+EditMode **2485/2485**、PlayMode **171/171**、EditorOnly **308/308** 全绿。
+
+### M3 —— 示例转纯 theme
+
+18 行 `attr.glass=` 搬进 `<Theme name="glass">`，文件头三条规矩的第 2 条补上形状例外，`<Screen>` 那段与 `CommonControlsRunner` 的注释改成「变体只剩 scale-mode 一处」的叙事。
+
+**外观不变是验过的，不是眼看的。** 写了个脚本按合并语义（global → theme 覆盖，按属性名原子；老写法再叠上变体命中）把 old/new 两份文件的**解析后属性映射**逐条比：12 个样式 × 2 套皮，**全部逐条相同**。比肉眼比对可靠，也比「跑一遍看看」快。
+
+`UIXmlLint` 13 文件 0 issue，EditMode 2485/2485。
+
+### M4 —— SKILL
+
+- `SKILL.md` 主题一节：「全局 `<Style>` 要写全套属性」加例外段落，讲清「形状属性是开关不是值」、豁免的全有或全无、`sprite` / `color` 不豁免的理由，以及 `<Frame>` 不自愈这条漏报。既有的 `card` / `radius="16"` 例子保留并注明「它落在 `<Frame>` 上所以对」。
+- `reference/glass.md`：新增「One theme glass, another bitmap」一节 —— 这是玻璃最常见的换皮场景，正面给出写法并写明「不要给像素侧加基线」。
+- lint 代码表补豁免说明。
+- `states.md` / `controls-progress.md` 查过，没有需要改指的旧惯用法（`radius.mobile` 那处带基值，是合法的变体写法）。
+
+## 11. 收尾状态
+
+四个里程碑全部完成，三套测试全绿（EditMode 2485 / PlayMode 171 / EditorOnly 308），`UIXmlLint` 13 文件 0 issue，`dotnet format --verify-no-changes --severity warn` 无输出。
+
+分支 `test/theme-procedural-shape-red`，四个 commit 一一对应 M0–M3，M4 并入最后一个。**未合并到 main。**


### PR DESCRIPTION
`Samples~/CommonControls` 里那 18 行 `radius.glass=` / `glass.glass=` 看起来像「主题和变体是两套并行的换皮机制」。其实不是——那是被一条 lint 规则逼出来的绕道。这个 PR 把绕道拆掉，让换皮**整个由 `<Theme>` 一个人管**，并顺手修掉同一条线上的一个相邻缺陷。

Spec：`docs~/superpowers/specs/2026-08-27-theme-procedural-shape-exemption-design.md`

## 当初为什么会走两条路

三步推导：

1. **对 `ProceduralControl` 来说，「写没写」才是开关，值是什么无所谓。** `Radius` / `Glass` / `BorderWidth` 这些 setter 一被调用就 `Surface.Declare(...)`，挂上 SDF 面并让 Image 退休（清 sprite + alpha 归零）。所以农场皮**必须一个 procedural 属性都不写**。
2. **但 `PUI-THEME-STYLE-SHAPE` 要求「所有主题解出同一套属性名」**，报错信息还专门建议「把 `radius` 加进全局 `<Style>` 当基线」——正好是第 1 条禁止的事。
3. **于是绕道**：属性**名**留在全局基线上，用 `attr.glass=` 让**值**只在 `glass` 变体激活时落地。

实测两种纯 theme 写法各自撞上什么：

| 写法 | 结果 |
|---|---|
| 属性只写在 `<Theme name="glass">` 里 | 8 条 `PUI-THEME-STYLE-SHAPE` |
| 按报错建议补基线（`radius=""`） | 换来 10 条 `PUI-PROC-SPRITE-CONFLICT`，**且不是误报**——farm 下真会丢贴图 |

## 为什么可以豁免

两条路给 applier 的信号**完全一样**：属性解析不出值 → setter 不调 → `BeginPass` 清标志 → `Reconcile` 关面板 → `Restore` 还原 Image。主题路径甚至更干净（`ReMerge` 连键都不留）。

证据在仓库里现成——变体侧的孪生规则 `VariantBaseRules.cs:90` 早就豁免了同一个自愈：

```csharp
// A control whose procedural surface toggles WHOLESALE with the variant reverts on its own
var proceduralSelfHeals = ProceduralSurfaceRules.AppliesTo(n.Tag) && !DeclaresBaseProcedural(n);
```

两份 spec 同一天写（2026-08-26），theme-driven-style §6.1 落笔时 procedural-surface 的 per-pass reconcile 还不存在。**时序遗漏，不是刻意取舍。**

## 改了什么

**① `ThemeStyleRules.CheckShape` 加程序化豁免**

豁免集从 `ProceduralAttrNames` 派生（`NeedsPanel` 去 `weld` + `InnerLayerRadius`），不新开手抄清单。两处有意排除：`weld` 不跨进控件；`color` 在 Image-backed 控件上是普通 tint，而且让它自愈的那条路径本身就是 ② 要修的缺陷。

判定「全有或全无」**跨全部主题算一次**再进两两比较——不能放进循环：那个循环拿排序第一的主题当参照，pairwise 会分别放过 `plain-vs-full` 和 `plain-vs-partial`，永远发现不了 `full` 与 `partial` 彼此不一致。

**已知漏报**：规则是样式级、跑在展开前，看不到 tag，而 `<Frame>` 的面板直接 `AddComponent` 挂在自己身上、不做 per-pass reconcile，**不自愈**。接受——误报会让 CLI 的非零 exit 挡住正确的 XML，这是仓库一贯取向。SKILL 里明写了。

**② `ProceduralSurface.Restore()` 别盖掉本轮刚写进去的值**（相邻缺陷，与 ① 正交）

`Retire()` 抓的快照不是「控件的内置默认」：它由 `Reconcile()` 调用、而 `Reconcile()` 跑在 `OnAfterApply`，抓到的是「首次开启表面那一轮作者声明的最终值」。`Restore()` 无条件写回它，而关闭模式的那一轮新皮肤的 setter 已经把值写进 Image 了。

触发条件：首次 `Open` 时程序化模式就开着（持久化的皮肤选择让 `Theme.Set` 跑在 `Open` 之前）。今天的 `.glass` 写法一样中招。

两半都改成问「本轮声明过吗」，不新增按属性的标志位：sprite 用 Image 自身状态当信号（`Retire()` 每轮清 null，此刻非 null 只可能是本轮写的），alpha 用现成的 `_hasFill`。

够不着的是「一套皮声明、另一套交给内置默认」这种不对称写法——快照与默认值在 Image 上无从分辨。两种拼法都有静态规则先报（`sprite` / `color` 都有意留在豁免之外，正是为了盖住这里）。

**③ 示例转纯 theme + ④ SKILL**

## 验证

| 检查 | 结果 |
|---|---|
| EditMode | 2485 / 2485 |
| PlayMode | 171 / 171 |
| EditorOnly | 308 / 308 |
| UIXmlLint | 13 文件 0 issue |
| `dotnet format --verify-no-changes --severity warn` | 无输出 |

新增 10 条测试（5 lint + 5 runtime），其中 6 条在 M0 是红的，M1/M2 逐一转绿；4 条绿色守卫防止修过头。

**示例外观不变是逐属性验过的，不是眼看的**：按合并语义（global → theme 覆盖、按属性名原子，老写法再叠上变体命中）比较 old/new 两份文件的解析后属性映射，12 个样式 × 2 套皮**全部逐条相同**。

## 两个夹具陷阱，已写进 spec 实施记录

- `ThemeDrivenRoundTrip_…` 第一版用 `UI.LoadDocument(label, xml)` 建文档，**绿了**——同步重载有意绕过 `RegisterThemesAndAutoSet`，玻璃皮从未上身，断言空跑通过。改用 fake-files + `LoadDocumentAsync` 立刻转红，并补了 `Assume.That` 守着这个坑。
- `StyleOnlyOneThemeDeclares_IsReported` 也拿 `glow` 当载体、会被豁免吃掉，一并改指到 `fontSize`（载体从 `<Image>` 换成 `<Text>`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhZySsbMocJuC1kULMtpf4