### PR TITLE
fix: 画布缩放改用 Expand —— 更吃紧的那条边决定缩放，设计不再被没预料到的宽高比裁掉

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -454,7 +454,7 @@ TMP_InputField；R3 `OnValueChanged` / `OnEndEdit` / `OnSubmit: string`。`<Inpu
 
 ### `<TabBar>`
 
-Tab 容器；私有 `ToggleGroup`（`allowSwitchOff=false`）+ `Horizontal` / `VerticalLayoutGroup`。纯布局无自身视觉（要背景条套 `<Image>`）。子节点可为直接 `<Tab>` 或含 `<Tab>` 的 Template wrapper（递归收集）。支持 `itemTemplate` + `BindItems`（同 `<ScrollList>`）。作为子节点的布局组——Tab 不能写 `anchor` / `margin`。**详见 [`reference/controls-tabs.md`](reference/controls-tabs.md)。**
+Tab 容器；私有 `ToggleGroup`（`allowSwitchOff=false`）+ `Horizontal` / `VerticalLayoutGroup`。纯布局无自身视觉（要背景条套 `<Image>`）。子节点可为直接 `<Tab>` 或含 `<Tab>` 的 Template wrapper（递归收集）——**wrapper 根必须自己写 `width`/`height`**（如 `width="stretch"`），`<Tab>` 的 native-size 保底只对直接子节点生效，wrapper 漏写会塌成 0 尺寸。支持 `itemTemplate` + `BindItems`（同 `<ScrollList>`）。作为子节点的布局组——Tab 不能写 `anchor` / `margin`。**详见 [`reference/controls-tabs.md`](reference/controls-tabs.md)。**
 
 | 属性 | 类型 / 取值 | 默认 | 说明 |
 |---|---|---|---|

--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -1046,7 +1046,7 @@ Source text goes directly inside `<Text>` / `<Btn>` and serves as the msgid for 
 **Reserved variant namespace**: the library auto-manages two namespaces — authors must NOT reuse these names for business state:
 
 - **Locale**: `UI.Locale.Set("zh-Hans")` internally registers `zh-Hans` (any locale code passed to `UI.Locale.Set`) as an active Variant.
-- **Orientation**: `portrait` and `landscape` are toggled automatically by a global tracker based on `Screen.width` vs `Screen.height` (equal dims → `landscape`, matching the CanvasScaler `match` auto-derivation). They are mutually exclusive. Use them as overrides — e.g. `<Screen reference="1920x1080" reference.portrait="1080x1920">`, `<Btn width="240" width.portrait="stretch"/>`. Portrait-locked games can ignore them (base values apply when no override exists, `landscape` overrides simply never fire). Users who want to fully self-manage can set `UI.Orientation.AutoTrack = false`.
+- **Orientation**: `portrait` and `landscape` are toggled automatically by a global tracker based on `Screen.width` vs `Screen.height` (equal dims → `landscape`, an arbitrary but stable tiebreak — the two are mutually exclusive and one always holds). They are mutually exclusive. Use them as overrides — e.g. `<Screen reference="1920x1080" reference.portrait="1080x1920">`, `<Btn width="240" width.portrait="stretch"/>`. Portrait-locked games can ignore them (base values apply when no override exists, `landscape` overrides simply never fire). Users who want to fully self-manage can set `UI.Orientation.AutoTrack = false`.
 
 ### Inline sprites / TMP rich text
 
@@ -1225,10 +1225,10 @@ Append a comma between two colour values to produce a **vertical two-stop gradie
 ```
 
 - `canvas="overlay|camera|world"`, default `overlay`. Picks the runtime `Canvas.renderMode` for this Screen. Everything else (worldCamera, sortingOrder) is configured C#-side via `UI.CanvasConfigurator`.
