### PR TITLE
feat: 内发光 innerGlow —— 程序化表面的第四层光

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -81,7 +81,7 @@ Pre-registered on `UI.Registry`. Use as XML tags by name. 速查目录如下；�
 
 | Tag | 用途 |
 |---|---|
-| `<Frame>` | 容器；可选程序化视觉（`color` / `radius` / `borderWidth` / `glow`）+ `mask="rect"` / `mask="self"`（裁成自绘形状）|
+| `<Frame>` | 容器；可选程序化视觉（`color` / `radius` / `borderWidth` / `glow` / `innerGlow`）+ `mask="rect"` / `mask="self"`（裁成自绘形状）|
 | `<SafeArea>` | 撑满父级、按设备安全区内缩（见本节末 **Safe area** 小节） |
 | `<Image>` | uGUI Image：sprite + 等比适配 + mask |
 | `<RawImage>` | uGUI RawImage：C# 设 Texture（动态图）+ contain/cover 适配 + mask |
@@ -109,7 +109,7 @@ Pre-registered on `UI.Registry`. Use as XML tags by name. 速查目录如下；�
 
 ### `<Frame>`
 
-Container. With none of the visual attributes below it is a bare `RectTransform` — no `Graphic`, no cost. Write any of them and Frame draws itself procedurally (rounded-rect SDF shader, no sprite): fill, corner radius, inner border, outer glow. Optional `RectMask2D` (`mask="rect"`), or a stencil clip to its own drawn shape (`mask="self"` — needs one of the visual attributes, since that is what gives the Frame a `Graphic`).
+Container. With none of the visual attributes below it is a bare `RectTransform` — no `Graphic`, no cost. Write any of them and Frame draws itself procedurally (rounded-rect SDF shader, no sprite): fill, corner radius, inner border, inner glow, outer glow. Optional `RectMask2D` (`mask="rect"`), or a stencil clip to its own drawn shape (`mask="self"` — needs one of the visual attributes, since that is what gives the Frame a `Graphic`).
 
 There is still **no `Image`** on a Frame, so `sprite=` does nothing (`PUI-CONTAINER-VISUAL-ATTR`) — use `<Image>` for sprite-based skins. A Frame never blocks clicks even when it draws; for a tinted clickable region use `<Btn>`.
 
@@ -124,6 +124,8 @@ There is still **no `Image`** on a Frame, so `sprite=` does nothing (`PUI-CONTAI
 | `borderColor` | hex / CSS / token / `/alpha`. **纯色 only** | `white` | 渐变值 = parse error |
 | `glow` | px | `0` | Outer glow radius. Inflates the drawn quad by this much (layout rect unchanged) |
 | `glowColor` | hex / CSS / token / `/alpha`. **纯色 only** | 跟随 `color` | Unset → the fill colour at full alpha, so `glow="12"` alone reads as "this shape glows" |
+| `innerGlow` | px | `0` | Inner glow — light falling off **inwards** from the outline. Pure material, so unlike `glow` it never touches the geometry |
+| `innerGlowColor` | hex / CSS / token / `/alpha`. **纯色 only** | `white` | Deliberately *not* the fill: an inner glow in the fill's own colour is invisible on an opaque fill. `/alpha` is the strength knob; a **dark** value is an inset shadow |
 | `glass` | `true` / `false` | `false` | Frosted-glass fill: the shape shows a blurred copy of the camera image instead of a flat colour. `color` becomes a tint on top of it. → `reference/glass.md` |
 | `frost` · `depth` · `dispersion` · `lightAngle` · `lightIntensity` · `saturation` · `noise` | 数值 | 见 glass.md | Glass tuning. Ignored without `glass="true"` (`PUI-GLASS-PARAM-NO-GLASS`) |
 | `weld` | px | `0` | Fuses this Frame's **direct glass children** into one continuous pane. → `reference/glass.md` |
@@ -132,7 +134,11 @@ There is still **no `Image`** on a Frame, so `sprite=` does nothing (`PUI-CONTAI
 <Frame color="surface/0.9" radius="16" borderWidth="1" borderColor="stroke/0.15"/>
 <Frame radius="pill" color="accent,accent-dark"/>          <!-- 胶囊 + 上下渐变 -->
 <Frame borderWidth="2" borderColor="#fff"/>                <!-- 无填充 = 空心描边框 -->
-<Frame color="danger" radius="20" glow="18"/>              <!-- 发光 -->
+<Frame color="danger" radius="20" glow="18"/>              <!-- 外发光 -->
+<Frame color="#c08f36" radius="hexagon 70" innerGlow="28"
+       innerGlowColor="#fff6cf" borderWidth="2"/>          <!-- 边缘被照亮的金属牌 -->
+<Frame color="surface" radius="12" innerGlow="20"
+       innerGlowColor="black/0.35"/>                       <!-- 深色 = 内阴影 / 边缘暗角 -->
 <Frame color="#1b263b" radius="0,0,16,16"/>                <!-- 只圆下面两角 -->
 <Frame color="accent" radius="cut 16"/>                    <!-- 四角 45° 斜切 -->
 <Frame color="accent" radius="hexagon"/>                   <!-- 左右收成尖的六边形 -->
@@ -142,7 +148,8 @@ There is still **no `Image`** on a Frame, so `sprite=` does nothing (`PUI-CONTAI
 </Frame>
 ```
 
-- Only `glow` is affected by a **祖先** `RectMask2D` clipping the extra quad away; a Frame's own `mask="rect"` / `mask="self"` clips its children, never itself.
+- Only `glow` is affected by a **祖先** `RectMask2D` clipping the extra quad away; a Frame's own `mask="rect"` / `mask="self"` clips its children, never itself. `innerGlow` paints strictly inside the shape, so nothing clips it and it costs no extra overdraw.
+- **`innerGlow` is measured from the shape edge**, and an inner border is painted on top of it. A thin translucent `borderColor` (`white/0.4` and friends) lets the glow continue seamlessly underneath; a thick opaque border covers the outermost `borderWidth` px of the band, so raise `innerGlow` to compensate.
 - `mask="self"` clips to the **shape**, not to what the Frame paints: an outer `glow` does not widen the clip, and a Frame with a `radius` but no `color` still clips (that is the invisible-clipper form above). So `radius=` alone is enough to define the mask.
 - Colour / radius / border changes are material-only — a Variant flip or a colour animation never rebuilds the canvas mesh. Frames sharing identical values (typically via `class=`) share one material and keep batching.
 - Layout-only containers (`<VStack>` / `<HStack>` / `<Grid>` / `<SafeArea>`) draw nothing — wrap them in a `<Frame>` for a background.
@@ -172,11 +179,11 @@ There is still **no `Image`** on a Frame, so `sprite=` does nothing (`PUI-CONTAI
 
 - **Mix freely per corner**: `radius="cut 16, 8, notch 8, 0"` is four different treatments.
 - **`pill` and `hexagon` are whole-shape keywords** — writing one inside a four-value list is a parse error. Both resolve against the live rect, so they follow a resizing panel on their own; `hexagon` in particular keeps its tips exactly at half height, which hand-written `cut` values would lose the moment the height changed.
-- **Border, glow, glass and `mask="self"` follow the new outline automatically** — no extra attributes, and an inner border keeps its width around a chamfer and around the inner corner of a notch.
+- **Border, both glows, glass and `mask="self"` follow the new outline automatically** — no extra attributes, and an inner border keeps its width around a chamfer and around the inner corner of a notch.
 - **One exception: `weld`.** A weld group fuses its members with a smooth union, which rounds every corner back off, so a welded block's treatment degrades to a plain round corner of the same reach. `PUI-WELD-CORNER` warns; see `reference/glass.md`.
 - Keywords are lower-case. `bevel` / `scoop` / `CUT` are parse errors that name the legal words.
 
-> **Which tags draw procedurally.** `radius` / `borderWidth` / `borderColor` / `glow` / `glowColor` / `glass` (+ its tuning params) work on **`<Frame>`, `<Btn>`, `<Tab>`, `<Toggle>`, `<Slider>`, `<Dropdown>`, `<InputField>`, `<ScrollList>` and `<Progress>`** — see **Procedural surfaces** below for what they do on a control.
+> **Which tags draw procedurally.** `radius` / `borderWidth` / `borderColor` / `glow` / `glowColor` / `innerGlow` / `innerGlowColor` / `glass` (+ its tuning params) work on **`<Frame>`, `<Btn>`, `<Tab>`, `<Toggle>`, `<Slider>`, `<Dropdown>`, `<InputField>`, `<ScrollList>` and `<Progress>`** — see **Procedural surfaces** below for what they do on a control.
 >
 > On any other tag — `<Image>`, `<RawImage>`, `<Text>`, `<Icon>`, `<TabBar>`, `<Carousel>`, `<Markdown>` — they are accepted by the parser and then silently dropped; `PUI-CONTAINER-VISUAL-ATTR` is the only thing that tells you. (`<Image>` / `<RawImage>` are deliberate: a sprite is their whole point, and a procedural rectangle is what `<Frame>` is for.)
 >
@@ -278,7 +285,7 @@ Image + Button + R3 `OnClick` / `OnState`。`<Btn>开始</Btn>` 简写生成内�
 | `tr` | bool | `true` | `false`=跳过 i18n |
 | `ctx` | string | — | msgctxt 消歧 |
 | `tint` | `multiply` / `linear` | — | 见 **Tint blend modes** |
-| `radius` · `borderWidth` · `borderColor` · `glow` · `glowColor` · `glass` (+ 玻璃调参) | 同 `<Frame>` | — | **程序化表面**，见下节 |
+| `radius` · `borderWidth` · `borderColor` · `glow` · `glowColor` · `innerGlow` · `innerGlowColor` · `glass` (+ 玻璃调参) | 同 `<Frame>` | — | **程序化表面**，见下节 |
 
 ### 程序化表面（`<Frame>` 之外的控件）
 
@@ -288,6 +295,8 @@ Image + Button + R3 `OnClick` / `OnState`。`<Btn>开始</Btn>` 简写生成内�
 <Btn radius="pill" color="accent" hoverColor="accent-light">确定</Btn>
 <Btn radius="12" glass="true" borderWidth="1" borderColor="white/0.5">玻璃按钮</Btn>
 <Tab radius="cut 14, cut 14, 0, 0">主页</Tab>                              <!-- 梯形页签 -->
+<Btn radius="hexagon 70" color="#efdca6,#c08f36" innerGlow="30"
+     innerGlowColor="#fff6cf" borderWidth="2" glow="36">开始匹配</Btn>       <!-- 发光金属牌 -->
 <Style name="skin" radius="10" borderWidth="1" borderColor="white/0.4"/>   <!-- 一个包换整套 -->
 ```
 
@@ -621,7 +630,7 @@ Other notes:
 **不变量与易踩坑**
 
 - 容器根上**都没有** `Image`,所以 `sprite=` 在它们上面一律无效。要 **sprite 底图**有两种写法,**优先用前者**:(1) 背景区域跟内容同区 → 直接拿 `<Image>` 当容器: `<Image sprite="...">...content...</Image>`(`<Image>` 是普通 Control,允许子节点,少一层节点);(2) 背景比内容更大(整屏底图 + 居中面板这类) → `<Image anchor="stretch"/>` 当**兄弟**放在内容之前(`<SafeArea>` 是唯一不可见还必须用兄弟模式的特例,因为它的 RectTransform 已经被 safeArea 偏移占用)。
-- 要**纯色 / 圆角 / 描边 / 发光**这类无图素底,直接写在 `<Frame>` 上(`color` / `radius` / `borderWidth` / `glow`,见 `<Frame>` 小节)——`<Frame>` 自己会画。`<*Stack>` / `<Grid>` / `<SafeArea>` 仍然只管排版、画不出任何东西,要底就外面套一层 `<Frame>`。
+- 要**纯色 / 圆角 / 描边 / 内外发光**这类无图素底,直接写在 `<Frame>` 上(`color` / `radius` / `borderWidth` / `glow` / `innerGlow`,见 `<Frame>` 小节)——`<Frame>` 自己会画。`<*Stack>` / `<Grid>` / `<SafeArea>` 仍然只管排版、画不出任何东西,要底就外面套一层 `<Frame>`。
 - `<Btn>` 的 Label 是 lazy：写 `<Btn/>`（无 `text=`、无子 `<Text>`、无内联文本）不会有 Label 子 GO；之后 C# 设 `BtnInstance.Text = "x"` 才会现场补一个。
 - `<Toggle>` 的 `targetGraphic` / `graphic` 在 `OnAttached` 内已绑死（Background / Checkmark），外部别再设；`group=` 不直接绑 Unity `ToggleGroup`，而是落到 `Screen.ToggleGroups.GetOrCreate(name)` 这个 Screen 范围的共享池里。
 - `<ScrollList>` 的 item 子节点在 `OnAttached` 阶段是空的，必须在 C# 端 `BindItems(observable, (slot, item) => ...)` 之后才出现；hot-reload 后也要重新 Bind。

--- a/.claude/skills/authoring-promptugui-xml/reference/glass.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/glass.md
@@ -2,7 +2,7 @@
 
 A glass Frame shows a blurred copy of the camera image inside its shape, with light catching its
 edges. It is the same rounded-rect SDF as a normal procedural Frame — `radius`, `borderWidth`,
-`glow` all behave identically — only the *fill* changes.
+`glow`, `innerGlow` all behave identically — only the *fill* changes.
 
 The look it aims at is a thin, flat frosted sheet (Figma-style glass), not a thick liquid lens. The
 interior is deliberately flat: refraction and lighting happen only within `depth` pixels of the edge.
@@ -47,7 +47,9 @@ attribute. Writing any of them without `glass="true"` is a lint error
 | `noise` | `0`–`1` | `0.02` | Frosted grain. Doubles as dithering against banding on large blurred areas |
 
 Reused unchanged: `color` (tint painted over the glass — comma gradients and `/alpha` work exactly as
-elsewhere), `radius`, `borderWidth` / `borderColor`, `glow` / `glowColor`.
+elsewhere), `radius`, `borderWidth` / `borderColor`, `glow` / `glowColor`,
+`innerGlow` / `innerGlowColor` (painted over the tint, so it lights the pane's edge without touching
+the backdrop it samples).
 
 Keep the tint alpha low (`white/0.06`, `#39f/0.15`). A tint at high alpha stops reading as glass and
 starts reading as a coloured panel with a blur behind it.
@@ -108,7 +110,7 @@ Where each parameter goes:
 
 | 写在 | 参数 |
 |---|---|
-| 容器（带 `weld` 的 Frame） | `frost` `dispersion` `lightAngle` `lightIntensity` `saturation` `noise`, and `borderWidth` / `borderColor` / `glow` / `glowColor` for the fused outline |
+| 容器（带 `weld` 的 Frame） | `frost` `dispersion` `lightAngle` `lightIntensity` `saturation` `noise`, and `borderWidth` / `borderColor` / `glow` / `glowColor` / `innerGlow` / `innerGlowColor` for the fused outline |
 | 每个玻璃子级 | `radius` `depth` `color` |
 
 The split is physical, not arbitrary: two halves of one continuous pane cannot be frosted differently
@@ -191,8 +193,8 @@ the structural codes above stay quiet rather than guess.
 
 ## When there is no backdrop
 
-Glass degrades to a plain translucent panel — the shape, tint, border and glow still draw, the blur
-does not — whenever:
+Glass degrades to a plain translucent panel — the shape, tint, border and both glows still draw, the
+blur does not — whenever:
 
 - the project has no URP ≥ 17 (the capture pass does not even compile in);
 - URP is installed but is not the active render pipeline;

--- a/Editor/XsdGenerator.cs
+++ b/Editor/XsdGenerator.cs
@@ -93,6 +93,8 @@ namespace PromptUGUI.Editor
                     ("borderColor", "xs:string", (string)null),
                     ("glow", "xs:string", (string)null),
                     ("glowColor", "xs:string", (string)null),
+                    ("innerGlow", "xs:string", (string)null),
+                    ("innerGlowColor", "xs:string", (string)null),
                     ("glass", "xs:string", (string)null),
                     ("frost", "xs:string", (string)null),
                     ("depth", "xs:string", (string)null),

--- a/Runtime/Controls/Frame.cs
+++ b/Runtime/Controls/Frame.cs
@@ -165,6 +165,23 @@ namespace PromptUGUI.Controls
             set => Panel.SetGlowColor(UI.Theme.Resolve(value));
         }
 
+        /// <summary>内发光宽度（px，从形状边缘向内衰减）。不改几何，也不影响布局。</summary>
+        [UIAttr, Preserve]
+        public string InnerGlow
+        {
+            set => Panel.SetInnerGlowSize(ProceduralValueParser.Pixels(value, "innerGlow"));
+        }
+
+        /// <summary>
+        /// 内发光色。纯色 only；默认白 —— 跟随填充色的话，在不透明填充上会完全看不见。
+        /// 写深色即内阴影 / 边缘暗角。
+        /// </summary>
+        [UIAttr, Preserve]
+        public string InnerGlowColor
+        {
+            set => Panel.SetInnerGlowColor(UI.Theme.Resolve(value));
+        }
+
         /// <summary>
         /// 玻璃模式：填充改为采样模糊后的 backdrop + 边缘折射 / 打光，形状仍是同一套 SDF。
         /// 见 <c>UI.Glass</c>：没有可用 backdrop（无 URP / 关闭画质选项 / 无相机）时自动退化成

--- a/Runtime/Controls/Internal/GlassGroupPanel.cs
+++ b/Runtime/Controls/Internal/GlassGroupPanel.cs
@@ -42,6 +42,8 @@ namespace PromptUGUI.Controls.Internal
         private static readonly int BorderWidthId = Shader.PropertyToID("_BorderWidth");
         private static readonly int GlowColorId = Shader.PropertyToID("_GlowColor");
         private static readonly int GlowSizeId = Shader.PropertyToID("_GlowSize");
+        private static readonly int InnerGlowColorId = Shader.PropertyToID("_InnerGlowColor");
+        private static readonly int InnerGlowSizeId = Shader.PropertyToID("_InnerGlowSize");
         private static readonly int GlassAId = Shader.PropertyToID("_GlassA");
         private static readonly int GlassBId = Shader.PropertyToID("_GlassB");
 
@@ -330,13 +332,15 @@ namespace PromptUGUI.Controls.Internal
             _material.SetVector(GlassBId,
                 new Vector4(Mathf.Sin(rad), Mathf.Cos(rad), intensity, saturation));
 
-            // Border and glow follow the fused outline, so they are the container's — a per-block
-            // border would draw exactly the dividing line the weld exists to remove.
+            // Border and both glows follow the fused outline, so they are the container's — a
+            // per-block one would draw exactly the dividing line the weld exists to remove.
             var c = _container != null ? _container.CurrentParams : default;
             _material.SetColor(BorderColorId, _container != null ? c.BorderColor : Color.white);
             _material.SetFloat(BorderWidthId, _container != null ? c.BorderWidth : 0f);
             _material.SetColor(GlowColorId, _container != null ? c.GlowColor : Color.white);
             _material.SetFloat(GlowSizeId, _container != null ? c.GlowSize : 0f);
+            _material.SetColor(InnerGlowColorId, _container != null ? c.InnerGlowColor : Color.white);
+            _material.SetFloat(InnerGlowSizeId, _container != null ? c.InnerGlowSize : 0f);
         }
 
         private void EnsureMaterial()

