### PR TITLE
feat: 角部处理 —— radius 从「半径」升级成「形状」（cut / notch / hexagon）

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -118,7 +118,7 @@ There is still **no `Image`** on a Frame, so `sprite=` does nothing (`PUI-CONTAI
 | `showMask` | bool | `true` | 仅 `mask="self"`。`false` = 只裁不画，一个隐形的圆角裁剪器 |
 | `maskPadding` | `T,R,B,L`（`_`=占位） | — | 仅 `mask="rect"` 时有效 |
 | `color` | hex / CSS named / theme token / `A,B` 渐变 / `/alpha` | — (无填充) | Fill. Same value grammar as everywhere else — see **Color Tokens**; a comma value is a top→bottom gradient |
-| `radius` | `R` / `TL,TR,BR,BL` / `pill` | `0` | Corner radius in px. Four values follow CSS `border-radius` order (clockwise from top-left). `pill` = fully rounded ends. Values larger than the shape are clamped, not an error |
+| `radius` | corner list / `pill` / `hexagon [W]` | `0` | The panel's **shape**, not only its radius. One value applies to all four corners; four follow CSS `border-radius` order (clockwise from top-left). Each corner is a bare number (round), `cut W[xH]` (chamfer) or `notch W[xH]` (rectangular bite). Sizes are px and are clamped to the rect, never an error. → **Corner treatments** below |
 | `borderWidth` | px | `0` | Inner border — drawn **inward** from the rect edge (CSS `border-box`), so it never changes layout |
 | `borderColor` | hex / CSS / token / `/alpha`. **纯色 only** | `white` | 渐变值 = parse error |
 | `glow` | px | `0` | Outer glow radius. Inflates the drawn quad by this much (layout rect unchanged) |
@@ -133,6 +133,8 @@ There is still **no `Image`** on a Frame, so `sprite=` does nothing (`PUI-CONTAI
 <Frame borderWidth="2" borderColor="#fff"/>                <!-- 无填充 = 空心描边框 -->
 <Frame color="danger" radius="20" glow="18"/>              <!-- 发光 -->
 <Frame color="#1b263b" radius="0,0,16,16"/>                <!-- 只圆下面两角 -->
+<Frame color="accent" radius="cut 16"/>                    <!-- 四角 45° 斜切 -->
+<Frame color="accent" radius="hexagon"/>                   <!-- 左右收成尖的六边形 -->
 <Frame glass="true" radius="16" frost="0.6"/>              <!-- 磨砂玻璃，见 glass.md -->
 <Frame radius="pill" mask="self" showMask="false">         <!-- 隐形圆角裁剪器 -->
   <Image type="cover" sprite="ui:avatar"/>
@@ -143,6 +145,35 @@ There is still **no `Image`** on a Frame, so `sprite=` does nothing (`PUI-CONTAI
 - `mask="self"` clips to the **shape**, not to what the Frame paints: an outer `glow` does not widen the clip, and a Frame with a `radius` but no `color` still clips (that is the invisible-clipper form above). So `radius=` alone is enough to define the mask.
 - Colour / radius / border changes are material-only — a Variant flip or a colour animation never rebuilds the canvas mesh. Frames sharing identical values (typically via `class=`) share one material and keep batching.
 - Layout-only containers (`<VStack>` / `<HStack>` / `<Grid>` / `<SafeArea>`) draw nothing — wrap them in a `<Frame>` for a background.
+
+#### Corner treatments — `cut` / `notch` / `hexagon`
+
+`radius` picks each corner's **treatment**, not just a radius, so the whole sci-fi / HUD shape vocabulary is one attribute. It works everywhere `radius` works — including the inner-layer forms (`fillRadius` / `handleRadius` / `frameRadius` / `maskRadius`), which share this grammar.
+
+| Written | Shape |
+|---|---|
+| `16` | round — a quarter circle of radius 16 (what `radius` always meant) |
+| `cut 16` | 45° chamfer, 16 along both edges |
+| `cut 24x16` | chamfer reaching 24 horizontally, 16 vertically — flatter or steeper at will |
+| `notch 12` | a 12×12 rectangular bite out of the corner |
+| `notch 12x6` | 12 wide, 6 deep |
+| `pill` | whole shape: both short-axis ends fully rounded |
+| `hexagon` | whole shape: left and right sides drawn to a point at the vertical centre |
+| `hexagon 32` | the same, with the tips reaching 32 in instead of the default half-height |
+
+```xml
+<Btn radius="cut 16">开始匹配</Btn>                        <!-- 四角斜切 -->
+<Btn radius="cut 16, 8, cut 16, 8">混用</Btn>              <!-- 逐角混用 -->
+<Btn radius="hexagon 40" color="gold">开始匹配</Btn>        <!-- 横幅式六边形 -->
+<Tab radius="cut 14, cut 14, 0, 0">主页</Tab>              <!-- 上两角切 = 梯形页签 -->
+<Frame radius="notch 12, 0, 0, notch 12" borderWidth="2"/>  <!-- 机械感缺口 -->
+```
+
+- **Mix freely per corner**: `radius="cut 16, 8, notch 8, 0"` is four different treatments.
+- **`pill` and `hexagon` are whole-shape keywords** — writing one inside a four-value list is a parse error. Both resolve against the live rect, so they follow a resizing panel on their own; `hexagon` in particular keeps its tips exactly at half height, which hand-written `cut` values would lose the moment the height changed.
+- **Border, glow, glass and `mask="self"` follow the new outline automatically** — no extra attributes, and an inner border keeps its width around a chamfer and around the inner corner of a notch.
+- **One exception: `weld`.** A weld group fuses its members with a smooth union, which rounds every corner back off, so a welded block's treatment degrades to a plain round corner of the same reach. `PUI-WELD-CORNER` warns; see `reference/glass.md`.
+- Keywords are lower-case. `bevel` / `scoop` / `CUT` are parse errors that name the legal words.
 
 > **Which tags draw procedurally.** `radius` / `borderWidth` / `borderColor` / `glow` / `glowColor` / `glass` (+ its tuning params) work on **`<Frame>`, `<Btn>`, `<Tab>`, `<Toggle>`, `<Slider>`, `<Dropdown>`, `<InputField>`, `<ScrollList>` and `<Progress>`** — see **Procedural surfaces** below for what they do on a control.
 >
@@ -255,6 +286,7 @@ Image + Button + R3 `OnClick` / `OnState`。`<Btn>开始</Btn>` 简写生成内�
 ```xml
 <Btn radius="pill" color="accent" hoverColor="accent-light">确定</Btn>
 <Btn radius="12" glass="true" borderWidth="1" borderColor="white/0.5">玻璃按钮</Btn>
+<Tab radius="cut 14, cut 14, 0, 0">主页</Tab>                              <!-- 梯形页签 -->
 <Style name="skin" radius="10" borderWidth="1" borderColor="white/0.4"/>   <!-- 一个包换整套 -->
 ```
 

--- a/.claude/skills/authoring-promptugui-xml/reference/glass.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/glass.md
@@ -98,6 +98,10 @@ their **thickness** — not a line — say which is primary.
   from the children.
 - Members stay ordinary nodes throughout: they lay out normally, hold children, and answer
   `Get<T>` as usual. Only their drawing moves to the group.
+- **Corner treatments do not survive the fusion.** The smooth-min that merges the members rounds
+  every corner back off, so a member written `radius="cut 16"` (or `notch` / `hexagon`) draws with a
+  plain round corner of the same reach. `PUI-WELD-CORNER` warns rather than errors — the shape and
+  the `weld` can easily arrive from two different theme packs. Drop `weld` to keep the shape.
 - A Variant may turn a block's `glass` on or off, or hide it: the group re-fuses in the same pass.
 
 Where each parameter goes:
@@ -174,6 +178,7 @@ of them is silent at runtime, which is why they exist.
 | `PUI-GLASS-WELD-SELF` | `weld` and `glass="true"` on the same node |
 | `PUI-GLASS-WELD-MEMBERS` | a weld group with fewer than 2 or more than 8 glass children |
 | `PUI-GLASS-WELD-PARAM-PLACEMENT` | a group-level parameter on a member, or a per-block one on the carrier |
+| `PUI-WELD-CORNER` | a `cut` / `notch` / `hexagon` radius on a welded block — fusion rounds it off |
 | `PUI-MASK-WELD-SELF` | `mask="self"` on a `weld` carrier — the fused pane is on a child |
 | `PUI-PROC-SPRITE-CONFLICT` | `sprite=` on a control that is drawing procedurally |
 | `PUI-PROC-STATE-SPRITE-CONFLICT` | `pressedSprite` / `disabledSprite` on a procedural surface |

--- a/Runtime/Controls/Internal/GlassGroupPanel.cs
+++ b/Runtime/Controls/Internal/GlassGroupPanel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using PromptUGUI.Parser;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -396,9 +397,18 @@ namespace PromptUGUI.Controls.Internal
         private static Vector4 ResolveRadius(in PanelParams p, Vector2 half)
         {
             var shortest = Mathf.Min(half.x, half.y);
-            // Unlike the single-panel shader, pill is resolved here: the group material is per-group
-            // anyway, so there is no material sharing left to protect by deferring it to the GPU.
-            var r = p.Pill ? new Vector4(shortest, shortest, shortest, shortest) : p.Radius;
+            // Unlike the single-panel shader, the whole-shape sentinels are resolved here: the group
+            // material is per-group anyway, so there is no material sharing left to protect by
+            // deferring them to the GPU.
+            //
+            // Corner treatments do not survive fusion at all. The group packs one radius vector per
+            // member and smooth-unions the fields, and that union rounds every corner back off — so
+            // carrying the kinds through would cost two more uniform arrays and still not draw a
+            // chamfer. They degrade to a round corner of the same reach; PUI-WELD-CORNER says so at
+            // lint time, since the shape and the weld can arrive from two different theme packs.
+            var r = p.Shape != PanelShape.None
+                ? new Vector4(shortest, shortest, shortest, shortest)
+                : p.CornerWidth;
             return new Vector4(
                 Mathf.Clamp(r.x, 0f, shortest), Mathf.Clamp(r.y, 0f, shortest),
                 Mathf.Clamp(r.z, 0f, shortest), Mathf.Clamp(r.w, 0f, shortest));

--- a/Runtime/Controls/Internal/ProceduralMaterialCache.cs
+++ b/Runtime/Controls/Internal/ProceduralMaterialCache.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using PromptUGUI.Parser;
 using UnityEngine;
 
 namespace PromptUGUI.Controls.Internal
@@ -73,33 +74,54 @@ namespace PromptUGUI.Controls.Internal
         public readonly Color FillBottom;
         public readonly Color BorderColor;
         public readonly Color GlowColor;
-        public readonly Vector4 Radius;
-        public readonly bool Pill;
+        /// <summary>Per-corner horizontal reach in CSS order; the radius when the corner is round.</summary>
+        public readonly Vector4 CornerWidth;
+        /// <summary>Per-corner vertical reach in CSS order; mirrors the width for a round corner.</summary>
+        public readonly Vector4 CornerHeight;
+        /// <summary>Per-corner <see cref="CornerKind"/> in CSS order, as the shader reads them.</summary>
+        public readonly Vector4 CornerKinds;
+        public readonly PanelShape Shape;
+        /// <summary>Hexagon tip reach; 0 means the shader takes half the rect height.</summary>
+        public readonly float HexWidth;
         public readonly float BorderWidth;
         public readonly float GlowSize;
         public readonly bool Glass;
         public readonly GlassParams GlassParams;
 
+        /// <summary>
+        /// Packs a parsed shape into the four vectors the shader reads. Sizes stay in canvas units
+        /// and whole-shape sentinels stay symbolic — both are resolved per-fragment against the live
+        /// rect, which is what keeps two same-styled panels of different sizes on one material.
+        /// </summary>
         public PanelParams(Color fillTop, Color fillBottom, Color borderColor, Color glowColor,
-                           Vector4 radius, bool pill, float borderWidth, float glowSize,
+                           in RadiusSpec radius, float borderWidth, float glowSize,
                            bool glass = false, GlassParams glassParams = default)
         {
             FillTop = fillTop;
             FillBottom = fillBottom;
             BorderColor = borderColor;
             GlowColor = glowColor;
-            Radius = radius;
-            Pill = pill;
+            CornerWidth = new Vector4(radius.TopLeftCorner.Width, radius.TopRightCorner.Width,
+                                      radius.BottomRightCorner.Width, radius.BottomLeftCorner.Width);
+            CornerHeight = new Vector4(radius.TopLeftCorner.Height, radius.TopRightCorner.Height,
+                                       radius.BottomRightCorner.Height, radius.BottomLeftCorner.Height);
+            CornerKinds = new Vector4((float)radius.TopLeftCorner.Kind, (float)radius.TopRightCorner.Kind,
+                                      (float)radius.BottomRightCorner.Kind, (float)radius.BottomLeftCorner.Kind);
+            Shape = radius.Shape;
+            HexWidth = radius.HexWidth;
             BorderWidth = borderWidth;
             GlowSize = glowSize;
             Glass = glass;
             GlassParams = glassParams;
         }
 
+        public bool Pill => Shape == PanelShape.Pill;
+
         public bool Equals(PanelParams o) =>
             FillTop == o.FillTop && FillBottom == o.FillBottom
             && BorderColor == o.BorderColor && GlowColor == o.GlowColor
-            && Radius == o.Radius && Pill == o.Pill
+            && CornerWidth == o.CornerWidth && CornerHeight == o.CornerHeight
+            && CornerKinds == o.CornerKinds && Shape == o.Shape && HexWidth == o.HexWidth
             && BorderWidth == o.BorderWidth && GlowSize == o.GlowSize
             && Glass == o.Glass
             // Short-circuit: an opaque panel's glass block is always None, so there is nothing to
@@ -116,8 +138,11 @@ namespace PromptUGUI.Controls.Internal
                 h = (h * 397) ^ FillBottom.GetHashCode();
                 h = (h * 397) ^ BorderColor.GetHashCode();
                 h = (h * 397) ^ GlowColor.GetHashCode();
-                h = (h * 397) ^ Radius.GetHashCode();
-                h = (h * 397) ^ Pill.GetHashCode();
+                h = (h * 397) ^ CornerWidth.GetHashCode();
+                h = (h * 397) ^ CornerHeight.GetHashCode();
+                h = (h * 397) ^ CornerKinds.GetHashCode();
+                h = (h * 397) ^ Shape.GetHashCode();
+                h = (h * 397) ^ HexWidth.GetHashCode();
                 h = (h * 397) ^ BorderWidth.GetHashCode();
                 h = (h * 397) ^ GlowSize.GetHashCode();
                 h = (h * 397) ^ Glass.GetHashCode();
@@ -153,7 +178,10 @@ namespace PromptUGUI.Controls.Internal
         private static readonly int BorderColorId = Shader.PropertyToID("_BorderColor");
         private static readonly int GlowColorId = Shader.PropertyToID("_GlowColor");
         private static readonly int RadiusId = Shader.PropertyToID("_Radius");
-        private static readonly int PillId = Shader.PropertyToID("_Pill");
+        private static readonly int CornerHeightId = Shader.PropertyToID("_CornerH");
+        private static readonly int CornerKindId = Shader.PropertyToID("_CornerKind");
+        private static readonly int ShapeId = Shader.PropertyToID("_Shape");
+        private static readonly int HexWidthId = Shader.PropertyToID("_HexW");
         private static readonly int BorderWidthId = Shader.PropertyToID("_BorderWidth");
         private static readonly int GlowSizeId = Shader.PropertyToID("_GlowSize");
 
@@ -230,8 +258,11 @@ namespace PromptUGUI.Controls.Internal
             mat.SetColor(FillBottomId, p.FillBottom);
             mat.SetColor(BorderColorId, p.BorderColor);
             mat.SetColor(GlowColorId, p.GlowColor);
-            mat.SetVector(RadiusId, p.Radius);
-            mat.SetFloat(PillId, p.Pill ? 1f : 0f);
+            mat.SetVector(RadiusId, p.CornerWidth);
+            mat.SetVector(CornerHeightId, p.CornerHeight);
+            mat.SetVector(CornerKindId, p.CornerKinds);
+            mat.SetFloat(ShapeId, (float)p.Shape);
+            mat.SetFloat(HexWidthId, p.HexWidth);
             mat.SetFloat(BorderWidthId, p.BorderWidth);
             mat.SetFloat(GlowSizeId, p.GlowSize);
             if (!p.Glass) return;

--- a/Runtime/Controls/Internal/ProceduralPanel.cs
+++ b/Runtime/Controls/Internal/ProceduralPanel.cs
@@ -290,10 +290,8 @@ namespace PromptUGUI.Controls.Internal
                                                   0f, _noise);
             }
 
-            return new PanelParams(
-                fillTop, fillBottom, border, glow,
-                new Vector4(_radius.TopLeft, _radius.TopRight, _radius.BottomRight, _radius.BottomLeft),
-                _radius.IsPill, _borderWidth, _glowSize, _glass, glassParams);
+            return new PanelParams(fillTop, fillBottom, border, glow, _radius,
+                                   _borderWidth, _glowSize, _glass, glassParams);
         }
 
         /// <summary>

--- a/Runtime/Core/Lint/GlassRules.cs
+++ b/Runtime/Core/Lint/GlassRules.cs
@@ -23,6 +23,7 @@ namespace PromptUGUI.Lint
         public const string WeldSelfCode = "PUI-GLASS-WELD-SELF";
         public const string WeldMembersCode = "PUI-GLASS-WELD-MEMBERS";
         public const string WeldParamPlacementCode = "PUI-GLASS-WELD-PARAM-PLACEMENT";
+        public const string WeldCornerCode = "PUI-WELD-CORNER";
 
         /// <summary>
         /// Shader uniform arrays are fixed size; the group shader carries eight slots. Kept in sync
@@ -136,6 +137,14 @@ namespace PromptUGUI.Lint
                         "ignored on a welded block — the blocks are one continuous pane, so they " +
                         $"share it. Move '{attr}' onto the <{n.Tag}> that carries 'weld'.");
                 }
+
+                if (HasCornerTreatment(child, styles))
+                    yield return new LintIssue(
+                        WeldCornerCode, child.Tag, child.Id,
+                        $"<{child.Tag} id='{child.Id}'>: corner treatments do not survive a weld. " +
+                        "The group fuses its members' shapes with a smooth union, which rounds " +
+                        "every corner back off, so this block draws with plain round corners of " +
+                        "the same reach. Drop 'weld' to keep the shape, or write a round radius.");
             }
 
             if (!countIsKnowable) yield break;
@@ -153,6 +162,37 @@ namespace PromptUGUI.Lint
                     $"{(members == 1 ? "child" : "children")} — 'weld' fuses two or more and does " +
                     "nothing here. Give the container more glass children, or drop 'weld' and let " +
                     "the child draw itself.");
+        }
+
+        /// <summary>
+        /// True when this node's <c>radius</c> asks for anything the weld shader cannot draw —
+        /// a per-corner <c>cut</c> / <c>notch</c>, or the <c>hexagon</c> sentinel.
+        /// </summary>
+        /// <remarks>
+        /// Variant values count: shape and weld can arrive from two different theme packs, so the
+        /// pairing is at least as likely to show up in one layout only. A value that does not parse
+        /// is left alone — <see cref="StyleRules"/> already reports the syntax error, and saying it
+        /// twice in two vocabularies helps nobody.
+        /// </remarks>
+        private static bool HasCornerTreatment(ElementNode n, StyleAttributeView styles)
+        {
+            styles.Resolve(n, "radius", out var baseValue, out var variants);
+
+            if (IsTreated(baseValue)) return true;
+            foreach (var (_, value) in variants)
+                if (IsTreated(value))
+                    return true;
+            return false;
+
+            static bool IsTreated(string value)
+            {
+                if (!RadiusParser.TryParse(value, out var spec, out _)) return false;
+                return spec.Shape == PanelShape.Hexagon
+                       || spec.TopLeftCorner.Kind != CornerKind.Round
+                       || spec.TopRightCorner.Kind != CornerKind.Round
+                       || spec.BottomRightCorner.Kind != CornerKind.Round
+                       || spec.BottomLeftCorner.Kind != CornerKind.Round;
+            }
         }
 
         private static bool IsGlassTrue(ElementNode n, StyleAttributeView styles)

--- a/Runtime/Core/Parser/RadiusParser.cs
+++ b/Runtime/Core/Parser/RadiusParser.cs
@@ -1,45 +1,166 @@
+using System;
 using System.Globalization;
 
 namespace PromptUGUI.Parser
 {
+    /// <summary>How one corner is taken off the rectangle.</summary>
+    /// <remarks>
+    /// The numeric values are part of the contract: they ride into the shader as
+    /// <c>_CornerKind</c> and are compared against the <c>PUGUI_CORNER_*</c> defines in
+    /// <c>UI-PanelSDF.cginc</c>.
+    /// </remarks>
+    public enum CornerKind
+    {
+        /// <summary>Quarter circle — the only treatment that existed before corner treatments.</summary>
+        Round = 0,
+        /// <summary>Straight chamfer from <c>Width</c> along one edge to <c>Height</c> along the other.</summary>
+        Cut = 1,
+        /// <summary>Rectangular bite of <c>Width</c> × <c>Height</c> taken out of the corner.</summary>
+        Notch = 2,
+    }
+
     /// <summary>
-    /// Corner-radius spec produced by <see cref="RadiusParser"/>. Four independent corners in CSS
-    /// <c>border-radius</c> order (clockwise from top-left) plus a <c>pill</c> sentinel.
+    /// A whole-shape keyword, which overrides every per-corner value. Both members resolve against
+    /// the live rect and are therefore deliberately left symbolic here — see
+    /// <see cref="RadiusSpec"/>.
+    /// </summary>
+    /// <remarks>Numeric values ride into the shader as <c>_Shape</c>; see <c>PUGUI_SHAPE_*</c>.</remarks>
+    public enum PanelShape
+    {
+        None = 0,
+        /// <summary>Both short-axis ends fully rounded: radius = min(width, height) / 2.</summary>
+        Pill = 1,
+        /// <summary>Left and right sides drawn to a point at the vertical centre.</summary>
+        Hexagon = 2,
+    }
+
+    /// <summary>One corner's treatment plus its two sizes, in canvas units.</summary>
+    /// <remarks>
+    /// <see cref="Height"/> mirrors <see cref="Width"/> for <see cref="CornerKind.Round"/> — a
+    /// circle has only one size — so the shader can read one size pair per corner without first
+    /// branching on the kind.
+    /// </remarks>
+    public readonly struct CornerSpec
+    {
+        public readonly CornerKind Kind;
+        /// <summary>Reach along the horizontal edge (for Round: the radius).</summary>
+        public readonly float Width;
+        /// <summary>Reach along the vertical edge (for Round: the radius).</summary>
+        public readonly float Height;
+
+        public CornerSpec(CornerKind kind, float width, float height)
+        {
+            Kind = kind; Width = width; Height = height;
+        }
+
+        public static CornerSpec Round(float radius)
+            => new CornerSpec(CornerKind.Round, radius, radius);
+
+        public static readonly CornerSpec Square = new CornerSpec(CornerKind.Round, 0f, 0f);
+
+        /// <summary>
+        /// True when this corner takes nothing off the rectangle. A treatment with either size at
+        /// zero removes no area, whatever its keyword says.
+        /// </summary>
+        public bool IsSquare => Width <= 0f || Height <= 0f;
+    }
+
+    /// <summary>
+    /// Corner spec produced by <see cref="RadiusParser"/>. Four independent corners in CSS
+    /// <c>border-radius</c> order (clockwise from top-left) plus the whole-shape sentinels.
     /// </summary>
     /// <remarks>
-    /// <see cref="IsPill"/> is deliberately NOT resolved to a number here: the pill radius is
-    /// <c>min(width, height) / 2</c>, which depends on the live rect. Resolving it in C# would make
-    /// two same-styled panels of different sizes carry different values and lose material sharing
-    /// (see <c>ProceduralMaterialCache</c>) — the shader resolves it per-fragment from its own size
-    /// input instead, for free.
+    /// <see cref="Shape"/> is deliberately NOT resolved to numbers here: the pill radius is
+    /// <c>min(width, height) / 2</c> and the hexagon tip is half the height, both of which depend
+    /// on the live rect. Resolving them in C# would make two same-styled panels of different sizes
+    /// carry different values and lose material sharing (see <c>ProceduralMaterialCache</c>) — the
+    /// shader resolves them per-fragment from its own size input instead, for free.
     /// </remarks>
     public readonly struct RadiusSpec
     {
-        public readonly float TopLeft;
-        public readonly float TopRight;
-        public readonly float BottomRight;
-        public readonly float BottomLeft;
-        public readonly bool IsPill;
+        public readonly CornerSpec TopLeftCorner;
+        public readonly CornerSpec TopRightCorner;
+        public readonly CornerSpec BottomRightCorner;
+        public readonly CornerSpec BottomLeftCorner;
 
-        public RadiusSpec(float tl, float tr, float br, float bl, bool isPill = false)
+        public readonly PanelShape Shape;
+
+        /// <summary>
+        /// How far a <see cref="PanelShape.Hexagon"/> tip reaches in from the left/right edge.
+        /// Zero means "auto": the shader takes half the height, giving a 45° tip.
+        /// </summary>
+        public readonly float HexWidth;
+
+        public RadiusSpec(CornerSpec topLeft, CornerSpec topRight,
+                          CornerSpec bottomRight, CornerSpec bottomLeft,
+                          PanelShape shape = PanelShape.None, float hexWidth = 0f)
         {
-            TopLeft = tl; TopRight = tr; BottomRight = br; BottomLeft = bl; IsPill = isPill;
+            TopLeftCorner = topLeft;
+            TopRightCorner = topRight;
+            BottomRightCorner = bottomRight;
+            BottomLeftCorner = bottomLeft;
+            Shape = shape;
+            HexWidth = hexWidth;
         }
+
+        /// <summary>Four round corners — the shape of every spec that existed before treatments.</summary>
+        public RadiusSpec(float tl, float tr, float br, float bl, bool isPill = false)
+            : this(CornerSpec.Round(tl), CornerSpec.Round(tr),
+                   CornerSpec.Round(br), CornerSpec.Round(bl),
+                   isPill ? PanelShape.Pill : PanelShape.None)
+        {
+        }
+
+        /// <summary>Horizontal reach of the top-left corner; its radius when the corner is round.</summary>
+        public float TopLeft => TopLeftCorner.Width;
+        public float TopRight => TopRightCorner.Width;
+        public float BottomRight => BottomRightCorner.Width;
+        public float BottomLeft => BottomLeftCorner.Width;
 
         public static readonly RadiusSpec Zero = new RadiusSpec(0f, 0f, 0f, 0f);
         public static readonly RadiusSpec Pill = new RadiusSpec(0f, 0f, 0f, 0f, true);
 
-        public bool IsZero => !IsPill && TopLeft == 0f && TopRight == 0f
-                              && BottomRight == 0f && BottomLeft == 0f;
+        public static RadiusSpec Hexagon(float hexWidth = 0f)
+            => new RadiusSpec(CornerSpec.Square, CornerSpec.Square,
+                              CornerSpec.Square, CornerSpec.Square,
+                              PanelShape.Hexagon, hexWidth);
+
+        public bool IsPill => Shape == PanelShape.Pill;
+
+        /// <summary>True when the panel is a plain rectangle — no sentinel, no corner takes anything off.</summary>
+        public bool IsZero => Shape == PanelShape.None
+                              && TopLeftCorner.IsSquare && TopRightCorner.IsSquare
+                              && BottomRightCorner.IsSquare && BottomLeftCorner.IsSquare;
     }
 
     /// <summary>
     /// Parses the <c>radius</c> attribute. Pure C# (no UnityEngine types) so the UIXmlLint CLI
     /// compiles it and surfaces syntax errors before the author ever opens Unity.
     /// </summary>
+    /// <remarks>
+    /// Grammar:
+    /// <code>
+    /// radius      := "" | whole-shape | corner-list
+    /// whole-shape := "pill" | "hexagon" [ SP number ]
+    /// corner-list := segment | segment "," segment "," segment "," segment
+    /// segment     := number | keyword SP size
+    /// keyword     := "cut" | "notch"
+    /// size        := number [ "x" number ]
+    /// </code>
+    /// Keywords are matched case-sensitively and lower-case: an author who writes <c>CUT</c> gets an
+    /// error naming the legal words, which is a better outcome than a silent case fix-up that lint
+    /// and runtime then have to agree on forever.
+    /// </remarks>
     public static class RadiusParser
     {
         public const string PillKeyword = "pill";
+        public const string HexagonKeyword = "hexagon";
+        public const string CutKeyword = "cut";
+        public const string NotchKeyword = "notch";
+
+        private const string LegalCornerWords =
+            "a number (round), '" + CutKeyword + " W' / '" + CutKeyword + " WxH', '" +
+            NotchKeyword + " W' / '" + NotchKeyword + " WxH'";
 
         /// <summary>Throwing wrapper used by the runtime attribute setters.</summary>
         public static RadiusSpec Parse(string value)
@@ -58,29 +179,31 @@ namespace PromptUGUI.Parser
             if (string.IsNullOrWhiteSpace(value)) return true;
 
             var raw = value.Trim();
+
+            // Whole-shape keywords span the entire value, so they are settled before the value is
+            // ever split on commas — otherwise "hexagon 32" would look like one malformed segment.
+            if (TryParseWholeShape(raw, out spec, out error, out var wasWholeShape)) return true;
+            if (wasWholeShape) return false;
+
             var parts = raw.Split(',');
 
-            if (parts.Length == 1 && string.Equals(parts[0].Trim(), PillKeyword,
-                                                   System.StringComparison.Ordinal))
+            foreach (var part in parts)
             {
-                spec = RadiusSpec.Pill;
-                return true;
-            }
-
-            for (var i = 0; i < parts.Length; i++)
-            {
-                if (!string.Equals(parts[i].Trim(), PillKeyword, System.StringComparison.Ordinal))
+                var keyword = FirstToken(part);
+                if (!string.Equals(keyword, PillKeyword, StringComparison.Ordinal)
+                    && !string.Equals(keyword, HexagonKeyword, StringComparison.Ordinal))
                     continue;
-                error = $"radius=\"{raw}\": '{PillKeyword}' is a whole-shape keyword and cannot be " +
-                        "mixed with per-corner values (write radius=\"pill\" on its own)";
+                error = $"radius=\"{raw}\": '{keyword}' is a whole-shape keyword and cannot be " +
+                        $"mixed with per-corner values (write radius=\"{keyword}\" on its own)";
                 return false;
             }
 
             if (parts.Length != 1 && parts.Length != 4)
             {
                 error = $"radius=\"{raw}\": expected 1 value (all corners), 4 values " +
-                        "(top-left,top-right,bottom-right,bottom-left) or the keyword " +
-                        $"'{PillKeyword}' — got {parts.Length} comma-separated values";
+                        "(top-left,top-right,bottom-right,bottom-left) or a whole-shape keyword " +
+                        $"('{PillKeyword}' / '{HexagonKeyword}') — got {parts.Length} " +
+                        "comma-separated values";
                 return false;
             }
 
@@ -100,10 +223,70 @@ namespace PromptUGUI.Parser
             return true;
         }
 
-        private static bool TryParseCorner(string segment, string raw, string corner,
-                                           out float result, out string error)
+        /// <param name="wasWholeShape">
+        /// True when the value opened with a whole-shape keyword, so a false return means "that
+        /// keyword was written wrong" rather than "this is a corner list" — without it the caller
+        /// would fall through and report a far less useful segment error.
+        /// </param>
+        private static bool TryParseWholeShape(string raw, out RadiusSpec spec, out string error,
+                                               out bool wasWholeShape)
         {
-            result = 0f;
+            spec = RadiusSpec.Zero;
+            error = null;
+            wasWholeShape = false;
+
+            // A comma means the author is writing a corner list. Handing those straight back lets
+            // the mix check own them, and "cannot be mixed with per-corner values" reads far better
+            // than a complaint about the keyword's own size grammar.
+            if (raw.IndexOf(',') >= 0) return false;
+
+            var tokens = Tokenize(raw);
+            if (tokens.Length == 0) return false;
+
+            if (string.Equals(tokens[0], PillKeyword, StringComparison.Ordinal))
+            {
+                wasWholeShape = true;
+                if (tokens.Length > 1)
+                {
+                    error = $"radius=\"{raw}\": '{PillKeyword}' takes no size — it is always " +
+                            "min(width, height) / 2";
+                    return false;
+                }
+                spec = RadiusSpec.Pill;
+                return true;
+            }
+
+            if (!string.Equals(tokens[0], HexagonKeyword, StringComparison.Ordinal)) return false;
+            wasWholeShape = true;
+
+            if (tokens.Length == 1)
+            {
+                spec = RadiusSpec.Hexagon();
+                return true;
+            }
+            if (tokens.Length > 2)
+            {
+                error = $"radius=\"{raw}\": '{HexagonKeyword}' takes at most one size " +
+                        $"(write radius=\"{HexagonKeyword}\" or radius=\"{HexagonKeyword} 32\")";
+                return false;
+            }
+            if (tokens[1].IndexOf('x') >= 0)
+            {
+                error = $"radius=\"{raw}\": '{HexagonKeyword}' takes a single horizontal size — " +
+                        "its tip height is always half the rect, so there is no second axis to set";
+                return false;
+            }
+            if (!TryParseNumber(tokens[1], raw, $"'{HexagonKeyword}' size", out var w, out error))
+                return false;
+
+            spec = RadiusSpec.Hexagon(w);
+            return true;
+        }
+
+        private static bool TryParseCorner(string segment, string raw, string corner,
+                                           out CornerSpec result, out string error)
+        {
+            result = CornerSpec.Square;
             error = null;
             var s = segment.Trim();
 
@@ -112,9 +295,87 @@ namespace PromptUGUI.Parser
                 error = $"radius=\"{raw}\": {corner} segment is empty";
                 return false;
             }
+
+            var tokens = Tokenize(s);
+
+            if (tokens.Length == 1)
+            {
+                if (IsCornerKeyword(tokens[0]))
+                {
+                    error = $"radius=\"{raw}\": {corner} segment '{s}' needs a size " +
+                            $"(write '{tokens[0]} 16' or '{tokens[0]} 24x16')";
+                    return false;
+                }
+                if (!TryParseNumber(tokens[0], raw, $"{corner} segment", out var r, out error))
+                {
+                    error += $" — expected {LegalCornerWords}";
+                    return false;
+                }
+                result = CornerSpec.Round(r);
+                return true;
+            }
+
+            if (tokens.Length > 2)
+            {
+                error = $"radius=\"{raw}\": {corner} segment '{s}' has too many parts — " +
+                        $"expected {LegalCornerWords}";
+                return false;
+            }
+
+            if (!TryParseKind(tokens[0], out var kind))
+            {
+                error = $"radius=\"{raw}\": {corner} segment '{s}' starts with an unknown " +
+                        $"keyword '{tokens[0]}' — expected {LegalCornerWords}";
+                return false;
+            }
+
+            if (!TryParseSize(tokens[1], raw, $"{corner} segment '{s}'", out var w, out var h,
+                              out error))
+                return false;
+
+            result = new CornerSpec(kind, w, h);
+            return true;
+        }
+
+        /// <summary>Parses <c>W</c> or <c>WxH</c>; a lone size squares itself (45° cut, square notch).</summary>
+        private static bool TryParseSize(string token, string raw, string where,
+                                         out float width, out float height, out string error)
+        {
+            width = 0f;
+            height = 0f;
+
+            var axes = token.Split('x');
+            if (axes.Length > 2)
+            {
+                error = $"radius=\"{raw}\": {where} has a malformed size '{token}' — " +
+                        "expected 'W' or 'WxH'";
+                return false;
+            }
+
+            if (!TryParseNumber(axes[0], raw, $"{where} width", out width, out error)) return false;
+            if (axes.Length == 1)
+            {
+                height = width;
+                return true;
+            }
+            return TryParseNumber(axes[1], raw, $"{where} height", out height, out error);
+        }
+
+        private static bool TryParseNumber(string token, string raw, string where,
+                                           out float result, out string error)
+        {
+            result = 0f;
+            error = null;
+            var s = token.Trim();
+
+            if (s.Length == 0)
+            {
+                error = $"radius=\"{raw}\": {where} is empty";
+                return false;
+            }
             if (!float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out result))
             {
-                error = $"radius=\"{raw}\": {corner} segment '{s}' is not a number";
+                error = $"radius=\"{raw}\": {where} '{s}' is not a number";
                 return false;
             }
             // "NaN" / "Infinity" parse fine under InvariantCulture, and NaN also slips past the
@@ -122,15 +383,43 @@ namespace PromptUGUI.Parser
             if (float.IsNaN(result) || float.IsInfinity(result))
             {
                 result = 0f;
-                error = $"radius=\"{raw}\": {corner} segment '{s}' is not a finite number";
+                error = $"radius=\"{raw}\": {where} '{s}' is not a finite number";
                 return false;
             }
             if (result < 0f)
             {
-                error = $"radius=\"{raw}\": {corner} segment '{s}' is negative";
+                error = $"radius=\"{raw}\": {where} '{s}' is negative";
                 return false;
             }
             return true;
         }
+
+        private static bool TryParseKind(string token, out CornerKind kind)
+        {
+            if (string.Equals(token, CutKeyword, StringComparison.Ordinal))
+            {
+                kind = CornerKind.Cut;
+                return true;
+            }
+            if (string.Equals(token, NotchKeyword, StringComparison.Ordinal))
+            {
+                kind = CornerKind.Notch;
+                return true;
+            }
+            kind = CornerKind.Round;
+            return false;
+        }
+
+        private static bool IsCornerKeyword(string token)
+            => TryParseKind(token, out _);
+
+        private static string FirstToken(string segment)
+        {
+            var tokens = Tokenize(segment);
+            return tokens.Length == 0 ? string.Empty : tokens[0];
+        }
+
+        private static string[] Tokenize(string s)
+            => s.Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
     }
 }

--- a/Runtime/Resources/PromptUGUI/Material/UI-GlassPanel.shader
+++ b/Runtime/Resources/PromptUGUI/Material/UI-GlassPanel.shader
@@ -19,9 +19,14 @@ Shader "UI/GlassPanel"
         _BorderColor ("Border Color", Color) = (1,1,1,1)
         _GlowColor   ("Glow Color",   Color) = (1,1,1,1)
 
-        // xyzw = top-left, top-right, bottom-right, bottom-left (CSS border-radius 顺序)
-        _Radius      ("Radius TL/TR/BR/BL", Vector) = (0,0,0,0)
-        _Pill        ("Pill Sentinel", Float) = 0
+        // 四个逐角向量一律是 xyzw = top-left, top-right, bottom-right, bottom-left
+        // （CSS border-radius 顺序）。_Radius 是每个角的**水平**伸出量，圆角时即半径。
+        _Radius      ("Corner Width TL/TR/BR/BL",  Vector) = (0,0,0,0)
+        _CornerH     ("Corner Height TL/TR/BR/BL", Vector) = (0,0,0,0)
+        _CornerKind  ("Corner Kind TL/TR/BR/BL (0 round / 1 cut / 2 notch)", Vector) = (0,0,0,0)
+        // 整形哨兵：0 无 / 1 pill / 2 hexagon。两者都依赖 rect 尺寸，逐片元解算。
+        _Shape       ("Shape Sentinel", Float) = 0
+        _HexW        ("Hexagon Tip Reach (0 = auto)", Float) = 0
         _BorderWidth ("Border Width",  Float) = 0
         _GlowSize    ("Glow Size",     Float) = 0
 
@@ -110,7 +115,10 @@ Shader "UI/GlassPanel"
             fixed4 _BorderColor;
             fixed4 _GlowColor;
             float4 _Radius;
-            float _Pill;
+            float4 _CornerH;
+            float4 _CornerKind;
+            float _Shape;
+            float _HexW;
             float _BorderWidth;
             float _GlowSize;
             float4 _GlassA;
@@ -152,8 +160,9 @@ Shader "UI/GlassPanel"
                 float2 p = IN.shape.xy;
                 float2 b = IN.shape.zw;
 
-                float4 r = PuguiResolveRadius(_Radius, _Pill, b);
-                float d = PuguiSdRoundBox(p, b, r);
+                PuguiCorner corner = PuguiResolveCorner(p, b, _CornerKind, _Radius,
+                                                       _CornerH, _Shape, _HexW);
+                float d = PuguiSdPanel(p, b, corner);
                 float fw = max(fwidth(d), 1e-4);
                 float inside = saturate(0.5 - d / fw);
 
@@ -179,7 +188,7 @@ Shader "UI/GlassPanel"
                     float2 uv = IN.screenPos.xy / max(IN.screenPos.w, 1e-5);
 
                     // 画布空间外法线：+Y 就是界面正上方，与 lightAngle 的定义同一套坐标系。
-                    float2 n = PuguiSdNormal(p, b, r);
+                    float2 n = PuguiPanelNormal(p, b, corner);
 
                     // 折射带：仅 -depth < d < 0。band 在带外沿=1、带内沿=0。
                     float band = depth > 0.0 ? saturate(1.0 + d / depth) * inside : 0.0;

--- a/Runtime/Resources/PromptUGUI/Material/UI-PanelSDF.cginc
+++ b/Runtime/Resources/PromptUGUI/Material/UI-PanelSDF.cginc
@@ -1,30 +1,172 @@
 // 程序化面板的共享形状层：UI-ProceduralPanel 与 UI-GlassPanel 都 include 这份，
-// 保证不透明面板和玻璃面板的圆角、pill 解算、抗锯齿宽度逐像素完全一致 ——
+// 保证不透明面板和玻璃面板的圆角、切角、pill / hexagon 解算、抗锯齿宽度逐像素完全一致 ——
 // 两块并排、只有填充方式不同的面板，边缘必须严丝合缝对齐。
 #ifndef PROMPTUGUI_PANEL_SDF_INCLUDED
 #define PROMPTUGUI_PANEL_SDF_INCLUDED
 
-// iq 的圆角矩形 SDF，四角半径独立。p 以矩形中心为原点，b 为半尺寸。
-// 返回值：负=内部，正=外部，绝对值≈到边界的距离（画布单位）。
-float PuguiSdRoundBox(float2 p, float2 b, float4 r)
+// 逐角处理方式，必须与 PromptUGUI.Parser.CornerKind 的数值一致。
+// 判定一律取中点阈值：uniform 里是精确的 0/1/2，但浮点等值比较没有必要的脆弱。
+#define PUGUI_KIND_ROUND       0.0
+#define PUGUI_KIND_CUT         1.0
+#define PUGUI_KIND_IS_ROUND(k) ((k) < 0.5)
+#define PUGUI_KIND_IS_NOTCH(k) ((k) > 1.5)
+
+// 整形哨兵，必须与 PromptUGUI.Parser.PanelShape 的数值一致。
+#define PUGUI_SHAPE_IS_PILL(s)    ((s) > 0.5)
+#define PUGUI_SHAPE_IS_HEXAGON(s) ((s) > 1.5)
+
+// 本片元所属那个角的处理方式与两轴尺寸（画布单位）。
+struct PuguiCorner
 {
-    // 象限选角：右半区取 (TR, BR)，左半区取 (TL, BL)；再按上下二选一。
-    float2 side = (p.x > 0.0) ? float2(r.y, r.z) : float2(r.x, r.w);
-    float radius = (p.y > 0.0) ? side.x : side.y;
-    float2 q = abs(p) - b + radius;
-    return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - radius;
+    float  kind;
+    float2 size;   // x = 沿水平边的伸出量，y = 沿垂直边的伸出量；round 时两者相等
+};
+
+// 折叠帧里的角象限距离场。u = abs(p) - b，角在原点、内部为负。
+// 折叠之后它同时就是矩形本身的 SDF —— 另外三个角的特征都在别的象限，够不着这里。
+float PuguiSdQuadrant(float2 u)
+{
+    return min(max(u.x, u.y), 0.0) + length(max(u, 0.0));
 }
 
-// pill 在 GPU 上解算而不是在 C# 里：它依赖 rect 尺寸，提前算掉会让同一 style
+// 折叠帧里的象限外法线（内部退化成「离哪条边最近就朝哪边」）。
+float2 PuguiSdQuadrantNormal(float2 u)
+{
+    return (max(u.x, u.y) > 0.0)
+        ? normalize(max(u, 0.0) + 1e-6)
+        : ((u.x > u.y) ? float2(1.0, 0.0) : float2(0.0, 1.0));
+}
+
+// iq 的圆角，写在折叠帧里：q = u + r 与原来的 abs(p) - b + radius 逐字等价。
+float PuguiSdRoundCorner(float2 u, float r)
+{
+    float2 q = u + r;
+    return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - r;
+}
+
+// 斜切角：矩形与一条斜边半平面求交。斜边从 A = (-W, 0) 连到 B = (0, -H)。
+float PuguiSdCutCorner(float2 u, float2 s)
+{
+    // 尺寸退化到 0 就什么也没切掉，顺带挡住下面 rsqrt 的零长度边。
+    if (min(s.x, s.y) <= 0.0) return PuguiSdQuadrant(u);
+
+    // 斜边外法线 n = (H, W)/L，过 A 点，于是 d = dot(u, n) + W*H/L。
+    float invL = rsqrt(s.x * s.x + s.y * s.y);
+    float dLine = (u.x * s.y + u.y * s.x + s.x * s.y) * invL;
+    float d = max(PuguiSdQuadrant(u), dLine);
+
+    // 内部：两个精确半空间取 max 就是精确解（离最近那条边的距离）。
+    if (d <= 0.0) return d;
+
+    // 外部：斜边两个端点之外的楔形区里，max(投影, 投影) 会低估到顶点的距离（45° 切角最多
+    // 8%）—— 直接后果是外发光在「斜边与直边相接」的那两个点上鼓出去一圈。改成量到斜边
+    // **线段**，直边只在它确实还存在的那一侧参与。
+    float2 w = u - float2(-s.x, 0.0);
+    float2 e = float2(s.x, -s.y);
+    float dOut = length(w - e * saturate(dot(w, e) / dot(e, e)));
+    // 外部且 u.x <= -W 时 u.y 必然为正（否则就在形状内），u.y 就是到顶边的距离；右边同理。
+    if (u.x <= -s.x) dOut = min(dOut, u.y);
+    if (u.y <= -s.y) dOut = min(dOut, u.x);
+    return dOut;
+}
+
+// 方形缺口：矩形挖掉角上一块 W×H。
+float PuguiSdNotchCorner(float2 u, float2 s)
+{
+    if (min(s.x, s.y) <= 0.0) return PuguiSdQuadrant(u);
+
+    // 这个角剩下的部分是两个象限的并集：一个止于 x = -W，一个止于 y = -H。
+    // 两个精确距离场取 min 就是精确的外部距离 —— 包括缺口造出来的那两个凸顶点。
+    float2 v1 = u - float2(-s.x, 0.0);
+    float2 v2 = u - float2(0.0, -s.y);
+    float d = min(PuguiSdQuadrant(v1), PuguiSdQuadrant(v2));
+    if (d >= 0.0) return d;
+
+    // 内部：并集取 min 在缺口的凹顶点处最多浅 sqrt(2) 倍，内描边会正好在那个角上鼓一块。
+    // 「矩形减去被挖掉的那块」在内部是精确的（两个场各自精确、相减处两条边就是真边界）。
+    float2 half = s * 0.5;
+    float2 q = abs(u + half) - half;
+    float dRect = min(max(q.x, q.y), 0.0) + length(max(q, 0.0));
+    return max(PuguiSdQuadrant(u), -dRect);
+}
+
+float2 PuguiSdCutNormal(float2 u, float2 s)
+{
+    if (min(s.x, s.y) <= 0.0) return PuguiSdQuadrantNormal(u);
+
+    float invL = rsqrt(s.x * s.x + s.y * s.y);
+    float dLine = (u.x * s.y + u.y * s.x + s.x * s.y) * invL;
+    // 三条半平面里最靠近 0 的那条就是最近的特征 —— 内外都成立，因为 SDF 本身就是它们的 max。
+    if (dLine >= max(u.x, u.y)) return float2(s.y, s.x) * invL;
+    return (u.x > u.y) ? float2(1.0, 0.0) : float2(0.0, 1.0);
+}
+
+float2 PuguiSdNotchNormal(float2 u, float2 s)
+{
+    if (min(s.x, s.y) <= 0.0) return PuguiSdQuadrantNormal(u);
+
+    // 缺口引入的两条边都是轴对齐的，法线仍然只有两种；变的是这个片元归哪个象限。
+    // 外部按更近的那个选（正确），内部按更深的那个选 —— 边缘打光只作用在边界附近的一条
+    // 窄带里，内部深处选谁都照不到。
+    float2 v1 = u - float2(-s.x, 0.0);
+    float2 v2 = u - float2(0.0, -s.y);
+    return (PuguiSdQuadrant(v1) < PuguiSdQuadrant(v2))
+        ? PuguiSdQuadrantNormal(v1)
+        : PuguiSdQuadrantNormal(v2);
+}
+
+// 挑出本片元所属的角，解算整形哨兵，再逐轴 clamp。
+//
+// pill / hexagon 在 GPU 上解算而不是在 C# 里：它们依赖 rect 尺寸，提前算掉会让同一 style
 // 的不同尺寸面板拿到不同材质参数，白白丢掉材质共享（见 ProceduralMaterialCache）。
-float4 PuguiResolveRadius(float4 radius, float pill, float2 halfSize)
+PuguiCorner PuguiResolveCorner(float2 p, float2 b, float4 kinds, float4 widths, float4 heights,
+                               float shape, float hexW)
 {
-    float shortest = min(halfSize.x, halfSize.y);
-    float4 r = (pill > 0.5) ? shortest.xxxx : radius;
-    return clamp(r, 0.0, shortest);
+    // xyzw = top-left, top-right, bottom-right, bottom-left（CSS border-radius 顺序）。
+    bool right = p.x > 0.0;
+    bool top = p.y > 0.0;
+    float2 kSide = right ? float2(kinds.y, kinds.z) : float2(kinds.x, kinds.w);
+    float2 wSide = right ? float2(widths.y, widths.z) : float2(widths.x, widths.w);
+    float2 hSide = right ? float2(heights.y, heights.z) : float2(heights.x, heights.w);
+
+    PuguiCorner c;
+    c.kind = top ? kSide.x : kSide.y;
+    c.size = float2(top ? wSide.x : wSide.y, top ? hSide.x : hSide.y);
+
+    if (PUGUI_SHAPE_IS_HEXAGON(shape))
+    {
+        // 左右两侧收成尖：每个角都是一次斜切，纵向伸出量恰好取半高，于是同一侧的两刀在
+        // 中线上相交成一个点。尺寸一变自动跟随，作者不需要手算。
+        c.kind = PUGUI_KIND_CUT;
+        c.size = float2((hexW > 0.0) ? hexW : b.y, b.y);
+    }
+    else if (PUGUI_SHAPE_IS_PILL(shape))
+    {
+        c.kind = PUGUI_KIND_ROUND;
+        float pillRadius = min(b.x, b.y);
+        c.size = float2(pillRadius, pillRadius);
+    }
+
+    // round 只有一个半径，仍按短边 clamp（椭圆角不是这个属性的语义）；
+    // cut / notch 两轴独立，各自 clamp 到半宽 / 半高，于是同一条边上的两个角永不穿越。
+    float shortest = min(b.x, b.y);
+    float radius = min(max(c.size.x, 0.0), shortest);
+    c.size = PUGUI_KIND_IS_ROUND(c.kind)
+        ? float2(radius, radius)
+        : clamp(c.size, float2(0.0, 0.0), b);
+    return c;
 }
 
-// 圆角矩形 SDF 的**解析**外法线（画布空间，+Y = 界面正上方）。
+// 面板形状的 SDF。返回值：负=内部，正=外部，绝对值≈到边界的距离（画布单位）。
+float PuguiSdPanel(float2 p, float2 b, PuguiCorner c)
+{
+    float2 u = abs(p) - b;
+    if (PUGUI_KIND_IS_ROUND(c.kind)) return PuguiSdRoundCorner(u, c.size.x);
+    if (PUGUI_KIND_IS_NOTCH(c.kind)) return PuguiSdNotchCorner(u, c.size);
+    return PuguiSdCutCorner(u, c.size);
+}
+
+// 面板形状的**解析**外法线（画布空间，+Y = 界面正上方）。
 //
 // 刻意不用 ddx/ddy(d) 求梯度，两个理由都是正确性而非性能：
 // 1) lightAngle 是画布空间的概念（0 = 正上方）。光栅空间 Y 轴朝向逐平台不同
@@ -32,19 +174,37 @@ float4 PuguiResolveRadius(float4 radius, float pill, float2 halfSize)
 //    在 GL 目标上整个上下翻转 —— 同一份 XML 在 WebGL 构建里长得不一样，且不报任何错。
 // 2) 导数指令在非均匀控制流里是未定义行为，而调用点在逐像素的 `inside > 0` 分支内。
 //
-// 解析式顺带比中心差分更省：直接对 PuguiSdRoundBox 求导，没有额外的 SDF 求值。
-// 分支外区（max(q)>0）法线是 normalize(max(q,0))；内区退化成"离哪条边最近就朝哪边"。
+// 解析式顺带比中心差分更省：直接对形状求导，没有额外的 SDF 求值。
+float2 PuguiPanelNormal(float2 p, float2 b, PuguiCorner c)
+{
+    float2 u = abs(p) - b;
+    float2 g;
+    if (PUGUI_KIND_IS_ROUND(c.kind)) g = PuguiSdQuadrantNormal(u + c.size.x);
+    else if (PUGUI_KIND_IS_NOTCH(c.kind)) g = PuguiSdNotchNormal(u, c.size);
+    else g = PuguiSdCutNormal(u, c.size);
+
+    // abs() 把四个象限折到第一象限求解，这里再折回去。
+    float2 s = float2(p.x >= 0.0 ? 1.0 : -1.0, p.y >= 0.0 ? 1.0 : -1.0);
+    return normalize(s * g);
+}
+
+// ---- 以下两个只剩 weld 融合面在用 -------------------------------------------------------
+// GlassGroupPanel 把成员形状打包成逐成员的 float4 半径数组再做 smooth-union，角部处理在那条
+// 路径上是降级成同 W 圆角的（见 PUI-WELD-CORNER），所以它要的仍是纯圆角版本。
+
+float PuguiSdRoundBox(float2 p, float2 b, float4 r)
+{
+    // 象限选角：右半区取 (TR, BR)，左半区取 (TL, BL)；再按上下二选一。
+    float2 side = (p.x > 0.0) ? float2(r.y, r.z) : float2(r.x, r.w);
+    float radius = (p.y > 0.0) ? side.x : side.y;
+    return PuguiSdRoundCorner(abs(p) - b, radius);
+}
+
 float2 PuguiSdNormal(float2 p, float2 b, float4 r)
 {
     float2 side = (p.x > 0.0) ? float2(r.y, r.z) : float2(r.x, r.w);
     float radius = (p.y > 0.0) ? side.x : side.y;
-    float2 q = abs(p) - b + radius;
-
-    float2 g = (max(q.x, q.y) > 0.0)
-        ? normalize(max(q, 0.0) + 1e-6)
-        : ((q.x > q.y) ? float2(1.0, 0.0) : float2(0.0, 1.0));
-
-    // abs() 把四个象限折到第一象限求解，这里再折回去。
+    float2 g = PuguiSdQuadrantNormal(abs(p) - b + radius);
     float2 s = float2(p.x >= 0.0 ? 1.0 : -1.0, p.y >= 0.0 ? 1.0 : -1.0);
     return normalize(s * g);
 }

--- a/Runtime/Resources/PromptUGUI/Material/UI-ProceduralPanel.shader
+++ b/Runtime/Resources/PromptUGUI/Material/UI-ProceduralPanel.shader
@@ -17,9 +17,14 @@ Shader "UI/ProceduralPanel"
         _BorderColor ("Border Color", Color) = (1,1,1,1)
         _GlowColor   ("Glow Color",   Color) = (1,1,1,1)
 
-        // xyzw = top-left, top-right, bottom-right, bottom-left (CSS border-radius 顺序)
-        _Radius      ("Radius TL/TR/BR/BL", Vector) = (0,0,0,0)
-        _Pill        ("Pill Sentinel", Float) = 0
+        // 四个逐角向量一律是 xyzw = top-left, top-right, bottom-right, bottom-left
+        // （CSS border-radius 顺序）。_Radius 是每个角的**水平**伸出量，圆角时即半径。
+        _Radius      ("Corner Width TL/TR/BR/BL",  Vector) = (0,0,0,0)
+        _CornerH     ("Corner Height TL/TR/BR/BL", Vector) = (0,0,0,0)
+        _CornerKind  ("Corner Kind TL/TR/BR/BL (0 round / 1 cut / 2 notch)", Vector) = (0,0,0,0)
+        // 整形哨兵：0 无 / 1 pill / 2 hexagon。两者都依赖 rect 尺寸，逐片元解算。
+        _Shape       ("Shape Sentinel", Float) = 0
+        _HexW        ("Hexagon Tip Reach (0 = auto)", Float) = 0
         _BorderWidth ("Border Width",  Float) = 0
         _GlowSize    ("Glow Size",     Float) = 0
 
@@ -102,7 +107,10 @@ Shader "UI/ProceduralPanel"
             fixed4 _BorderColor;
             fixed4 _GlowColor;
             float4 _Radius;
-            float _Pill;
+            float4 _CornerH;
+            float4 _CornerKind;
+            float _Shape;
+            float _HexW;
             float _BorderWidth;
             float _GlowSize;
 
@@ -123,8 +131,9 @@ Shader "UI/ProceduralPanel"
                 float2 p = IN.shape.xy;
                 float2 b = IN.shape.zw;
 
-                float4 r = PuguiResolveRadius(_Radius, _Pill, b);
-                float d = PuguiSdRoundBox(p, b, r);
+                PuguiCorner corner = PuguiResolveCorner(p, b, _CornerKind, _Radius,
+                                                       _CornerH, _Shape, _HexW);
+                float d = PuguiSdPanel(p, b, corner);
                 float fw = max(fwidth(d), 1e-4);
 
                 float inside = saturate(0.5 - d / fw);

--- a/Tests/EditMode/Application/StyleIntegrationTests.cs
+++ b/Tests/EditMode/Application/StyleIntegrationTests.cs
@@ -41,7 +41,7 @@ namespace PromptUGUI.Tests.Application
             UI.LoadDocumentAsync("main").GetAwaiter().GetResult();
 
             var p = PanelOf(UI.Open("S").Get<Frame>("f"));
-            Assert.AreEqual(16f, p.CurrentParams.Radius.x);
+            Assert.AreEqual(16f, p.CurrentParams.CornerWidth.x);
         }
 
         [Test]
@@ -59,7 +59,7 @@ namespace PromptUGUI.Tests.Application
             UI.LoadCommonLibraryAsync("lib", "ui").GetAwaiter().GetResult();
             UI.LoadDocumentAsync("main").GetAwaiter().GetResult();
 
-            Assert.AreEqual(24f, PanelOf(UI.Open("S").Get<Frame>("f")).CurrentParams.Radius.x);
+            Assert.AreEqual(24f, PanelOf(UI.Open("S").Get<Frame>("f")).CurrentParams.CornerWidth.x);
         }
 
         [Test]
@@ -103,7 +103,7 @@ namespace PromptUGUI.Tests.Application
                             </PromptUGUI>";
             UI.ReloadCommonLibraryAsync("lib").GetAwaiter().GetResult();
 
-            Assert.AreEqual(2f, PanelOf(UI.Open("S").Get<Frame>("f")).CurrentParams.Radius.x);
+            Assert.AreEqual(2f, PanelOf(UI.Open("S").Get<Frame>("f")).CurrentParams.CornerWidth.x);
         }
 
         [Test]
@@ -119,16 +119,16 @@ namespace PromptUGUI.Tests.Application
             var frame = s.Get<Frame>("f");
             var panel = PanelOf(frame);
             var go = frame.GameObject;
-            Assert.AreEqual(16f, panel.CurrentParams.Radius.x);
+            Assert.AreEqual(16f, panel.CurrentParams.CornerWidth.x);
 
             UI.Variants.Set("mobile", true);
 
             Assert.AreSame(go, frame.GameObject, "a Variant flip must never rebuild GameObjects");
             Assert.AreSame(panel, PanelOf(frame), "…nor re-create the panel component");
-            Assert.AreEqual(4f, panel.CurrentParams.Radius.x);
+            Assert.AreEqual(4f, panel.CurrentParams.CornerWidth.x);
 
             UI.Variants.Set("mobile", false);
-            Assert.AreEqual(16f, panel.CurrentParams.Radius.x, "…and it must revert");
+            Assert.AreEqual(16f, panel.CurrentParams.CornerWidth.x, "…and it must revert");
         }
 
         /// <summary>
@@ -151,13 +151,13 @@ namespace PromptUGUI.Tests.Application
             UI.LoadDocument("t", xml);
             var s = UI.Open("S");
 
-            Assert.AreEqual(16f, PanelOf(s.Get<Frame>("f")).CurrentParams.Radius.x);
+            Assert.AreEqual(16f, PanelOf(s.Get<Frame>("f")).CurrentParams.CornerWidth.x);
 
             var btn = s.Get<Btn>("b").GameObject;
             var surface = btn.transform.Find("__Surface");
             Assert.IsNotNull(surface, "the same pack has to reach the Btn's shape too");
             var panel = surface.GetComponent<PromptUGUI.Controls.Internal.ProceduralPanel>();
-            Assert.AreEqual(16f, panel.CurrentParams.Radius.x);
+            Assert.AreEqual(16f, panel.CurrentParams.CornerWidth.x);
             Assert.AreEqual(new Color32(0x12, 0x34, 0x56, 0xff), (Color32)panel.CurrentParams.FillTop);
 
             Assert.AreEqual(0, btn.GetComponent<UnityEngine.UI.Image>().color.a,

--- a/Tests/EditMode/Controls/CornerTreatmentRenderTests.cs
+++ b/Tests/EditMode/Controls/CornerTreatmentRenderTests.cs
@@ -1,0 +1,253 @@
+using System.IO;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    /// <summary>
+    /// Do the corner treatments actually change the pixels? The parser tests prove the grammar
+    /// reaches <c>RadiusSpec</c> and the material tests prove it reaches the shader's uniforms —
+    /// and both stay green if the SDF ignores what it is handed. Only a render catches that.
+    ///
+    /// <para>Every probe is a geometric predicate rather than a golden image: for a treatment of
+    /// reach R at a corner, the diagonal boundary sits at 0.293R for <c>round</c>, 0.5R for
+    /// <c>cut</c> and 1.0R for <c>notch</c>, so one probe at 0.4R and one at 0.7R tell the three
+    /// apart with several pixels of margin either way. Same explicit <c>Camera.Render()</c> harness
+    /// as <see cref="ProceduralSurfaceRenderTests"/>.</para>
+    /// </summary>
+    public class CornerTreatmentRenderTests
+    {
+        private const int Size = 256;
+
+        /// <summary>Rect size of the probed Frame, in canvas units. Probes are normalised to it.</summary>
+        private const float W = 200f;
+        private const float H = 160f;
+
+        private Camera _ui;
+        private RenderTexture _uiRt;
+        private Texture2D _shot;
+        private Rect _rect;
+        private float _w = W;
+        private float _h = H;
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            _uiRt = new RenderTexture(Size, Size, 24) { name = "CornerTreatmentUIRT" };
+            _ui = new GameObject("CornerTreatmentUICamera").AddComponent<Camera>();
+            _ui.clearFlags = CameraClearFlags.SolidColor;
+            _ui.backgroundColor = Color.black;
+            _ui.targetTexture = _uiRt;
+            _ui.cullingMask = ~0;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UI.ResetForTests();
+            if (_shot != null) Object.DestroyImmediate(_shot);
+            if (_ui != null) Object.DestroyImmediate(_ui.gameObject);
+            if (_uiRt != null)
+            {
+                _uiRt.Release();
+                Object.DestroyImmediate(_uiRt);
+            }
+        }
+
+        /// <summary>Renders one Frame and leaves the frame buffer ready for <see cref="At"/>.</summary>
+        private void Render(string attrs, string dumpName, float width = W, float height = H)
+        {
+            _w = width;
+            _h = height;
+            UI.UnloadAll();
+            UI.LoadDocument("t", $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Frame id='f' anchor='center' width='{width}' height='{height}' color='#3366ff' {attrs}/>
+</Screen></PromptUGUI>");
+            var screen = UI.Open("S");
+
+            var canvas = screen.RootGameObject.GetComponentInParent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceCamera;
+            canvas.worldCamera = _ui;
+            canvas.planeDistance = 10f;
+
+            Canvas.ForceUpdateCanvases();
+            _ui.Render();
+
+            if (_shot != null) Object.DestroyImmediate(_shot);
+            _shot = new Texture2D(Size, Size, TextureFormat.RGBA32, false);
+            var previous = RenderTexture.active;
+            RenderTexture.active = _uiRt;
+            _shot.ReadPixels(new Rect(0, 0, Size, Size), 0, 0);
+            _shot.Apply();
+            RenderTexture.active = previous;
+
+            var path = Path.Combine(UnityEngine.Application.temporaryCachePath, dumpName);
+            File.WriteAllBytes(path, _shot.EncodeToPNG());
+            Debug.Log($"PromptUGUI corner-treatment render dump: {path}");
+
+            var rt = (RectTransform)screen.Get<Frame>("f").GameObject.transform;
+            var corners = new Vector3[4];
+            rt.GetWorldCorners(corners);
+            var a = RectTransformUtility.WorldToScreenPoint(_ui, corners[0]);
+            var c = RectTransformUtility.WorldToScreenPoint(_ui, corners[2]);
+            _rect = Rect.MinMaxRect(Mathf.Min(a.x, c.x), Mathf.Min(a.y, c.y),
+                                   Mathf.Max(a.x, c.x), Mathf.Max(a.y, c.y));
+
+            // A canvas scale surprise would shrink the rect until every probe lands on background
+            // and every "is it painted" assertion passes for the wrong reason.
+            Assert.Greater(_rect.width, width * 0.5f,
+                "the probed rect rendered far smaller than its canvas size — probes would be meaningless");
+        }
+
+        /// <summary>Samples the rendered Frame at a point given in canvas units in from a corner.</summary>
+        private Color AtCornerInset(float insetX, float insetY, bool left = true, bool top = true)
+        {
+            var u = (left ? insetX : _w - insetX) / _w;
+            var v = (top ? _h - insetY : insetY) / _h;
+            return At(u, v);
+        }
+
+        /// <summary>Samples the rendered Frame in normalised rect coordinates (0,0 = bottom-left).</summary>
+        private Color At(float u, float v)
+            => _shot.GetPixel(Mathf.RoundToInt(Mathf.Lerp(_rect.xMin, _rect.xMax, u)),
+                              Mathf.RoundToInt(Mathf.Lerp(_rect.yMin, _rect.yMax, v)));
+
+        // Both halves matter: the white border is as blue as the fill is, so a blue-only test
+        // cannot tell "filled" from "the border grew over this point".
+        private static void AssertPainted(Color c, string what)
+        {
+            Assert.Greater(c.b, 0.5f, $"{what} — expected the blue fill, got {c}");
+            Assert.Less(c.r, 0.5f, $"{what} — expected the fill, but this is the white border: {c}");
+        }
+
+        private static void AssertBackground(Color c, string what)
+            => Assert.Less(c.b, 0.2f, $"{what} — expected background, got {c}");
+
+        private static void AssertBorder(Color c, string what)
+            => Assert.Greater(c.r, 0.6f, $"{what} — expected the white border, got {c}");
+
+        private const float R = 60f;
+
+        // ---- the three treatments are told apart by the same two probes ----------------------
+
+        [Test]
+        public void Round_FillsBothDiagonalProbes()
+        {
+            // Guard as much as baseline: the round path must keep drawing exactly what it drew
+            // before corner treatments existed.
+            Render($"radius='{R}'", "pugui-corner-round.png");
+            AssertPainted(AtCornerInset(0.4f * R, 0.4f * R, true, true),
+                          "a round corner's diagonal boundary is at 0.293R, so 0.4R is inside");
+            AssertPainted(AtCornerInset(0.7f * R, 0.7f * R, true, true), "…and so is 0.7R");
+            AssertBackground(AtCornerInset(0.1f * R, 0.1f * R, true, true),
+                             "…while 0.1R is still outside the arc");
+        }
+
+        [Test]
+        public void Cut_RemovesTheCornerAlongAStraightLine()
+        {
+            Render($"radius='cut {R}'", "pugui-corner-cut.png");
+            AssertBackground(AtCornerInset(0.4f * R, 0.4f * R, true, true),
+                             "a 45° cut's diagonal boundary is at 0.5R, so 0.4R must be gone");
+            AssertPainted(AtCornerInset(0.7f * R, 0.7f * R, true, true),
+                          "…and 0.7R must survive — this is what separates cut from notch");
+        }
+
+        [Test]
+        public void Notch_RemovesTheWholeCornerSquare()
+        {
+            Render($"radius='notch {R}'", "pugui-corner-notch.png");
+            AssertBackground(AtCornerInset(0.7f * R, 0.7f * R, true, true),
+                             "the whole R x R square is bitten out, so 0.7R is inside the bite");
+            AssertPainted(AtCornerInset(1.3f * R, 1.3f * R, true, true),
+                          "…and everything past it is untouched");
+            AssertPainted(AtCornerInset(1.3f * R, 0.3f * R, true, true),
+                          "…including the strip that runs along the top edge past the bite");
+        }
+
+        [Test]
+        public void PerCornerMixing_TreatsEachCornerOnItsOwn()
+        {
+            Render($"radius='cut {R}, {R}, cut {R}, {R}'", "pugui-corner-mixed.png");
+            AssertBackground(AtCornerInset(0.4f * R, 0.4f * R, true, true), "top-left is cut");
+            AssertPainted(AtCornerInset(0.4f * R, 0.4f * R, false, true), "top-right is round");
+            AssertBackground(AtCornerInset(0.4f * R, 0.4f * R, false, false), "bottom-right is cut");
+            AssertPainted(AtCornerInset(0.4f * R, 0.4f * R, true, false), "bottom-left is round");
+        }
+
+        // ---- two axes, and which is which -----------------------------------------------------
+
+        [Test]
+        public void CutWidthByHeight_ReachesFurtherAlongTheAxisItNames()
+        {
+            // Swapping the axes would flip both probes, so this pins the order as well as the shape.
+            Render("radius='cut 80x30'", "pugui-corner-cut-wxh.png");
+            AssertBackground(AtCornerInset(40f, 8f, true, true),
+                             "80 wide means 40 in from the left is still inside the cut near the top");
+            AssertPainted(AtCornerInset(8f, 40f, true, true),
+                          "…while 30 tall means 40 down the side is already past it");
+        }
+
+        // ---- whole-shape sentinels --------------------------------------------------------------
+
+        [Test]
+        public void Hexagon_DrawsTipsAtTheVerticalCentre()
+        {
+            Render("radius='hexagon'", "pugui-corner-hexagon.png");
+            AssertPainted(At(0.06f, 0.5f), "the left tip is filled at mid height");
+            AssertBackground(At(0.10f, 0.25f), "…and the same column is cut away below the tip");
+            AssertBackground(At(0.06f, 0.75f), "…and above it — a point, not an edge");
+            AssertPainted(At(0.5f, 0.95f), "…while the flat top edge between the two tips stays");
+        }
+
+        [Test]
+        public void HexagonWithSize_ControlsHowFarTheTipReachesIn()
+        {
+            // The bare keyword takes half the height (80 units here), which cuts this probe away —
+            // see the previous test's second assertion, which is the same point.
+            Render("radius='hexagon 20'", "pugui-corner-hexagon-sized.png");
+            AssertPainted(At(0.10f, 0.25f),
+                          "a 20-unit tip leaves standing what the 80-unit default cuts off");
+            AssertPainted(At(0.06f, 0.5f), "…and it is still a tip at mid height");
+        }
+
+        // ---- what the corner SDF has to be accurate about, not just shaped like -----------------
+
+        [Test]
+        public void CutBorder_KeepsItsWidthAlongTheChamfer()
+        {
+            // The chamfer runs from 60 in along the top to 60 down the side, so its midpoint is at
+            // inset (30, 30) and its inward normal is the diagonal. Walking in from there crosses
+            // the border band at 8 units — if the field were scaled anywhere along the chamfer, one
+            // of these two probes would land on the wrong side.
+            Render($"radius='cut {R}' borderWidth='8' borderColor='white'", "pugui-corner-cut-border.png");
+            AssertBorder(AtCornerInset(32.83f, 32.83f), "4 units in from the chamfer is inside the border");
+            AssertPainted(AtCornerInset(44.14f, 44.14f), "…and 20 units in is past it, back to the fill");
+        }
+
+        [Test]
+        public void NotchBorder_DoesNotFattenAtTheReflexCorner()
+        {
+            // Union-by-min reads up to sqrt(2) too shallow at the inner corner of a notch, which
+            // would push the border's inner edge out from 20 units to 28. The second probe sits in
+            // that window: it is fill under the exact field and border under the sloppy one.
+            Render($"radius='notch {R}' borderWidth='20' borderColor='white'",
+                   "pugui-corner-notch-border.png");
+            AssertBorder(AtCornerInset(67.07f, 67.07f), "10 units in from the reflex corner is border");
+            AssertPainted(AtCornerInset(76.97f, 76.97f),
+                          "…and 24 units in is fill — the border must not have stretched to 28");
+        }
+
+        [Test]
+        public void Pill_StillRoundsBothEnds()
+        {
+            Render("radius='pill'", "pugui-corner-pill.png", 200f, 80f);
+            AssertPainted(At(0.5f, 0.5f), "the middle of a pill is filled");
+            AssertBackground(At(0.005f, 0.98f), "…and its corners are not");
+        }
+    }
+}

--- a/Tests/EditMode/Controls/CornerTreatmentRenderTests.cs.meta
+++ b/Tests/EditMode/Controls/CornerTreatmentRenderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ab61c535b84a9857f82455bf0ca54041

--- a/Tests/EditMode/Controls/FrameProceduralPanelTests.cs
+++ b/Tests/EditMode/Controls/FrameProceduralPanelTests.cs
@@ -83,7 +83,7 @@ namespace PromptUGUI.Tests.EditMode.Controls
         public void Radius_FourValues_LandInCssOrder()
         {
             var p = PanelOf(Load("color='#fff' radius='1,2,3,4'"));
-            Assert.AreEqual(new Vector4(1f, 2f, 3f, 4f), p.CurrentParams.Radius);
+            Assert.AreEqual(new Vector4(1f, 2f, 3f, 4f), p.CurrentParams.CornerWidth);
             Assert.IsFalse(p.CurrentParams.Pill);
         }
 
@@ -92,7 +92,7 @@ namespace PromptUGUI.Tests.EditMode.Controls
         {
             var p = PanelOf(Load("color='#fff' radius='pill'"));
             Assert.IsTrue(p.CurrentParams.Pill);
-            Assert.AreEqual(Vector4.zero, p.CurrentParams.Radius);
+            Assert.AreEqual(Vector4.zero, p.CurrentParams.CornerWidth);
         }
 
         [Test]

--- a/Tests/EditMode/Controls/InnerLayerRadiusTests.cs
+++ b/Tests/EditMode/Controls/InnerLayerRadiusTests.cs
@@ -72,7 +72,7 @@ namespace PromptUGUI.Tests.EditMode.Controls
 
             var panel = SurfaceUnder(s, "Fill Area/Fill");
             Assert.IsNotNull(panel, "fillRadius must give the filled segment its own surface");
-            Assert.AreEqual(6f, panel.CurrentParams.Radius.x);
+            Assert.AreEqual(6f, panel.CurrentParams.CornerWidth.x);
             Assert.IsTrue(panel.IsPanelVisible, "fillColor has to reach it, or the bar disappears");
         }
 
@@ -100,8 +100,8 @@ namespace PromptUGUI.Tests.EditMode.Controls
         {
             var s = Load("Slider", "radius='4' fillRadius='6' handleRadius='pill'");
 
-            Assert.AreEqual(4f, SurfaceUnder(s, "Background").CurrentParams.Radius.x);
-            Assert.AreEqual(6f, SurfaceUnder(s, "Fill Area/Fill").CurrentParams.Radius.x);
+            Assert.AreEqual(4f, SurfaceUnder(s, "Background").CurrentParams.CornerWidth.x);
+            Assert.AreEqual(6f, SurfaceUnder(s, "Fill Area/Fill").CurrentParams.CornerWidth.x);
             Assert.IsTrue(SurfaceUnder(s, "Handle Slide Area/Handle").CurrentParams.Pill);
         }
 
@@ -114,7 +114,7 @@ namespace PromptUGUI.Tests.EditMode.Controls
 
             var panel = SurfaceUnder(p, "MaskWrapper/Fill");
             Assert.IsNotNull(panel);
-            Assert.AreEqual(6f, panel.CurrentParams.Radius.x);
+            Assert.AreEqual(6f, panel.CurrentParams.CornerWidth.x);
         }
 
         [Test]
@@ -149,7 +149,7 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var p = Load("Progress", "radius='4' maskRadius='12' bgColor='#22345a'");
             var mask = p.GameObject.transform.Find("MaskWrapper").GetComponent<UnityEngine.UI.Mask>();
 
-            Assert.AreEqual(12f, ((ProceduralPanel)mask.graphic).CurrentParams.Radius.x);
+            Assert.AreEqual(12f, ((ProceduralPanel)mask.graphic).CurrentParams.CornerWidth.x);
         }
 
         [Test]

--- a/Tests/EditMode/Lint/GlassRulesTests.cs
+++ b/Tests/EditMode/Lint/GlassRulesTests.cs
@@ -180,5 +180,57 @@ namespace PromptUGUI.Tests.EditMode.Lint
                         PureContainerVisualAttrRules.VisualAttrCode, "c"),
                     $"<{tag}> draws nothing, so glass on it is silently dropped");
         }
+
+        // ---- corner treatments do not survive the fusion ----
+
+        [TestCase("cut 16")]
+        [TestCase("notch 8")]
+        [TestCase("hexagon")]
+        [TestCase("0, cut 12, 0, 0")]
+        public void CornerTreatmentOnAWeldedBlock_IsFlagged(string radius)
+        {
+            // The group packs one radius vector per member and smooth-unions the fields, which
+            // rounds every corner back off. The block still draws — as a plain round corner — so
+            // this is a warning about a shape the author will not get, not a broken document.
+            Assert.IsTrue(Has(Walk($@"<Frame id='g' weld='16'>
+      <Frame id='a' glass='true' radius='{radius}'/>
+      <Frame id='b' glass='true'/>
+    </Frame>"), GlassRules.WeldCornerCode, "a"));
+        }
+
+        [Test]
+        public void RoundRadiusOnAWeldedBlock_IsFine()
+        {
+            Assert.IsFalse(Has(Walk(@"<Frame id='g' weld='16'>
+      <Frame id='a' glass='true' radius='12'/>
+      <Frame id='b' glass='true' radius='pill'/>
+    </Frame>"), GlassRules.WeldCornerCode));
+        }
+
+        [Test]
+        public void CornerTreatmentOutsideAWeldGroup_IsFine()
+        {
+            Assert.IsFalse(Has(Walk("<Frame id='f' radius='cut 16'/>"), GlassRules.WeldCornerCode));
+        }
+
+        [Test]
+        public void VariantOnlyCornerTreatmentOnAWeldedBlock_IsFlagged()
+        {
+            // Shape and weld can arrive from two different theme packs, so the pairing is at least
+            // as likely to appear in one layout only.
+            Assert.IsTrue(Has(Walk(@"<Frame id='g' weld='16'>
+      <Frame id='a' glass='true' radius.mobile='cut 16'/>
+      <Frame id='b' glass='true'/>
+    </Frame>"), GlassRules.WeldCornerCode, "a"));
+        }
+
+        [Test]
+        public void UnparseableRadiusOnAWeldedBlock_IsLeftToTheSyntaxRules()
+        {
+            Assert.IsFalse(Has(Walk(@"<Frame id='g' weld='16'>
+      <Frame id='a' glass='true' radius='bevel 4'/>
+      <Frame id='b' glass='true'/>
+    </Frame>"), GlassRules.WeldCornerCode));
+        }
     }
 }

--- a/Tests/EditMode/Parser/CornerTreatmentParserTests.cs
+++ b/Tests/EditMode/Parser/CornerTreatmentParserTests.cs
@@ -1,0 +1,180 @@
+using NUnit.Framework;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.EditMode.Parser
+{
+    /// <summary>
+    /// The corner-treatment half of the <c>radius</c> value grammar: <c>cut</c> / <c>notch</c>
+    /// per corner, and <c>hexagon</c> alongside <c>pill</c> as a whole-shape sentinel.
+    ///
+    /// <para>Round-only values live in <see cref="RadiusParserTests"/> and stay there — that file
+    /// is now also the compatibility guard for everything this grammar extension must not
+    /// disturb.</para>
+    /// </summary>
+    public class CornerTreatmentParserTests
+    {
+        // ---- cut ----------------------------------------------------------------------------
+
+        [Test]
+        public void Cut_SingleSize_IsSymmetric_OnAllFourCorners()
+        {
+            var spec = RadiusParser.Parse("cut 16");
+            foreach (var c in new[] { spec.TopLeftCorner, spec.TopRightCorner,
+                                      spec.BottomRightCorner, spec.BottomLeftCorner })
+            {
+                Assert.AreEqual(CornerKind.Cut, c.Kind);
+                Assert.AreEqual(16f, c.Width);
+                Assert.AreEqual(16f, c.Height, "a single size is a 45° cut: height tracks width");
+            }
+        }
+
+        [Test]
+        public void Cut_WidthByHeight_KeepsAxesIndependent()
+        {
+            // The flat hexagon tip in the reference art is a wide, shallow cut — 45° cannot do it.
+            var spec = RadiusParser.Parse("cut 24x16");
+            Assert.AreEqual(24f, spec.TopLeftCorner.Width);
+            Assert.AreEqual(16f, spec.TopLeftCorner.Height);
+        }
+
+        [Test]
+        public void Cut_MixesPerCornerWithBareRoundValues()
+        {
+            var spec = RadiusParser.Parse("cut 16, 8, cut 16, 8");
+            Assert.AreEqual(CornerKind.Cut, spec.TopLeftCorner.Kind);
+            Assert.AreEqual(16f, spec.TopLeftCorner.Width);
+            Assert.AreEqual(CornerKind.Round, spec.TopRightCorner.Kind);
+            Assert.AreEqual(8f, spec.TopRightCorner.Width);
+            Assert.AreEqual(CornerKind.Cut, spec.BottomRightCorner.Kind);
+            Assert.AreEqual(CornerKind.Round, spec.BottomLeftCorner.Kind);
+        }
+
+        [Test]
+        public void Cut_ToleratesExtraWhitespaceBetweenKeywordAndSize()
+        {
+            var spec = RadiusParser.Parse(" cut   16 , 0 , 0 , 0 ");
+            Assert.AreEqual(CornerKind.Cut, spec.TopLeftCorner.Kind);
+            Assert.AreEqual(16f, spec.TopLeftCorner.Width);
+        }
+
+        // ---- notch --------------------------------------------------------------------------
+
+        [Test]
+        public void Notch_SingleSize_IsSquare()
+        {
+            var spec = RadiusParser.Parse("notch 12");
+            Assert.AreEqual(CornerKind.Notch, spec.TopLeftCorner.Kind);
+            Assert.AreEqual(12f, spec.TopLeftCorner.Width);
+            Assert.AreEqual(12f, spec.TopLeftCorner.Height);
+        }
+
+        [Test]
+        public void Notch_TopTwoCornersOnly()
+        {
+            var spec = RadiusParser.Parse("notch 12, notch 12, 0, 0");
+            Assert.AreEqual(CornerKind.Notch, spec.TopLeftCorner.Kind);
+            Assert.AreEqual(CornerKind.Notch, spec.TopRightCorner.Kind);
+            Assert.AreEqual(CornerKind.Round, spec.BottomRightCorner.Kind);
+            Assert.AreEqual(0f, spec.BottomRightCorner.Width);
+        }
+
+        [Test]
+        public void Notch_WidthByHeight_IsHorizontalThenDepth()
+        {
+            var spec = RadiusParser.Parse("notch 12x6");
+            Assert.AreEqual(12f, spec.TopLeftCorner.Width);
+            Assert.AreEqual(6f, spec.TopLeftCorner.Height);
+        }
+
+        // ---- hexagon ------------------------------------------------------------------------
+
+        [Test]
+        public void Hexagon_BareKeyword_LeavesTheTipSizeToTheShader()
+        {
+            // Same reasoning as pill: the tip height is half the live rect, so resolving anything
+            // size-dependent here would give two same-styled panels different material keys.
+            var spec = RadiusParser.Parse("hexagon");
+            Assert.AreEqual(PanelShape.Hexagon, spec.Shape);
+            Assert.AreEqual(0f, spec.HexWidth, "0 means 'auto' — the shader takes half the height");
+            Assert.IsFalse(spec.IsPill);
+        }
+
+        [Test]
+        public void Hexagon_WithSize_CarriesTheHorizontalReachOnly()
+        {
+            var spec = RadiusParser.Parse("hexagon 32");
+            Assert.AreEqual(PanelShape.Hexagon, spec.Shape);
+            Assert.AreEqual(32f, spec.HexWidth);
+        }
+
+        [Test]
+        public void Hexagon_RejectsWidthByHeight_BecauseHeightIsAlwaysHalfTheRect()
+        {
+            var ex = Assert.Throws<ParseException>(() => RadiusParser.Parse("hexagon 32x16"));
+            StringAssert.Contains("hexagon", ex.Message);
+        }
+
+        [Test]
+        public void Hexagon_MixedWithPerCornerValues_Throws()
+        {
+            var ex = Assert.Throws<ParseException>(() => RadiusParser.Parse("hexagon,0,0,0"));
+            StringAssert.Contains("hexagon", ex.Message);
+        }
+
+        // ---- errors -------------------------------------------------------------------------
+
+        [TestCase("bevel 16")]
+        [TestCase("scoop 8")]
+        [TestCase("CUT 16")]
+        public void UnknownKeyword_Throws_ListingTheLegalOnes(string value)
+        {
+            var ex = Assert.Throws<ParseException>(() => RadiusParser.Parse(value));
+            StringAssert.Contains("cut", ex.Message);
+            StringAssert.Contains("notch", ex.Message);
+        }
+
+        [TestCase("cut")]
+        [TestCase("notch")]
+        public void KeywordWithoutSize_Throws(string value)
+        {
+            var ex = Assert.Throws<ParseException>(() => RadiusParser.Parse(value));
+            StringAssert.Contains("size", ex.Message);
+        }
+
+        [TestCase("cut 16x")]
+        [TestCase("cut x8")]
+        [TestCase("cut 16x8x4")]
+        [TestCase("cut axb")]
+        public void MalformedSize_Throws(string value)
+        {
+            Assert.Throws<ParseException>(() => RadiusParser.Parse(value));
+        }
+
+        [Test]
+        public void NegativeSizeComponent_Throws()
+        {
+            var ex = Assert.Throws<ParseException>(() => RadiusParser.Parse("cut 16x-2"));
+            StringAssert.Contains("negative", ex.Message);
+        }
+
+        [Test]
+        public void NonFiniteSizeComponent_Throws()
+        {
+            Assert.IsFalse(RadiusParser.TryParse("cut NaNx4", out _, out var error));
+            Assert.IsNotNull(error);
+        }
+
+        [Test]
+        public void TooManyTokensInASegment_Throws()
+        {
+            Assert.Throws<ParseException>(() => RadiusParser.Parse("cut 16 8"));
+        }
+
+        [Test]
+        public void MalformedSegment_NamesTheCorner()
+        {
+            var ex = Assert.Throws<ParseException>(() => RadiusParser.Parse("0, 0, bevel 4, 0"));
+            StringAssert.Contains("bottom-right", ex.Message);
+        }
+    }
+}

--- a/Tests/EditMode/Parser/CornerTreatmentParserTests.cs.meta
+++ b/Tests/EditMode/Parser/CornerTreatmentParserTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 022d48dff7df4e1bcab6f237c3769385

--- a/Tests/EditMode/Parser/RadiusSpecCompatTests.cs
+++ b/Tests/EditMode/Parser/RadiusSpecCompatTests.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.EditMode.Parser
+{
+    /// <summary>
+    /// <see cref="RadiusSpec"/> is public surface — custom control authors read it. The corner
+    /// grammar extension widens the struct, and every member that shipped before has to keep
+    /// meaning exactly what it meant: <c>TopLeft</c> and friends are the corner's horizontal size
+    /// (for a round corner, its radius), and <c>IsPill</c> is still the pill sentinel.
+    /// </summary>
+    public class RadiusSpecCompatTests
+    {
+        [Test]
+        public void LegacyConstructor_StillBuildsFourRoundCorners()
+        {
+            var spec = new RadiusSpec(1f, 2f, 3f, 4f);
+            Assert.AreEqual(1f, spec.TopLeft);
+            Assert.AreEqual(2f, spec.TopRight);
+            Assert.AreEqual(3f, spec.BottomRight);
+            Assert.AreEqual(4f, spec.BottomLeft);
+            Assert.AreEqual(CornerKind.Round, spec.TopLeftCorner.Kind);
+            Assert.AreEqual(PanelShape.None, spec.Shape);
+        }
+
+        [Test]
+        public void RoundCorner_HeightMirrorsWidth()
+        {
+            // A round corner has no second axis — keeping height == width lets the shader read one
+            // size pair per corner without branching on kind just to fetch it.
+            var spec = RadiusParser.Parse("8");
+            Assert.AreEqual(8f, spec.TopLeftCorner.Width);
+            Assert.AreEqual(8f, spec.TopLeftCorner.Height);
+        }
+
+        [Test]
+        public void PillStatic_AndIsPill_StillAgree()
+        {
+            Assert.IsTrue(RadiusSpec.Pill.IsPill);
+            Assert.AreEqual(PanelShape.Pill, RadiusSpec.Pill.Shape);
+            Assert.IsFalse(RadiusSpec.Zero.IsPill);
+        }
+
+        [Test]
+        public void ZeroSizedTreatment_IsStillASquareCorner()
+        {
+            // A cut with no size removes nothing; IsZero exists to answer "is this square?", so it
+            // must not be fooled by a keyword that happens to be present.
+            Assert.IsTrue(RadiusParser.Parse("cut 0").IsZero);
+            Assert.IsTrue(RadiusParser.Parse("notch 8x0").IsZero);
+            Assert.IsFalse(RadiusParser.Parse("cut 8").IsZero);
+            Assert.IsFalse(RadiusParser.Parse("hexagon").IsZero);
+        }
+    }
+}

--- a/Tests/EditMode/Parser/RadiusSpecCompatTests.cs.meta
+++ b/Tests/EditMode/Parser/RadiusSpecCompatTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9cba7f38dc1be65178cc21d1e18418e8

--- a/docs~/superpowers/specs/2026-08-27-corner-treatments-design.md
+++ b/docs~/superpowers/specs/2026-08-27-corner-treatments-design.md
@@ -1,0 +1,271 @@
+# 角部处理：cut / notch / hexagon —— 程序化表面的形状词汇（第一层）
+
+> 状态：**已实现**（M0–M3 一轮做完，见 §11）。本文保留设计推理与实施记录。
+> 相关：`2026-08-23-procedural-style-design.md`（`radius` 语法的出处，§2.1/§2.2）、
+> `2026-08-26-procedural-surface-design.md`（`__Surface` / 内层 `<layer>Radius` / mask="self"）、
+> `2026-08-23-glass-fill-design.md`（玻璃填充与边缘光照）、
+> `2026-08-27-theme-procedural-shape-exemption-design.md`（SHAPE 规则）。
+
+## 1. 问题
+
+程序化表面只会画圆角矩形。`PuguiSdRoundBox`（`UI-PanelSDF.cginc`）是整套形状系统唯一的
+SDF —— 四角独立半径加 `pill`，到此为止。而科幻 HUD 风格（参考需求图：星海指挥官主界面）的
+形状词汇是：
+
+- 左右切成尖端的六边形主按钮（「开始匹配」横幅）；
+- 上两角斜切的梯形 Tab（底部导航）；
+- 斜切角卡片、方形缺口面板（军事/机械 HUD 惯用语）。
+
+这些形状今天在这个库里**做不出来**。作者唯一的退路是贴图（sprite / `.pxl`）——而贴图皮肤
+恰恰被 #104 刚打通的「主题换形状」排除在外：主题能把一个控件从像素风换成玻璃圆角，
+却换不成玻璃切角。程序化表面的能力半径就是主题系统的能力半径，圆角矩形是当前的硬边界。
+
+**分层设计的位置**：这是形状扩展的第一层（角部处理词汇表）。第二层（边缘装饰原语
+bracket / tick 等）与第三层（任意路径逃生舱）另行立项，本文不涉及。
+
+## 2. 否决的方案
+
+**SVG / 任意路径作为主接口。否决，三条理由，第一条是硬的。**
+
+1. **打断整条 SDF 派生链。** border 向内描、glow 向外晕、glass 的折射与边缘光照
+   （`PuguiSdNormal` 解析法线）、`mask="self"` 的实心区裁剪、weld 融合、
+   `ProceduralMaterialCache` 的材质共享 —— 全部派生自解析 SDF。任意贝塞尔要么曲面细分成
+   mesh（上述全灭，mesh 给不出法线），要么烘焙 SDF 纹理（法线退化为差分采样、材质按纹理
+   失效、需要整条烘焙管线）。#104 建立的「一份 cginc 同时喂不透明面与玻璃面」的架构会碎掉。
+2. **没有拉伸语义。** SDF 参数以画布单位表达，角是角、边是边，任意尺寸下锐利（`radius`
+   的既有行为）。SVG viewBox 一拉伸角就变形，要自己发明路径版 9-slice。
+3. **LLM 写 SVG 语法流利，坐标是盲画的。** 没有渲染反馈闭环时摆坐标成功率很低（`.pxl`
+   工作流配 PxlPreview 正是为此）。从枚举词汇表选参数是 LLM 最可靠的操作方式，还能进
+   纯 C# 的 UIXmlLint。
+
+**独立 `corner=` 属性 / CSS `corner-shape` 双属性镜像。否决。** `radius` 的值语法被五个
+属性共用（`radius` / `fillRadius` / `handleRadius` / `frameRadius` / `maskRadius`），扩展
+值语法让五者一次获得能力、一个解析器改动；独立属性意味着属性面积 ×5 加并存冲突规则。
+双属性镜像（尺寸列表 + 形状列表按位对齐）在 Variant 只覆盖其一时会失步 —— 单属性覆盖
+是原子的。
+
+## 3. 方案总览
+
+扩展 `radius=` 的**值语法**：逐角值从「半径」升级为「处理方式 + 尺寸」，整形关键字在
+`pill` 旁边加 `hexagon`。
+
+```xml
+<Btn radius="cut 16">                     <!-- 四角 45° 斜切 -->
+<Btn radius="cut 16, 8, cut 16, 8">       <!-- 对角斜切 + 圆角混用 -->
+<Btn radius="cut 24x16">                  <!-- 横 24 纵 16 的扁平斜切 -->
+<Frame radius="notch 12, 0, notch 12, 0"> <!-- 上两角方形缺口 -->
+<Btn radius="hexagon">                    <!-- 左右尖端六边形，纵向恒=半高 -->
+<Btn radius="hexagon 32">                 <!-- 尖端横向伸出 32 -->
+```
+
+现状全部原样兼容：`radius="8"`、四值、`pill`、空串。border / glow / glass / mask 自动
+跟随新轮廓，**零个新属性**。
+
+## 4. 语法
+
+```
+radius      := "" | whole-shape | corner-list
+whole-shape := "pill" | "hexagon" [ SP number ]
+corner-list := segment | segment "," segment "," segment "," segment
+segment     := number                        // round，现状语义不变；0 = 方角
+             | keyword SP size
+keyword     := "cut" | "notch"
+size        := number [ "x" number ]         // W 或 WxH，画布单位
+```
+
+- 四值顺序仍是 CSS 序（TL,TR,BR,BL 顺时针自左上）；单值应用到四角。
+- `cut W`：45° 对称斜切；`cut WxH`：横向 W、纵向 H 的斜切（参考图的扁平尖端 = 大W小H）。
+- `notch W`：W×W 方形缺口；`notch WxH`：横向 W、纵深 H。
+- 逐角混用合法：`radius="cut 16, 8, notch 8, 0"`。
+- `hexagon`：左右两侧切成尖端 —— TL/BL 与 TR/BR 各以纵向 H=半高的斜切相接于中线。
+  纵向尺寸在 shader 逐像素解算（同 `pill` 的理由：依赖 rect 尺寸，CPU 解算会丢材质共享，
+  见 `RadiusParser.cs` 的 remarks）。裸 `hexagon` 横向也取半高（45° 尖端）；`hexagon 32`
+  指定横向伸出量。
+- `pill` / `hexagon` 与逐角值混写是 parse error（沿用 pill 现有规则与措辞风格）。
+- 空串 = `Zero`（方角）照旧 —— Variant 只能改值不能删属性，`radius.desktop=""` 是退回
+  方角的唯一写法，必须保持合法。
+- 负数 / NaN / Infinity 检查逐字段沿用现有实现。
+- **关键字与 `x` 分隔符小写、`x` 两侧无空格、关键字与尺寸之间以空白分隔（容忍多个空格）**
+  （`Trim` 后按空白切分）。大小写不做宽容：报错消息里列出合法词，LLM 照错误自纠比
+  静默容错更可靠，且 lint / 运行时行为一致。
+
+### 4.1 解析错误（parse-time，纯 C# 子集，CLI 同步可见）
+
+| 情形 | 结果 |
+|---|---|
+| 未知关键字（`bevel 16` / `scoop 8`） | error：列出合法词 `cut` / `notch`（及裸数字、`pill` / `hexagon`） |
+| 关键字后缺尺寸（`cut`） | error |
+| `WxH` 段不是两个有限非负数（`cut 16x` / `cut x8` / `cut 16x-2`） | error，指明是哪个角哪一段 |
+| `pill` / `hexagon` 混入四值列表 | error（沿用 pill 措辞：whole-shape keyword，单独成值） |
+| `hexagon 32x16` | error：hexagon 只收横向一个参数，纵向恒为半高 |
+| 逗号切出 2 段或 ≥5 段 | error（照旧） |
+
+## 5. 语义
+
+**clamp 按轴独立，仍在 shader 逐像素做。** `cut` / `notch` 的 W clamp 到半宽、H clamp 到
+半高 —— 每轴 clamp 保证相邻两角同轴尺寸之和不超边长，角不互相穿越。round 沿用
+「clamp 到短边半长」不变（`PuguiResolveRadius` 现状）。`hexagon` 的 H 恒取半高，于是
+TL/BL（TR/BR 同理）的斜切精确相接成尖端，尺寸变化自动跟随，作者不需要手算。
+
+**派生特性自动跟随，逐条：**
+
+- **border**：向内描，压在填充上（`_BorderWidth > 0` 的 uniform 分支不变），沿新轮廓。
+- **glow**：`saturate(1 - d/_GlowSize)` 只依赖外侧距离场 —— cut 外侧距离要做到精确
+  （§6.2），notch 凹角处的近似误差要 render test 验收（§6.2）。
+- **glass**：折射与边缘光照走 `PuguiSdNormal`，cut 区法线 = 斜边半平面法线，notch 区
+  = 缺口两条边的盒法线 —— 解析可写，画布空间语义（GL 翻转问题）与现状一致。
+- **`mask="self"` / `maskRadius`**：遮罩形状 = SDF 实心区（M-mask 那四行），cut / notch /
+  hexagon 的裁剪免费成立。Progress 的 `maskRadius` 自动跟随 `radius`（`DeclaredRadius`
+  流经，见 `ProceduralControl.cs:96`），语法升级后跟随语义不变。
+- **纵向渐变填充**：`t = (p.y + b.y) / 2b.y` 只看包围盒，与角部处理无关，不变。
+- **`PUI-PROG-FILL-RADIUS-MODE`**（`mode="fill"` × `fillRadius` 冲突）不受影响。
+
+**weld 是唯一的例外：v1 不支持。** `GlassGroupPanel` 把成员形状打包成 `_WeldRects` +
+`_WeldRadii`（float4，pill 已在 CPU 解算），融合走 `PuguiSmin`。逐成员再带 kind + H 两组
+数组、smooth-union 又会把角熔圆 —— 复杂度买不到观感。规则：weld 成员的 radius 含
+cut / notch / hexagon 时，**CPU 打包处降级为同 W 的圆角**，lint 报 warning
+`PUI-WELD-CORNER`（不是 error：形状与 weld 可能来自两个主题包的合流，作者未必同屏写过）。
+
+## 6. 实现地图
+
+### 6.1 数据流（改动点自上而下）
+
+| 层 | 文件 | 改动 |
+|---|---|---|
+| 解析 | `Runtime/Core/Parser/RadiusParser.cs` | 语法升级；`RadiusSpec` 结构扩展（§6.3）。纯 C# 子集不变，CLI lint 免费获得新语法报错（`StyleRules.cs:86` 已在调 `TryParse`） |
+| 控件 | `ProceduralControl.cs:98` / `Frame.cs:137` / `Slider.cs:170,199` / `Progress.cs:111,171,192` | **零改动** —— 全部只做 `RadiusParser.Parse` → `SetRadius(RadiusSpec)` 透传 |
+| 面板 | `Runtime/Controls/Internal/ProceduralPanel.cs:158` | `SetRadius` 签名不变；`FlushParams` 的 `PanelParams` 打包扩展 |
+| 材质键 | `ProceduralMaterialCache.cs:70` | `PanelParams` 增 kind / H / shape 字段，参与相等比较与哈希 |
+| shader | `UI-PanelSDF.cginc` + `UI-ProceduralPanel.shader` / `UI-GlassPanel.shader` | 形状函数广义化（§6.2）；材质属性：`_Radius`（语义变为逐角 W）+ 新增 `_CornerKind`(float4: 0 round / 1 cut / 2 notch)、`_CornerH`(float4)、`_Shape`(float: 0 none / 1 pill / 2 hexagon，替代 `_Pill`)、`_HexW` |
+| weld | `GlassGroupPanel` 打包处 + `UI-GlassGroup.shader` | 降级为圆角（§5），shader 不动 |
+| lint | `Runtime/Core/Lint/` | `PUI-WELD-CORNER`（§5）；语法错误走 parser，无新规则 |
+| XSD | `Editor/XsdGenerator.cs:91` | `radius` 本就是无 pattern 的 `xs:string`，无改动 |
+| SHAPE 规则 | `ThemeStyleRules` (#105) | 属性名集合没变，无改动 —— 守卫测试确认 |
+
+### 6.2 shader：形状函数广义化
+
+`PuguiSdRoundBox(p, b, r)` → `PuguiSdPanel(p, b, kind4, w4, h4)`，三个 shader 共 include
+一处改。逐象限选角（现有的 `p.x > 0` / `p.y > 0` 二选一逻辑照旧），按该角 kind 分派：
+
+- **round**：现有路径逐字不变。round-only 面板（含 pill）改前改后**逐像素一致**，用
+  render test 钉住 —— 这是本设计对已出货皮肤的零回归承诺。
+- **cut**：矩形与斜边半平面求交（`max`）。半平面交在两条边界法线的夹角区内会低估到顶点
+  的距离 → glow 在斜切角外侧被撑大。修正：夹角区取到**斜边线段端点**的精确距离
+  （同 round 角用 `length()` 精确化的思路）。外侧距离精确是 glow 不失真的验收线。
+- **notch**：矩形减去角上的方块（`max(d, -dNotch)`）。减法 SDF 在凹角外侧近处是近似 ——
+  glow 在缺口腔内的观感要 render test 验收，误差不可接受时再换精确分段距离（到缺口两条
+  边的线段距离），spec 不预先绑死实现。
+- **`PuguiResolveRadius` → `PuguiResolveCorners`**：pill / hexagon 哨兵解算 + 每轴 clamp。
+  hexagon：四角 kind=cut，H = `b.y`，W = `_HexW > 0 ? _HexW : b.y`（再 clamp 到 `b.x`）。
+- **`PuguiSdNormal` 同步扩展**：cut 区返回斜边法线，notch 区返回缺口盒法线 —— 玻璃边缘
+  光照与折射的方向正确性靠它。象限折回（`s * g`）逻辑沿用。
+
+**成本**：新增分支全是「材质 uniform 决定路径」的分支，与 `_BorderWidth > 0` 同类 ——
+全体 fragment 同路径，开销可忽略。不用新词汇的面板多读几个 uniform，几何、材质共享、
+合批行为不变。
+
+### 6.3 `RadiusSpec` 结构扩展（兼容性）
+
+`RadiusSpec` 是 public struct（自定义控件作者可能在用）。扩展保持既有成员语义：
+
+- `TopLeft` / `TopRight` / `BottomRight` / `BottomLeft` 保留，语义 = 该角的 W（round 时
+  即半径，逐字兼容）；`IsPill` 保留。
+- 新增：逐角 `CornerKind`（`Round` / `Cut` / `Notch`）与 H；整形 `Shape`
+  （`None` / `Pill` / `Hexagon`）与 `HexW`。`IsPill` 改为 `Shape == Pill` 的只读别名。
+- 现有构造函数保留（构造出全 round），新形态走新构造。
+
+## 7. SKILL 更新（每个落地里程碑的同一 PR 内）
+
+- `authoring-promptugui-xml/SKILL.md`：`radius` 行改写 —— 值语法表加 `cut` / `notch` /
+  `hexagon` 与 WxH 形态，示例给参考图三件套（六边形主按钮 / 梯形 Tab / 缺口面板）；
+  程序化表面小节提一句 weld 例外。
+- `reference/glass.md`：weld 小节补 `PUI-WELD-CORNER` 一句。
+- C# SKILL 不动（`RadiusSpec` 扩展兼容，控件作者 API 无感知）。
+
+## 8. 已定的决策（2026-08-27 与作者对齐）
+
+1. **扩展 `radius` 值语法，不加新属性。** 理由见 §2。属性名叫 radius 而值可以是切角，
+   语义略扭 —— 接受，五属性一次获得能力的收益压倒命名洁癖。
+2. **v1 词汇 = `cut` + `notch`；`scoop`（内凹圆）与 `squircle`（超椭圆）不进。** scoop
+   参考图用不到；squircle 无解析 SDF（迭代逼近）、与 HUD 风格无关。语法按 §4 设计成
+   可平滑追加新关键字。
+3. **命名用 `cut` 不用 CSS 的 `bevel`。** 既然没有镜像 CSS 的双属性模型，对齐 CSS 词汇
+   的收益已经不大；`cut 16` 更短更直读。`notch` 保留 CSS 词（无更口语的替代）。
+4. **双值 `WxH` 进 v1。** 45° 对称切角做不出参考图的扁平尖端；SDF 仍解析，语法只多一种
+   段形态。
+5. **`hexagon` 整形关键字进 v1。** 尖端要求切角纵向恰=半高，作者手算会在尺寸变化时失效
+   —— 与 pill 同型的问题用同型的解法（shader 哨兵解算，保材质共享）。
+6. **竖版 hexagon（上下尖端）不进 v1。** 需求出现时加方向参数，语法可平滑扩展。
+7. **weld × 新词汇：运行时降级圆角 + lint warning。** 理由见 §5。
+
+## 9. 开放问题（实现期已结）
+
+- ~~notch 凹角 glow 的验收标准~~ —— 结论比预想的更重：近似不只影响 glow，**内描边**也会在
+  凹顶点鼓一块。做成了精确的双场解（§11）。
+- ~~`_Shape` 替代 `_Pill` 的材质资产引用~~ —— 全仓只有一个序列化 `.mat`
+  （`UI-LinearLightTint.mat`），走的是另一个 shader。改名安全。
+
+## 10. 里程碑拆分（草案）
+
+| | 内容 | 依赖 |
+|---|---|---|
+| **M0 Red** | `RadiusParser` 新语法全矩阵（§4 + §4.1 逐条）+ `RadiusSpec` 兼容契约 + round-only 逐像素回归的 render 基线 | 无 |
+| **M1 cut + hexagon** | parser / `RadiusSpec` / `PanelParams` / cginc（cut + 哨兵解算 + 法线）/ 三 shader 属性；SKILL 同 PR。参考图刚需先落地 | M0 |
+| **M2 notch** | notch SDF + 凹角 glow render 验收；SKILL 同 PR | M1 |
+| **M3 收尾** | weld 降级 + `PUI-WELD-CORNER` + `glass.md`；SHAPE 规则守卫确认 | M1 |
+
+四档一轮做完，没有拆成四个 PR：M1 落地后 M2 只是 cginc 里多一个 `PuguiSdNotchCorner`，
+M3 只是一条 lint —— 拆开的收益不抵四轮 Unity 编译 + 三次文档往返。
+
+## 11. 实施记录
+
+**验证结果**：EditMode 2531 / EditorOnly 308 / PlayMode 171 全绿；`dotnet format --verify-no-changes`
+无改动；`UIXmlLint Runtime/Resources/` 零 issue。
+
+### 11.1 兑现了「round-only 逐像素不变」
+
+不是靠断言，是**量出来的**：把三份 shader `git stash` 回 HEAD（新 C# 设的
+`_CornerH` / `_CornerKind` / `_Shape` 在旧 shader 上是静默 no-op，`_Radius` 语义对 round 逐字
+未变），渲染同一个 `radius='60'` 面板，与新 shader 的输出比对 —— **0 个像素不同**。
+
+前提是渲染确定性，这一条也单独验了：同一构建连跑两次，输出 0 差异。有了这个前提，后面
+所有的「改了 shader 有没有效果」才能用像素 diff 来回答。
+
+### 11.2 两处精度问题，第二处比 spec 预估的严重
+
+**cut 的外部**：`max(dBox, dLine)` 在斜边两个端点外的楔形里最多低估 7.6%（45° 时），会让
+外发光在那两点鼓出去。按 §6.2 的计划做了线段距离修正。
+
+**notch 的内部**：spec 只担心了 glow，实际上**内描边**才是被咬到的那个。并集取 min 在凹顶点
+处最多浅 √2 倍，`borderWidth=20` 的描边会一路铺到 28 —— 在缺口的内角上肉眼可见地鼓一块。
+最终用两个场按符号分流：外部 `min(两个象限场)`（精确，含缺口造出的两个凸顶点），内部
+`max(dBox, -dRect)`（精确，因为两个场各自精确、相减处两条边就是真边界）。
+
+### 11.3 两个把「测试通过」变成假消息的坑
+
+**坑一：测试程序集编译失败时，`run_tests` 跑的是上一次的旧程序集，而且报告 Passed。**
+`PanelParams.Radius` → `CornerWidth` 的改名让 15 处既有测试调用点编译不过，而那一轮
+`run_tests` 报了 2485/2485 通过 —— 跑的全是改名生效前的旧 DLL。后续只在同一个 group 上过滤时
+才露馅（`total: 0`）。**每次 refresh 之后必须先 `read_console(types=["error"])`**，通过数不能
+当编译成功的证据。
+
+**坑二：第一版精度测试根本不可能失败。** `AssertPainted` 只查蓝通道，而白色描边的蓝通道也是
+1.0 —— 于是「填充」和「描边盖过来了」这两种结果它都判通过。把 notch 的精确修正换成
+`if (true) return d;` 之后测试**照样绿**，才发现问题在测试而不是 shader。修成同时要求红通道低
+（填充 `#3366ff` 红=0.2，描边白=1.0）之后，falsification probe 如期报红、报的还是预测的那句话。
+
+这条值得记住的地方在于：**做了 falsification 才知道守卫是假的**。像素 diff 显示那次改动确实
+动了 431 个像素、其中就有探针那一格，但断言看不见它。
+
+### 11.4 实现上的小结论
+
+- **控件层真的零改动** —— 五个 `radius` 属性全是 `Parse → SetRadius(RadiusSpec)` 透传，
+  语法升级完全被 `RadiusParser` + `PanelParams` 吸收。Progress 的 `maskRadius` 自动跟随白拿。
+- **`PanelParams.Radius` 改名成 `CornerWidth`** —— 升级之后它装的是「逐角水平伸出量」，
+  只在圆角时才等于半径，留着旧名字会持续误导。
+- **`PuguiSdRoundBox` / `PuguiSdNormal` 原样保留**给 weld 融合面用，于是 `UI-GlassGroup.shader`
+  一行没动，weld 降级只发生在 CPU 打包处（`GlassGroupPanel.ResolveRadius`）。
+- **round 分支走的是同一份 `PuguiSdRoundCorner`**（`q = u + r` 与原来的 `abs(p) - b + radius`
+  逐字等价），这是 §11.1 那个 0 差异的直接来源。
+- **正方形 rect 上 `hexagon` 退化成菱形** —— 尖端自动尺寸取半高、再按半宽 clamp，两者相等时
+  上下的平边长度归零。不是缺陷，但值得作者知道：六边形要横向长条的 rect。


### PR DESCRIPTION
异形按钮和边缘装饰这类科幻 HUD 词汇，今天在这个库里只能靠贴图 —— 而贴图皮肤恰恰被
#104 打通的「主题换形状」排除在外：程序化表面只会画圆角矩形，主题的能力半径就到此为止。

这是形状扩展的**第一层**（角部处理词汇表）。第二层（边缘装饰原语 `<Decor>`）与第三层
（任意路径逃生舱）另行立项，本 PR 不涉及。

设计：`docs~/superpowers/specs/2026-08-27-corner-treatments-design.md`

## 做了什么

扩展 `radius` 的**值语法**而不是新加属性：每角可以是裸数字（round）、`cut W[xH]`（斜切）、
`notch W[xH]`（方形缺口），整形关键字在 `pill` 旁边加 `hexagon [W]`。

```xml
<Btn radius="cut 16">开始匹配</Btn>                       <!-- 四角斜切 -->
<Btn radius="cut 16, 8, cut 16, 8">混用</Btn>             <!-- 逐角混用 -->
<Btn radius="hexagon 40">开始匹配</Btn>                    <!-- 横幅式六边形 -->
<Tab radius="cut 14, cut 14, 0, 0">主页</Tab>             <!-- 梯形页签 -->
<Frame radius="notch 12, 0, 0, notch 12"/>                <!-- 机械感缺口 -->
```

`radius` / `fillRadius` / `handleRadius` / `frameRadius` / `maskRadius` 五个属性一次全部
获得能力，**控件层零改动** —— 它们本来就是 `Parse → SetRadius(RadiusSpec)` 透传。
border / glow / glass / `mask="self"` 自动跟随新轮廓，**零新增属性**。

现状全部兼容：`radius="8"` / 四值 / `pill` / `""` 逐字未变。

## 为什么不是 SVG

评估过，否决，理由在 spec §2。最硬的一条：border 向内描、glow 向外晕、glass 的折射与边缘
光照（解析法线）、`mask="self"` 的实心区裁剪、weld 融合、材质共享 —— 全部派生自解析 SDF。
任意贝塞尔要么曲面细分成 mesh（上述全灭），要么烘焙 SDF 纹理（法线退化、材质按纹理失效）。
另外 SVG 没有拉伸语义，而按钮是要变尺寸的。

## 改动面

| 层 | 内容 |
|---|---|
| `Core/Parser` | `RadiusSpec` 扩展成逐角 `(Kind, W, H)` + 整形哨兵；旧成员语义逐字不变（`TopLeft` 仍是该角的水平伸出量，圆角时即半径）。纯 C# 子集不动，CLI lint 白拿新语法报错 |
| `UI-PanelSDF.cginc` | 形状函数广义化；round 分支走同一份 `PuguiSdRoundCorner` |
| 材质 | `_Pill` → `_Shape`，新增 `_CornerH` / `_CornerKind` / `_HexW`；`PanelParams.Radius` 改名 `CornerWidth` |
| weld | 按设计降级为同 W 圆角（smooth-min 会把角熔圆），新 lint `PUI-WELD-CORNER`（warning，形状与 weld 可能来自两个主题包）。`UI-GlassGroup.shader` 一行未动 |
| SKILL | 主文档新增「Corner treatments」小节 + `radius` 行改写；`reference/glass.md` 记 weld 例外 |

## 两处精度是花了力气的

不是「形状对了就行」：

- **cut 的外部**：`max(dBox, dLine)` 在斜边端点外的楔形里最多低估 7.6%（45° 时），外发光会
  在那两点鼓出去 —— 加了线段距离修正。
- **notch 的内部**：并集取 min 在凹顶点最多浅 √2 倍，`borderWidth=20` 的描边会一路铺到 28、
  在缺口内角肉眼可见地鼓一块。**spec 只预估了 glow，实际被咬到的是描边。** 改成按符号分流：
  外部两个象限场取 min，内部矩形减缺口，两侧都精确。

## 验证

**「round-only 逐像素不变」是量出来的，不是断言的**：把三份 shader `git stash` 回 HEAD 渲染
同一个圆角面板对比 —— **0 个像素不同**。前提（同构建两次渲染的确定性）也单独验了，同样 0 差异。

**精度那条测试做了 falsification**：把 notch 的精确修正换成 `if (true) return d;`，测试如期报红。
第一版**根本不可能失败**（`AssertPainted` 只查蓝通道，而白色描边的蓝通道也是 1.0），正是这一步
发现的 —— 记在 spec §11.3。

- EditMode **2531** / EditorOnly **308** / PlayMode **171** 全绿
- `dotnet format --verify-no-changes --severity warn` 无改动
- `UIXmlLint Runtime/Resources/` 零 issue

## 已知边界

正方形 rect 上 `hexagon` 会退化成菱形（尖端自动取半高、再按半宽 clamp，两者相等时平边归零）。
不是缺陷，六边形要横向长条的 rect —— 已写进 SKILL。

竖版 hexagon（上下尖端）不在 v1；`scoop`（内凹圆）与 `squircle` 同样不在，语法留了平滑追加
新关键字的口子。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhZySsbMocJuC1kULMtpf4