-- `reference="WxH"` → CanvasScaler 切到 `ScaleWithScreenSize`，referenceResolution 即该值。`matchWidthOrHeight` 按朝向自动推断：W ≥ H 锁宽（0），H > W 锁高（1）。
+- `reference="WxH"` → CanvasScaler 切到 `ScaleWithScreenSize` + `screenMatchMode=Expand`，referenceResolution 即该值。Expand = `scaleFactor = min(屏宽/参考宽, 屏高/参考高)`：**更吃紧的那条边决定缩放**，所以整个参考矩形在任何宽高比下都放得下，设计不会被作者没预料到的屏幕比例裁掉（超宽显示器、比 16:9 更长的手机）。画布本身仍铺满屏幕（两轴测量值都 ≥ 参考尺寸），拉伸锚定的背景照常填满，富余落在更宽松的那条边上。
 - 未设 / `reference=""` → 保留默认 `ConstantPixelSize, scaleFactor=1` 行为；XML 数字直接 = 设备像素。
 - `.variant` 形态：`reference.mobile="..."` 同其他属性 variant 规则；变体切换时 CanvasScaler 立即重应用。
-- 要 `match=0.5` 折中或改 `referencePixelsPerUnit`：走 `UI.CanvasConfigurator` 手改。**不要在两条路径同时改 CanvasScaler** —— variant flip 时 XML 路径会覆盖 configurator 的改动。
+- 要锁死某条边（`screenMatchMode=MatchWidthOrHeight` + `matchWidthOrHeight=0/0.5/1`）或改 `referencePixelsPerUnit`：走 `UI.CanvasConfigurator` 手改。**不要在两条路径同时改 CanvasScaler** —— variant flip 时 XML 路径会覆盖 configurator 的改动。
 - `scale-mode="auto|pixel"` (+ `.variant`)：默认 `auto` = 上面 `reference` 的连续缩放语义。`pixel` 切到 `ConstantPixelSize` + 整数倍 `scaleFactor`（fit-inside 取小；屏幕 < 设计时 snap 到 1/2、1/4、1/8 等保 2x2 干净降采样）。**必须配 `reference="WxH"`**，否则运行期 `Debug.LogError` 并降级 `scaleFactor=1`。像素美术 / 等距图项目用 —— sprite 永远整数倍渲染到屏幕像素。项目级默认走 C# `UI.DefaultScaleMode = ScaleMode.Pixel`；具体 Screen 想退回连续缩放写 `scale-mode="auto"`。
 
 ### Relative scale (`scale="N"`) — box-preserving