--- a/Runtime/Controls/Internal/ProceduralMaterialCache.cs
+++ b/Runtime/Controls/Internal/ProceduralMaterialCache.cs
@@ -74,6 +74,12 @@ namespace PromptUGUI.Controls.Internal
         public readonly Color FillBottom;
         public readonly Color BorderColor;
         public readonly Color GlowColor;
+        /// <summary>
+        /// Inner glow tint. Unlike <see cref="GlowColor"/> it does NOT fall back to the fill — an
+        /// inner glow in the fill's own colour is invisible on an opaque fill, which is the common
+        /// case, so the default is plain white (spec 2026-08-28 §5.4).
+        /// </summary>
+        public readonly Color InnerGlowColor;
         /// <summary>Per-corner horizontal reach in CSS order; the radius when the corner is round.</summary>
         public readonly Vector4 CornerWidth;
         /// <summary>Per-corner vertical reach in CSS order; mirrors the width for a round corner.</summary>
@@ -85,6 +91,8 @@ namespace PromptUGUI.Controls.Internal
         public readonly float HexWidth;
         public readonly float BorderWidth;
         public readonly float GlowSize;
+        /// <summary>Inner glow band width, measured inwards from the shape edge.</summary>
+        public readonly float InnerGlowSize;
         public readonly bool Glass;
         public readonly GlassParams GlassParams;
 
@@ -94,13 +102,15 @@ namespace PromptUGUI.Controls.Internal
         /// rect, which is what keeps two same-styled panels of different sizes on one material.
         /// </summary>
         public PanelParams(Color fillTop, Color fillBottom, Color borderColor, Color glowColor,
-                           in RadiusSpec radius, float borderWidth, float glowSize,
+                           Color innerGlowColor, in RadiusSpec radius, float borderWidth,
+                           float glowSize, float innerGlowSize,
                            bool glass = false, GlassParams glassParams = default)
         {
             FillTop = fillTop;
             FillBottom = fillBottom;
             BorderColor = borderColor;
             GlowColor = glowColor;
+            InnerGlowColor = innerGlowColor;
             CornerWidth = new Vector4(radius.TopLeftCorner.Width, radius.TopRightCorner.Width,
                                       radius.BottomRightCorner.Width, radius.BottomLeftCorner.Width);
             CornerHeight = new Vector4(radius.TopLeftCorner.Height, radius.TopRightCorner.Height,
@@ -111,6 +121,7 @@ namespace PromptUGUI.Controls.Internal
             HexWidth = radius.HexWidth;
             BorderWidth = borderWidth;
             GlowSize = glowSize;
+            InnerGlowSize = innerGlowSize;
             Glass = glass;
             GlassParams = glassParams;
         }
@@ -120,9 +131,11 @@ namespace PromptUGUI.Controls.Internal
         public bool Equals(PanelParams o) =>
             FillTop == o.FillTop && FillBottom == o.FillBottom
             && BorderColor == o.BorderColor && GlowColor == o.GlowColor
+            && InnerGlowColor == o.InnerGlowColor
             && CornerWidth == o.CornerWidth && CornerHeight == o.CornerHeight
             && CornerKinds == o.CornerKinds && Shape == o.Shape && HexWidth == o.HexWidth
             && BorderWidth == o.BorderWidth && GlowSize == o.GlowSize
+            && InnerGlowSize == o.InnerGlowSize
             && Glass == o.Glass
             // Short-circuit: an opaque panel's glass block is always None, so there is nothing to
             // compare — and opaque is the overwhelmingly common case.
@@ -138,6 +151,7 @@ namespace PromptUGUI.Controls.Internal
                 h = (h * 397) ^ FillBottom.GetHashCode();
                 h = (h * 397) ^ BorderColor.GetHashCode();
                 h = (h * 397) ^ GlowColor.GetHashCode();
+                h = (h * 397) ^ InnerGlowColor.GetHashCode();
                 h = (h * 397) ^ CornerWidth.GetHashCode();
                 h = (h * 397) ^ CornerHeight.GetHashCode();
                 h = (h * 397) ^ CornerKinds.GetHashCode();
@@ -145,6 +159,7 @@ namespace PromptUGUI.Controls.Internal
                 h = (h * 397) ^ HexWidth.GetHashCode();
                 h = (h * 397) ^ BorderWidth.GetHashCode();
                 h = (h * 397) ^ GlowSize.GetHashCode();
+                h = (h * 397) ^ InnerGlowSize.GetHashCode();
                 h = (h * 397) ^ Glass.GetHashCode();
                 if (Glass) h = (h * 397) ^ GlassParams.GetHashCode();
                 return h;
@@ -177,6 +192,7 @@ namespace PromptUGUI.Controls.Internal
         private static readonly int FillBottomId = Shader.PropertyToID("_FillBottom");
         private static readonly int BorderColorId = Shader.PropertyToID("_BorderColor");
         private static readonly int GlowColorId = Shader.PropertyToID("_GlowColor");
+        private static readonly int InnerGlowColorId = Shader.PropertyToID("_InnerGlowColor");
         private static readonly int RadiusId = Shader.PropertyToID("_Radius");
         private static readonly int CornerHeightId = Shader.PropertyToID("_CornerH");
         private static readonly int CornerKindId = Shader.PropertyToID("_CornerKind");
@@ -184,6 +200,7 @@ namespace PromptUGUI.Controls.Internal
         private static readonly int HexWidthId = Shader.PropertyToID("_HexW");
         private static readonly int BorderWidthId = Shader.PropertyToID("_BorderWidth");
         private static readonly int GlowSizeId = Shader.PropertyToID("_GlowSize");
+        private static readonly int InnerGlowSizeId = Shader.PropertyToID("_InnerGlowSize");
 
         // Seven glass floats ride two vectors: fewer SetX calls, and the light angle arrives as a
         // direction so the shader never runs sin/cos per fragment.
@@ -258,6 +275,7 @@ namespace PromptUGUI.Controls.Internal
             mat.SetColor(FillBottomId, p.FillBottom);
             mat.SetColor(BorderColorId, p.BorderColor);
             mat.SetColor(GlowColorId, p.GlowColor);
+            mat.SetColor(InnerGlowColorId, p.InnerGlowColor);
             mat.SetVector(RadiusId, p.CornerWidth);
             mat.SetVector(CornerHeightId, p.CornerHeight);
             mat.SetVector(CornerKindId, p.CornerKinds);
@@ -265,6 +283,7 @@ namespace PromptUGUI.Controls.Internal
             mat.SetFloat(HexWidthId, p.HexWidth);
             mat.SetFloat(BorderWidthId, p.BorderWidth);
             mat.SetFloat(GlowSizeId, p.GlowSize);
+            mat.SetFloat(InnerGlowSizeId, p.InnerGlowSize);
             if (!p.Glass) return;
 
             var g = p.GlassParams;

--- a/Runtime/Controls/Internal/ProceduralPanel.cs
+++ b/Runtime/Controls/Internal/ProceduralPanel.cs
@@ -6,8 +6,8 @@ using UnityEngine.UI;
 namespace PromptUGUI.Controls.Internal
 {
     /// <summary>
-    /// Draws a rounded rectangle — fill (optionally a vertical gradient), inner border and outer
-    /// glow — straight from a signed distance field, with no sprite involved. With
+    /// Draws a rounded rectangle — fill (optionally a vertical gradient), inner border, inner glow
+    /// and outer glow — straight from a signed distance field, with no sprite involved. With
     /// <c>glass="true"</c> the fill becomes a blurred sample of the captured backdrop plus edge
     /// refraction and lighting; the shape, border and glow are the same SDF either way. Lazily
     /// attached by <see cref="Frame"/> the first time the author writes one of the procedural visual
@@ -18,8 +18,8 @@ namespace PromptUGUI.Controls.Internal
     /// <item>Colour / radius / border / glow-colour changes touch only the material, so a Variant
     /// flip or a colour tween never rebuilds the canvas mesh.</item>
     /// <item>Attribute writes only flag the material dirty; the parameters are resolved once per
-    /// canvas rebuild (see <see cref="FlushParams"/>), so applying fourteen attributes at
-    /// instantiation costs one material lookup, not fourteen.</item>
+    /// canvas rebuild (see <see cref="FlushParams"/>), so applying sixteen attributes at
+    /// instantiation costs one material lookup, not sixteen.</item>
     /// <item>Geometry is dirtied only when the glow radius (which inflates the quad) or overall
     /// visibility changes.</item>
     /// <item>A fully transparent panel emits no geometry at all — zero overdraw, which is the
@@ -40,9 +40,13 @@ namespace PromptUGUI.Controls.Internal
         private Color _borderColor = Color.white;
         private Color _glowColor = Color.white;
         private bool _glowColorExplicit;
+        // No "explicit" twin: unlike the outer glow this one does not fall back to the fill, so
+        // white IS the default rather than a stand-in for one (spec 2026-08-28 §5.4).
+        private Color _innerGlowColor = Color.white;
         private RadiusSpec _radius = RadiusSpec.Zero;
         private float _borderWidth;
         private float _glowSize;
+        private float _innerGlowSize;
 
         private bool _glass;
         private float _frost = GlassAttrParser.DefaultFrost;
@@ -186,6 +190,18 @@ namespace PromptUGUI.Controls.Internal
             MarkDirty();
         }
 
+        public void SetInnerGlowSize(float size)
+        {
+            _innerGlowSize = Mathf.Max(0f, size);
+            MarkDirty();
+        }
+
+        public void SetInnerGlowColor(Color color)
+        {
+            _innerGlowColor = color;
+            MarkDirty();
+        }
+
         public void SetGlass(bool glass)
         {
             if (_glass == glass) return;
@@ -271,6 +287,7 @@ namespace PromptUGUI.Controls.Internal
             var fillTop = _fillTop;
             var fillBottom = _fillBottom;
             var border = _borderColor;
+            var innerGlow = _innerGlowColor;
             if (_grayed)
             {
                 // Disabled greying has to happen HERE, inside the parameters, not by swapping the
@@ -282,6 +299,7 @@ namespace PromptUGUI.Controls.Internal
                 fillBottom = Desaturate(fillBottom);
                 border = Desaturate(border);
                 glow = Desaturate(glow);
+                innerGlow = Desaturate(innerGlow);
                 if (_glass)
                     // Grey glass AND thin glass: dropping saturation alone still reads as a live,
                     // refracting pane. A disabled control should look inert, so the bevel goes too.
@@ -290,8 +308,8 @@ namespace PromptUGUI.Controls.Internal
                                                   0f, _noise);
             }
 
-            return new PanelParams(fillTop, fillBottom, border, glow, _radius,
-                                   _borderWidth, _glowSize, _glass, glassParams);
+            return new PanelParams(fillTop, fillBottom, border, glow, innerGlow, _radius,
+                                   _borderWidth, _glowSize, _innerGlowSize, _glass, glassParams);
         }
 
         /// <summary>