--- a/.claude/skills/authoring-promptugui-xml/reference/controls-tabs.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/controls-tabs.md
@@ -63,9 +63,27 @@ Template root and put its content **inside** the Tab (children overlay the bg, F
 </TabBar>
 ```
 
-TabBar collects the Tab whether it is the Template root (as here) or nested inside a wrapper; auto-select and `OnSelectionChanged` work the same either way. Lint rules `PUI-TABBAR-CHILD` and `PUI-TAB-PARENT` are suppressed for Template-instance roots. The Tab's `width`/`height` is its layout-group cell size; its children use their own `anchor` / `margin` (Tab is not a layout group). Omit them and the Tab sizes to its own label (plus padding, min 44px tap target) — it never collapses to zero. `width="stretch"` splits the bar's remaining space evenly, exactly as in `<HStack>`.
+TabBar collects the Tab whether it is the Template root (as here) or nested inside a wrapper; auto-select and `OnSelectionChanged` work the same either way. Lint rules `PUI-TABBAR-CHILD` and `PUI-TAB-PARENT` are suppressed for Template-instance roots. The Tab's `width`/`height` is its layout-group cell size; its children use their own `anchor` / `margin` (Tab is not a layout group). Omit them and the Tab sizes to its own label (plus padding, min 44px tap target) — it never collapses to zero, **as long as the `<Tab>` is the Template root** (see the wrapper note below). `width="stretch"` splits the bar's remaining space evenly, exactly as in `<HStack>`.
 
-> ⚠️ **Behaviour change.** `width` / `height` on a `<Tab>` used to be silently ignored — TabBar's layout group was left at Unity's default `childControlWidth/Height = false`, which only positions children and never resizes them, so every Tab stayed at the default 100×100 (overflowing the bar and overlapping its neighbours). TabBar now configures the group like `<VStack>` / `<HStack>` do, so the values you write actually land. Existing TabBars will shift — toward what the markup always said. Keep decorative children `raycastTarget=false` (`<Icon>` already is; add it on `<Text>`) so clicks fall through to the containing Tab.
+> ⚠️ **Wrapper roots must carry the size themselves.** That zero-collapse safety net is `Tab.GetNativeSize()`, and it only fires for the node TabBar actually lays out. Wrap the Tab — `<Frame><Tab .../></Frame>`, the usual way to hang a separator / badge / second layer *outside* the Tab's own bg — and TabBar's layout child is the `<Frame>`, which has no native size at all. With `childControlWidth/Height = true` and nothing written on the wrapper, its preferred size resolves to **0**: every tab collapses and piles up at the same spot. Exactly the `<HStack>` rule, and it bites the same way — **put `width` / `height` (or `width="stretch"`) on the wrapper root, not only on the inner `<Tab>`**:
+>
+> ```xml
+> <Template name="ChannelTab">
+>   <Param name="text"/>
+>   <Param name="sep" default="true"/>
+>   <!-- 尺寸写在 wrapper 上；漏了就塌成 0 宽，三个 tab 重叠在 x=0 -->
+>   <Frame width="stretch" height="18">
+>     <Tab id="tab" anchor="stretch" sprite="" selectedSprite="ui:tab_selected">
+>       <Text anchor="stretch" align="center" fontSize="12" raycastTarget="false">{{text}}</Text>
+>     </Tab>
+>     <Image if="{{sep}}" anchor="stretch-right" width="1" raycastTarget="false"/>
+>   </Frame>
+> </Template>
+> ```
+>
+> The inner `<Tab anchor="stretch">` then fills the wrapper — it is a free-positioned child of a `<Frame>`, not a layout-group child, so `anchor` / `margin` are legal on it there.
+
+> ⚠️ **Behaviour change.** `width` / `height` on a `<Tab>` used to be silently ignored — TabBar's layout group was left at Unity's default `childControlWidth/Height = false`, which only positions children and never resizes them, so every Tab stayed at the default 100×100 (overflowing the bar and overlapping its neighbours). TabBar now configures the group like `<VStack>` / `<HStack>` do, so the values you write actually land. The other half of the same switch: `childForceExpand*` is now `false` where Unity's serialized default is `true`, so Unity no longer forces `flexible = 1` onto every child in `GetChildSizes` — tabs that used to spread out and fill the bar regardless of the markup now sit at their preferred size, packed at the start of the bar (and a sizeless wrapper root, at width 0). Existing TabBars will shift — toward what the markup always said; add `width="stretch"` to get the even split back. Keep decorative children `raycastTarget=false` (`<Icon>` already is; add it on `<Text>`) so clicks fall through to the containing Tab.
 
 For dynamic data, use `BindItems` with `itemTemplate="FileTab"` (the same Template works for both patterns).
 

--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -285,7 +285,7 @@ await UI.Locale.SetAsync("en");   // waits for download + refresh to finish (use
 
 ## 7. XML Authoring Best Practices
 
-**`<Screen>`: use `reference` + `reference.portrait` so one XML serves both landscape and portrait.** `reference` is the design resolution; the CanvasScaler switches to scale-with-screen and auto-locks the edge by orientation (lock width when W≥H, lock height when H>W). `portrait` / `landscape` are orientation variants the library **tracks automatically** (see Variant below).
+**`<Screen>`: use `reference` + `reference.portrait` so one XML serves both landscape and portrait.** `reference` is the design resolution; the CanvasScaler switches to scale-with-screen in Expand mode: it scales by whichever axis is tighter (`min(screenW/refW, screenH/refH)`), so the whole design always fits on any aspect ratio and is never cropped — the slack lands on the looser axis, absorbed by edge anchoring and `<SafeArea>`. `portrait` / `landscape` are orientation variants the library **tracks automatically** (see Variant below).
 
 ```xml
 <Screen name="MainMenu" reference="640x360" reference.portrait="360x640">

--- a/BEST_PRACTICES.zh.md
+++ b/BEST_PRACTICES.zh.md
@@ -287,7 +287,7 @@ await UI.Locale.SetAsync("en");   // 等下载 + 重刷完成（之后要立刻�
 
 ## 7. XML 书写最佳实践
 
-**`<Screen>`：用 `reference` + `reference.portrait` 让一份 XML 同时供横竖屏。** `reference` 是设计分辨率，CanvasScaler 切到按屏缩放，并按朝向自动锁边（W≥H 锁宽、H>W 锁高）。`portrait` / `landscape` 是库**自动跟踪**的朝向变体（见下方 Variant）。
+**`<Screen>`：用 `reference` + `reference.portrait` 让一份 XML 同时供横竖屏。** `reference` 是设计分辨率，CanvasScaler 切到按屏缩放的 Expand 模式：按更吃紧的那条边缩放（`min(屏宽/参考宽, 屏高/参考高)`），整份设计在任何宽高比下都完整放得下、永不被裁，富余空间落在更宽松的那条边上——交给边缘锚定和 `<SafeArea>` 吸收。`portrait` / `landscape` 是库**自动跟踪**的朝向变体（见下方 Variant）。
 
 ```xml
 <Screen name="MainMenu" reference="640x360" reference.portrait="360x640">

--- a/Runtime/Application/Internal/OrientationTracker.cs
+++ b/Runtime/Application/Internal/OrientationTracker.cs
@@ -40,8 +40,8 @@ namespace PromptUGUI.Application.Internal
                 ? ScreenSizeOverride()
                 : new Vector2(UnityEngine.Screen.width, UnityEngine.Screen.height);
             if (size.x <= 0f || size.y <= 0f) return;
-            // 等宽高视为 landscape：与 `Screen.ApplyCanvasScaler` 里
-            // `size.x >= size.y` 锁宽的判定保持一致。
+            // 等宽高视为 landscape：任意但稳定的 fallback（正方形屏幕极少见），
+            // 两个 reserved variant 必须互斥、总有一个成立。
             UI.Orientation.Set(size.y > size.x);
         }
     }

--- a/Runtime/Application/Screen.cs
+++ b/Runtime/Application/Screen.cs
@@ -258,16 +258,22 @@ namespace PromptUGUI.Application
             var size = parsed.Value;
             scaler.uiScaleMode = UnityEngine.UI.CanvasScaler.ScaleMode.ScaleWithScreenSize;
             scaler.referenceResolution = size;
-            scaler.matchWidthOrHeight = size.x >= size.y ? 0f : 1f;
-            // Cache the effective factor for 'Nx' scale. Replicates Unity's
-            // ScaleWithScreenSize output at the match endpoints we use (0 → width-locked,
-            // 1 → height-locked). Same screen-size source as pixel mode.
+            // Expand, not a matchWidthOrHeight heuristic: scaleFactor = min(screen/ref per
+            // axis), so whichever axis is tighter drives the scale and the whole reference
+            // rect always fits — the design is never cropped by an aspect the author did
+            // not anticipate (ultrawide desktops, phones taller than 16:9). The canvas
+            // still covers the screen; it just measures >= reference on both axes, so
+            // stretched backgrounds keep filling and the slack lands on the looser axis.
+            // A locked-edge look (or 0.5) is still reachable via CanvasConfigurator.
+            scaler.screenMatchMode = UnityEngine.UI.CanvasScaler.ScreenMatchMode.Expand;
+            // Cache the effective factor for 'Nx' scale — replicates the Expand formula
+            // above. Same screen-size source as pixel mode. Both reference dimensions are
+            // parser-guaranteed positive (ReferenceSyntax); a degenerate screen size falls
+            // back to 1 in ApplyScales, which already guards on factor > 0.
             var screenPx = UI.CanvasSizeOverride != null
                 ? UI.CanvasSizeOverride()
                 : ReadCanvasRectSize();
-            _canvasFactor = size.x >= size.y
-                ? (size.x > 0f ? screenPx.x / size.x : 1f)
-                : (size.y > 0f ? screenPx.y / size.y : 1f);
+            _canvasFactor = UnityEngine.Mathf.Min(screenPx.x / size.x, screenPx.y / size.y);
         }
 
         private void ApplyPixel(UnityEngine.UI.CanvasScaler scaler)

--- a/Tests/EditMode/Application/ScreenReferenceResolutionTests.cs
+++ b/Tests/EditMode/Application/ScreenReferenceResolutionTests.cs
@@ -116,7 +116,7 @@ namespace PromptUGUI.Tests.Application
         }
 
         [Test]
-        public void Open_landscape_reference_sets_match_zero()
+        public void Open_landscape_reference_uses_expand()
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
@@ -128,11 +128,12 @@ namespace PromptUGUI.Tests.Application
             Assert.AreEqual(UnityEngine.UI.CanvasScaler.ScaleMode.ScaleWithScreenSize,
                             scaler.uiScaleMode);
             Assert.AreEqual(new UnityEngine.Vector2(1920, 1080), scaler.referenceResolution);
-            Assert.AreEqual(0f, scaler.matchWidthOrHeight);
+            Assert.AreEqual(UnityEngine.UI.CanvasScaler.ScreenMatchMode.Expand,
+                            scaler.screenMatchMode);
         }
 
         [Test]
-        public void Open_portrait_reference_sets_match_one()
+        public void Open_portrait_reference_uses_expand()
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
@@ -141,11 +142,13 @@ namespace PromptUGUI.Tests.Application
             UI.LoadDocument("t", xml);
             var screen = UI.Open("S");
             var scaler = screen.RootGameObject.GetComponent<UnityEngine.UI.CanvasScaler>();
-            Assert.AreEqual(1f, scaler.matchWidthOrHeight);
+            Assert.AreEqual(new UnityEngine.Vector2(1080, 1920), scaler.referenceResolution);
+            Assert.AreEqual(UnityEngine.UI.CanvasScaler.ScreenMatchMode.Expand,
+                            scaler.screenMatchMode);
         }
 
         [Test]
-        public void Open_square_reference_sets_match_zero()
+        public void Open_square_reference_uses_expand()
         {
             const string xml = @"<?xml version='1.0' encoding='utf-8'?>
 <PromptUGUI version='1'>
@@ -154,7 +157,8 @@ namespace PromptUGUI.Tests.Application
             UI.LoadDocument("t", xml);
             var screen = UI.Open("S");
             var scaler = screen.RootGameObject.GetComponent<UnityEngine.UI.CanvasScaler>();
-            Assert.AreEqual(0f, scaler.matchWidthOrHeight);
+            Assert.AreEqual(UnityEngine.UI.CanvasScaler.ScreenMatchMode.Expand,
+                            scaler.screenMatchMode);
         }
 
         [Test]
@@ -192,13 +196,13 @@ namespace PromptUGUI.Tests.Application
             var screen = UI.Open("S");
             var scaler = screen.RootGameObject.GetComponent<UnityEngine.UI.CanvasScaler>();
             Assert.AreEqual(new UnityEngine.Vector2(1920, 1080), scaler.referenceResolution);
-            Assert.AreEqual(0f, scaler.matchWidthOrHeight);
 
             UI.Variants.Set("mobile", true);
             try
             {
                 Assert.AreEqual(new UnityEngine.Vector2(1080, 1920), scaler.referenceResolution);
-                Assert.AreEqual(1f, scaler.matchWidthOrHeight);
+                Assert.AreEqual(UnityEngine.UI.CanvasScaler.ScreenMatchMode.Expand,
+                                scaler.screenMatchMode);
             }
             finally { UI.Variants.Set("mobile", false); }
         }
@@ -241,7 +245,46 @@ namespace PromptUGUI.Tests.Application
             UI.Variants.Set("mobile", true);
             UI.Variants.Set("mobile", false);
             Assert.AreEqual(new UnityEngine.Vector2(1920, 1080), scaler.referenceResolution);
-            Assert.AreEqual(0f, scaler.matchWidthOrHeight);
+            Assert.AreEqual(UnityEngine.UI.CanvasScaler.ScreenMatchMode.Expand,
+                            scaler.screenMatchMode);
+        }
+
+        [Test]
+        public void Auto_factor_scales_by_the_tighter_axis_on_a_tall_phone()
+        {
+            // 1080x1920 design on a 1179x2556 phone (taller than 16:9). Width is the
+            // tighter axis (1179/1080 = 1.092 < 2556/1920 = 1.331), so Expand scales by
+            // width and the full 1080 design width still fits; the slack lands on height.
+            // The retired lock-by-orientation rule locked height here and pushed ~194
+            // design units of width off-screen. 'Nx' divides by the cached factor, which
+            // is how the choice becomes observable.
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(1179f, 2556f);
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' reference='1080x1920'><Frame id='f' scale='1x'/></Screen>
+</PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(1080f / 1179f, rt.localScale.x, 1e-5f);
+        }
+
+        [Test]
+        public void Auto_factor_scales_by_the_tighter_axis_on_an_ultrawide_desktop()
+        {
+            // 1920x1080 design on 2560x1080 (21:9). Height is the tighter axis
+            // (1080/1080 = 1 < 2560/1920 = 1.333), so the full 1080 design height fits
+            // and the extra width is slack. Locking width would have scaled 1.333x and
+            // cropped 270 design units of height.
+            UI.CanvasSizeOverride = () => new UnityEngine.Vector2(2560f, 1080f);
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Screen name='S' reference='1920x1080'><Frame id='f' scale='1x'/></Screen>
+</PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var screen = UI.Open("S");
+            var rt = screen.Get("f").RectTransform;
+            Assert.AreEqual(1f, rt.localScale.x, 1e-5f);
         }
     }
 }

--- a/Tests/EditMode/Application/ScreenScaleModeTests.cs
+++ b/Tests/EditMode/Application/ScreenScaleModeTests.cs
@@ -442,7 +442,7 @@ namespace PromptUGUI.Tests.Application
             var scaler = screen.RootGameObject.GetComponent<UnityEngine.UI.CanvasScaler>();
             Assert.AreEqual(UnityEngine.UI.CanvasScaler.ScaleMode.ScaleWithScreenSize, scaler.uiScaleMode);
             // Auto leaves scaleFactor at default 1; Unity computes effective scale
-            // internally from referenceResolution + matchWidthOrHeight, not from
+            // internally from referenceResolution + screenMatchMode, not from
             // CanvasScaler.scaleFactor (which only applies in ConstantPixelSize mode).
             Assert.AreEqual(1f, scaler.scaleFactor, 1e-6f);
         }

--- a/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
+++ b/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
@@ -229,7 +229,9 @@ Template 同名（含 commons 与各 Import 的任意组合）→ 报错；`as="
 
 `<Screen>` 上可选属性 `reference="WxH"` 把 CanvasScaler 切到 `ScaleWithScreenSize`，
 `referenceResolution` 即该值。不设 = `ConstantPixelSize, scaleFactor=1`（零迁移默认）。
-`matchWidthOrHeight` 按朝向自动推断：W ≥ H → 0（锁宽），H > W → 1（锁高）。
+`screenMatchMode = Expand`（since 2026-08-28，取代原先按朝向推断 `matchWidthOrHeight` 的规则）：
+`scaleFactor = min(屏宽/参考宽, 屏高/参考高)`，更吃紧的那条边决定缩放，参考矩形在任何
+宽高比下都完整放得下；画布两轴测量值仍 ≥ 参考尺寸，故拉伸锚定的背景照常铺满。
 支持 `.variant` 形态（`reference.mobile="1080x1920"`），变体翻转时通过 `ReSolve`
 立即重应用。完整设计见独立 spec
 [`2026-05-13-screen-reference-resolution-design.md`](2026-05-13-screen-reference-resolution-design.md)。

--- a/docs~/superpowers/specs/2026-05-13-screen-reference-resolution-design.md
+++ b/docs~/superpowers/specs/2026-05-13-screen-reference-resolution-design.md
@@ -5,6 +5,15 @@
 **作用域**：在 `<Screen>` 上新增可选属性 `reference="WxH"`，让作者直接在 XML 里声明 CanvasScaler 的参考分辨率，把当前"默认 1:1 物理像素 + CanvasConfigurator 手改"的隐式契约显式化为业内通行的 `ScaleWithScreenSize` 配方。支持 `.variant` 形态，满足"一份 XML 横屏 PC + 竖屏手机"核心用例。
 **依赖**：[`2026-05-07-promptugui-description-language-design.md`](2026-05-07-promptugui-description-language-design.md) §5 / §6（Screen 顶层属性、anchor/size 语义）；现有 `VariantResolver` / `ElementNode.VariantOverrides` 基础设施
 
+> **2026-08-28 修订（RR-D6 已被取代）**：`matchWidthOrHeight` 的按朝向自动推断已下线，
+> 改为 `screenMatchMode = CanvasScaler.ScreenMatchMode.Expand`——`scaleFactor = min(屏宽/参考宽,
+> 屏高/参考高)`，更吃紧的那条边决定缩放。原规则「横屏锁宽、竖屏锁高」等于**锁长边**：设备比参考
+> 更极端时（超宽显示器 21:9、比 16:9 更长的手机），自由的那条短边在设计单位上缩水，作者写死尺寸
+> 的内容被推出屏幕（1080×1920 设计跑 1179×2556 手机上横向丢 ~194 单位；1920×1080 设计跑 2560×1080
+> 上纵向丢 270 单位）。Expand 无需朝向启发式即可保证参考矩形永远完整放得下，且画布两轴测量值仍
+> ≥ 参考尺寸，拉伸锚定的背景照常铺满。要锁死某条边仍走 `CanvasConfigurator`（RR-D7 的逃生口不变）。
+> 本文档以下内容保留原始设计记录，不再反映实现。
+
 ---
 
 ## 1. 背景与目标
@@ -73,7 +82,7 @@
 | RR-D3 | 值格式 | `"WxH"`（两个正浮点 / 整数），`x` 分隔 | 跟 `size=` parser 完全对齐；不接受关键字（无 `auto` / `none`），空串 = "无参考" |
 | RR-D4 | 默认行为（不设） | `ConstantPixelSize, scaleFactor=1`（保持当前行为） | 零迁移；现有项目升级后视觉零变化 |
 | RR-D5 | 设了值的行为 | `ScaleWithScreenSize, referenceResolution=parsed, matchWidthOrHeight=自动推断` | Unity 标准做法，对齐业内 |
-| RR-D6 | matchWidthOrHeight 推断规则 | W ≥ H → 0（锁宽），H > W → 1（锁高） | 横屏锁宽、竖屏锁高是 Unity 教程 / asset store 的事实标准；正方形（极少见）锁宽是稳定 fallback |
+| ~~RR-D6~~ | ~~matchWidthOrHeight 推断规则~~（2026-08-28 取代，见顶部修订）| W ≥ H → 0（锁宽），H > W → 1（锁高） | 横屏锁宽、竖屏锁高是 Unity 教程 / asset store 的事实标准；正方形（极少见）锁宽是稳定 fallback |
 | RR-D7 | matchWidthOrHeight 自定义 | XML 不暴露；走 `CanvasConfigurator` | 99% 用例不需要；不暴露避免 API 噪声 |
 | RR-D8 | Variant 支持 | 是。`reference.mobile="1080x1920"` 等同其他属性 `.variant` 形态 | 项目核心用例"PC 横屏 + 手机竖屏一份 XML"；用户显式同意 |
 | RR-D9 | Variant 清空语义 | `reference.var=""` → 该变体下回到 `ConstantPixelSize` | 跟 `size.var=""` 的"清空"语义一致 |


### PR DESCRIPTION
## 问题

`<Screen reference="WxH">` 原来按参考分辨率的朝向推断 `matchWidthOrHeight`（W ≥ H → 0 锁宽，H > W → 1 锁高，[spec RR-D6](docs~/superpowers/specs/2026-05-13-screen-reference-resolution-design.md)）。这条对称规则实际上是**锁长边**：被锁的边设计单位数恒定，**另一条短边**按实际宽高比伸缩，比参考更极端的方向就会在设计单位上缩水，作者写死尺寸的内容被推出屏幕。

而设备偏移的方向恰好是它最吃亏的那边——现代手机全都比 16:9 更长、显示器越来越宽：

| 设计 | 设备 | 旧规则 | 后果 |
|---|---|---|---|
| 1080×1920 | 1179×2556（iPhone 15） | 锁高，scale 1.331 | 画布宽只剩 886 设计单位，1080 宽的设计左右各丢 ~97 |
| 1920×1080 | 2560×1080（21:9） | 锁宽，scale 1.333 | 画布高只剩 810，上下各丢 135 |

RR-D6 当时给的理由只有一句「横屏锁宽、竖屏锁高是 Unity 教程 / asset store 的事实标准」，没有推导。

## 改法

改用 `CanvasScaler.ScreenMatchMode.Expand`：

```
scaleFactor = min(屏宽/参考宽, 屏高/参考高)
```

更吃紧的那条边决定缩放，参考矩形在任何宽高比下都完整放得下。画布两轴测量值仍 ≥ 参考尺寸，所以拉伸锚定的背景照常铺满，富余落在更宽松的那条边上，交给边缘锚定与 `<SafeArea>` 吸收。不需要朝向启发式，正方形参考也不再是特例。

顺带对齐了两条路径：`scale-mode="pixel"` 的 `PixelScaleSolver` 本来就是同一个 fit-inside `min()`（`PixelScaleSolver.cs:21`），只是额外做整数吸附——现在 auto 与 pixel 共用同一个基础公式，pixel 只是在它上面多一层取整。

`Nx` / `<r>r` 依赖的 `_canvasFactor` 同步换成 `Mathf.Min(...)`；顺带删掉 `size.x > 0` 的冗余守卫（`ReferenceSyntax` 在 parse 期已保证两维为正）。

## 测试

5 处 match 断言改成 `screenMatchMode`。新增两个用 `scale='1x'`（`localScale = 1/canvasFactor`）把 factor 暴露出来的用例——光断言枚举值证明不了取的是哪条边：

- `Auto_factor_scales_by_the_tighter_axis_on_a_tall_phone`：1080×1920 设计跑 1179×2556 → `localScale = 1080/1179`（锁宽）
- `Auto_factor_scales_by_the_tighter_axis_on_an_ultrawide_desktop`：1920×1080 设计跑 2560×1080 → `localScale = 1`（锁高）

其余 `CanvasSizeOverride` 测试用的画布尺寸都是参考分辨率的等比整数倍，`min()` 两轴同值，不受影响。

| 程序集 | 结果 |
|---|---|
| `PromptUGUI.Tests.EditMode` | 2640 / 2640 |
| `PromptUGUI.Tests.EditorOnly` | 308 / 308 |
| `PromptUGUI.Tests.PlayMode` | 171 / 171 |

`dotnet format --verify-no-changes --severity warn` 通过。

## 文档

master spec §5.6、XML skill 的 `reference=` 条目与 reserved-variant 说明（原文引用了已失效的 match 推断规则）、`BEST_PRACTICES.md` / `.zh.md`、`OrientationTracker` 与 `ScreenScaleModeTests` 里引用旧规则的注释，以及 RR 设计文档顶部的修订说明 + RR-D6 标记为已取代（RR-D7 的 `CanvasConfigurator` 逃生口不变）。

## 破坏性

默认视觉行为会变：设了 `reference=` 且实际宽高比与参考不同的 Screen，缩放系数和以前不一样（永远 ≤ 旧值，即 UI 不会变大只会变小/持平，换来的是不裁切）。要保留旧的锁边行为，走 `UI.CanvasConfigurator` 手设 `screenMatchMode = MatchWidthOrHeight` + `matchWidthOrHeight`。

## 已知未修

`CanvasConfigurator` 只在 `Open()` 时调用一次（`Screen.cs:132`），`ReSolve`（`Screen.cs:868`）和 canvas resize（`Screen.cs:600`）重跑 `ApplyCanvasScaler` 时不重调——所以 configurator 里改的 `screenMatchMode` 会在朝向切换 / variant 翻转后被打回 Expand。既有行为，与本次改动无关，等实际遇到再说。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfFCb9D4m1WL7Ji2JUpUy9