@@ -364,6 +382,9 @@ namespace PromptUGUI.Controls.Internal
             if (_fillTop.a > 0f || _fillBottom.a > 0f) return true;
             if (_borderWidth > 0f && _borderColor.a > 0f) return true;
             if (_glowSize > 0f) return true;
+            // A ring of light with no fill behind it is a legitimate look, same standing as the
+            // border-only hollow box above.
+            if (_innerGlowSize > 0f && _innerGlowColor.a > 0f) return true;
             return false;
         }
 
@@ -379,7 +400,7 @@ namespace PromptUGUI.Controls.Internal
         /// <summary>
         /// Records that the parameters changed, without touching the material. Resolving is deferred
         /// to <see cref="FlushParams"/> so a run of attribute writes — instantiation applies up to
-        /// fourteen of them — collapses into a single cache lookup.
+        /// sixteen of them — collapses into a single cache lookup.
         /// </summary>
         private void MarkDirty()
         {

--- a/Runtime/Controls/ProceduralControl.cs
+++ b/Runtime/Controls/ProceduralControl.cs
@@ -9,7 +9,7 @@ namespace PromptUGUI.Controls
 {
     /// <summary>
     /// A control whose primary surface can be drawn procedurally instead of by an <c>Image</c> —
-    /// the same rounded-rect SDF (fill / border / glow / glass) <c>&lt;Frame&gt;</c> draws, so a
+    /// the same rounded-rect SDF (fill / border / glows / glass) <c>&lt;Frame&gt;</c> draws, so a
     /// theme can swap a control's <em>shape</em> and not just its colours.
     ///
     /// <para>Declaring any of the attributes below lazily attaches a <see cref="ProceduralSurface"/>;
@@ -24,7 +24,7 @@ namespace PromptUGUI.Controls
     /// <remarks>
     /// The attributes are declared once here rather than per control because
     /// <c>ControlMeta.Build</c> reflects with <c>BindingFlags.Public | BindingFlags.Instance</c>,
-    /// which includes inherited properties — so a subclass gets all thirteen for free.
+    /// which includes inherited properties — so a subclass gets all fifteen for free.
     /// </remarks>
     public abstract class ProceduralControl : Control
     {
@@ -133,6 +133,20 @@ namespace PromptUGUI.Controls
         public string GlowColor
         {
             set { var v = UI.Theme.Resolve(value); Surface.Declare(p => p.SetGlowColor(v)); }
+        }
+
+        /// <summary>内发光宽度（px，从形状边缘向内衰减）。不改几何。</summary>
+        [UIAttr, Preserve]
+        public string InnerGlow
+        {
+            set { var v = ProceduralValueParser.Pixels(value, "innerGlow"); Surface.Declare(p => p.SetInnerGlowSize(v)); }
+        }
+
+        /// <summary>内发光色。纯色 only；默认白。写深色即内阴影。</summary>
+        [UIAttr, Preserve]
+        public string InnerGlowColor
+        {
+            set { var v = UI.Theme.Resolve(value); Surface.Declare(p => p.SetInnerGlowColor(v)); }
         }
 
         /// <summary>玻璃模式：填充改为采样模糊后的 backdrop + 边缘折射 / 打光。</summary>

--- a/Runtime/Core/Lint/GlassRules.cs
+++ b/Runtime/Core/Lint/GlassRules.cs
@@ -41,7 +41,7 @@ namespace PromptUGUI.Lint
         {
             GlassAttrParser.Frost, GlassAttrParser.Dispersion, GlassAttrParser.LightAngle,
             GlassAttrParser.LightIntensity, GlassAttrParser.Saturation, GlassAttrParser.Noise,
-            "borderWidth", "borderColor", "glow", "glowColor",
+            "borderWidth", "borderColor", "glow", "glowColor", "innerGlow", "innerGlowColor",
         };
 
         /// <summary>

--- a/Runtime/Core/Lint/ProceduralAttrNames.cs
+++ b/Runtime/Core/Lint/ProceduralAttrNames.cs
@@ -22,6 +22,7 @@ namespace PromptUGUI.Lint
         public static readonly string[] PanelAttaching =
         {
             "color", "radius", "borderWidth", "borderColor", "glow", "glowColor",
+            "innerGlow", "innerGlowColor",
             "glass", "frost", "depth", "dispersion", "lightAngle", "lightIntensity",
             "saturation", "noise",
         };
@@ -36,6 +37,7 @@ namespace PromptUGUI.Lint
         public static readonly string[] All =
         {
             "color", "radius", "borderWidth", "borderColor", "glow", "glowColor",
+            "innerGlow", "innerGlowColor",
             "glass", "frost", "depth", "dispersion", "lightAngle", "lightIntensity",
             "saturation", "noise", "weld",
         };
@@ -66,6 +68,7 @@ namespace PromptUGUI.Lint
         public static readonly string[] NeedsPanel =
         {
             "radius", "borderWidth", "borderColor", "glow", "glowColor",
+            "innerGlow", "innerGlowColor",
             "glass", "frost", "depth", "dispersion", "lightAngle", "lightIntensity",
             "saturation", "noise", "weld",
         };

--- a/Runtime/Core/Lint/StyleRules.cs
+++ b/Runtime/Core/Lint/StyleRules.cs
@@ -22,7 +22,7 @@ namespace PromptUGUI.Lint
         private static readonly char[] ClassSeparators = { ' ', '\t', '\n', '\r' };
 
         /// <summary>Attributes parsed as a plain non-negative pixel count.</summary>
-        private static readonly string[] PixelAttrs = { "borderWidth", "glow" };
+        private static readonly string[] PixelAttrs = { "borderWidth", "glow", "innerGlow" };
 
         public static IEnumerable<LintIssue> Check(ElementNode n)
         {

--- a/Runtime/Resources/PromptUGUI/Material/UI-GlassGroup.shader
+++ b/Runtime/Resources/PromptUGUI/Material/UI-GlassGroup.shader
@@ -14,8 +14,10 @@ Shader "UI/GlassGroup"
 
         _BorderColor ("Border Color", Color) = (1,1,1,1)
         _GlowColor   ("Glow Color",   Color) = (1,1,1,1)
+        _InnerGlowColor ("Inner Glow Color", Color) = (1,1,1,1)
         _BorderWidth ("Border Width",  Float) = 0
         _GlowSize    ("Glow Size",     Float) = 0
+        _InnerGlowSize ("Inner Glow Size", Float) = 0
         _Weld        ("Weld Radius",   Float) = 8
 
         _GlassA ("frost / _ / dispersion / noise", Vector) = (0.5, 0, 0, 0.02)
@@ -98,8 +100,10 @@ Shader "UI/GlassGroup"
 
             fixed4 _BorderColor;
             fixed4 _GlowColor;
+            fixed4 _InnerGlowColor;
             float _BorderWidth;
             float _GlowSize;
+            float _InnerGlowSize;
             float _Weld;
             float4 _GlassA;
             float4 _GlassB;
@@ -258,13 +262,13 @@ Shader "UI/GlassGroup"
                 tint.a *= inside;
                 float4 col = PuguiOver(tint, base);
 
-                if (_GlowSize > 0.0)
-                {
-                    float g = saturate(1.0 - d / _GlowSize);
-                    float4 glow = _GlowColor;
-                    glow.a *= g * g * (1.0 - inside);
-                    col = PuguiOver(col, glow);
-                }
+                // 内发光：外发光的镜像 —— 画在形状内侧、压在填充之上。
+                // 排在外发光之前，让外发光的 under 合成看到「填充 + 内发光」这一个完整实心体
+                // （两者除 AA 那一像素外并不相交，所以顺序只影响那一像素）。
+                col = PuguiApplyInnerGlow(col, d, inside, _InnerGlowSize, _InnerGlowColor);
+
+                // 外发光：仅在形状外侧衰减。
+                col = PuguiApplyOuterGlow(col, d, inside, _GlowSize, _GlowColor);
 
                 // 保底描边沿融合后的外轮廓走，交界内部自然没有它 —— 这正是要的效果。
                 if (_BorderWidth > 0.0)

--- a/Runtime/Resources/PromptUGUI/Material/UI-GlassPanel.shader
+++ b/Runtime/Resources/PromptUGUI/Material/UI-GlassPanel.shader
@@ -18,6 +18,7 @@ Shader "UI/GlassPanel"
         _FillBottom  ("Fill Bottom",  Color) = (0,0,0,0)
         _BorderColor ("Border Color", Color) = (1,1,1,1)
         _GlowColor   ("Glow Color",   Color) = (1,1,1,1)
+        _InnerGlowColor ("Inner Glow Color", Color) = (1,1,1,1)
 
         // 四个逐角向量一律是 xyzw = top-left, top-right, bottom-right, bottom-left
         // （CSS border-radius 顺序）。_Radius 是每个角的**水平**伸出量，圆角时即半径。
@@ -29,6 +30,7 @@ Shader "UI/GlassPanel"
         _HexW        ("Hexagon Tip Reach (0 = auto)", Float) = 0
         _BorderWidth ("Border Width",  Float) = 0
         _GlowSize    ("Glow Size",     Float) = 0
+        _InnerGlowSize ("Inner Glow Size", Float) = 0
 
         // 七个玻璃参数打包成两个向量：少几次 SetX，且光照角在 CPU 侧就化成方向，
         // fragment 里不用跑 sin/cos。
@@ -114,6 +116,7 @@ Shader "UI/GlassPanel"
             fixed4 _FillBottom;
             fixed4 _BorderColor;
             fixed4 _GlowColor;
+            fixed4 _InnerGlowColor;
             float4 _Radius;
             float4 _CornerH;
             float4 _CornerKind;
@@ -121,6 +124,7 @@ Shader "UI/GlassPanel"
             float _HexW;
             float _BorderWidth;
             float _GlowSize;
+            float _InnerGlowSize;
             float4 _GlassA;
             float4 _GlassB;
 
@@ -235,14 +239,13 @@ Shader "UI/GlassPanel"
                 tint.a *= inside;
                 float4 col = PuguiOver(tint, base);
 
+                // 内发光：外发光的镜像 —— 画在形状内侧、压在填充之上。
+                // 排在外发光之前，让外发光的 under 合成看到「填充 + 内发光」这一个完整实心体
+                // （两者除 AA 那一像素外并不相交，所以顺序只影响那一像素）。
+                col = PuguiApplyInnerGlow(col, d, inside, _InnerGlowSize, _InnerGlowColor);
+
                 // 外发光：仅在形状外侧衰减。
-                if (_GlowSize > 0.0)
-                {
-                    float g = saturate(1.0 - d / _GlowSize);
-                    float4 glow = _GlowColor;
-                    glow.a *= g * g * (1.0 - inside);
-                    col = PuguiOver(col, glow);
-                }
+                col = PuguiApplyOuterGlow(col, d, inside, _GlowSize, _GlowColor);
 
                 // 内描边：低对比背景下物理高光会消失，而 UI 的边界不能跟着消失 —— 这一层是保底。
                 if (_BorderWidth > 0.0)

--- a/Runtime/Resources/PromptUGUI/Material/UI-PanelSDF.cginc
+++ b/Runtime/Resources/PromptUGUI/Material/UI-PanelSDF.cginc
@@ -217,6 +217,38 @@ float4 PuguiOver(float4 src, float4 dst)
     return float4(rgb, a);
 }
 
+// ---- 两层发光 ----
+//
+// 三个面板 shader（不透明 / 玻璃 / 融合）逐字共用这两个函数，而不是各抄一份四行 ——
+// 内外发光必须是**同一条曲线的镜像**：glow 与 innerGlow 等宽时，读起来要是跨越边缘的一整圈
+// 对称光晕，而不是两种手感的光拼在一起。三份复制迟早会漂移成后者。
+//
+// size == 0 必须整段跳过。这是 uniform 分支，全体 fragment 走同一条路径，开销可忽略。
+
+// 外发光：只在形状**外侧**（d > 0）衰减，画在已有内容的**下面**。
+// 平方让边缘更快收住，更像光晕而不是色块。
+float4 PuguiApplyOuterGlow(float4 col, float d, float inside, float size, float4 color)
+{
+    if (size <= 0.0) return col;
+    float g = saturate(1.0 - d / size);
+    color.a *= g * g * (1.0 - inside);
+    return PuguiOver(col, color);
+}
+
+// 内发光：只在形状**内侧**（-size < d < 0）衰减，画在填充之**上**。
+//
+// 起点是形状边缘 d = 0，不是描边内沿（Photoshop Inner Glow 语义）：库里最常见的细半透明描边
+// （white/0.4 之流）下，发光会延续到描边底下、边缘无缝；改成从描边内沿量，那个常见配置里
+// 描边带就会比紧邻的发光暗，边缘冒出一条 1px 暗缝。粗不透明描边会盖掉最外几 px，作者把数值
+// 调大即可 —— 用一个罕见配置的精度换一个常见配置的正确。
+float4 PuguiApplyInnerGlow(float4 col, float d, float inside, float size, float4 color)
+{
+    if (size <= 0.0) return col;
+    float g = saturate(1.0 + d / size);
+    color.a *= g * g * inside;
+    return PuguiOver(color, col);
+}
+
 // ---- 装饰原语（<Decor>）的形状层 ----
 //
 // 三个形状都在**规范朝向**里定义：bracket 抱住自己包围盒的左上角，tick 尖端朝下。

--- a/Runtime/Resources/PromptUGUI/Material/UI-ProceduralPanel.shader
+++ b/Runtime/Resources/PromptUGUI/Material/UI-ProceduralPanel.shader
@@ -16,6 +16,7 @@ Shader "UI/ProceduralPanel"
         _FillBottom  ("Fill Bottom",  Color) = (0,0,0,0)
         _BorderColor ("Border Color", Color) = (1,1,1,1)
         _GlowColor   ("Glow Color",   Color) = (1,1,1,1)
+        _InnerGlowColor ("Inner Glow Color", Color) = (1,1,1,1)
 
         // 四个逐角向量一律是 xyzw = top-left, top-right, bottom-right, bottom-left
         // （CSS border-radius 顺序）。_Radius 是每个角的**水平**伸出量，圆角时即半径。
@@ -27,6 +28,7 @@ Shader "UI/ProceduralPanel"
         _HexW        ("Hexagon Tip Reach (0 = auto)", Float) = 0
         _BorderWidth ("Border Width",  Float) = 0
         _GlowSize    ("Glow Size",     Float) = 0
+        _InnerGlowSize ("Inner Glow Size", Float) = 0
 
         _StencilComp ("Stencil Comparison", Float) = 8
         _Stencil ("Stencil ID", Float) = 0
@@ -106,6 +108,7 @@ Shader "UI/ProceduralPanel"
             fixed4 _FillBottom;
             fixed4 _BorderColor;
             fixed4 _GlowColor;
+            fixed4 _InnerGlowColor;
             float4 _Radius;
             float4 _CornerH;
             float4 _CornerKind;
@@ -113,6 +116,7 @@ Shader "UI/ProceduralPanel"
             float _HexW;
             float _BorderWidth;
             float _GlowSize;
+            float _InnerGlowSize;
 
             v2f vert(appdata_t v)
             {
@@ -143,14 +147,13 @@ Shader "UI/ProceduralPanel"
                 float4 col = lerp(_FillBottom, _FillTop, t);
                 col.a *= inside;
 
-                // 外发光：仅在形状外侧衰减，平方让边缘更快收住、更像光晕而不是色块。
-                if (_GlowSize > 0.0)
-                {
-                    float g = saturate(1.0 - d / _GlowSize);
-                    float4 glow = _GlowColor;
-                    glow.a *= g * g * (1.0 - inside);
-                    col = PuguiOver(col, glow);
-                }
+                // 内发光：外发光的镜像 —— 画在形状内侧、压在填充之上。
+                // 排在外发光之前，让外发光的 under 合成看到「填充 + 内发光」这一个完整实心体
+                // （两者除 AA 那一像素外并不相交，所以顺序只影响那一像素）。
+                col = PuguiApplyInnerGlow(col, d, inside, _InnerGlowSize, _InnerGlowColor);
+
+                // 外发光：仅在形状外侧衰减。
+                col = PuguiApplyOuterGlow(col, d, inside, _GlowSize, _GlowColor);
 
                 // 内描边：向内绘制（border-box 直觉），压在填充之上。
                 // _BorderWidth==0 时必须整段跳过 —— 否则下面的覆盖率退化成边缘 AA 带，

--- a/Tests/EditMode/Controls/FrameGlassPanelTests.cs
+++ b/Tests/EditMode/Controls/FrameGlassPanelTests.cs
@@ -71,6 +71,23 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
+        public void Glass_CarriesTheInnerGlow()
+        {
+            // Same SDF, same four layers of light — only the *fill* differs between the two
+            // shaders, so an inner glow has to reach the glass material identically.
+            var p = PanelOf(Load("glass='true' innerGlow='14' innerGlowColor='#fff3c4/0.8'"));
+            Assert.AreEqual(14f, p.CurrentParams.InnerGlowSize);
+            Assert.AreEqual(new Color(1f, 243f / 255f, 196f / 255f, 0.8f),
+                            p.CurrentParams.InnerGlowColor);
+        }
+
+        [Test]
+        public void GlassInnerGlowOnly_IsStillVisible()
+        {
+            Assert.IsTrue(PanelOf(Load("glass='true' innerGlow='10'")).IsPanelVisible);
+        }
+
+        [Test]
         public void NonGlassPanel_KeepsUsingTheOpaqueShader()
         {
             var f = Load("color='#ff0000' width='100' height='50'");

--- a/Tests/EditMode/Controls/FrameProceduralPanelTests.cs
+++ b/Tests/EditMode/Controls/FrameProceduralPanelTests.cs
@@ -120,6 +120,139 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.AreEqual(new Color(0f, 0f, 1f, 1f), p.CurrentParams.GlowColor);
         }
 
+        // ---- inner glow (spec 2026-08-28) ----
+
+        [Test]
+        public void InnerGlow_ParsesPixels()
+        {
+            Assert.AreEqual(12f, PanelOf(Load("color='#fff' innerGlow='12'")).CurrentParams.InnerGlowSize);
+        }
+
+        [Test]
+        public void InnerGlow_Empty_ResetsToZero()
+        {
+            // A Variant can only change a value, never remove the attribute — "" is the author's
+            // only way back to none (same contract glow and radius have).
+            Assert.AreEqual(0f, PanelOf(Load("color='#fff' innerGlow=''")).CurrentParams.InnerGlowSize);
+        }
+
+        [Test]
+        public void InnerGlow_RejectsNonNumeric()
+        {
+            var ex = Assert.Throws<ParseException>(() => Load("innerGlow='soft'"));
+            StringAssert.Contains("innerGlow", ex.Message);
+        }
+
+        [Test]
+        public void InnerGlow_RejectsNegative()
+        {
+            Assert.Throws<ParseException>(() => Load("innerGlow='-4'"));
+        }
+
+        [Test]
+        public void InnerGlow_RejectsNaN()
+        {
+            Assert.Throws<ParseException>(() => Load("innerGlow='NaN'"));
+        }
+
+        [Test]
+        public void InnerGlowColor_DefaultsToWhite()
+        {
+            // Deliberately NOT the fill colour the way glowColor is: an inner glow in the fill's own
+            // colour is invisible on an opaque fill, which is the overwhelmingly common case. White
+            // reads as "the edge is lit" and shows up on any fill (spec §5.4).
+            var p = PanelOf(Load("color='#ff0000' innerGlow='8'"));
+            Assert.AreEqual(Color.white, p.CurrentParams.InnerGlowColor,
+                "following the fill would make innerGlow='8' alone draw nothing at all");
+        }
+
+        [Test]
+        public void InnerGlowColor_ExplicitWins()
+        {
+            var p = PanelOf(Load("color='#ff0000' innerGlow='8' innerGlowColor='#0000ff/0.5'"));
+            Assert.AreEqual(new Color(0f, 0f, 1f, 0.5f), p.CurrentParams.InnerGlowColor);
+        }
+
+        [Test]
+        public void InnerGlowColor_RejectsGradient()
+        {
+            Assert.Throws<ParseException>(() => Load("innerGlow='8' innerGlowColor='#fff,#000'"));
+        }
+
+        [Test]
+        public void InnerGlowOnly_NoFill_IsVisible()
+        {
+            // A hollow ring of light, same standing as the border-only hollow box above.
+            Assert.IsTrue(PanelOf(Load("innerGlow='8'")).IsPanelVisible);
+        }
+
+        [Test]
+        public void InnerGlow_TransparentColour_IsNotVisible()
+        {
+            Assert.IsFalse(PanelOf(Load("innerGlow='8' innerGlowColor='#ffffff/0'")).IsPanelVisible,
+                "an invisible panel must cost zero overdraw, whatever the size attribute says");
+        }
+
+        [Test]
+        public void InnerGlow_DoesNotInflateMesh()
+        {
+            // The whole point of the mirror: it draws INSIDE the shape, so unlike glow it never
+            // touches the geometry — no extra overdraw, and no ancestor RectMask2D interaction.
+            var f = Load("color='#fff' innerGlow='20' width='100' height='50' anchor='top-left'");
+            var vh = new VertexHelper();
+            PanelOf(f).BuildMeshForTests(vh);
+
+            var v = default(UIVertex);
+            vh.PopulateUIVertex(ref v, 2);
+            Assert.AreEqual(50f, v.uv0.x, 0.01f, "an inner glow must not grow the drawn quad");
+            Assert.AreEqual(25f, v.uv0.y, 0.01f);
+        }
+
+        [Test]
+        public void SameInnerGlow_SharesOneMaterial()
+        {
+            const string xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Style name='plate' color='#222' innerGlow='10' innerGlowColor='#fff3c4'/>
+  <Screen name='S'>
+    <Frame id='a' class='plate' height='40'/>
+    <Frame id='b' class='plate' height='90'/>
+  </Screen>
+</PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var s = UI.Open("S");
+            Assert.AreSame(PanelOf(s.Get<Frame>("a")).material, PanelOf(s.Get<Frame>("b")).material);
+        }
+
+        [TestCase("innerGlow='10'", "innerGlow='14'")]
+        [TestCase("innerGlow='10'", "innerGlow='10' innerGlowColor='#f00'")]
+        public void DifferentInnerGlow_SplitsTheMaterial(string a, string b)
+        {
+            // Both halves have to be in the cache key, or two panels that render differently would
+            // be handed the same material.
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Frame id='a' color='#222' {a}/>
+  <Frame id='b' color='#222' {b}/>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            var s = UI.Open("S");
+            Assert.AreNotSame(PanelOf(s.Get<Frame>("a")).material, PanelOf(s.Get<Frame>("b")).material);
+        }
+
+        [Test]
+        public void Disabled_DesaturatesTheInnerGlow()
+        {
+            // Greying happens inside the parameters (the material carries the shape and cannot be
+            // swapped) — so every colour has to be walked, including this one.
+            var p = PanelOf(Load("color='#ff0000' innerGlow='8' innerGlowColor='#00ff00'"));
+            p.SetDisabledGrayscale(true);
+
+            var c = p.CurrentParams.InnerGlowColor;
+            Assert.AreEqual(c.r, c.g, 0.001f, $"a disabled surface must not keep a coloured rim, got {c}");
+            Assert.AreEqual(c.g, c.b, 0.001f);
+        }
+
         [Test]
         public void BorderColor_RejectsGradient()
         {

--- a/Tests/EditMode/Controls/GlassWeldGroupTests.cs
+++ b/Tests/EditMode/Controls/GlassWeldGroupTests.cs
@@ -175,6 +175,33 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         [Test]
+        public void InnerGlow_ComesFromTheContainer()
+        {
+            // It follows the FUSED outline, so like the border and the outer glow it belongs to the
+            // container — a per-member inner glow would trace exactly the dividing lines the weld
+            // exists to remove.
+            var mat = GroupOf(Open(@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Frame id='g' weld='10' innerGlow='12' innerGlowColor='#ff0000' anchor='top-left'
+         width='200' height='100'>
+    <Frame id='a' glass='true' anchor='top-left' width='100' height='40'/>
+    <Frame id='b' glass='true' anchor='bottom-right' width='60' height='30'/>
+  </Frame>
+</Screen></PromptUGUI>"), "g").MaterialForTests;
+
+            Assert.AreEqual(12f, mat.GetFloat("_InnerGlowSize"), 0.001f);
+            Assert.AreEqual(new Color(1f, 0f, 0f, 1f), mat.GetColor("_InnerGlowColor"));
+        }
+
+        [Test]
+        public void InnerGlow_DefaultsToNoneOnTheGroup()
+        {
+            var mat = GroupOf(Open(TwoBlocks), "g").MaterialForTests;
+            Assert.AreEqual(0f, mat.GetFloat("_InnerGlowSize"), 0.001f,
+                "nobody wrote innerGlow, so the fused pane must not sprout one");
+        }
+
+        [Test]
         public void GroupParams_FallBackToDefaultsWithoutAContainerPanel()
         {
             var mat = GroupOf(Open(@"<?xml version='1.0' encoding='utf-8'?>

--- a/Tests/EditMode/Controls/InnerGlowRenderTests.cs
+++ b/Tests/EditMode/Controls/InnerGlowRenderTests.cs
@@ -1,0 +1,219 @@
+using System.IO;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    /// <summary>
+    /// Does the inner glow actually reach the pixels? Every parameter test in this feature reads
+    /// back <c>PanelParams</c>, and all of them stay green if the shader ignores the two new
+    /// uniforms — the same failure mode the corner treatments hit (grammar green, uniforms green,
+    /// SDF unchanged).
+    ///
+    /// <para>Each probe is a predicate on the falloff rather than a golden image: the glow is
+    /// <c>saturate(1 + d/size)²</c> over a dark fill, so brightness must fall monotonically inwards
+    /// from the edge and be back to the fill by the time the band ends. Same explicit
+    /// <c>Camera.Render()</c> harness as <see cref="CornerTreatmentRenderTests"/>.</para>
+    /// </summary>
+    public class InnerGlowRenderTests
+    {
+        private const int Size = 256;
+
+        /// <summary>Rect size of the probed Frame, in canvas units. Probes are normalised to it.</summary>
+        private const float W = 200f;
+        private const float H = 160f;
+
+        /// <summary>Glow band width used by most probes; wide enough to sample several points in.</summary>
+        private const float Band = 40f;
+
+        private Camera _ui;
+        private RenderTexture _uiRt;
+        private Texture2D _shot;
+        private Rect _rect;
+
+        [SetUp]
+        public void SetUp()
+        {
+            UI.ResetForTests();
+            _uiRt = new RenderTexture(Size, Size, 24) { name = "InnerGlowUIRT" };
+            _ui = new GameObject("InnerGlowUICamera").AddComponent<Camera>();
+            _ui.clearFlags = CameraClearFlags.SolidColor;
+            _ui.backgroundColor = Color.black;
+            _ui.targetTexture = _uiRt;
+            _ui.cullingMask = ~0;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UI.ResetForTests();
+            if (_shot != null) Object.DestroyImmediate(_shot);
+            if (_ui != null) Object.DestroyImmediate(_ui.gameObject);
+            if (_uiRt != null)
+            {
+                _uiRt.Release();
+                Object.DestroyImmediate(_uiRt);
+            }
+        }
+
+        /// <summary>Renders one Frame and leaves the frame buffer ready for <see cref="At"/>.</summary>
+        private void Render(string attrs, string dumpName)
+        {
+            UI.UnloadAll();
+            // A near-black fill so the glow is the only thing that can brighten a probe.
+            UI.LoadDocument("t", $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Frame id='f' anchor='center' width='{W}' height='{H}' color='#101010' {attrs}/>
+</Screen></PromptUGUI>");
+            var screen = UI.Open("S");
+
+            var canvas = screen.RootGameObject.GetComponentInParent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceCamera;
+            canvas.worldCamera = _ui;
+            canvas.planeDistance = 10f;
+
+            Canvas.ForceUpdateCanvases();
+            _ui.Render();
+
+            if (_shot != null) Object.DestroyImmediate(_shot);
+            _shot = new Texture2D(Size, Size, TextureFormat.RGBA32, false);
+            var previous = RenderTexture.active;
+            RenderTexture.active = _uiRt;
+            _shot.ReadPixels(new Rect(0, 0, Size, Size), 0, 0);
+            _shot.Apply();
+            RenderTexture.active = previous;
+
+            var path = Path.Combine(UnityEngine.Application.temporaryCachePath, dumpName);
+            File.WriteAllBytes(path, _shot.EncodeToPNG());
+            Debug.Log($"PromptUGUI inner-glow render dump: {path}");
+
+            var rt = (RectTransform)screen.Get<Frame>("f").GameObject.transform;
+            var corners = new Vector3[4];
+            rt.GetWorldCorners(corners);
+            var a = RectTransformUtility.WorldToScreenPoint(_ui, corners[0]);
+            var c = RectTransformUtility.WorldToScreenPoint(_ui, corners[2]);
+            _rect = Rect.MinMaxRect(Mathf.Min(a.x, c.x), Mathf.Min(a.y, c.y),
+                                    Mathf.Max(a.x, c.x), Mathf.Max(a.y, c.y));
+
+            Assert.Greater(_rect.width, W * 0.5f,
+                "the probed rect rendered far smaller than its canvas size — probes would be meaningless");
+        }
+
+        /// <summary>Samples in normalised rect coordinates (0,0 = bottom-left).</summary>
+        private Color At(float u, float v)
+            => _shot.GetPixel(Mathf.RoundToInt(Mathf.Lerp(_rect.xMin, _rect.xMax, u)),
+                              Mathf.RoundToInt(Mathf.Lerp(_rect.yMin, _rect.yMax, v)));
+
+        /// <summary>Samples on the vertical centre line, <paramref name="inset"/> units in from the left edge.</summary>
+        private Color LeftInset(float inset) => At(inset / W, 0.5f);
+
+        private static float Luma(Color c) => c.r * 0.299f + c.g * 0.587f + c.b * 0.114f;
+
+        // ---- the falloff ------------------------------------------------------------------------
+
+        [Test]
+        public void InnerGlow_BrightensTheEdgeAndFadesInwards()
+        {
+            Render($"innerGlow='{Band}'", "pugui-inner-glow-falloff.png");
+
+            var edge = Luma(LeftInset(3f));
+            var mid = Luma(LeftInset(Band * 0.5f));
+            var past = Luma(LeftInset(Band * 1.6f));
+            var centre = Luma(At(0.5f, 0.5f));
+
+            Assert.Greater(edge, 0.4f, $"the edge must be lit by the glow, got {edge:F3}");
+            Assert.Less(mid, edge, $"…and fade inwards: mid {mid:F3} should be under edge {edge:F3}");
+            Assert.Greater(mid, past, $"…monotonically: past-band {past:F3} should be under mid {mid:F3}");
+            Assert.Less(past, 0.15f,
+                $"…and be back to the near-black fill outside the band, got {past:F3}");
+            Assert.AreEqual(centre, past, 0.03f, "past the band is indistinguishable from the centre");
+        }
+
+        [Test]
+        public void WithoutInnerGlow_TheEdgeIsJustTheFill()
+        {
+            // The baseline the falloff test is measured against — and the guard that a stray
+            // uniform default does not light every panel in the library.
+            Render("", "pugui-inner-glow-none.png");
+            Assert.Less(Luma(LeftInset(3f)), 0.15f, "no innerGlow ⇒ no rim");
+        }
+
+        [Test]
+        public void InnerGlowColor_TintsTheRim()
+        {
+            Render($"innerGlow='{Band}' innerGlowColor='#ff0000'", "pugui-inner-glow-red.png");
+            var edge = LeftInset(3f);
+            Assert.Greater(edge.r, 0.4f, $"expected a red rim, got {edge}");
+            Assert.Less(edge.g, 0.25f, $"…red, not white — got {edge}");
+        }
+
+        [Test]
+        public void InnerGlowAlpha_ScalesTheStrength()
+        {
+            Render($"innerGlow='{Band}'", "pugui-inner-glow-full.png");
+            var full = Luma(LeftInset(3f));
+            Render($"innerGlow='{Band}' innerGlowColor='white/0.3'", "pugui-inner-glow-weak.png");
+            var weak = Luma(LeftInset(3f));
+
+            Assert.Less(weak, full * 0.7f,
+                $"/alpha is the strength knob: {weak:F3} should be well under {full:F3}");
+            Assert.Greater(weak, 0.05f, "…but still visible");
+        }
+
+        // ---- it stays inside, and under the border ----------------------------------------------
+
+        [Test]
+        public void InnerGlow_DrawsNothingOutsideTheShape()
+        {
+            // The mirror of the outer glow, and the reason the quad is not inflated: everything it
+            // paints is within the rect.
+            Render($"radius='40' innerGlow='{Band}'", "pugui-inner-glow-inside-only.png");
+            Assert.Less(Luma(At(0.01f, 0.99f)), 0.1f,
+                "the rect corner lies outside a radius-40 shape and must stay background");
+        }
+
+        [Test]
+        public void OpaqueBorder_CoversTheOutermostPixelsOfTheBand()
+        {
+            // Measured from the shape edge (Photoshop Inner Glow), so a border painted afterwards
+            // sits on top of the brightest part of it — spec §5.3.
+            Render($"innerGlow='{Band}' borderWidth='10' borderColor='#0000ff'",
+                   "pugui-inner-glow-under-border.png");
+
+            var border = LeftInset(4f);
+            Assert.Greater(border.b, 0.5f, $"the border must paint over the glow, got {border}");
+            Assert.Less(border.r, 0.35f, $"…opaquely — got {border}");
+            Assert.Greater(Luma(LeftInset(14f)), Luma(LeftInset(Band * 1.6f)),
+                "…while the glow continues inwards past the border band");
+        }
+
+        // ---- it follows the outline, whatever the outline is -------------------------------------
+
+        [Test]
+        public void InnerGlow_FollowsAChamferedOutline()
+        {
+            // Derived from the same SDF, so the corner vocabulary needs no attributes of its own.
+            // Probe just inside the chamfer's midpoint, where a rect-shaped glow would leave the
+            // fill dark.
+            Render($"radius='cut 60' innerGlow='{Band}'", "pugui-inner-glow-cut.png");
+
+            var nearChamfer = At(36f / W, (H - 36f) / H);
+            Assert.Greater(Luma(nearChamfer), 0.3f,
+                $"the light must hug the chamfer, not the rect corner behind it, got {nearChamfer}");
+        }
+
+        [Test]
+        public void InnerGlow_FollowsAHexagonOutline()
+        {
+            Render($"radius='hexagon' innerGlow='{Band}'", "pugui-inner-glow-hexagon.png");
+
+            // Just inside the left tip: on a rect outline this column is 0.06W from the edge and
+            // would be lit anyway, so the discriminating probe is the one further in along the
+            // slanted edge, near the top where a hexagon has already cut the shape away.
+            Assert.Greater(Luma(At(0.10f, 0.5f)), 0.3f, "the tip is lit");
+            Assert.Greater(Luma(At(0.5f, 0.93f)), 0.3f, "…and so is the flat top edge between the tips");
+        }
+    }
+}

--- a/Tests/EditMode/Controls/InnerGlowRenderTests.cs.meta
+++ b/Tests/EditMode/Controls/InnerGlowRenderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ebe2a8b1d219e3bc7a6dacb4cd4b7976

--- a/Tests/EditMode/Controls/ProceduralSurfaceContractTests.cs
+++ b/Tests/EditMode/Controls/ProceduralSurfaceContractTests.cs
@@ -115,6 +115,8 @@ namespace PromptUGUI.Tests.EditMode.Controls
         [TestCase("radius='8'")]
         [TestCase("borderWidth='2' borderColor='#fff'")]
         [TestCase("glow='6'")]
+        [TestCase("innerGlow='6'")]
+        [TestCase("innerGlowColor='#fff'")]
         [TestCase("glass='true'")]
         public void AnyPanelAttachingAttr_AttachesASurface(string attrs)
         {

--- a/Tests/EditMode/Editor/XsdGeneratorTests.cs
+++ b/Tests/EditMode/Editor/XsdGeneratorTests.cs
@@ -22,6 +22,16 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
+        public void Frame_lists_its_inner_glow_attributes()
+        {
+            // Frame's attribute list is hand-written rather than reflected, so every attribute
+            // added to it has to be added there too or authoring tools flag valid XML as invalid.
+            var xsd = XsdGenerator.Generate(new ControlRegistry());
+            StringAssert.Contains("name=\"innerGlow\"", xsd);
+            StringAssert.Contains("name=\"innerGlowColor\"", xsd);
+        }
+
+        [Test]
         public void Custom_control_appears_with_UIAttr_attributes()
         {
             var r = new ControlRegistry();

--- a/Tests/EditMode/Lint/DecorRulesTests.cs
+++ b/Tests/EditMode/Lint/DecorRulesTests.cs
@@ -153,6 +153,16 @@ namespace PromptUGUI.Tests.EditMode.Lint
         }
 
         [Test]
+        public void InnerGlowOnDecor_IsStillReported()
+        {
+            // A 2px stroke has no inside to light. Only the outer glow pair carries over to a
+            // decoration; the inner one belongs to a surface.
+            CollectionAssert.Contains(
+                Codes("<Decor id='d' kind='bracket' innerGlow='6'/>"),
+                PureContainerVisualAttrRules.VisualAttrCode);
+        }
+
+        [Test]
         public void CleanDecor_HasNoIssues()
         {
             Assert.IsEmpty(IRWalker.Walk(Parse(

--- a/Tests/EditMode/Lint/GlassRulesTests.cs
+++ b/Tests/EditMode/Lint/GlassRulesTests.cs
@@ -123,6 +123,8 @@ namespace PromptUGUI.Tests.EditMode.Lint
         [TestCase("frost='0.8'")]
         [TestCase("lightAngle='30'")]
         [TestCase("saturation='1.4'")]
+        [TestCase("innerGlow='8'")]
+        [TestCase("innerGlowColor='#fff'")]
         public void GroupParamOnABlock_IsFlagged(string attr)
         {
             // Two halves of one continuous pane cannot be frosted differently or lit from different
@@ -149,6 +151,8 @@ namespace PromptUGUI.Tests.EditMode.Lint
         [TestCase("frost='heavy'")]
         [TestCase("noise='5'")]
         [TestCase("depth='-3'")]
+        [TestCase("innerGlow='soft'")]
+        [TestCase("innerGlow='-2'")]
         public void BadValues_AreFlagged(string attr)
         {
             Assert.IsTrue(Has(Walk($"<Frame id='f' glass='true' {attr}/>"),

--- a/Tests/EditMode/Lint/PureContainerVisualAttrRulesTests.cs
+++ b/Tests/EditMode/Lint/PureContainerVisualAttrRulesTests.cs
@@ -34,6 +34,8 @@ namespace PromptUGUI.Tests.EditMode.Lint
         [TestCase("borderColor")]
         [TestCase("glow")]
         [TestCase("glowColor")]
+        [TestCase("innerGlow")]
+        [TestCase("innerGlowColor")]
         public void Frame_ProceduralVisualAttrs_NoIssue(string attr)
         {
             // Frame 现在自己画这些 —— 曾经的 "silently ignored" 警告已经过时。
@@ -86,6 +88,8 @@ namespace PromptUGUI.Tests.EditMode.Lint
         [TestCase("HStack", "radius")]
         [TestCase("Grid", "borderWidth")]
         [TestCase("SafeArea", "glow")]
+        [TestCase("VStack", "innerGlow")]
+        [TestCase("Grid", "innerGlowColor")]
         public void LayoutOnlyContainers_ProceduralAttrs_Issue(string tag, string attr)
         {
             // 这些容器既没 Graphic 也没 ProceduralPanel —— 指路"套一层 Frame"。
@@ -172,6 +176,7 @@ namespace PromptUGUI.Tests.EditMode.Lint
         [TestCase("Icon", "frost")]
         [TestCase("RawImage", "radius")]
         [TestCase("Image", "weld")]
+        [TestCase("Text", "innerGlow")]
         public void ControlWithoutASurface_ProceduralAttr_VisualAttrIssue(string tag, string attr)
         {
             var n = new ElementNode(tag) { Id = "x" };

--- a/Tests/EditMode/Lint/ThemeStyleRulesTests.cs
+++ b/Tests/EditMode/Lint/ThemeStyleRulesTests.cs
@@ -97,6 +97,21 @@ namespace PromptUGUI.Tests.EditMode.Lint
         }
 
         [Test]
+        public void InnerGlowOnlyOneThemeSets_IsExempt()
+        {
+            // Same reasoning as every other shape attribute: the theme that writes none of them
+            // turns the surface off wholesale and the Image comes back, so nothing is left stuck.
+            var issues = Lint(@"
+                <Style name='btn' sprite='ui:wood' color='#E8D2A8'/>
+                <Theme name='farm'><Style name='btn' color='#E8D2A8'/></Theme>
+                <Theme name='gold'><Style name='btn' sprite='none' color='#C39A45'
+                       radius='10' innerGlow='14' innerGlowColor='#FFF3C4'/></Theme>
+                <Screen name='S'><Btn id='b' class='btn'/></Screen>");
+
+            Assert.IsEmpty(issues.Where(i => i.Code == ThemeStyleRules.ShapeCode));
+        }
+
+        [Test]
         public void InnerLayerRadius_IsExempt()
         {
             var issues = Lint(@"

--- a/docs~/superpowers/specs/2026-08-28-inner-glow-design.md
+++ b/docs~/superpowers/specs/2026-08-28-inner-glow-design.md
@@ -1,0 +1,374 @@
+# 内发光 `innerGlow` —— 程序化表面的第四层光
+
+> 状态：**已实现**（M0 + M1 一轮做完，见 §12）。决策见 §8，2026-08-28 与作者对齐。
+> 相关：`2026-08-23-procedural-style-design.md`（`glow` / `glowColor` 的出处，§2.1；shader 分段 §2.2）、
+> `2026-08-26-procedural-surface-design.md`（`ProceduralControl` 让九个控件共享同一套属性）、
+> `2026-08-23-glass-fill-design.md`（玻璃填充 + weld 容器持有轮廓参数）、
+> `2026-08-27-corner-treatments-design.md`（cut / notch / hexagon —— 内发光必须原样跟随这些轮廓）、
+> `2026-08-27-theme-procedural-shape-exemption-design.md`（SHAPE 规则的程序化豁免集从 `NeedsPanel` 派生）。
+
+## 1. 问题
+
+参考需求图（星海指挥官主界面）的「开始匹配」主按钮，剥掉外圈线条只看本体，是四层光叠出来的：
+
+| 层 | 观感 | 今天 |
+|---|---|---|
+| 金色上下渐变填充 | 顶部略亮、底部略暗 | ✅ `color="A,B"` |
+| **边缘一圈浅黄向内衰减 ~15px** | 轮廓被光照亮、中心回到本色 | ❌ |
+| 1px 亮描边压在最外沿 | 轮廓的硬边 | ✅ `borderWidth` / `borderColor` |
+| 柔和金色光晕溢出到形状外 | 「在发光」 | ✅ `glow` / `glowColor` |
+
+缺的那一层就是 Photoshop 意义上的 **Inner Glow（边缘模式）**。程序化表面今天从 SDF 派生出
+填充、内描边、外发光、玻璃折射四样东西，**没有任何一样在轮廓内侧带衰减地画东西** ——
+描边是硬边带，填充只有纵向渐变。于是参考图里最能决定「高级金属牌」质感的那一层做不出来。
+
+现有的绕路全部不成立：
+
+- **贴图**：丢掉主题换形状（#104 打通的能力，corner spec §1 的同一条论证）。
+- **内嵌一层 `<Frame borderWidth="14" borderColor="white/0.3">`**：硬边带、无衰减；内层 Frame
+  是矩形内缩，跟不上外层的 `cut` / `hexagon` 轮廓；每个按钮多一个 draw call。
+- **玻璃的 `lightIntensity` 边缘光**：只在 `glass="true"` 下存在，方向性、依赖 backdrop，
+  不是这个东西。
+
+同一机制换个深色就是**内阴影 / 边缘暗角**（CSS `box-shadow: inset`）—— 一个属性两种用途，
+所以混合方式的选择（§8.3）比看起来重要。
+
+**分层位置**：这是程序化表面「光」的第二个原语（第一个是外发光）。参考图剩下的两处差距 ——
+顶部冠形凸起（第 7/8 条边）与斜向光带 `sheen` —— 另行立项，本文不涉及。
+
+## 2. 否决的方案
+
+**`glow="12 inset"`（CSS 式关键字，复用 `glow` 属性）。否决。** 参考图同时需要外发光和
+内发光；一个属性只能表达其一，`glowColor` 也没法一分为二。属性面积 +2 是正确的代价。
+
+**screen / additive 混合。否决。** screen 更像「光」，但只能变亮，做不了内阴影；additive
+在非 HDR 的 UI 上容易过曝且不可控。两者都会是这个库里唯一一处非 source-over 的合成 ——
+`PuguiOver` 是填充 / 描边 / 外发光 / 玻璃 tint 全部共用的合成方式，`/alpha` 控强度的心智
+模型一致。要更亮，作者把 `innerGlowColor` 调浅就行。
+
+**方向性内发光（用 `lightAngle` 调制成 bevel / emboss）。不进 v1。** 参考图四边亮度均匀，
+是内发光不是斜面。方向性版本是自然的扩展位（§9），但它引入的是另一个视觉概念。
+
+**`<Decor>` 支持。否决。** 装饰原语是 2px 笔画和薄三角，没有「内部」可言；
+`PureContainerVisualAttrRules` 已经把 `NeedsPanel` 里 Decor 不支持的名字报成
+`PUI-CONTAINER-VISUAL-ATTR`，新名字自动落进去。
+
+**逐状态变体 `hoverInnerGlow` 等。不进 v1。** 状态反应器（`StateTintReactor`）只驱动
+`Graphic.color` 整体 tint，没有任何程序化参数有逐状态版本；要「hover 时边缘更亮」走
+`<Show on="state-hover">` 叠一层，与今天 `glow` 的处理一致。
+
+## 3. 方案总览
+
+两个新属性，语法、解析器、落点全部镜像 `glow` / `glowColor`：
+
+```xml
+<Frame color="#1b263b" radius="16" innerGlow="12"/>                           <!-- 白色边缘光 -->
+<Btn radius="hexagon 60" color="#ead49a,#c39a45"
+     innerGlow="16" innerGlowColor="#fff3c4/0.9"
+     borderWidth="1" borderColor="#fff0b8/0.9"
+     glow="24" glowColor="#e8b860/0.5">开始匹配</Btn>                           <!-- 参考图 -->
+<Frame color="surface" radius="12" innerGlow="20" innerGlowColor="black/0.35"/> <!-- 内阴影 -->
+<Style name="gold-plate" innerGlow="14" innerGlowColor="#fff3c4/0.9" borderWidth="1"/>
+```
+
+- `innerGlow`：px，发光带宽度，从形状边缘向内量。
+- `innerGlowColor`：纯色，默认 `white`。
+- 作用面 = `glow` 的作用面：`<Frame>`、`ProceduralControl` 的九个控件（Btn / Tab / Toggle /
+  Slider / Dropdown / InputField / ScrollList / Progress / …）、weld 容器（融合后的轮廓）。
+- **纯材质参数**：不外扩 quad、不动布局、不动顶点；Variant / 主题切换只换材质。
+
+## 4. 语法
+
+| 属性 | 类型 / 取值 | 默认 | 说明 |
+|---|---|---|---|
+| `innerGlow` | px（非负有限数） | `0` | 内发光带宽度。`""` = 退回 0（Variant 只能改值不能删属性，同 `glow`） |
+| `innerGlowColor` | hex / CSS 名 / 主题 token / `/alpha`，**纯色 only** | `white` | 发光色；`/alpha` 就是强度旋钮 |
+
+### 4.1 解析错误（parse-time，纯 C# 子集，CLI 同步可见）
+
+全部复用既有 chokepoint，**不新增错误码**：
+
+| 写法 | 结果 |
+|---|---|
+| `innerGlow="abc"` | `ProceduralValueParser.Pixels`：`innerGlow="abc": expected a number of pixels (e.g. "1", "2.5")` |
+| `innerGlow="-4"` | `must not be negative` |
+| `innerGlow="NaN"` | `must be a finite number` |
+| `innerGlowColor="a,b"` | `UI.Theme.Resolve` 拒绝渐变（同 `borderColor` / `glowColor`） |
+| `<Style innerGlow="abc">` | `PUI-PROCEDURAL-VALUE`（`StyleRules.PixelAttrs` 加名字即可） |
+
+## 5. 语义
+
+### 5.1 带与衰减
+
+设 `d` 为 SDF（内部为负），`inside` 为抗锯齿覆盖率：
+
+```
+g = saturate(1 + d / innerGlow)      // d ∈ [-innerGlow, 0] → g ∈ [0, 1]，边缘处 1
+alpha = innerGlowColor.a × g² × inside
+```
+
+与外发光同一条 `g²` 曲线、镜像方向。这样 `glow="12" innerGlow="12"` 读起来是**跨越边缘的一整圈
+对称光晕**，而不是两种手感的光拼在一起。`g²` 让能量收在边缘附近、中心保持本色 ——
+Photoshop 的默认内发光大致也是这个曲线。不提供 choke / spread 旋钮（§9）。
+
+### 5.2 合成顺序
+
+```
+不透明面：  填充 → [内发光 over] → 外发光 (under) → 描边 over
+玻璃面：    玻璃体 → tint over → [内发光 over] → 外发光 (under) → 描边 over
+```
+
+内发光紧跟在填充（玻璃是 tint）之后：外发光带 `(1 - inside)`、内发光带 `inside`，两者除
+AA 那一像素外不相交，谁先谁后只影响那一像素；把内发光放在外发光之前，让外发光的 under
+合成看到的是「填充 + 内发光」这一个完整实心体。描边始终最后，压在所有东西上面。
+
+`mask="self"` 的遮罩覆盖率仍取 `inside`（形状就是形状，与画了什么无关）—— 内发光在形状
+内部，本来就不会改变它。
+
+### 5.3 起点：从形状边缘 d = 0 量起，描边压在上面
+
+Photoshop Inner Glow 语义（§8.4）。`borderWidth="1" innerGlow="16"`：发光带 16px，最外 1px 被
+描边盖住。
+
+- **半透明细描边**（库里最常见的 `borderColor="white/0.4"` / `stroke/0.15`）：发光延续到描边
+  底下，描边区 = 描边色 over 满强度发光 → 边缘最亮、无缝。
+- **粗不透明描边**：最外 `borderWidth` px 的发光被盖掉，作者看到的带比写的窄、起点强度是
+  `(1 - borderWidth/innerGlow)²`。把数值调大即可，文档写明。
+
+否决的 CSS `inset box-shadow` 语义（从描边内沿量）在半透明描边下会在边缘出 1px 暗缝 ——
+一个常见配置里的视觉 bug，比「粗描边要调大数值」严重得多。
+
+### 5.4 默认色：`white`
+
+外发光默认跟随填充色，因为「这个形状在发光」是它的默认含义。内发光跟填充同色、填充又不
+透明时**完全不可见** —— 那个默认是个陷阱。`white` 是「边缘被光照亮」的直觉，任何填充上
+都可见，且与 `borderColor` 的默认一致。要暖色 / 冷色作者显式写。
+
+显式值优先，`/alpha` 缩放强度；不做「跟随 `glowColor`」的联动。
+
+### 5.5 可见性
+
+`innerGlow > 0 && innerGlowColor.a > 0` 让面板可见 —— 没有填充、没有描边、只有内发光是一个
+合法的形态（空心的发光环，同 border-only 的先例），`ComputeVisible` 加一条。
+
+### 5.6 形状跟随
+
+派生自同一份 SDF，圆角 / `cut` / `notch` / `pill` / `hexagon` 一律自动跟随，不需要任何新
+属性；`notch` 凹顶点处内描边已是精确解（corner spec §11），内发光吃同一个 `d`，同样精确。
+
+### 5.7 disabled
+
+`_grayed` 时 `innerGlowColor` 与其他三种颜色一起 `Desaturate` —— 灰掉的按钮不该有一圈
+彩色内光。
+
+### 5.8 玻璃与 weld
+
+- **玻璃面**：同一段代码，画在 tint 之上；backdrop 不可用的降级路径（半透明面板）照画。
+- **weld 容器**：内发光沿**融合后**的轮廓走，所以是容器的参数（`GlassRules.GroupAttrs` +2，
+  `GlassGroupPanel` 发布容器的 `InnerGlow*` 到组材质）。写在成员上会被
+  `PUI-GLASS-WELD-PARAM-PLACEMENT` 报出来 —— 既有规则，只扩名字表。理由同描边：逐成员
+  的内发光会在焊缝处画出 weld 存在的意义就是要抹掉的那条分界。
+
+### 5.9 不到达的地方
+
+| 地方 | 行为 | 机制 |
+|---|---|---|
+| 内层 `<layer>Radius`（`fillRadius` 等） | 无 `fillInnerGlow` | procedural-surface spec §6：内层 shape-only |
+| `<Decor>` | 静默丢弃 → `PUI-CONTAINER-VISUAL-ATTR` | `NeedsPanel` − `DecorRules.SupportedProceduralAttrs`，自动 |
+| `<VStack>` / `<HStack>` / `<Grid>` / `<SafeArea>` | 同上，指路「套一层 Frame」 | `ProceduralAttrNames.All`，自动 |
+| `<Animation>` | 不可动画 | 没有任何程序化参数可动画，不新开口 |
+| SHAPE 主题规则 | 进豁免集 | `ThemeStyleRules` 从 `NeedsPanel` 派生，自动 |
+| `VariantBaseRules` | 与 `glow` 同待遇 | 从 `NeedsPanel` 派生，自动 |
+
+### 5.10 材质共享与性能
+
+`PanelParams` 多两个字段，参与 `Equals` / `GetHashCode`。同 style 的面板照旧共用一个材质；
+只有内发光不同的两块面板是两个材质 —— 与任何其他参数相同。fragment 多一个 uniform 分支 +
+四条算术，`_InnerGlowSize == 0` 时整段跳过（同 `_BorderWidth` 的注释：uniform 分支全体
+fragment 同路径，开销可忽略）。
+
+**不动几何**：`MarkDirty` 的顶点脏检查只看 `_glowSize`，内发光不加进去。
+
+## 6. 实现地图
+
+### 6.1 数据流（改动点自上而下）
+
+| 文件 | 改动 |
+|---|---|
+| `Runtime/Resources/PromptUGUI/Material/UI-PanelSDF.cginc` | 新增 `PuguiApplyInnerGlow(col, d, inside, size, color)`：§5.1 的四行，三个 shader 共用，保证不透明面 / 玻璃面 / 融合面逐像素一致（corner spec 的「一份 cginc 喂所有面」原则） |
+| `UI-ProceduralPanel.shader` / `UI-GlassPanel.shader` / `UI-GlassGroup.shader` | `_InnerGlowSize` / `_InnerGlowColor` 属性 + 声明 + 在 §5.2 的位置调一次 helper。`UI-Decor.shader` **不改** |
+| `Controls/Internal/ProceduralMaterialCache.cs` | `PanelParams` + `InnerGlowColor` / `InnerGlowSize`（ctor、`Equals`、`GetHashCode`）；`Configure` 两个 `SetX`；两个 `PropertyToID` |
+| `Controls/Internal/ProceduralPanel.cs` | 字段 `_innerGlowColor = white` / `_innerGlowSize`；`SetInnerGlowSize` / `SetInnerGlowColor`；`BuildParams` 传入 + `_grayed` 时 `Desaturate`；`ComputeVisible` 加一条 |
+| `Controls/Internal/GlassGroupPanel.cs` | 组材质发布容器的 `InnerGlowColor` / `InnerGlowSize`（同 `BorderColor` / `GlowSize` 那两行的旁边） |
+| `Controls/Frame.cs` | `[UIAttr] InnerGlow` / `InnerGlowColor`，直连 `Panel.SetX` |
+| `Controls/ProceduralControl.cs` | 同名两个 `[UIAttr]`，走 `Surface.Declare` —— 九个控件自动获得 |
+| `Core/Lint/ProceduralAttrNames.cs` | `PanelAttaching` / `All` / `NeedsPanel` 各 +2（`ProceduralAttrNamesTests` 守镜像） |
+| `Core/Lint/StyleRules.cs` | `PixelAttrs` + `"innerGlow"` |
+| `Core/Lint/GlassRules.cs` | `GroupAttrs` + `"innerGlow"`, `"innerGlowColor"` |
+| `Core/Lint/PureContainerVisualAttrRules.cs` | 消息文案里「Only glow / glowColor carry over」依旧成立，不改 |
+| `Editor/XsdGenerator.cs` | Frame 手写清单 +2（注释明说「every attribute added to it has to be added here too」） |
+
+`PanelParams` 的 ctor 签名变了，实现时 grep 全部构造点（`ProceduralPanel.BuildParams` 与测试）。
+
+### 6.2 shader 段落
+
+```hlsl
+// UI-PanelSDF.cginc
+// 内发光：仅在形状内侧衰减，与外发光镜像 —— 同一条 g² 曲线，于是 glow 与 innerGlow 等宽时
+// 读起来是跨越边缘的一整圈对称光晕。从 d=0 量起，描边随后压在上面（Photoshop Inner Glow 语义）。
+float4 PuguiApplyInnerGlow(float4 col, float d, float inside, float size, float4 color)
+{
+    if (size <= 0.0) return col;
+    float g = saturate(1.0 + d / size);
+    color.a *= g * g * inside;
+    return PuguiOver(color, col);
+}
+```
+
+调用点：不透明面在 `col.a *= inside` 之后、外发光之前；玻璃面与融合面在 `col = PuguiOver(tint, base)` 之后、外发光之前。
+
+**外发光是否一并抽成 `PuguiApplyOuterGlow`**：建议同 PR 做（三份复制的四行代码正是 cginc
+要消灭的漂移），但必须逐像素不变 —— `CornerTreatmentRenderTests` / `ProceduralSurfaceRenderTests`
+/ `GlassRenderTests` 的既有基线是守卫。做不到逐像素不变就不抽，不为这个特性冒险。
+
+### 6.3 CLI
+
+`Core/Lint` 三处改动都是名字表，纯 C# 子集不变。UIXmlLint 两遍（raw + expanded）自动覆盖
+`<Style innerGlow=>` 经 `class=` 落到控件上的情形。
+
+## 7. SKILL 更新（同 PR，英文）
+
+`authoring-promptugui-xml/SKILL.md`：
+
+- 原语目录 `<Frame>` 行：`color` / `radius` / `borderWidth` / `glow` 后追加 `innerGlow`。
+- `<Frame>` 属性表：`glowColor` 之后 +2 行（§4 的表），示例块加一行金色 hexagon + 内发光，
+  一行 `black/0.35` 内阴影（让「同一属性两种用途」进作者的视野）。
+- 「Only `glow` is affected by an ancestor `RectMask2D`」那条：补一句 `innerGlow` 永远在 rect
+  内，不受影响。
+- Corner treatments 小节「Border, glow, glass and `mask="self"` follow the new outline
+  automatically」→ 加 inner glow。
+- 「Which tags draw procedurally」引用块与 Procedural surfaces 一节的属性行：加 `innerGlow` /
+  `innerGlowColor`。
+- 描边与内发光的叠放规则一句话：measured from the shape edge, an opaque border covers the
+  outermost `borderWidth` px of it —— 粗描边要把数值调大。
+
+`reference/glass.md`：开头「`glow` all behave identically」与参数归属表（容器行）加
+`innerGlow` / `innerGlowColor`。
+
+`reference/decor.md`：**不改**（Decor 不支持，lint 会报）。C# skill 不改（无公共 API 变化）。
+
+## 8. 已定的决策（2026-08-28 与作者对齐）
+
+1. **两个新属性 `innerGlow` / `innerGlowColor`，不复用 `glow` 加关键字。** 参考图同时要
+   内外两层，一个属性表达不了（§2）。
+2. **默认色 `white`。** 跟随填充色在不透明填充上不可见，是陷阱；跟随 `glowColor` 同理
+   （§5.4）。
+3. **source-over 合成。** 与库里所有合成一致，`/alpha` 控强度；深色即内阴影，一属性两用
+   （§2）。
+4. **发光带从形状边缘 d = 0 量起，描边压在上面。** Photoshop 语义；半透明细描边无缝，粗
+   描边调大数值（§5.3）。
+5. **衰减曲线与外发光同为 `g²`。** 内外等宽时是一整圈对称光晕（§5.1）。
+6. **不进 v1**：`<Decor>`、内层 `fillInnerGlow` 等、逐状态 `hoverInnerGlow`、`<Animation>`
+   开口、choke / spread 旋钮、方向性 bevel（§2 / §9）。
+7. **weld：容器持有，成员写了报 `PUI-GLASS-WELD-PARAM-PLACEMENT`。** 同描边（§5.8）。
+
+## 9. 开放问题 / 扩展位
+
+- **外发光抽 helper 是否同 PR**（§6.2）：倾向做，以既有 render 基线为准绳；实现期定。
+- **`Editor/XsdGenerator.cs` 的 Btn 手写清单今天就缺 `radius` / `glow` 等整组程序化属性**
+  （只有 Frame 那份清单是全的）—— 既有缺口，不在本特性范围，记一笔。
+- 扩展位（不做，留名）：`innerGlowChoke`（Photoshop 的 choke%）；方向性内发光 = bevel /
+  emboss（复用 `lightAngle` 语义，边缘光强按 `dot(n, lightDir)` 调制 —— `PuguiPanelNormal`
+  已经有了）；`sheen` 斜向光带（参考图的下一层）；`glowOffset`（drop shadow，procedural-style
+  spec §7 已记）。
+
+## 10. 里程碑拆分
+
+| | 内容 | 依赖 |
+|---|---|---|
+| **M0 Red** | §11 全部测试先红：解析 / 默认色 / 可见性 / 不外扩 / 材质共享 / disabled 灰化 / lint 三处名字表 / weld 归属 / XSD / render 断言 | 无 |
+| **M1 实现** | cginc helper + 三 shader + `PanelParams` + `ProceduralPanel` + `GlassGroupPanel` + 两处 `[UIAttr]` + 三处 lint 名字表 + XSD + SKILL（§7） | M0 |
+
+一个 PR（分支 `feat/inner-glow`）。改动面全是「顺着 `glow` 的管线各加一份」，拆开没有收益。
+验证：EditMode / EditorOnly / PlayMode 全绿 + `dotnet format --verify-no-changes` + UIXmlLint
+跑 `Runtime/Resources/` 无新 issue。
+
+## 11. 测试（Red 先行）
+
+**`FrameProceduralPanelTests`**（材质参数观测走 `CurrentParams`，与 `Glow*` 测试同型）
+
+- `InnerGlow_ParsesPixels`：`innerGlow='12'` → `InnerGlowSize == 12`。
+- `InnerGlow_Empty_ResetsToZero`；`InnerGlow_Negative_Rejected`；`InnerGlow_NaN_Rejected`。
+- `InnerGlowColor_DefaultsToWhite`：`color='#ff0000' innerGlow='8'` → `InnerGlowColor == white`
+  （**不是**填充色 —— 断言消息写明陷阱）。
+- `InnerGlowColor_ExplicitWins`；`InnerGlowColor_RejectsGradient`。
+- `InnerGlowOnly_IsVisible`：无 fill 无 border，`innerGlow='8'` → `IsPanelVisible`。
+- `InnerGlow_DoesNotInflateMesh`：`innerGlow='20'` 的 mesh 包围盒 == 布局 rect（对照
+  `Glow_InflatesMeshByGlowRadius`）。
+- `InnerGlow_ChangeDoesNotDirtyVertices`：改 `innerGlow` 不触发顶点重建（走既有的
+  vertices-dirty 观测方式，若无则用 `BuildMeshForTests` 前后顶点相等代替）。
+- `Disabled_DesaturatesInnerGlowColor`。
+- `SameInnerGlow_SharesOneMaterial` / `DifferentInnerGlow_SplitsMaterial`
+  （`ProceduralMaterialCache.LiveMaterialCount`）。
+
+**`ProceduralSurfaceContractTests`**：`AnyPanelAttachingAttr_AttachesASurface` 的用例表加
+`innerGlow='8'` 与 `innerGlowColor='#fff'` 两条（Btn 上写了就进程序化模式）。
+
+**`FrameGlassPanelTests` / `GlassWeldGroupTests`**：玻璃面参数带 `InnerGlow*`；weld 组材质
+拿到容器的值、成员的值不进组材质。
+
+**Lint**
+
+- `ProceduralAttrNamesTests`：镜像测试自动覆盖（名字必须是 `<Frame>` 的真实属性）。
+- `GlassRulesTests.BadValues_AreFlagged` 的用例表加 `innerGlow`（`PUI-PROCEDURAL-VALUE` 今天在
+  那个类里测）；`BadValuesInAStyle_AreFlaggedWhereTheyAreWritten` 同型加一条 `<Style innerGlow='abc'>`。
+- `PureContainerVisualAttrRulesTests`：`<VStack innerGlow=>` 与 `<Decor innerGlow=>` 都报。
+- `GlassRulesStyleAwareTests`：成员上的 `innerGlow` → `PUI-GLASS-WELD-PARAM-PLACEMENT`。
+- `ThemeStyleRulesTests`：一个主题写整套（含 `innerGlow`）、另一主题不写 → 豁免、不报。
+
+**XSD**（`XsdGeneratorTests`，substring）：Frame 含 `innerGlow` 与 `innerGlowColor`。
+
+**Render**（`ProceduralSurfaceRenderTests` 的 RT 读像素套路）
+
+- 纯色填充 + `innerGlow`：边缘内 2px 处的亮度 > 中心亮度；形状外 1px 处与无内发光时**逐像素
+  相等**（不外扩）。
+- `+ borderWidth='4' borderColor='#000'`：描边区读到黑（描边在上）。
+- `cut 16` 与 `hexagon` 各一例：斜边内侧同样变亮（形状跟随）。
+- 既有 round-only 基线（`CornerTreatmentRenderTests`）在 `innerGlow` 缺省时逐像素不变 ——
+  这条同时守住 §6.2 外发光抽 helper 的重构。
+
+## 12. 实施记录
+
+**验证结果**：EditMode 2680 / EditorOnly 309 / PlayMode 171 全通过；
+`dotnet format --verify-no-changes --severity warn` exit 0；
+`UIXmlLint Runtime/Resources/` no issues across 8 files。
+
+### 12.1 §6.2 的外发光重构：做了，而且是零风险的
+
+spec 把「外发光是否一并抽成 helper」列为开放问题，担心逐像素漂移。实际抽出来之后
+`PuguiApplyOuterGlow` 的指令序列与原来那四行**逐字相同**（只是把 `_GlowSize` / `_GlowColor`
+换成形参），三个 shader 的既有 render 基线全部照常通过 —— 包括
+`CornerTreatmentRenderTests` 那组「round-only 逐像素不变」的守卫。三份复制就此消掉。
+
+内外两层现在是 cginc 里紧挨着的一对函数，镜像关系一眼可见 —— 这正是当初要求「同一条曲线」
+的那个约束能长期活下去的形式。
+
+### 12.2 一个 spec 没写、但实现时必须决定的点：可见性的 alpha 检查
+
+`ComputeVisible` 里既有两种写法并存：border 是 `_borderWidth > 0 && _borderColor.a > 0`，
+而 glow 只有 `_glowSize > 0`（不看 alpha）。内发光跟了 **border** 那一支 —— 它和 border 一样画在
+形状内部，`innerGlowColor="white/0"` 是作者明确说「这一层关掉」，不该因此让一个本来全透明的
+面板产生一个 4 顶点的空 draw。外发光那条不一致是既有行为，不在本特性范围内动。
+
+### 12.3 计数注释的连带修改
+
+`ProceduralPanel` 的类注释和 `MarkDirty` 注释里写着「applying fourteen attributes at
+instantiation」，`ProceduralControl` 写着「a subclass gets all thirteen for free」—— 属性 +2 之后
+都得跟着改（16 / 15）。这类散在注释里的硬编码计数没有任何测试守着，只能靠改属性时顺手 grep。
+
+### 12.4 视觉验收
+
+按参考图配出的那颗按钮（`radius="hexagon 70"` + 金色渐变 + `innerGlow="34"` +
+`borderWidth="2"` + `glow="40"`）渲染出来就是参考图主按钮的观感：亮边向内衰减到金色本体、
+细亮描边、外侧柔和光晕。剩余差距与 §1 的判断一致 —— 顶部冠形凸起、斜向光带、细线纹样，
+三者都在本 spec 范围之外。


### PR DESCRIPTION
外发光在 SDF 外侧衰减；把符号翻过来就是内发光。

参考需求图的「开始匹配」金色主按钮，剥掉外圈线条只看本体，是四层叠出来的：渐变填充 + **边缘一圈浅黄向内衰减** + 1px 亮描边 + 外侧柔和光晕。只有第二层这个库画不出来 —— 程序化表面从 SDF 派生出填充、内描边、外发光、玻璃折射四样东西，**没有任何一样在轮廓内侧带衰减地画东西**。填充只有纵向渐变，描边是硬边带。于是最能决定「高级金属牌」质感的那一层只能退回贴图，而贴图皮肤恰恰被 #104 的「主题换形状」排除在外。

设计见 `docs~/superpowers/specs/2026-08-28-inner-glow-design.md`（含 §12 实施记录）。

## 是什么

两个属性 `innerGlow` / `innerGlowColor`，语法、解析器、落点全部镜像 `glow` / `glowColor` —— 于是 `<Frame>` 与九个程序化控件（Btn / Tab / Toggle / Slider / Dropdown / InputField / ScrollList / Progress）一次全部拿到。

```xml
<Btn radius="hexagon 70" color="#efdca6,#c08f36"
     innerGlow="30" innerGlowColor="#fff6cf"
     borderWidth="2" glow="36">开始匹配</Btn>              <!-- 参考图那颗按钮 -->

<Frame color="surface" radius="12" innerGlow="20"
       innerGlowColor="black/0.35"/>                      <!-- 深色 = 内阴影 / 边缘暗角 -->
```

**纯材质参数**：不外扩 quad、不动布局、不动顶点。Variant 翻转与主题切换只换材质，canvas mesh 不重建；同 style 的面板照旧共用一个材质、照旧合批。

`cut` / `notch` / `pill` / `hexagon` 全部自动跟随 —— 派生自同一个 `d`，不需要任何新属性。

## 三处与外发光刻意不同

前两条是设计期与作者对齐的，第三条是实现时才浮出来的。

1. **默认色是 `white`，不跟随填充。** 外发光跟填充是对的（「这个形状在发光」）；内发光跟填充同色、填充又不透明时**完全看不见** —— 那个默认是个陷阱。`white` 是「边缘被光照亮」的直觉，任何填充上都可见，且与 `borderColor` 的默认一致。副产品：写深色就是内阴影，一个属性两种用途。

2. **发光带从形状边缘 `d = 0` 量起，描边随后压在上面**（Photoshop Inner Glow 语义，而非 CSS `inset box-shadow`）。库里最常见的半透明细描边（`white/0.4` / `stroke/0.15`）下，发光延续到描边底下、边缘无缝；改成从描边内沿量，那个常见配置里描边带就会比紧邻的发光暗，边缘冒出一条 1px 暗缝。粗不透明描边会盖掉最外几 px，作者调大数值即可 —— 用一个罕见配置的精度换一个常见配置的正确。

3. **可见性检查看 alpha**（跟 `border` 那一支，不跟 `glow`）。`ComputeVisible` 里本就两种写法并存：border 看 `_borderColor.a`，glow 不看。`innerGlowColor="white/0"` 是作者明确说「这一层关掉」，不该因此让一个本来全透明的面板产生一个 4 顶点的空 draw。外发光那条不一致是既有行为，本 PR 不动。

## 顺带：三份复制的外发光抽进了 cginc

spec 把这条列为开放问题（担心逐像素漂移）。实际抽出来后 `PuguiApplyOuterGlow` 的指令序列与原来那四行**逐字相同**，只是把 `_GlowSize` / `_GlowColor` 换成形参 —— 三个 shader 的既有 render 基线全部照常通过，包括 `CornerTreatmentRenderTests` 那组「round-only 逐像素不变」的守卫。

收益不只是少两份复制：内外两层现在是 cginc 里紧挨着的一对函数，「同一条 `g²` 曲线的镜像」这个约束在形式上就看得见。这条约束是有视觉意义的 —— `glow` 与 `innerGlow` 等宽时，读起来必须是**跨越边缘的一整圈对称光晕**，而不是两种手感的光拼在一起；三份复制迟早会漂移成后者。

## weld

内发光沿**融合后**的轮廓走，所以和描边、外发光一样是容器的参数（`GlassGroupPanel` 发布容器的 `InnerGlow*` 到组材质）。写在成员上由既有的 `PUI-GLASS-WELD-PARAM-PLACEMENT` 报出来 —— 只扩了名字表，没有新规则。理由同描边：逐成员的内发光会在焊缝处画出 weld 存在的意义就是要抹掉的那条分界。

## 渲染结果

8 条 render test 落成几何谓词：亮度从边缘向内**单调**衰减、出带即回到填充本色、形状外逐像素不变（不外溢是这个特性与 `glow` 的分水岭）、不透明描边盖住最外几 px 而发光在其内侧继续、`cut` 与 `hexagon` 的斜边内侧同样被照亮。每条各 dump 一张 PNG 并肉眼确认过。

另按参考图配了一颗金色六边形按钮渲染验收：亮边向内衰减到金色本体、细亮描边、外侧柔和光晕 —— 就是参考图主按钮的观感。剩余差距与 spec §1 的判断一致：顶部冠形凸起（要给 SDF 加一条边）、斜向光带 `sheen`、细线纹样，三者都在本 PR 范围之外。

## 不到达的地方（都是既有机制自动覆盖的）

| 地方 | 行为 |
|---|---|
| `<Decor>` | 2px 笔画没有「内部」可言 → `PUI-CONTAINER-VISUAL-ATTR` |
| `<VStack>` / `<HStack>` / `<Grid>` / `<SafeArea>` | 同上，指路「套一层 `<Frame>`」 |
| 内层 `fillRadius` 等 | 无 `fillInnerGlow`（内层 shape-only） |
| SHAPE 主题豁免 / `VariantBaseRules` | 从 `NeedsPanel` 派生，加名字即生效 |

## 测试与 lint

| | |
|---|---|
| 新增测试 | 面板参数 13 + 玻璃 2 + weld 2 + 渲染 8 + lint 7 + XSD 1 |
| EditMode | 2680 / 2680 |
| EditorOnly | 309 / 309 |
| PlayMode | 171 / 171 |
| `dotnet format --verify-no-changes` | 干净 |
| `UIXmlLint Runtime/Resources/` | no issues |

SKILL 同 PR 更新：`authoring-promptugui-xml/SKILL.md`（`<Frame>` 属性表 + 示例 + 描边叠放规则 + 程序化表面一节）、`reference/glass.md`（参数归属表 + 降级路径）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfFCb9D4m1WL7Ji2JUpUy9
