### PR TITLE
feat: <TabMenu> —— 弹出式 Tab 组（频道切换器 / 折叠导航）

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/SKILL.md
+++ b/.claude/skills/authoring-promptugui-xml/SKILL.md
@@ -99,13 +99,14 @@ Pre-registered on `UI.Registry`. Use as XML tags by name. 速查目录如下；�
 | `<Progress>` | 只读线性进度条 |
 | `<TabBar>` | 互斥选项卡容器 |
 | `<Tab>` | 选项卡（`bind` 显隐 `<Frame>`） |
+| `<TabMenu>` | 弹出式 Tab 组：收起=选中项 icon+文字+箭头，展开=一列 `<Tab>` |
 | `<Carousel>` | 翻页轮播卡（+ `fill="false"` 居中选择器） |
 | `<Show>` | 按状态显隐子树的无视觉 wrapper |
 | `<Decor>` | 角/边装饰：角括号 / 指示三角 / 强调线 / 贴图纹样（不参与排版）→ `reference/decor.md` |
 | `<Markdown>` | Renders a Markdown document into a scrollable subtree  |
 | `<FocusCursor>` | Screen-level cursor overlay for directional navigation. **Not a registered control** — not `Get<T>`-able; removed from the control tree before instantiation. → `reference/navigation.md` |
 
-> Re-skinning a built-in: every inner layer has an XML hook — `<Slider fill= handle=>`, `<Toggle checkmark=>`, `<Dropdown arrow= itemColor= scrollbar*=>`, `<ScrollList scrollbar*=>`, `<Progress fill= bg= frame=>`. Each takes a `<layer>` (sprite) / `<layer>Color` pair, and `""` clears the sprite for a flat look. Reach for those first. They are still *reference implementations*: for structural changes (a different popup layout, extra chrome) write your own `Control` and register it over the tag — `UI.Registry.Register<MyDropdown>("Dropdown")`. The built-ins are `sealed`, so you replace rather than subclass; see scripting-promptugui-csharp.
+> Re-skinning a built-in: every inner layer has an XML hook — `<Slider fill= handle=>`, `<Toggle checkmark=>`, `<Dropdown arrow= itemColor= scrollbar*=>`, `<TabMenu arrow= arrowColor=>`, `<ScrollList scrollbar*=>`, `<Progress fill= bg= frame=>`. Each takes a `<layer>` (sprite) / `<layer>Color` pair, and `""` clears the sprite for a flat look. Reach for those first. They are still *reference implementations*: for structural changes (a different popup layout, extra chrome) write your own `Control` and register it over the tag — `UI.Registry.Register<MyDropdown>("Dropdown")`. The built-ins are `sealed`, so you replace rather than subclass; see scripting-promptugui-csharp.
 
 ### `<Frame>`
 
@@ -191,7 +192,7 @@ There is still **no `Image`** on a Frame, so `sprite=` does nothing (`PUI-CONTAI
 - **One exception: `weld`.** A weld group fuses its members with a smooth union, which rounds every corner back off, so a welded block's treatment degrades to a plain round corner of the same reach. `PUI-WELD-CORNER` warns; see `reference/glass.md`.
 - Keywords are lower-case. `bevel` / `scoop` / `CUT` / `R6` are parse errors that name the legal words.
 
-> **Which tags draw procedurally.** `radius` / `borderWidth` / `borderColor` / `glow` / `glowColor` / `innerGlow` / `innerGlowColor` / `glass` (+ its tuning params) work on **`<Frame>`, `<Btn>`, `<Tab>`, `<Toggle>`, `<Slider>`, `<Dropdown>`, `<InputField>`, `<ScrollList>` and `<Progress>`** — see **Procedural surfaces** below for what they do on a control.
+> **Which tags draw procedurally.** `radius` / `borderWidth` / `borderColor` / `glow` / `glowColor` / `innerGlow` / `innerGlowColor` / `glass` (+ its tuning params) work on **`<Frame>`, `<Btn>`, `<Tab>`, `<TabMenu>`, `<Toggle>`, `<Slider>`, `<Dropdown>`, `<InputField>`, `<ScrollList>` and `<Progress>`** — see **Procedural surfaces** below for what they do on a control.
 >
 > On any other tag — `<Image>`, `<RawImage>`, `<Text>`, `<Icon>`, `<TabBar>`, `<Carousel>`, `<Markdown>` — they are accepted by the parser and then silently dropped; `PUI-CONTAINER-VISUAL-ATTR` is the only thing that tells you. (`<Image>` / `<RawImage>` are deliberate: a sprite is their whole point, and a procedural rectangle is what `<Frame>` is for.)
 >
@@ -297,7 +298,7 @@ Image + Button + R3 `OnClick` / `OnState`。`<Btn>开始</Btn>` 简写生成内�
 
 ### 程序化表面（`<Frame>` 之外的控件）
 
-在 `<Btn>` / `<Tab>` / `<Toggle>` / `<Slider>` / `<Dropdown>` / `<InputField>` / `<ScrollList>` / `<Progress>` 上写 `radius`（或任一其它程序化属性），该控件的**主表面**就改用自绘的圆角矩形 SDF，取值语义与 `<Frame>` 逐字相同。主题因此能换掉控件的**形状**，不只是颜色。
+在 `<Btn>` / `<Tab>` / `<TabMenu>` / `<Toggle>` / `<Slider>` / `<Dropdown>` / `<InputField>` / `<ScrollList>` / `<Progress>` 上写 `radius`（或任一其它程序化属性），该控件的**主表面**就改用自绘的圆角矩形 SDF，取值语义与 `<Frame>` 逐字相同。主题因此能换掉控件的**形状**，不只是颜色。
 
 ```xml
 <Btn radius="pill" color="accent" hoverColor="accent-light">确定</Btn>
@@ -313,6 +314,7 @@ Image + Button + R3 `OnClick` / `OnState`。`<Btn>开始</Btn>` 简写生成内�
 | 控件 | 主表面 |
 |---|---|
 | `<Btn>` `<Tab>` `<Dropdown>` `<InputField>` `<ScrollList>` | 控件自身的背景 |
+| `<TabMenu>` | **弹窗面板**（不是收起状态的把手 —— 把手默认透明，要底就套一层 `<Frame>`） |
 | `<Toggle>` | **勾选框**（不含 label） |
 | `<Slider>` | **轨道**（不含滑块） |
 | `<Progress>` | **bg 层**（在 mask 内） |
@@ -661,7 +663,7 @@ Other notes:
 | `stateReact="false"` | bool (default `true`) | Opts this node **and its whole subtree** out of an ancestor `<Btn>` / `<Tab>` / `<Toggle>`'s `*Modulate` fan-out. Has no effect on `*Color` (absolute — bg only, never fanned out). See `reference/states.md`. |
 | `flow="false"` | bool (default `true`) | **Layout-group children only** (direct child of `<VStack>` / `<HStack>` / `<Grid>`). Opts the child **out of the layout flow**: the group neither positions it nor counts it toward its own preferred size, and `anchor` / `margin` / `N%` regain full free-positioning semantics against the group's rect. Use for a 9-slice background layer / badge / overlay inside a hug-sized stack — see **Out-of-flow children** below. Inert under a free-positioning parent (`PUI-FLOW-OUTSIDE-GROUP`). Variant-overridable (`flow.portrait="false"`). |
 | `scale="N"` / `scale="Nx"` / `scale="<r>r"` | float `N` / `Nx` (int) / `<r>r` (float) | Three forms: `N` = box-preserving (a render-density knob, **not** a resize knob); `Nx` = N physical px per design-unit (constant across factors, **doesn't grow with the window**); `<r>r` = `r×` the canvas factor **snapped to an integer** (**grows with the window yet stays pixel-aligned**). `scale="2"` ≠ `scale="2x"`. Full formulas / examples / caveats: see **Relative scale** / **Device-density** / **Canvas-relative snapped** below. |
-| `focus="true"` | bool | **Selectable controls only** (`<Btn>` / `<Tab>` / `<Toggle>` / `<Slider>` / `<Dropdown>` / `<InputField>` / `<ScrollList>`). Marks this control as the initial EventSystem selection when the Screen opens in Directional navigation mode. First `focus="true"` in document order wins. Does NOT apply to `BindItems`-generated dynamic controls. No-op when `UI.UseGamepadNavigation()` has not been called. → [`reference/navigation.md`](reference/navigation.md) |
+| `focus="true"` | bool | **Selectable controls only** (`<Btn>` / `<Tab>` / `<TabMenu>` / `<Toggle>` / `<Slider>` / `<Dropdown>` / `<InputField>` / `<ScrollList>`). Marks this control as the initial EventSystem selection when the Screen opens in Directional navigation mode. First `focus="true"` in document order wins. Does NOT apply to `BindItems`-generated dynamic controls. No-op when `UI.UseGamepadNavigation()` has not been called. → [`reference/navigation.md`](reference/navigation.md) |
 | `nav="none"` | `"none"` | **Selectable controls only.** Removes the control from the directional navigation graph — arrow keys / gamepad skip it entirely (neither focused to nor from). The control remains clickable via pointer. |
 | `navUp` / `navDown` / `navLeft` / `navRight` | element `id` | **Selectable controls only.** Explicit directional-navigation override: pins the neighbor in that cardinal direction. Unspecified directions auto-fill geometrically (writing only `navDown="id"` does NOT dead-end up/left/right). Missing or inactive-variant `id` → silently falls back to geometric (no runtime throw; inactive-block targets self-heal on the activating ReSolve); CLI `PUI-NAV-UNKNOWN-TARGET` catches typos statically. Variant-overridable (`navDown.mobile="id2"`). → [`reference/navigation.md`](reference/navigation.md) |
 
@@ -673,11 +675,11 @@ Other notes:
 
 `anchor` and `margin` are **NOT** available on `<VStack>` / `<HStack>` / `<Grid>`.
 
-**Inside `<VStack>` / `<HStack>`**, a child's explicit `size` / `width` / `height` is written to `LayoutElement.preferredX` **and `minX`** with `flexibleX=0` (not to `sizeDelta`). So `<Btn size="64x64"/>` inside a VStack is **strictly 64×64** — the layout group will neither stretch **nor shrink** it: the pinned `minX` means even a space-constrained group can't compress it (it overflows the group instead). This is what keeps a fixed-size trailing control at full size — e.g. an edit `<Btn size="12x12"/>` after an intrinsic-width `<Text>` in an `<HStack>`: when the text grows past the available width, the text (whose `minWidth` stays 0) gives way (compresses / ellipsizes), the button does **not**. Only `stretch` / `stretch*N` (`minX` stays `-1`, shrinkable to 0) and the native-fallback axes below remain compressible. **Per-axis native fallback** (CSS `inline-block` 直觉): each axis the author omits is independently filled from the control's intrinsic content size, so `<Btn width="100"/>` keeps `preferredWidth=100` and gets `preferredHeight=44` (Btn's default). Controls that report a native size: `<Btn>`、`<Toggle>`、`<Icon>`、`<Dropdown>`、`<Slider>`、`<ScrollList>`、`<InputField>`；`<Image>` 当 sprite 非空时 (e.g. `<Btn>OK</Btn>` widens to fit text + padding, default height 44; `<Toggle>静音</Toggle>` widens to fit text + 28 padding, default height 44; `<Dropdown/>` defaults 160×44; `<InputField/>` defaults 160×44; `<Slider/>` defaults 160×44 horizontal or 44×160 vertical; `<ScrollList/>` defaults 160×200 vertical or 200×160 horizontal; `<Image sprite="..."/>` defaults to `sprite.rect.size / pixelsPerUnit`); the native-filled axis keeps `flexibleX=-1` (the LE "no opinion" sentinel) so an intrinsic `ILayoutElement` can still contribute. 无 sprite 的 `<Image/>` 拿不到 native → 那一轴回到 `preferredX=-1` 哨兵，看自带 `ILayoutElement` 报告，空状态多半 0，要可见自己写 size。
+**Inside `<VStack>` / `<HStack>`**, a child's explicit `size` / `width` / `height` is written to `LayoutElement.preferredX` **and `minX`** with `flexibleX=0` (not to `sizeDelta`). So `<Btn size="64x64"/>` inside a VStack is **strictly 64×64** — the layout group will neither stretch **nor shrink** it: the pinned `minX` means even a space-constrained group can't compress it (it overflows the group instead). This is what keeps a fixed-size trailing control at full size — e.g. an edit `<Btn size="12x12"/>` after an intrinsic-width `<Text>` in an `<HStack>`: when the text grows past the available width, the text (whose `minWidth` stays 0) gives way (compresses / ellipsizes), the button does **not**. Only `stretch` / `stretch*N` (`minX` stays `-1`, shrinkable to 0) and the native-fallback axes below remain compressible. **Per-axis native fallback** (CSS `inline-block` 直觉): each axis the author omits is independently filled from the control's intrinsic content size, so `<Btn width="100"/>` keeps `preferredWidth=100` and gets `preferredHeight=44` (Btn's default). Controls that report a native size: `<Btn>`、`<Toggle>`、`<Icon>`、`<Dropdown>`、`<Slider>`、`<ScrollList>`、`<InputField>`、`<TabMenu>`；`<Image>` 当 sprite 非空时 (e.g. `<Btn>OK</Btn>` widens to fit text + padding, default height 44; `<Toggle>静音</Toggle>` widens to fit text + 28 padding, default height 44; `<Dropdown/>` defaults 160×44; `<InputField/>` defaults 160×44; `<Slider/>` defaults 160×44 horizontal or 44×160 vertical; `<ScrollList/>` defaults 160×200 vertical or 200×160 horizontal; `<Image sprite="..."/>` defaults to `sprite.rect.size / pixelsPerUnit`); the native-filled axis keeps `flexibleX=-1` (the LE "no opinion" sentinel) so an intrinsic `ILayoutElement` can still contribute. 无 sprite 的 `<Image/>` 拿不到 native → 那一轴回到 `preferredX=-1` 哨兵，看自带 `ILayoutElement` 报告，空状态多半 0，要可见自己写 size。
 
 **`<Text>` 是这条规则的例外 —— 在 V/HStack 里它不拍 native 快照。** Because TMP_Text is itself a live `ILayoutElement`, every axis the author omits is left at the `-1` sentinel so TMP drives it **dynamically**: a fixed-width or `width="stretch"` `wrap="true"` `<Text>` grows its **height to fit the wrapped content** (multi-line, and it re-measures whenever the text changes); a bare `<Text>Hi</Text>` with both axes omitted is sized entirely by TMP (no `LayoutElement` is attached). So **auto-height multiline labels come for free — just leave `height` off** (no placeholder-text trick needed). To pin a fixed height instead, write an explicit `height=`. (This only applies inside `<VStack>` / `<HStack>`; in free-positioning — next paragraph — `<Text>` still uses its native size, since `sizeDelta` is set once and an omitted-size label would otherwise be invisible.)
 
-**Inside `<Frame>` / `<Screen>` / `<SafeArea>` (free-positioning)**, a child's `size` / `width` / `height` is written to `RectTransform.sizeDelta`. **Per-axis native fallback**：`anchor` 该轴不 stretch + 该轴没写 size + 控件有 intrinsic content size（`<Btn>`、`<Toggle>`、`<Icon>`、`<Dropdown>`、`<Slider>`、`<ScrollList>`、`<InputField>`(默认 160×44)；`<Text>` 当 text 非空时取 TMP `preferredWidth/Height`；`<Image>` 当 sprite 非空时取 `sprite.rect.size / pixelsPerUnit`）→ 该轴 `sizeDelta` 用 native 兜底（避免 0 不可见）；写了的那一轴保留作者值。例：`<Text height="12">Lv. 45</Text>` 在 Frame 里 → 高 12 固定、宽按 TMP `preferredWidth` 自适应。空文本 `<Text/>` / 无 sprite 的 `<Image/>` 整体保持 `sizeDelta=(0,0)`，得自己写 `size` 或 `anchor="stretch"` + `margin`。
+**Inside `<Frame>` / `<Screen>` / `<SafeArea>` (free-positioning)**, a child's `size` / `width` / `height` is written to `RectTransform.sizeDelta`. **Per-axis native fallback**：`anchor` 该轴不 stretch + 该轴没写 size + 控件有 intrinsic content size（`<Btn>`、`<Toggle>`、`<Icon>`、`<Dropdown>`、`<Slider>`、`<ScrollList>`、`<InputField>`(默认 160×44)、`<TabMenu>`(hug caption，最小高 44)；`<Text>` 当 text 非空时取 TMP `preferredWidth/Height`；`<Image>` 当 sprite 非空时取 `sprite.rect.size / pixelsPerUnit`）→ 该轴 `sizeDelta` 用 native 兜底（避免 0 不可见）；写了的那一轴保留作者值。例：`<Text height="12">Lv. 45</Text>` 在 Frame 里 → 高 12 固定、宽按 TMP `preferredWidth` 自适应。空文本 `<Text/>` / 无 sprite 的 `<Image/>` 整体保持 `sizeDelta=(0,0)`，得自己写 `size` 或 `anchor="stretch"` + `margin`。
 
 **`<Frame>` 默认 anchor 按轴 fill-or-fit**: 作者**没写** `anchor=` 时，Frame 按 size 是否存在分轴决定 —— 写过 `size`/`width`/`height` 的轴默认 top/left + 用作者写的值；没写的轴默认 stretch（填满父）。`<Frame/>` 两轴都 stretch（fill parent），`<Frame width="100"/>` X 轴固定 100、Y 轴 stretch，`<Frame size="100x50"/>` 两轴都 top-left 固定。镜像 CSS 块流：`<div style="width:100px">` 高度按 `auto` 撑开。**显式写 `anchor=`** 仍按原规则严格校验（`anchor="stretch"` + size attr 仍是 parse error）。其他控件维持 `(top, left)` 默认。
 
@@ -866,7 +868,7 @@ Three consequences worth internalising:
 - A project with no theme styles costs exactly nothing; this is all opt-in.
 
 **Exception: never give a shape attribute a baseline on an Image-backed control.** On the controls listed
-under 程序化表面 (`<Btn>` `<Tab>` `<Toggle>` `<Slider>` `<Dropdown>` `<InputField>` `<ScrollList>`
+under 程序化表面 (`<Btn>` `<Tab>` `<TabMenu>` `<Toggle>` `<Slider>` `<Dropdown>` `<InputField>` `<ScrollList>`
 `<Progress>`), `radius` / `glass` / `border*` / `glow*` / the glass parameters /
 `<layer>Radius` are **switches, not values**: writing one at all attaches the
 SDF face and retires the Image, whatever the value. So `radius=""` as a "baseline" does not mean
@@ -1177,7 +1179,7 @@ Append a comma between two colour values to produce a **vertical two-stop gradie
 ```
 
 **Where gradients work** — every attribute that paints a `Graphic`:
-- `color` on `<Image>` / `<Icon>` / `<RawImage>` / `<Btn>` / `<Tab>` / `<Toggle>` / `<Dropdown>` (+ `popupColor`) / `<Progress>` (`color`, `bgColor`, `frameColor`) / `<ScrollList>` (`color`, `frameColor`) / `<Slider>` (`bgColor`) / `<InputField>` (bg only, see below) / `<Text>`
+- `color` on `<Image>` / `<Icon>` / `<RawImage>` / `<Btn>` / `<Tab>` / `<TabMenu>` (popup panel) / `<Toggle>` / `<Dropdown>` (+ `popupColor`) / `<Progress>` (`color`, `bgColor`, `frameColor`) / `<ScrollList>` (`color`, `frameColor`) / `<Slider>` (`bgColor`) / `<InputField>` (bg only, see below) / `<Text>`
 - Absolute state colours: `hoverColor` / `pressedColor` / `selectedColor` / `disabledColor`
 
 **Where gradients are NOT supported** (runtime error; static lint):
@@ -1210,7 +1212,7 @@ Append a comma between two colour values to produce a **vertical two-stop gradie
 
 ## Tint blend modes
 
-`tint=` chooses how a control's `color` combines with its sprite. Available on these controls: `<Image>`, `<Icon>`, `<Btn>`, `<Toggle>`, `<Slider>`, `<Dropdown>`, `<ScrollList>`, `<InputField>`, `<Progress>`, `<Tab>`. On `<Tab>` `tint` applies to the bg; since `selectedSprite` now swaps the bg's own sprite, the selected sprite is tinted too. Not supported on `<Text>` (TMP uses its own shader, not the UI Image shader).
+`tint=` chooses how a control's `color` combines with its sprite. Available on these controls: `<Image>`, `<Icon>`, `<Btn>`, `<Toggle>`, `<Slider>`, `<Dropdown>`, `<ScrollList>`, `<InputField>`, `<Progress>`, `<Tab>`, `<TabMenu>` (its popup panel). On `<Tab>` `tint` applies to the bg; since `selectedSprite` now swaps the bg's own sprite, the selected sprite is tinted too. Not supported on `<Text>` (TMP uses its own shader, not the UI Image shader).
 
 | `tint`               | Blend                                                                                                                                  | Use it for                                                                                   |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
@@ -1399,7 +1401,7 @@ PromptUGUI never auto-enables masking — you must opt in via `mask=`. Two reaso
 
 ## Gamepad / Keyboard Navigation
 
-`<FocusCursor>` is a **`<Screen>`-level child element** (not a registered control — removed from the control tree by the parser, NOT instantiated at the cursor position). Its first child subtree is the cursor visual, which the library slides to the focused control's edge each frame. Navigation must be enabled from C# via `UI.UseGamepadNavigation()` once at startup (New Input System only). `focus="true"` marks the initial selection on open; `nav="none"` removes a control from the navigation graph; `navUp/navDown/navLeft/navRight="id"` pin explicit directional targets (unspecified directions auto-fill geometrically; only `<Btn>` / `<Tab>` / `<Toggle>` / `<Slider>` / `<Dropdown>` / `<InputField>` / `<ScrollList>` accept these attributes — `PUI-NAV-ON-NON-SELECTABLE` catches misuse). A built-in default cursor is used when `<FocusCursor>` is omitted. Modal focus trap (navigation contained inside the active modal, restored on close) is automatic. **Full attribute table, cursor animation, explicit nav overrides, modal trap, lint rules, complete XML + C# examples: [`reference/navigation.md`](reference/navigation.md).**
+`<FocusCursor>` is a **`<Screen>`-level child element** (not a registered control — removed from the control tree by the parser, NOT instantiated at the cursor position). Its first child subtree is the cursor visual, which the library slides to the focused control's edge each frame. Navigation must be enabled from C# via `UI.UseGamepadNavigation()` once at startup (New Input System only). `focus="true"` marks the initial selection on open; `nav="none"` removes a control from the navigation graph; `navUp/navDown/navLeft/navRight="id"` pin explicit directional targets (unspecified directions auto-fill geometrically; only `<Btn>` / `<Tab>` / `<TabMenu>` / `<Toggle>` / `<Slider>` / `<Dropdown>` / `<InputField>` / `<ScrollList>` accept these attributes — `PUI-NAV-ON-NON-SELECTABLE` catches misuse). A built-in default cursor is used when `<FocusCursor>` is omitted. Modal focus trap (navigation contained inside the active modal, restored on close) is automatic. **Full attribute table, cursor animation, explicit nav overrides, modal trap, lint rules, complete XML + C# examples: [`reference/navigation.md`](reference/navigation.md).**
 
 ## Quick reference (cheatsheet)
 
@@ -1421,7 +1423,7 @@ FRAME VISUAL  <Frame color="surface/0.9" radius="16" borderWidth="1" borderColor
               no visual attrs → bare RectTransform (zero cost)    sprite= still does nothing (use <Image>)
 
 BUILT-INS     <Frame> <Image> <Text> <VStack> <HStack> <Grid> <Btn> <Icon>
-              <Toggle> <Slider> <Dropdown> <ScrollList> <InputField>
+              <Toggle> <Slider> <Dropdown> <ScrollList> <InputField> <TabMenu>
               <Progress value="0.6" fill="ui:bar"/>  最简；mask= + 不设 bg → mask sprite 自动可见兼当底；radial 进度环不在 <Progress> 范围
               <TabBar><Tab text="A" sprite="..." selectedSprite="..." bind="frame_a" isOn="true"/>...</TabBar>  互斥 + Tab 自管 sprite/selectedSprite + bind 自动 toggle Frame
               <Carousel itemTemplate="Card" interval="5" dots="bottom-center" dotSprite="ui:dot" dotColor="#888" dotSelectedColor="#fff"/>  翻页 + 自动播放 + 拖动 + 状态化指示点；卡片走 C# BindItems；当前页 resize 不重置

--- a/.claude/skills/authoring-promptugui-xml/reference/animations.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/animations.md
@@ -32,7 +32,12 @@
 | `state-selected`   | The nearest ancestor `<Tab>` / `<Toggle>` is the active/`isOn` one at rest; fires on selection and once at open if already on. **Meaningful only with a `<Tab>` / `<Toggle>` source — a `<Btn>` never emits it.** |
 | `state-disabled`   | The nearest ancestor `<Btn>` / `<Tab>` / `<Toggle>` enters Disabled                                                                                                                                               |
 | `state-...@<id>`   | Same, but the source is the `<Btn>` / `<Tab>` / `<Toggle>` with `<id>` (any of the five `state-*` values)                                                                                                         |
+| `expand`           | The nearest **ancestor** `<TabMenu>` opens. Fires on open, not on close                                                                                                                                            |
+| `collapse`         | The nearest ancestor `<TabMenu>` closes                                                                                                                                                                            |
+| `expand@<id>` · `collapse@<id>` | Same, but the source is the `<TabMenu>` with `<id>` in this Trigger's subtree                                                                                                                        |
 | `manual`           | Does not auto-fire; C# must call `Fire()`                                                                                                                                                                         |
+
+**`expand` / `collapse` are not called `open` / `close`** — `on="open"` already means "the Screen opened". They exist because a `<TabMenu>`'s panel is an internal node you cannot wrap in an `<Animation>`; the panel's own entrance is the menu's `transition=` attribute, and these are for animating the **rows** inside it. They resolve upward exactly like `state-*`, and the popup they live in is switched off while collapsed — which the ancestor walk accounts for.
 
 **`state-*` source resolution is UPWARD**: unlike `click` / `hover-enter` / `press` (which search this Trigger's **subtree downward** for a `<Btn>` / `<Image>` source), `state-*` resolves to the nearest `<Btn>` / `<Tab>` / `<Toggle>` **ancestor** (`state-...@<id>` targets a specific source control by id). A bare `state-*` with no `<Btn>` / `<Tab>` / `<Toggle>` ancestor is a runtime error (and `PUI-STATE-NO-SOURCE` in the lint CLI; `@id` forms and Template bodies are exempt). They **fire on entering** the state, so `state-normal` fires once at open and `<Animation on="state-pressed">` plays on press with `<Animation on="state-normal">` as its natural revert.
 
@@ -134,6 +139,19 @@ Text family default: looks for the unique `<Text>` in the subtree. Multiple `<Te
 - `on="click"` requires a unique `<Btn>` descendant; multiple → use `on="click@<id>"` to disambiguate; zero `<Btn>` → error
 
 ## Patterns
+
+**Menu rows entering with the popup** — one `<Animation on="expand">` per row, reused via a Template:
+
+```xml
+<Template name="ChannelRow">
+  <Param name="text"/>
+  <Animation on="expand" type="slidein-left" duration="0.12s">
+    <Tab id="tab" text="{{text}}"/>
+  </Animation>
+</Template>
+
+<TabMenu id="channel" itemTemplate="ChannelRow" popupWidth="240" padding="8"/>
+```
 
 **Menu entry stagger** (v1 has no stagger sugar — write siblings with explicit delays):
 

--- a/.claude/skills/authoring-promptugui-xml/reference/controls-tabs.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/controls-tabs.md
@@ -146,7 +146,7 @@ Plus every common attribute (`anchor` / `size` / `margin` / `hidden` / `interact
 | `textColor` | color | ink | Caption colour — distinct from `color`, which fills the panel |
 | `font` | string | `default` | Font slot |
 | `iconSize` | float | `24` | Caption icon edge; the slot takes no space when the selected tab has no `icon` |
-| `arrow` · `arrowColor` | sprite / color | `pugui_caret` | `arrow=""` hides the caret (a sprite-less Image would draw a solid block). Flips 180° while open |
+| `arrow` · `arrowColor` | sprite / color | `pugui_caret` | `arrow=""` hides the caret (a sprite-less Image would draw a solid block). **Flips vertically** while open — mirrored, not rotated, so it never shifts sideways |
 | `arrowSize` | float | `16` | Caret edge |
 | `gap` | float | `6` | Space between icon, label and caret |
 
@@ -167,6 +167,26 @@ the right width from the first frame. Like `<Btn>`, its layout box does not re-m
 caption changes at runtime — the caption contents (label, then caret) do follow the new text, but
 neighbours in an `<HStack>` only shift on the next `ReSolve`. Give the handle an explicit `width` if
 your channel names vary wildly in length.
+
+### Restyling the caret
+
+`arrow=` takes the same sprite key as any other sprite attribute — `ui:chevron` (SpriteSet) or a bare
+`Resources` path — and `arrowColor` / `arrowSize` do the rest. Pack them into a `<Style>` and pull it
+in with `class=` like any other attribute bag:
+
+```xml
+<Style name="menu-caret" arrow="ui:chevron_down" arrowColor="white/0.7" arrowSize="14" gap="8"/>
+
+<TabMenu id="channel" class="menu-caret" fontSize="22">…</TabMenu>
+```
+
+`arrow=""` (or `arrow="none"`) hides it entirely — the caret is a glyph, not a panel, so a
+sprite-less `Image` would render as a solid block rather than nothing.
+
+The caret is a single `Image`, not an authorable subtree: it draws whatever sprite you hand it,
+flipped vertically while the menu is open. If you need two genuinely different glyphs for the two
+states, hide the built-in one (`arrow=""`) and put your own `<Show on="state-*">` pair inside a
+wrapping `<Frame>` next to the menu.
 
 ### `<Tab>` inside a `<TabMenu>`
 

--- a/.claude/skills/authoring-promptugui-xml/reference/controls-tabs.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/controls-tabs.md
@@ -1,6 +1,8 @@
-# Tabs (`<TabBar>` / `<Tab>`)
+# Tabs (`<TabBar>` / `<TabMenu>` / `<Tab>`)
 
-> Part of the **authoring-promptugui-xml** skill. Main reference: [`../SKILL.md`](../SKILL.md). The `<TabBar>` / `<Tab>` attribute tables live in the main doc's built-in primitives catalog; read this for layout patterns and lint rules. State colours: see [`states.md`](states.md).
+> Part of the **authoring-promptugui-xml** skill. Main reference: [`../SKILL.md`](../SKILL.md). The `<TabBar>` / `<Tab>` attribute tables live in the main doc's built-in primitives catalog; read this for layout patterns, the `<TabMenu>` attribute table, and lint rules. State colours: see [`states.md`](states.md).
+
+**Two containers, one set of rows.** `<TabBar>` lays its `<Tab>`s out in a bar; `<TabMenu>` folds the same tabs into a popup and shows the selected one as its handle. Everything a `<Tab>` does — `bind=`, `isOn`, state colours, `selectedSprite`, procedural surfaces, `<Show on="state-*">`, `BindItems` — is identical in both.
 
 `<TabBar>` 是 Tab 的容器；私有 `ToggleGroup`（`allowSwitchOff=false`）保证互斥，私有 `HorizontalLayoutGroup` / `VerticalLayoutGroup`（看 `direction=`）排布。**TabBar 本身没视觉**，只是布局容器；每个 `<Tab>` 自带 `sprite`（常态底）；`selectedSprite` 在选中时把 bg 自己的 `overrideSprite` 换成它、取消选中再换回 `sprite`（单图，无独立 overlay 节点；由 `isOn` 驱动，hover/按下选中 tab 不影响它；设了会把 `transition` 切到 None）。不写 `selectedSprite` 时 Tab 退化成纯色按钮视觉，互斥仍在。`selectedSprite=""` / `none` = 无 swap（no-op）。
 
@@ -87,10 +89,143 @@ TabBar collects the Tab whether it is the Template root (as here) or nested insi
 
 For dynamic data, use `BindItems` with `itemTemplate="FileTab"` (the same Template works for both patterns).
 
+## `<TabMenu>` — the folded tab group
+
+Collapsed, it is the selected tab's icon + text + a caret; expanded, a panel of `<Tab>` rows drops
+below it. Reach for it when a bar would not fit — a channel switcher in a chat header, a sort order,
+a folded-up navigation.
+
+```xml
+<Style name="menu-item" sprite="" height="44" radius="8"
+       hoverColor="white/0.08" selectedColor="primary/0.35" fontSize="18"/>
+
+<HStack anchor="top-stretch" height="64" padding="0,16,0,16" spacing="8">
+  <TabMenu id="channel" fontSize="22" textColor="white" iconSize="24"
+           popupWidth="240" padding="8" spacing="4"
+           radius="12" glass="true" color="primary-dark/0.6" borderWidth="1">
+    <Tab class="menu-item" icon="ui:globe" text="World"  bind="ch_world" isOn="true"/>
+    <Tab class="menu-item" icon="ui:guild" text="Guild"  bind="ch_guild"/>
+    <Tab class="menu-item" icon="ui:team"  text="Party"  bind="ch_party"/>
+  </TabMenu>
+  <Frame width="stretch"/>
+  <Text fontSize="20">128</Text>
+</HStack>
+
+<Frame id="ch_world" anchor="stretch" margin="64,0,0,0">…</Frame>
+<Frame id="ch_guild" anchor="stretch" margin="64,0,0,0">…</Frame>
+<Frame id="ch_party" anchor="stretch" margin="64,0,0,0">…</Frame>
+```
+
+### The surface is the popup, not the handle
+
+This is the one thing to internalise: **`color` / `sprite` / `radius` / `glass` / `borderWidth` /
+`<Decor>` on a `<TabMenu>` all describe the panel that drops down.** The collapsed handle is
+transparent by design and hugs its caption, so the caret sits right after the text.
+
+Want a background behind the handle too? Wrap it — the same move that gives a `<TabBar>` a bar:
+
+```xml
+<Frame radius="20" color="surface/0.6" borderWidth="1">
+  <TabMenu id="sort" anchor="stretch" margin="0,12,0,12" fontSize="16">
+    <Tab text="Newest" isOn="true"/>
+    <Tab text="Hottest"/>
+  </TabMenu>
+</Frame>
+```
+
+### Attributes
+
+Plus every common attribute (`anchor` / `size` / `margin` / `hidden` / `interactable` / `class` /
+`if` / `focus` / `nav*`) and all fifteen procedural ones — **which land on the popup panel**.
+
+**The handle:**
+
+| Attribute | Type | Default | Notes |
+|---|---|---|---|
+| `fontSize` | float | `24` | Caption size |
+| `textColor` | color | ink | Caption colour — distinct from `color`, which fills the panel |
+| `font` | string | `default` | Font slot |
+| `iconSize` | float | `24` | Caption icon edge; the slot takes no space when the selected tab has no `icon` |
+| `arrow` · `arrowColor` | sprite / color | `pugui_caret` | `arrow=""` hides the caret (a sprite-less Image would draw a solid block). Flips 180° while open |
+| `arrowSize` | float | `16` | Caret edge |
+| `gap` | float | `6` | Space between icon, label and caret |
+
+**The popup:**
+
+| Attribute | Type | Default | Notes |
+|---|---|---|---|
+| `popupWidth` | float | auto | Panel width. Unset = the wider of the handle and the rows |
+| `popupGap` | float | `4` | Space between handle and panel |
+| `padding` | `t,r,b,l` / `v,h` / `all` | `0` | Inside the panel |
+| `spacing` | float | `0` | Between rows |
+| `color` · `sprite` · `tint` | | rounded white | The panel's fill / skin. `sprite=""` = flat colour |
+| `transition` | duration | `0.15s` | Open / close animation. `0` snaps |
+| `itemTemplate` | tag / Template | `Tab` | For `BindItems`, same as `<TabBar>` |
+
+### `<Tab>` inside a `<TabMenu>`
+
+Identical to a `<Tab>` in a bar, with two differences:
+
+- **`width` does nothing** — rows always span the panel (`PUI-TABMENU-ITEM-WIDTH` says so). Size the
+  menu with `popupWidth` instead. `height` works normally; omit it and the row sizes to its label.
+- `anchor` / `margin` are illegal, as in any layout group.
+
+The selected tab's `text` and `icon` are what the handle mirrors, so a Template-wrapped row that
+carries its content in child `<Text>` / `<Icon>` nodes leaves the caption empty — put `text=` on the
+`<Tab>` itself.
+
+### Opening and closing
+
+Clicking the handle toggles. The menu closes when a row is picked (**including re-picking the one
+already selected**), when the click-catcher behind the panel is clicked, and on Escape / gamepad B.
+At most one menu is open anywhere at a time.
+
+Expanded is **runtime state**: a resize, a Variant flip or a theme switch re-measures the panel but
+never closes it, and there is no `expanded=` attribute — a menu always starts closed.
+
+The panel gets its own `Canvas` with `overrideSorting` while open, which is what lifts it above the
+page **and** frees it from an ancestor mask — a `<TabMenu>` inside a `<ScrollList>` still drops a
+full, unclipped menu. It hangs below the handle, left-aligned; it flips above when there is not
+enough room below and more above, and slides back inside the right edge if it would overflow.
+
+### Animating the rows
+
+The panel is an internal node, so you cannot wrap it in an `<Animation>` — that is what `transition`
+is for. The rows are yours, via `on="expand"` / `on="collapse"`
+(see [`animations.md`](animations.md)):
+
+```xml
+<Template name="ChannelRow">
+  <Param name="text"/>
+  <Param name="icon"/>
+  <Param name="bind"/>
+  <Animation on="expand" type="slidein-left" duration="0.12s">
+    <Tab id="tab" class="menu-item" icon="ui:{{icon}}" text="{{text}}" bind="{{bind}}"/>
+  </Animation>
+</Template>
+
+<TabMenu id="channel" itemTemplate="ChannelRow" popupWidth="240" padding="8"/>
+```
+
+```csharp
+screen.Get<TabMenu>("channel")
+      .BindItems(channels, (Tab tab, Channel c) => { tab.Text = c.Name; tab.Icon = c.IconKey; })
+      .AddTo(screen);
+```
+
+### Lint rules
+
+| Code | Fires when | Level |
+|---|---|---|
+| `PUI-TABMENU-CHILD` | A direct child's subtree holds no `<Tab>`, is not a Template invocation, and is not `<Decor>` | warning |
+| `PUI-TABMENU-ITEM-WIDTH` | A row (or the `<Tab>` inside it) declares `width` — including a variant-only one | warning |
+| `PUI-EXPAND-NO-SOURCE` | A bare `on="expand"` / `on="collapse"` with no `<TabMenu>` ancestor (`@id` forms and Template bodies exempt) | error |
+| `PUI-LAYOUT-ANCHOR` / `PUI-LAYOUT-MARGIN` | A row writes `anchor` / `margin` | error |
+
 ## Lint 规则
 
 | Code                   | 触发条件                                                                              | 级别    |
 | ---------------------- | ------------------------------------------------------------------------------------- | ------- |
-| `PUI-TAB-PARENT`       | `<Tab>` 不在 `<TabBar>` 直接父节点下（Template-instance root 内的 Tab 已豁免）        | warning |
+| `PUI-TAB-PARENT`       | `<Tab>` 不在 `<TabBar>` / `<TabMenu>` 直接父节点下（Template-instance root 内的 Tab 已豁免） | warning |
 | `PUI-TABBAR-CHILD`     | `<TabBar>` 的直接子节点不是 `<Tab>`，且子树里既无字面 `<Tab>` 也无模板调用（Template wrapper 与模板调用均已豁免——后者是非内置 tag，CLI 不展开 `<Import>`，可能含 `<Tab>`，如 `itemTemplate` 项） | warning |
 | `PUI-TABBAR-DIRECTION` | `direction` 不是 `horizontal` / `vertical`                                            | error   |

--- a/.claude/skills/authoring-promptugui-xml/reference/controls-tabs.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/controls-tabs.md
@@ -162,6 +162,12 @@ Plus every common attribute (`anchor` / `size` / `margin` / `hidden` / `interact
 | `transition` | duration | `0.15s` | Open / close animation. `0` snaps |
 | `itemTemplate` | tag / Template | `Tab` | For `BindItems`, same as `<TabBar>` |
 
+The handle is measured from the **selected** tab's text and icon at open time, so it is laid out at
+the right width from the first frame. Like `<Btn>`, its layout box does not re-measure when the
+caption changes at runtime — the caption contents (label, then caret) do follow the new text, but
+neighbours in an `<HStack>` only shift on the next `ReSolve`. Give the handle an explicit `width` if
+your channel names vary wildly in length.
+
 ### `<Tab>` inside a `<TabMenu>`
 
 Identical to a `<Tab>` in a bar, with two differences:

--- a/.claude/skills/authoring-promptugui-xml/reference/navigation.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/navigation.md
@@ -167,7 +167,22 @@ Pin specific directional inputs to a target control by id:
 | `navLeft` | Selectable controls | element `id` | Explicit left target |
 | `navRight` | Selectable controls | element `id` | Explicit right target |
 
-**Selectable controls** (the only tags that accept these attributes): `<Btn>`, `<Tab>`, `<Toggle>`, `<Slider>`, `<Dropdown>`, `<InputField>`, `<ScrollList>`.
+**Selectable controls** (the only tags that accept these attributes): `<Btn>`, `<Tab>`, `<TabMenu>`, `<Toggle>`, `<Slider>`, `<Dropdown>`, `<InputField>`, `<ScrollList>`.
+
+## Popup focus trap (`<TabMenu>`)
+
+An open `<TabMenu>` traps directional focus inside its panel, the same way a modal traps it inside
+itself — the panel covers the page and its rows are the only sensible targets. Opening lands the
+focus on the **currently selected** row, not blindly on the first one.
+
+Closing restores whatever owned the focus before, which is not always "nothing": open a menu inside
+a modal and closing it hands the trap back to the modal rather than freeing it. The focus itself
+returns to the handle, so the user resumes where they opened the menu from.
+
+Escape and gamepad **B** both close an open menu, and the press is consumed there — a modal behind
+it survives that press and closes on the next one. The full-screen click-catcher behind the panel is
+excluded from the navigation graph (`Navigation.Mode.None`), so directional input can never land on
+it.
 
 Writing nav attributes on a non-selectable tag (`<Frame>`, `<Image>`, `<Text>`, etc.) is a no-op at runtime and triggers `PUI-NAV-ON-NON-SELECTABLE` in the lint CLI and a runtime warning.
 

--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -343,6 +343,46 @@ Setting `tab.IsOn = true` triggers mutex (other Tabs flip to false via the TabBa
 
 `bar.BindItems<T, TSlot>` lets the template root be any `IControl`; `bar.BindItems<T>` is shorthand when the template root _is_ a `<Tab>` directly. The `<Tab>` reachable inside the slot is found via `ScopedIds` first, then a recursive child walk — Templates without an id'd Tab still work as long as exactly one `<Tab>` exists in the subtree.
 
+### TabMenu
+
+The same tab group, folded into a popup. **Every selection member above works identically** —
+`OnSelectionChanged`, `SelectedTab`, `SelectedIndex`, `Count`, `GetAt`, both `BindItems` overloads,
+`itemTemplate` — because `<TabBar>` and `<TabMenu>` share one implementation. What it adds is the
+open / closed state:
+
+```csharp
+var menu = screen.Get<TabMenu>("channel");
+
+menu.OnSelectionChanged
+    .Subscribe(tab => Chat.Switch(tab?.Id))
+    .AddTo(screen);
+
+menu.OnExpanded.Subscribe(_ => Sfx.Play("ui_open")).AddTo(screen);
+menu.OnCollapsed.Subscribe(_ => Sfx.Play("ui_close")).AddTo(screen);
+
+menu.IsExpanded;    // read-only
+menu.Expand();      // no-op when already open, or when interactable is false
+menu.Collapse();
+menu.Toggle();      // what clicking the handle does
+
+// Dynamic rows — identical to TabBar:
+menu.BindItems(channels, (Tab tab, Channel c) => { tab.Text = c.Name; tab.Icon = c.IconKey; })
+    .AddTo(screen);
+```
+
+The collapsed handle mirrors the **selected** tab's `text` and `icon`, so `tab.Text = "…"` on the
+selected row re-captions the menu automatically; `menu.RefreshCaption()` exists but you should not
+normally need it.
+
+Picking a row closes the menu — including re-picking the row already selected, which uGUI's
+`ToggleGroup` swallows (no `onValueChanged`) and which `OnSelectionChanged` therefore never sees.
+Setting `tab.IsOn = true` from code closes it too, and works even while the menu is closed: the rows
+live in a deactivated popup where uGUI's own mutual exclusion does not run, so the shared tab-group
+core enforces it instead.
+
+Expanded is runtime state — `screen.ReSolve()` (a resize, a Variant flip, a theme switch) re-measures
+the panel but never closes it.
+
 ### Carousel
 
 ```csharp
@@ -582,8 +622,8 @@ UI.Registry.Register<MyControl>("MyControl", optionalPrefab: null);
 - Supported types: `string` / `int` / `float` / `bool`. Use string + parse internally for everything else.
 - `[UIAttr(IsSprite = true)]` marks an attribute whose value is a sprite reference resolved via `UI.ResolveSprite` (or `UI.SpriteResolver` for atlas-only `ns:name` lookups). The Editor "Sync Sprite Sets" feature reads this flag to discover which attribute names per tag carry sprite refs, so the atlas auto-packs sprites referenced via non-`sprite` attribute names too (e.g. `<Progress fill='ui:foo' bg='ui:bar' frame='ui:baz' mask='ui:qux'/>`). Custom controls whose setter calls `UI.ResolveSprite` should set the flag; without it, only the conventional attribute name `sprite` is scanned and you'll see "missing sprite" warnings at sync time.
 - `[Bind]` on a field auto-wires a child component from a Prefab by child name. Useful when the control has a non-trivial Prefab structure.
-- `<Toggle>` / `<Slider>` / `<Dropdown>` / `<ScrollList>` are reference implementations, and **every built-in control is `sealed`** — you cannot subclass them. Two options, in order:
-  1. **Re-skin from XML.** Each inner layer has a `<layer>` (sprite) / `<layer>Color` attribute pair: `<Slider fill= fillColor= handle= handleColor=>`, `<Toggle checkmark= checkmarkColor=>`, `<Dropdown arrow= arrowColor= itemColor= itemTextColor= checkmark* scrollbar*>`, `<ScrollList scrollbar* scrollbarHandle*>`, `<Progress fill= bg= frame= mask=>`. `""` clears a sprite, giving a flat colour-only layer. This covers pixel borders, flat/glass looks and per-theme recolouring without any C#.
+- `<Toggle>` / `<Slider>` / `<Dropdown>` / `<ScrollList>` / `<TabMenu>` are reference implementations, and **every built-in control is `sealed`** — you cannot subclass them. Two options, in order:
+  1. **Re-skin from XML.** Each inner layer has a `<layer>` (sprite) / `<layer>Color` attribute pair: `<Slider fill= fillColor= handle= handleColor=>`, `<Toggle checkmark= checkmarkColor=>`, `<Dropdown arrow= arrowColor= itemColor= itemTextColor= checkmark* scrollbar*>`, `<TabMenu arrow= arrowColor=>`, `<ScrollList scrollbar* scrollbarHandle*>`, `<Progress fill= bg= frame= mask=>`. `""` clears a sprite, giving a flat colour-only layer. This covers pixel borders, flat/glass looks and per-theme recolouring without any C#.
   2. **Replace the tag.** For structural changes (different popup layout, extra chrome, new interaction), write your own `Control` and register it over the built-in tag before any Screen opens: `UI.Registry.Register<MyDropdown>("Dropdown")`. XML keeps saying `<Dropdown>`; the registry decides which class builds it. Don't modify the base controls.
 - **IL2CPP Managed Stripping (Medium+)**: setter-only `[UIAttr]` properties get their `PropertyInfo` metadata stripped (`Type.GetProperties()` returns nothing for them), reflection misses the property, attribute silently reverts to default in Player builds with no error log. **Pair every `[UIAttr]` and `[Bind]` with `[Preserve]`**: `[UIAttr, Preserve] public string Color { set { ... } }`. `PromptUGUI.Registry.PreserveAttribute` is name-matched by Mono.Linker (any class named exactly `PreserveAttribute`, inheritance does **not** count). All built-in controls already do this; custom controls must too.
 
@@ -637,7 +677,8 @@ EVENTS (R3)    .OnClick                Btn
                                         Focused = Directional nav mode only; reuses hover visual
                .OnValueChanged         Toggle:bool / Slider:float / InputField:string / Tab:bool
                .OnSelected             Dropdown:int / Tab:Unit (on=true only)
-               .OnSelectionChanged     TabBar:Tab (the newly-on Tab, or null when emptied)
+               .OnSelectionChanged     TabBar/TabMenu:Tab (the newly-on Tab, or null when emptied)
+               .OnExpanded/.OnCollapsed TabMenu:Unit (popup opened / closed)
                .OnCurrentChanged       Carousel:int (any-source page change, deduped)
                .OnEndEdit / .OnSubmit  InputField:string
                .Subscribe(...).AddTo(screen)   tie lifetime — ALWAYS
@@ -647,12 +688,14 @@ EVENTS (R3)    .OnClick                Btn
 DATA PUSH      Dropdown.BindOptions(Observable<IEnumerable<string>>)
                ScrollList.BindItems(Observable<IReadOnlyList<T>>, (slot,t)=>...)
                TabBar.BindItems(Observable<IReadOnlyList<T>>, (Tab tab,t)=>...)
+               TabMenu.BindItems(...)  same shape — one shared tab-group implementation
                                        or BindItems<T,TSlot>(...) for wrapped templates
                Carousel.BindItems(Observable<IReadOnlyList<T>>, (IControl card,t)=>...[, key: o=>o.Id])
                                                               // key optional: re-centre the centred card by identity on re-emit
                                        or BindItems<T,TSlot>(...) for typed card template
                .AddTo(screen)
-               TabBar query: .Count / .SelectedIndex (-1 if empty) / .SelectedTab / .GetAt(i)
+               TabBar/TabMenu query: .Count / .SelectedIndex (-1 if empty) / .SelectedTab / .GetAt(i)
+               TabMenu state: .IsExpanded / .Expand() / .Collapse() / .Toggle()
                Carousel query: .Count / .Current (get/set) / .Playing (get/set) / .GoTo(i,animated) / .Next() / .Previous()
 
 MARKDOWN       md.Text = "…"                                 set → full re-render (runtime-owned)

--- a/Runtime/Application/BuiltinPrimitives.cs
+++ b/Runtime/Application/BuiltinPrimitives.cs
@@ -24,6 +24,7 @@ namespace PromptUGUI.Application
             reg.Register<Toggle>("Toggle", null, defaultTextAttr: "text", runtimeStateAttr: "isOn");
             reg.Register<Tab>("Tab", null, defaultTextAttr: "text", runtimeStateAttr: "isOn");
             reg.Register<TabBar>("TabBar", null);
+            reg.Register<TabMenu>("TabMenu", null);
             reg.Register<Slider>("Slider", null, runtimeStateAttr: "value");
             reg.Register<Progress>("Progress", null, runtimeStateAttr: "value");
             reg.Register<Dropdown>("Dropdown", null, runtimeStateAttr: "value");

--- a/Runtime/Application/Modals/ModalEscapeListener.cs
+++ b/Runtime/Application/Modals/ModalEscapeListener.cs
@@ -12,6 +12,13 @@ namespace PromptUGUI.Application.Modals
     {
         internal Action OnEscape;
 
+        /// <summary>
+        /// Also listen on the gamepad's Cancel button. Off for modals — a modal is dismissed with
+        /// Start, and East stays free for the navigation controller to read as "back". A popup that
+        /// is not a modal (an open <see cref="Controls.TabMenu"/>) does want East to close it.
+        /// </summary>
+        internal bool AlsoCancelButton;
+
 #if ENABLE_INPUT_SYSTEM
         private global::UnityEngine.InputSystem.InputAction _action;
         private global::UnityEngine.InputSystem.InputActionMap _map;
@@ -22,6 +29,7 @@ namespace PromptUGUI.Application.Modals
             _action = _map.AddAction("Escape", global::UnityEngine.InputSystem.InputActionType.Button);
             _action.AddBinding("<Keyboard>/escape");
             _action.AddBinding("<Gamepad>/start");
+            if (AlsoCancelButton) _action.AddBinding("<Gamepad>/buttonEast");
             _action.performed += OnPerformed;
             _map.Enable();
         }

--- a/Runtime/Application/Screen.cs
+++ b/Runtime/Application/Screen.cs
@@ -918,9 +918,15 @@ namespace PromptUGUI.Application
         /// page behind it (modal focus correctness — see <see cref="Navigation.ExplicitNavigationResolver"/>).
         /// Called by <see cref="UI.Modal"/> after the modal binds (buttons shown/hidden finalized).
         /// </summary>
-        internal void ConfineNavigationToSelf()
+        internal void ConfineNavigationToSelf() => ConfineNavigationTo(RootGameObject);
+
+        /// <summary>
+        /// Cage directional navigation inside <paramref name="root"/> — the whole screen for a modal,
+        /// a single popup panel for an open <see cref="Controls.TabMenu"/>. Pass null to lift the cage.
+        /// </summary>
+        internal void ConfineNavigationTo(UnityEngine.GameObject root)
         {
-            NavConfineRoot = RootGameObject;
+            NavConfineRoot = root;
             // The resolver forces a canvas update in confine mode so the geometric neighbours are
             // computed against a current layout (the modal's overlay canvas is sized there too).
             Navigation.ExplicitNavigationResolver.Resolve(this, _nodeMap, Variants,

--- a/Runtime/Application/ScreenInstantiator.cs
+++ b/Runtime/Application/ScreenInstantiator.cs
@@ -210,6 +210,9 @@ namespace PromptUGUI.Application
             else if (node.Tag == "TabBar")
                 foreach (var issue in TabRules.CheckTabBar(node))
                     Debug.LogWarning(issue.Message);
+            else if (node.Tag == "TabMenu")
+                foreach (var issue in PromptUGUI.Lint.TabMenuRules.CheckTabMenu(node))
+                    Debug.LogWarning(issue.Message);
             else if (node.Tag == "Carousel")
                 foreach (var issue in PromptUGUI.Lint.CarouselRules.CheckCarousel(node))
                     Debug.LogWarning(issue.Message);

--- a/Runtime/Application/ScreenInstantiator.cs
+++ b/Runtime/Application/ScreenInstantiator.cs
@@ -285,7 +285,7 @@ namespace PromptUGUI.Application
                 control.ReplaceScopedIds(childScope);
             }
 
-            var selfIsLayoutGroup = node.Tag is "VStack" or "HStack" or "Grid" or "TabBar" or "Carousel";
+            var selfIsLayoutGroup = node.Tag is "VStack" or "HStack" or "Grid" or "TabBar" or "TabMenu" or "Carousel";
             foreach (var c in node.Children)
             {
                 if (node.Tag == "Carousel")

--- a/Runtime/Application/UI.Modal.cs
+++ b/Runtime/Application/UI.Modal.cs
@@ -201,6 +201,11 @@ namespace PromptUGUI.Application
 
             private static void OnEscapePressed(Slot slot)
             {
+                // An open <TabMenu> is closer to the user than the modal it sits in, so it answers
+                // Escape first. Both listeners hear the same press and their order is undefined, so
+                // this also returns true when the menu already closed itself this frame — otherwise
+                // one press would close the menu AND the modal behind it.
+                if (Controls.TabMenu.TryConsumeEscape()) return;
                 if (Tutorial.IsBlockingInput) return;   // Block 引导期间吞 ESC(不关下层模态)
                 if (_stack.Count == 0 || _stack[_stack.Count - 1] != slot) return;
                 slot.Entry.TryEscape(() => OnEntryClosed(slot));

--- a/Runtime/Application/UI.cs
+++ b/Runtime/Application/UI.cs
@@ -1127,6 +1127,7 @@ namespace PromptUGUI.Application
             Router.ResetForTestsInternal();
             Tutorial.ResetForTestsInternal();
             Navigation.ResetForTestsInternal();
+            Controls.TabMenu.ResetForTestsInternal();
             Modal.CancelAllForTeardown();
             Modals.LoadingOverlay.CancelAllForTeardown();
             Toasts.ToastOverlay.CancelAllForTeardown();

--- a/Runtime/Controls/Internal/AnimationSpec.cs
+++ b/Runtime/Controls/Internal/AnimationSpec.cs
@@ -213,7 +213,14 @@ namespace PromptUGUI.Controls.Internal
         private static float ParseFloat(string s)
             => float.Parse(s, NumberStyles.Float, CultureInfo.InvariantCulture);
 
-        private static float ParseSeconds(string s)
+        /// <summary>
+        /// The one duration grammar every control shares: <c>"0.3s"</c> / <c>"300ms"</c> / a bare
+        /// number of seconds. Internal rather than private so <see cref="TabMenu"/>'s
+        /// <c>transition</c> reads exactly the same way <c>&lt;Animation duration&gt;</c> does —
+        /// a second copy would be a second grammar the day one of them grew a unit.
+        /// </summary>
+        /// <exception cref="System.FormatException">The numeric part is not a number.</exception>
+        internal static float ParseSeconds(string s)
         {
             if (string.IsNullOrEmpty(s)) return 0f;
             s = s.Trim();

--- a/Runtime/Controls/Internal/PaddingParser.cs
+++ b/Runtime/Controls/Internal/PaddingParser.cs
@@ -1,0 +1,51 @@
+using UnityEngine;
+
+namespace PromptUGUI.Controls.Internal
+{
+    /// <summary>
+    /// Parses the <c>padding</c> attribute shared by the layout-group controls
+    /// (<see cref="TabBar"/>, <see cref="TabMenu"/>) into a <see cref="RectOffset"/>.
+    ///
+    /// <para>Three shorthands, CSS-order per segment count: <c>"all"</c> /
+    /// <c>"vertical,horizontal"</c> / <c>"top,right,bottom,left"</c>.</para>
+    /// </summary>
+    /// <remarks>
+    /// Lenient by construction, and deliberately so: this is the behaviour <c>TabBar</c> shipped
+    /// with, extracted verbatim so the move stays a pure refactor. An unparseable segment reads as
+    /// 0 and an unsupported segment count (3, or 5+) yields an all-zero offset — neither raises.
+    /// The lint layer is where a malformed <c>padding</c> should be reported; changing it to throw
+    /// here would break documents that render fine today.
+    /// </remarks>
+    internal static class PaddingParser
+    {
+        /// <param name="value">The raw attribute text. Null / empty returns <paramref name="fallback"/>.</param>
+        /// <param name="fallback">Returned only when the value is absent; null means a zero offset.</param>
+        public static RectOffset Parse(string value, RectOffset fallback = null)
+        {
+            if (string.IsNullOrEmpty(value)) return fallback ?? new RectOffset();
+
+            var parts = value.Split(',');
+            int t = 0, r = 0, b = 0, l = 0;
+            switch (parts.Length)
+            {
+                case 1:
+                    int.TryParse(parts[0], out t);
+                    r = b = l = t;
+                    break;
+                case 2:
+                    int.TryParse(parts[0], out t);
+                    b = t;
+                    int.TryParse(parts[1], out r);
+                    l = r;
+                    break;
+                case 4:
+                    int.TryParse(parts[0], out t);
+                    int.TryParse(parts[1], out r);
+                    int.TryParse(parts[2], out b);
+                    int.TryParse(parts[3], out l);
+                    break;
+            }
+            return new RectOffset(l, r, t, b);
+        }
+    }
+}

--- a/Runtime/Controls/Internal/PaddingParser.cs.meta
+++ b/Runtime/Controls/Internal/PaddingParser.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 78e1eb7d5d77d4fc6b3436454a07dec7

--- a/Runtime/Controls/Internal/PopupPlacer.cs
+++ b/Runtime/Controls/Internal/PopupPlacer.cs
@@ -1,0 +1,59 @@
+using UnityEngine;
+
+namespace PromptUGUI.Controls.Internal
+{
+    /// <summary>Where a dropped panel ends up, relative to the handle it hangs from.</summary>
+    internal readonly struct PopupPlacement
+    {
+        public readonly Vector2 Anchor;            // both anchorMin and anchorMax — a corner of the handle
+        public readonly Vector2 Pivot;
+        public readonly Vector2 AnchoredPosition;
+        public readonly bool FlippedUp;
+
+        public PopupPlacement(Vector2 anchor, Vector2 pivot, Vector2 anchoredPosition, bool flippedUp)
+        {
+            Anchor = anchor;
+            Pivot = pivot;
+            AnchoredPosition = anchoredPosition;
+            FlippedUp = flippedUp;
+        }
+    }
+
+    /// <summary>
+    /// Solves where a <see cref="TabMenu"/>'s popup panel sits: under the handle and left-aligned
+    /// with it by default, flipped above when the room below cannot hold it, and pulled left when it
+    /// would spill past the right edge (spec §7.2).
+    ///
+    /// <para>Deliberately pure — every input is a plain rect, so the rules are unit-testable without
+    /// a live Canvas, which EditMode cannot size deterministically.</para>
+    /// </summary>
+    internal static class PopupPlacer
+    {
+        /// <param name="handle">The collapsed handle's rect, in the root canvas's local space.</param>
+        /// <param name="panel">The panel's width and height.</param>
+        /// <param name="canvas">The root canvas's rect, same space as <paramref name="handle"/>.</param>
+        /// <param name="gap">Vertical space left between handle and panel.</param>
+        public static PopupPlacement Solve(Rect handle, Vector2 panel, Rect canvas, float gap)
+        {
+            var roomBelow = handle.yMin - canvas.yMin;
+            var roomAbove = canvas.yMax - handle.yMax;
+            var needed = panel.y + gap;
+
+            // Flip only when it actually helps: a panel taller than both sides stays put (down is
+            // the convention) rather than jumping upward for no gain.
+            var flipUp = needed > roomBelow && roomAbove > roomBelow;
+
+            // Left-aligned with the handle, then pulled back inside the right edge if it spills —
+            // and never pushed past the left edge in the process.
+            var dx = 0f;
+            var overflowRight = handle.xMin + panel.x - canvas.xMax;
+            if (overflowRight > 0f) dx = -overflowRight;
+            var leftLimit = canvas.xMin - handle.xMin;
+            if (dx < leftLimit) dx = leftLimit;
+
+            return flipUp
+                ? new PopupPlacement(new Vector2(0f, 1f), new Vector2(0f, 0f), new Vector2(dx, gap), true)
+                : new PopupPlacement(new Vector2(0f, 0f), new Vector2(0f, 1f), new Vector2(dx, -gap), false);
+        }
+    }
+}

--- a/Runtime/Controls/Internal/PopupPlacer.cs.meta
+++ b/Runtime/Controls/Internal/PopupPlacer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cbc1117950a07219da9181d01ee17932

--- a/Runtime/Controls/Internal/PuiToggle.cs
+++ b/Runtime/Controls/Internal/PuiToggle.cs
@@ -14,9 +14,21 @@ namespace PromptUGUI.Controls.Internal
     internal sealed class PuiToggle : UnityToggle, IStateSource
     {
         private readonly StateBroadcaster _broadcaster = new();
+        private readonly Subject<Unit> _clicked = new();
         private int _bornFrame = int.MinValue;
 
         public Observable<InteractState> OnState => _broadcaster.OnState;
+
+        /// <summary>
+        /// Fires on every activation — pointer click or gamepad/keyboard Submit — <b>including</b>
+        /// one that does not change <c>isOn</c>.
+        ///
+        /// <para><c>onValueChanged</c> cannot serve this: inside a <c>ToggleGroup</c> with
+        /// <c>allowSwitchOff=false</c>, re-picking the already-selected member is swallowed
+        /// (<c>isOn</c> was already true), so nothing is emitted. <see cref="TabMenu"/> needs the
+        /// click regardless — picking the current channel still has to close the menu.</para>
+        /// </summary>
+        internal Observable<Unit> OnClicked => _clicked;
         public InteractState Current => _broadcaster.Current;
         public void RegisterShow(InteractState state, Action reevaluate) => _broadcaster.RegisterShow(state, reevaluate);
         public bool IsShowStateClaimed(InteractState state) => _broadcaster.IsShowStateClaimed(state);
@@ -55,6 +67,18 @@ namespace PromptUGUI.Controls.Internal
         {
             if (UI.Navigation.TryWakeOnSubmit()) return;
             base.OnSubmit(eventData);
+            // After the early return, deliberately: a wake-only Submit recalls the focus cursor
+            // and is NOT an activation (see nav-hidden-submit-wake).
+            _clicked.OnNext(Unit.Default);
+        }
+
+        public override void OnPointerClick(PointerEventData eventData)
+        {
+            base.OnPointerClick(eventData);
+            // Same button filter uGUI's Toggle applies before InternalToggle: a right-click is not
+            // an activation, and firing here would let it close a TabMenu the base ignored.
+            if (eventData.button != PointerEventData.InputButton.Left) return;
+            _clicked.OnNext(Unit.Default);
         }
 
         /// <summary>Test hook: drive a transition without a live EventSystem (ordinal — the test
@@ -62,8 +86,12 @@ namespace PromptUGUI.Controls.Internal
         internal void SimulateState(int selectionStateOrdinal)
             => DoStateTransition((SelectionState)selectionStateOrdinal, instant: true);
 
+        /// <summary>Test hook: raise <see cref="OnClicked"/> without a live EventSystem.</summary>
+        internal void SimulateClickForTests() => _clicked.OnNext(Unit.Default);
+
         protected override void OnDestroy()
         {
+            _clicked.Dispose();
             _broadcaster.Dispose();
             base.OnDestroy();
         }

--- a/Runtime/Controls/Internal/TabGroupCore.cs
+++ b/Runtime/Controls/Internal/TabGroupCore.cs
@@ -187,8 +187,38 @@ namespace PromptUGUI.Controls.Internal
                 var captured = t;
                 captured.OnValueChanged
                     .Where(on => on)
-                    .Subscribe(_ => _selectionChanged.OnNext(captured))
+                    .Subscribe(_ =>
+                    {
+                        // Before announcing: SelectedTab reports the FIRST tab whose IsOn is set, so
+                        // a stale second selection would be handed to subscribers.
+                        EnforceExclusive(captured);
+                        _selectionChanged.OnNext(captured);
+                    })
                     .AddTo(_tabSubs);
+            }
+        }
+
+        /// <summary>
+        /// Turns every tab but <paramref name="winner"/> off.
+        /// </summary>
+        /// <remarks>
+        /// The group's <c>ToggleGroup</c> normally does this, but only for tabs that are
+        /// <em>active</em>: uGUI's <c>Toggle.Set</c> gates the <c>NotifyToggleOn</c> call on
+        /// <c>IsActive()</c>, and a toggle also unregisters itself from the group in
+        /// <c>OnDisable</c>. A <see cref="TabMenu"/> keeps its rows inside a collapsed (inactive)
+        /// popup, so a code-driven <c>tab.IsOn = true</c> while the menu is closed would otherwise
+        /// leave the previous tab on as well — two selected tabs, two visible bound pages.
+        ///
+        /// <para>Redundant for <see cref="TabBar"/>, where the ToggleGroup got there first, and
+        /// harmless: assigning <c>isOn</c> a value it already holds returns early in uGUI, so no
+        /// event is re-raised and the recursion terminates immediately.</para>
+        /// </remarks>
+        private void EnforceExclusive(Tab winner)
+        {
+            for (int i = 0; i < _tabs.Count; i++)
+            {
+                var t = _tabs[i];
+                if (!ReferenceEquals(t, winner) && t.IsOn) t.IsOn = false;
             }
         }
 

--- a/Runtime/Controls/Internal/TabGroupCore.cs
+++ b/Runtime/Controls/Internal/TabGroupCore.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using PromptUGUI.Application;
+using PromptUGUI.IR;
+using PromptUGUI.Parser;
+using R3;
+using UnityEngine;
+
+namespace PromptUGUI.Controls.Internal
+{
+    /// <summary>
+    /// The tab-group semantics shared by <see cref="TabBar"/> (tabs laid out in a bar) and
+    /// <see cref="TabMenu"/> (the same tabs folded into a popup): collecting static
+    /// <c>&lt;Tab&gt;</c> children, <c>BindItems</c> + <c>itemTemplate</c> rebuilds, initial-selection
+    /// reconciliation, and the per-tab subscriptions feeding <see cref="SelectionChanged"/>.
+    ///
+    /// <para>One implementation, two hosts — the presentation (layout group vs. popup panel) is the
+    /// only thing the two controls own themselves. The owner supplies the RectTransform new items
+    /// parent into via <c>itemHost</c>, since <see cref="TabBar"/> hosts them on itself while
+    /// <see cref="TabMenu"/> hosts them inside its popup's content node.</para>
+    /// </summary>
+    internal sealed class TabGroupCore : IDisposable
+    {
+        private readonly Control _owner;
+        private readonly Func<RectTransform> _itemHost;
+        private readonly List<Tab> _tabs = new();
+        private readonly Subject<Tab> _selectionChanged = new();
+
+        // BindItems / itemTemplate state — factory resolution is deferred to first
+        // Rebuild so that OwnerScreenOf(owner) sees the Screen registered in UI._open
+        // (XML setter time may pre-date Open(); also lets tests rely on default "Tab").
+        private string _itemTemplate = "Tab";
+        private Func<RectTransform, IControl> _factory;
+        private IDisposable _itemsSub;
+
+        // Per-Tab subscriptions kept alive until next rebuild / Dispose; reset
+        // both on dynamic Rebuild and on static OnAfterApply so reapply replaces them.
+        private CompositeDisposable _tabSubs;
+
+        // BindItems 接管卡片来源后置位：之后 ReSolve 触发的 CollectStatic 不得把
+        // 已 Dispose 的静态 Tab 收回 _tabs（镜像 CarouselView._bound）。
+        private bool _bound;
+
+        public TabGroupCore(Control owner, Func<RectTransform> itemHost)
+        {
+            _owner = owner;
+            _itemHost = itemHost;
+        }
+
+        public string ItemTemplate
+        {
+            set { _itemTemplate = string.IsNullOrEmpty(value) ? "Tab" : value; _factory = null; }
+        }
+
+        public IReadOnlyList<Tab> Tabs => _tabs;
+
+        public Observable<Tab> SelectionChanged => _selectionChanged;
+
+        public int SelectedIndex
+        {
+            get
+            {
+                for (int i = 0; i < _tabs.Count; i++)
+                    if (_tabs[i].IsOn) return i;
+                return -1;
+            }
+        }
+
+        public Tab SelectedTab
+        {
+            get
+            {
+                var idx = SelectedIndex;
+                return idx >= 0 ? _tabs[idx] : null;
+            }
+        }
+
+        public IDisposable BindItems<T, TSlot>(
+            Observable<IReadOnlyList<T>> source,
+            Action<TSlot, T> bind,
+            Action beforeRebuild = null,
+            Action afterRebuild = null) where TSlot : class, IControl
+        {
+            _itemsSub?.Dispose();
+            _itemsSub = source.Subscribe(items =>
+            {
+                beforeRebuild?.Invoke();
+                Rebuild(items, bind);
+                afterRebuild?.Invoke();
+            });
+            return _itemsSub;
+        }
+
+        private void Rebuild<T, TSlot>(IReadOnlyList<T> items, Action<TSlot, T> bind)
+            where TSlot : class, IControl
+        {
+            if (_factory == null) _factory = ResolveFactory(_itemTemplate);
+            ClearTabs();
+            var host = _itemHost();
+            for (int i = 0; i < items.Count; i++)
+            {
+                var node = _factory(host);
+                var typed = node as TSlot;
+                if (typed == null)
+                    throw new InvalidCastException(
+                        $"itemTemplate='{_itemTemplate}' instantiated {node.GetType().Name}, expected {typeof(TSlot).Name}");
+
+                var tab = node as Tab ?? FindTabIn(node);
+                if (tab == null)
+                    throw new InvalidCastException(
+                        $"itemTemplate='{_itemTemplate}' root contains no <Tab>; cannot bind.");
+
+                _tabs.Add(tab);
+                // Tab.OnAttached already wired ToggleGroup via FindAncestorToggleGroup.
+                // Per-tab sprite / selectedSprite live on Tab itself — set them on the
+                // itemTemplate body (e.g. <Template name="MyTab"><Tab sprite="..."/></Template>)
+                // if every dynamic Tab should share the same visual.
+                bind(typed, items[i]);
+            }
+            SyncInitialSelection();
+            WireTabSubscriptions();
+            if (_tabs.Count == 0) _selectionChanged.OnNext(null);
+        }
+
+        private void ClearTabs()
+        {
+            _bound = true;
+            _tabSubs?.Dispose();
+            _tabSubs = null;
+            foreach (var t in _tabs) t.Dispose();
+            _tabs.Clear();
+        }
+
+        /// <summary>
+        /// Tab is a pure C# Control (not a MonoBehaviour), so GetComponentInChildren
+        /// can't find it. ScrollList-style template wrappers expose the full id scope on
+        /// the root via ReplaceScopedIds — look there first; if the template has no
+        /// id'd Tab, fall back to a recursive Children walk so wrappers without ids still work.
+        /// </summary>
+        public static Tab FindTabIn(IControl node)
+        {
+            foreach (var c in node.ScopedIds.Values)
+                if (c is Tab t) return t;
+            if (node is Control ctrl)
+            {
+                foreach (var child in ctrl.Children)
+                {
+                    if (child is Tab t) return t;
+                    var nested = FindTabIn(child);
+                    if (nested != null) return nested;
+                }
+            }
+            return null;
+        }
+
+        private Func<RectTransform, IControl> ResolveFactory(string tag)
+        {
+            var owner = UI.OwnerScreenOf(_owner);
+            if (owner?.Def?.Templates != null && owner.Def.Templates.TryGetValue(tag, out var tpl))
+            {
+                ItemTemplateGuard.EnsureInstantiable(tag, tpl);
+                return parent =>
+                {
+                    var instantiator = UI.GetInstantiator();
+                    return instantiator.InstantiateNode(tpl.Body, parent, owner);
+                };
+            }
+            if (UI.Registry.Has(tag))
+            {
+                return parent =>
+                {
+                    var instantiator = UI.GetInstantiator();
+                    var node = new ElementNode(tag);
+                    return instantiator.InstantiateNode(node, parent, owner);
+                };
+            }
+            throw new ParseException(
+                $"<{_owner.GetType().Name} itemTemplate='{tag}'>: tag is neither a registered Control nor a Template");
+        }
+
+        public void WireTabSubscriptions()
+        {
+            _tabSubs?.Dispose();
+            _tabSubs = new CompositeDisposable();
+            foreach (var t in _tabs)
+            {
+                var captured = t;
+                captured.OnValueChanged
+                    .Where(on => on)
+                    .Subscribe(_ => _selectionChanged.OnNext(captured))
+                    .AddTo(_tabSubs);
+            }
+        }
+
+        public void SyncInitialSelection()
+        {
+            if (_tabs.Count == 0) return;
+
+            // (1) Reconcile: any unselected Tab with a bind clears its Frame
+            foreach (var t in _tabs)
+                if (!t.IsOn) t.ForceSyncBindFrame(isOn: false);
+
+            // (2) Auto-select first if nothing on
+            bool anyOn = false;
+            foreach (var t in _tabs) if (t.IsOn) { anyOn = true; break; }
+            if (!anyOn) _tabs[0].IsOn = true;
+        }
+
+        public void CollectStatic(IReadOnlyList<IControl> children)
+        {
+            if (_bound) return;
+            _tabs.Clear();
+            foreach (var child in children)
+            {
+                if (child is Tab tab) { _tabs.Add(tab); continue; }
+                // Template-wrapper case: a <Tab> nested inside a Template-expanded
+                // child (e.g. <FileTab><Frame><Tab/></Frame></FileTab>). Reuse the
+                // same recursive walk used by BindItems for itemTemplate.
+                var found = FindTabIn(child);
+                if (found != null) _tabs.Add(found);
+            }
+        }
+
+        public void Dispose()
+        {
+            _tabSubs?.Dispose();
+            _itemsSub?.Dispose();
+            _selectionChanged.Dispose();
+        }
+    }
+}

--- a/Runtime/Controls/Internal/TabGroupCore.cs.meta
+++ b/Runtime/Controls/Internal/TabGroupCore.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 893108b52e437dffd92a3e1b51c8c96a

--- a/Runtime/Controls/Internal/TabMenuMarker.cs
+++ b/Runtime/Controls/Internal/TabMenuMarker.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+namespace PromptUGUI.Controls.Internal
+{
+    /// <summary>
+    /// A component-shaped handle back to the <see cref="TabMenu"/> that owns this GameObject.
+    ///
+    /// <para><c>TabMenu</c>, like every other control here, is a plain C# object, so a
+    /// <c>&lt;Trigger on="expand"&gt;</c> nested inside the popup cannot reach it with a
+    /// <c>GetComponentInParent</c> walk. This marker is what that walk finds — the same trick
+    /// <c>IStateSource</c> uses for <c>state-*</c> triggers, which resolve upward for the same
+    /// reason.</para>
+    /// </summary>
+    internal sealed class TabMenuMarker : MonoBehaviour
+    {
+        internal TabMenu Owner;
+    }
+}

--- a/Runtime/Controls/Internal/TabMenuMarker.cs.meta
+++ b/Runtime/Controls/Internal/TabMenuMarker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e94038c9d87b8ead1958c6a0ff82315f

--- a/Runtime/Controls/Internal/TriggerSourceResolver.cs
+++ b/Runtime/Controls/Internal/TriggerSourceResolver.cs
@@ -133,5 +133,36 @@ namespace PromptUGUI.Controls.Internal
                     $"{ctrl.GetType().Name}, not a state source. state-* triggers require a <Btn>/<Tab>/<Toggle>.");
             return src;
         }
+
+        /// <summary>
+        /// Finds the <see cref="TabMenu"/> an <c>expand</c> / <c>collapse</c> trigger listens to.
+        /// Resolves <b>upward</b>, like <see cref="FindStateSource"/> and for the same reason: the
+        /// natural place for one is on a row inside the menu it belongs to.
+        /// </summary>
+        /// <param name="trigger">触发器控件</param>
+        /// <param name="sourceId">空 → 沿 GameObject 树向上找最近的 TabMenu；非空 → 走 ScopedIds 精确查找 + 类型校验</param>
+        public static TabMenu FindTabMenu(Trigger trigger, string sourceId)
+        {
+            if (string.IsNullOrEmpty(sourceId))
+            {
+                // includeInactive: a collapsed menu's popup — where these triggers live — is
+                // switched off, and the default active-only walk would never reach the marker.
+                var marker = trigger.GameObject.GetComponentInParent<TabMenuMarker>(true);
+                if (marker == null || marker.Owner == null)
+                    throw new InvalidOperationException(
+                        $"<Trigger on=\"expand\"/\"collapse\"> in '{trigger.Id ?? trigger.GameObject.name}': " +
+                        "no <TabMenu> ancestor found. Place it inside one, or use expand@<id>.");
+                return marker.Owner;
+            }
+
+            if (!trigger.ScopedIds.TryGetValue(sourceId, out var ctrl))
+                throw new InvalidOperationException(
+                    $"<Trigger on=\"expand@{sourceId}\"> in '{trigger.Id ?? trigger.GameObject.name}': " +
+                    $"id '{sourceId}' not found in trigger subtree scope");
+
+            return ctrl as TabMenu ?? throw new InvalidOperationException(
+                $"<Trigger on=\"expand@{sourceId}\">: id '{sourceId}' is a " +
+                $"{ctrl.GetType().Name}, not a <TabMenu>. expand / collapse require a <TabMenu>.");
+        }
     }
 }

--- a/Runtime/Controls/Internal/TriggerSpec.cs
+++ b/Runtime/Controls/Internal/TriggerSpec.cs
@@ -6,12 +6,13 @@ namespace PromptUGUI.Controls.Internal
     {
         Open, Loop, Click, Manual, HoverEnter, HoverExit, Press,
         StateNormal, StateHover, StatePressed, StateSelected, StateDisabled,
+        Expand, Collapse,
     }
 
     internal sealed class TriggerSpec
     {
         public TriggerKind Kind;
-        public string SourceId;  // non-null for Click / HoverEnter / HoverExit / Press / state-* with @id
+        public string SourceId;  // non-null for Click / HoverEnter / HoverExit / Press / state-* / expand / collapse with @id
 
         private static readonly (string prefix, TriggerKind kind)[] s_prefixedKinds = {
             ("click@",          TriggerKind.Click),
@@ -23,6 +24,9 @@ namespace PromptUGUI.Controls.Internal
             ("state-pressed@",  TriggerKind.StatePressed),
             ("state-selected@", TriggerKind.StateSelected),
             ("state-disabled@", TriggerKind.StateDisabled),
+            // Not "open@" / "close@": on="open" already means "the Screen opened".
+            ("expand@",         TriggerKind.Expand),
+            ("collapse@",       TriggerKind.Collapse),
         };
 
         public static TriggerSpec Parse(string value)
@@ -42,6 +46,8 @@ namespace PromptUGUI.Controls.Internal
                 case "state-pressed": return new TriggerSpec { Kind = TriggerKind.StatePressed };
                 case "state-selected": return new TriggerSpec { Kind = TriggerKind.StateSelected };
                 case "state-disabled": return new TriggerSpec { Kind = TriggerKind.StateDisabled };
+                case "expand": return new TriggerSpec { Kind = TriggerKind.Expand };
+                case "collapse": return new TriggerSpec { Kind = TriggerKind.Collapse };
             }
             foreach (var (prefix, kind) in s_prefixedKinds)
             {
@@ -57,7 +63,8 @@ namespace PromptUGUI.Controls.Internal
             throw new ArgumentException(
                 $"Invalid trigger 'on=\"{value}\"' — expected one of: open / loop / click / click@<id> / " +
                 "hover-enter / hover-enter@<id> / hover-exit / hover-exit@<id> / press / press@<id> / " +
-                "state-normal / state-hover / state-pressed / state-selected / state-disabled (each also with @<id>) / manual");
+                "state-normal / state-hover / state-pressed / state-selected / state-disabled (each also with @<id>) / " +
+                "expand / expand@<id> / collapse / collapse@<id> / manual");
         }
     }
 }

--- a/Runtime/Controls/Show.cs
+++ b/Runtime/Controls/Show.cs
@@ -54,6 +54,8 @@ namespace PromptUGUI.Controls
             TriggerKind.HoverEnter => _spec.SourceId == null ? "hover-enter" : "hover-enter@" + _spec.SourceId,
             TriggerKind.HoverExit => _spec.SourceId == null ? "hover-exit" : "hover-exit@" + _spec.SourceId,
             TriggerKind.Press => _spec.SourceId == null ? "press" : "press@" + _spec.SourceId,
+            TriggerKind.Expand => _spec.SourceId == null ? "expand" : "expand@" + _spec.SourceId,
+            TriggerKind.Collapse => _spec.SourceId == null ? "collapse" : "collapse@" + _spec.SourceId,
             _ => _spec.Kind.ToString(),
         };
 

--- a/Runtime/Controls/Tab.cs
+++ b/Runtime/Controls/Tab.cs
@@ -191,6 +191,7 @@ namespace PromptUGUI.Controls
             {
                 if (string.IsNullOrEmpty(value) && _label == null) return;
                 EnsureLabel().text = value ?? "";
+                ContentChanged?.Invoke();
             }
         }
 
@@ -241,6 +242,7 @@ namespace PromptUGUI.Controls
                     if (_label != null) _label.rectTransform.offsetMin = new Vector2(32f, 0f);
                 }
                 _icon.sprite = UI.ResolveSprite(value);
+                ContentChanged?.Invoke();
             }
         }
 
@@ -388,6 +390,29 @@ namespace PromptUGUI.Controls
 
         public Observable<bool> OnValueChanged => _changed;
         public Observable<Unit> OnSelected => _selected;
+
+        // ── Caption mirroring, for <TabMenu> (spec §5.2) ───────────────────────────────────
+        // A TabMenu's collapsed handle shows whichever Tab is selected. It reads the displayed
+        // text / icon back rather than the declared attribute values, so a caption also tracks a
+        // BindItems bind() or a code-side assignment — anything that reached the live label.
+
+        /// <summary>What the label currently shows, or null when this Tab never grew one.</summary>
+        internal string CaptionText => _label != null ? _label.text : null;
+
+        /// <summary>The icon sprite currently shown, or null when this Tab has no icon.</summary>
+        internal UnityEngine.Sprite CaptionIcon => _icon != null ? _icon.sprite : null;
+
+        /// <summary>Raised whenever <see cref="Text"/> or <see cref="Icon"/> changes what is shown.</summary>
+        internal event System.Action ContentChanged;
+
+        /// <summary>
+        /// Every activation of this Tab, including a click that leaves <c>isOn</c> untouched — see
+        /// <see cref="PuiToggle.OnClicked"/> for why <see cref="OnValueChanged"/> cannot serve.
+        /// </summary>
+        internal Observable<Unit> OnActivated => _toggle.OnClicked;
+
+        /// <summary>Test hook: raise <see cref="OnActivated"/> without a live EventSystem.</summary>
+        internal void SimulateClickForTests() => _toggle.SimulateClickForTests();
 
         protected internal override Transform ChildHostTransform
             => _offsetHolder != null ? _offsetHolder : RectTransform;

--- a/Runtime/Controls/TabBar.cs
+++ b/Runtime/Controls/TabBar.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using PromptUGUI.Application;
-using PromptUGUI.IR;
-using PromptUGUI.Parser;
+using PromptUGUI.Controls.Internal;
 using PromptUGUI.Registry;
 using R3;
 using UnityEngine;
@@ -17,23 +15,16 @@ namespace PromptUGUI.Controls
         private string _direction = "horizontal";
         private float _spacing;
         private string _padding;
-        private readonly List<Tab> _tabs = new();
-        private readonly Subject<Tab> _selectionChanged = new();
 
-        // BindItems / itemTemplate state — factory resolution is deferred to first
-        // Rebuild so that OwnerScreenOf(this) sees the Screen registered in UI._open
-        // (XML setter time may pre-date Open(); also lets tests rely on default "Tab").
-        private string _itemTemplate = "Tab";
-        private Func<RectTransform, IControl> _factory;
-        private IDisposable _itemsSub;
+        // Tab-group semantics (static collection / BindItems / initial selection / subscriptions)
+        // live in TabGroupCore, shared with <TabMenu>. TabBar owns only the presentation: which
+        // LayoutGroup arranges the tabs, and how it sizes them.
+        private readonly TabGroupCore _core;
 
-        // Per-Tab subscriptions kept alive until next rebuild / Dispose; reset
-        // both on dynamic Rebuild and on static OnAfterApply so reapply replaces them.
-        private CompositeDisposable _tabSubs;
-
-        // BindItems 接管卡片来源后置位：之后 ReSolve 触发的 CollectStaticTabs 不得把
-        // 已 Dispose 的静态 Tab 收回 _tabs（镜像 CarouselView._bound）。
-        private bool _bound;
+        public TabBar()
+        {
+            _core = new TabGroupCore(this, () => RectTransform);
+        }
 
         public override void OnAttached()
         {
@@ -59,33 +50,15 @@ namespace PromptUGUI.Controls
         public string Padding { set { _padding = value; ApplySpacingPadding(); } }
 
         [UIAttr, Preserve]
-        public string ItemTemplate
-        {
-            set { _itemTemplate = string.IsNullOrEmpty(value) ? "Tab" : value; _factory = null; }
-        }
+        public string ItemTemplate { set => _core.ItemTemplate = value; }
 
-        public int Count => _tabs.Count;
+        public int Count => _core.Tabs.Count;
 
-        public int SelectedIndex
-        {
-            get
-            {
-                for (int i = 0; i < _tabs.Count; i++)
-                    if (_tabs[i].IsOn) return i;
-                return -1;
-            }
-        }
+        public int SelectedIndex => _core.SelectedIndex;
 
-        public Tab SelectedTab
-        {
-            get
-            {
-                var idx = SelectedIndex;
-                return idx >= 0 ? _tabs[idx] : null;
-            }
-        }
+        public Tab SelectedTab => _core.SelectedTab;
 
-        public Tab GetAt(int index) => _tabs[index];
+        public Tab GetAt(int index) => _core.Tabs[index];
 
         public IDisposable BindItems<T>(
             Observable<IReadOnlyList<T>> source,
@@ -95,144 +68,13 @@ namespace PromptUGUI.Controls
         public IDisposable BindItems<T, TSlot>(
             Observable<IReadOnlyList<T>> source,
             Action<TSlot, T> bind) where TSlot : class, IControl
-        {
-            _itemsSub?.Dispose();
-            _itemsSub = source.Subscribe(items => Rebuild(items, bind));
-            return _itemsSub;
-        }
-
-        private void Rebuild<T, TSlot>(IReadOnlyList<T> items, Action<TSlot, T> bind)
-            where TSlot : class, IControl
-        {
-            if (_factory == null) _factory = ResolveFactory(_itemTemplate);
-            ClearTabs();
-            for (int i = 0; i < items.Count; i++)
-            {
-                var node = _factory(RectTransform);
-                var typed = node as TSlot;
-                if (typed == null)
-                    throw new InvalidCastException(
-                        $"itemTemplate='{_itemTemplate}' instantiated {node.GetType().Name}, expected {typeof(TSlot).Name}");
-
-                var tab = node as Tab ?? FindTabIn(node);
-                if (tab == null)
-                    throw new InvalidCastException(
-                        $"itemTemplate='{_itemTemplate}' root contains no <Tab>; cannot bind.");
-
-                _tabs.Add(tab);
-                // Tab.OnAttached already wired ToggleGroup via FindAncestorToggleGroup.
-                // Per-tab sprite / selectedSprite live on Tab itself — set them on the
-                // itemTemplate body (e.g. <Template name="MyTab"><Tab sprite="..."/></Template>)
-                // if every dynamic Tab should share the same visual.
-                bind(typed, items[i]);
-            }
-            SyncInitialSelection();
-            WireTabSubscriptions();
-            if (_tabs.Count == 0) _selectionChanged.OnNext(null);
-        }
-
-        private void ClearTabs()
-        {
-            _bound = true;
-            _tabSubs?.Dispose();
-            _tabSubs = null;
-            foreach (var t in _tabs) t.Dispose();
-            _tabs.Clear();
-        }
-
-        // Tab is a pure C# Control (not a MonoBehaviour), so GetComponentInChildren
-        // can't find it. ScrollList-style template wrappers expose the full id scope on
-        // the root via ReplaceScopedIds — look there first; if the template has no
-        // id'd Tab, fall back to a recursive Children walk so wrappers without ids still work.
-        private static Tab FindTabIn(IControl node)
-        {
-            foreach (var c in node.ScopedIds.Values)
-                if (c is Tab t) return t;
-            if (node is Control ctrl)
-            {
-                foreach (var child in ctrl.Children)
-                {
-                    if (child is Tab t) return t;
-                    var nested = FindTabIn(child);
-                    if (nested != null) return nested;
-                }
-            }
-            return null;
-        }
-
-        private Func<RectTransform, IControl> ResolveFactory(string tag)
-        {
-            var owner = UI.OwnerScreenOf(this);
-            if (owner?.Def?.Templates != null && owner.Def.Templates.TryGetValue(tag, out var tpl))
-            {
-                Internal.ItemTemplateGuard.EnsureInstantiable(tag, tpl);
-                return parent =>
-                {
-                    var instantiator = UI.GetInstantiator();
-                    return instantiator.InstantiateNode(tpl.Body, parent, owner);
-                };
-            }
-            if (UI.Registry.Has(tag))
-            {
-                return parent =>
-                {
-                    var instantiator = UI.GetInstantiator();
-                    var node = new ElementNode(tag);
-                    return instantiator.InstantiateNode(node, parent, owner);
-                };
-            }
-            throw new ParseException(
-                $"<TabBar itemTemplate='{tag}'>: tag is neither a registered Control nor a Template");
-        }
+            => _core.BindItems(source, bind);
 
         internal override void OnAfterApply()
         {
-            CollectStaticTabs();
-            SyncInitialSelection();
-            WireTabSubscriptions();
-        }
-
-        private void WireTabSubscriptions()
-        {
-            _tabSubs?.Dispose();
-            _tabSubs = new CompositeDisposable();
-            foreach (var t in _tabs)
-            {
-                var captured = t;
-                captured.OnValueChanged
-                    .Where(on => on)
-                    .Subscribe(_ => _selectionChanged.OnNext(captured))
-                    .AddTo(_tabSubs);
-            }
-        }
-
-        private void SyncInitialSelection()
-        {
-            if (_tabs.Count == 0) return;
-
-            // (1) Reconcile: any unselected Tab with a bind clears its Frame
-            foreach (var t in _tabs)
-                if (!t.IsOn) t.ForceSyncBindFrame(isOn: false);
-
-            // (2) Auto-select first if nothing on
-            bool anyOn = false;
-            foreach (var t in _tabs) if (t.IsOn) { anyOn = true; break; }
-            if (!anyOn) _tabs[0].IsOn = true;
-        }
-
-        private void CollectStaticTabs()
-        {
-            if (_bound) return;
-            _tabs.Clear();
-            foreach (var child in Children)
-            {
-                if (child is Tab tab) { _tabs.Add(tab); continue; }
-                // Template-wrapper case: a <Tab> nested inside a Template-expanded
-                // child (e.g. <FileTab><Frame><Tab/></Frame></FileTab>). Reuse the
-                // same recursive walk used by BindItems for itemTemplate.
-                var found = FindTabIn(child);
-                if (found != null) _tabs.Add(found);
-            }
+            _core.CollectStatic(Children);
+            _core.SyncInitialSelection();
+            _core.WireTabSubscriptions();
         }
 
         private void ApplyDirection()
@@ -273,21 +115,7 @@ namespace PromptUGUI.Controls
                 case VerticalLayoutGroup v: v.spacing = _spacing; ApplyChildSizing(v); break;
             }
             if (string.IsNullOrEmpty(_padding) || _layout == null) return;
-            var parts = _padding.Split(',');
-            int t = 0, r = 0, b = 0, l = 0;
-            switch (parts.Length)
-            {
-                case 1: int.TryParse(parts[0], out t); r = b = l = t; break;
-                case 2:
-                    int.TryParse(parts[0], out t); b = t;
-                    int.TryParse(parts[1], out r); l = r; break;
-                case 4:
-                    int.TryParse(parts[0], out t);
-                    int.TryParse(parts[1], out r);
-                    int.TryParse(parts[2], out b);
-                    int.TryParse(parts[3], out l); break;
-            }
-            _layout.padding = new RectOffset(l, r, t, b);
+            _layout.padding = PaddingParser.Parse(_padding, _layout.padding);
         }
 
         /// <summary>
@@ -307,13 +135,11 @@ namespace PromptUGUI.Controls
             lg.childForceExpandHeight = false;
         }
 
-        public Observable<Tab> OnSelectionChanged => _selectionChanged;
+        public Observable<Tab> OnSelectionChanged => _core.SelectionChanged;
 
         public override void Dispose()
         {
-            _tabSubs?.Dispose();
-            _itemsSub?.Dispose();
-            _selectionChanged.Dispose();
+            _core.Dispose();
             base.Dispose();
         }
     }

--- a/Runtime/Controls/TabMenu.cs
+++ b/Runtime/Controls/TabMenu.cs
@@ -475,8 +475,21 @@ namespace PromptUGUI.Controls
         internal static bool HasExpandedMenu => s_expanded != null;
 
         private GameObject _blocker;
+        private GameObject _prevConfineRoot;
+
+        // True only while Expand() is bringing the panel up. Activating the popup subtree makes uGUI
+        // revalidate the ToggleGroup on enable, which re-announces the already-selected tab — and
+        // "a tab was selected" is otherwise the signal to close. Without this guard a menu closes
+        // itself in the same call that opened it.
+        private bool _expanding;
+        private PromptUGUI.Application.Modals.ModalEscapeListener _escapeListener;
         private readonly Subject<Unit> _expandedSubject = new();
         private readonly Subject<Unit> _collapsedSubject = new();
+
+        // The frame an Escape was already spent on. UI.Modal's handler and this menu's own listener
+        // both answer the same press in an undefined order, so whichever runs second has to see the
+        // press as gone or one key would close the menu and the modal behind it.
+        private static int s_escapeFrame = int.MinValue;
 
         public bool IsExpanded { get; private set; }
 
@@ -497,7 +510,21 @@ namespace PromptUGUI.Controls
             if (s_expanded != null && s_expanded != this) s_expanded.Collapse();
             s_expanded = this;
             IsExpanded = true;
+            _expanding = true;
+            try
+            {
+                ExpandCore();
+            }
+            finally
+            {
+                _expanding = false;
+            }
 
+            _expandedSubject.OnNext(Unit.Default);
+        }
+
+        private void ExpandCore()
+        {
             _popup.gameObject.SetActive(true);
 
             var rootCanvas = RootCanvas();
@@ -507,9 +534,9 @@ namespace PromptUGUI.Controls
 
             EnsureBlocker(rootCanvas, baseOrder + PopupSortingOffset - 1);
             PlacePopup();
+            PushNavigation();
+            EnableEscapeListener(true);
             PlayTransition(expanding: true);
-
-            _expandedSubject.OnNext(Unit.Default);
         }
 
         public void Collapse()
@@ -519,6 +546,8 @@ namespace PromptUGUI.Controls
             if (s_expanded == this) s_expanded = null;
 
             if (_blocker != null) _blocker.SetActive(false);
+            EnableEscapeListener(false);
+            PopNavigation();
             PlayTransition(expanding: false);
 
             _collapsedSubject.OnNext(Unit.Default);
@@ -615,6 +644,106 @@ namespace PromptUGUI.Controls
             if (_popup == null) return;
             _popupCanvas.overrideSorting = false;
             _popup.gameObject.SetActive(false);
+        }
+
+        // ── Directional navigation & Escape ───────────────────────────────────────────────
+
+        /// <summary>
+        /// Cages the focus inside the open panel and lands it on the current choice.
+        /// </summary>
+        /// <remarks>
+        /// Remembers whatever owned the focus before — an enclosing modal, usually — rather than
+        /// assuming "nothing". Restoring to null instead would silently free a modal's trap the
+        /// first time someone opened a menu inside it.
+        /// </remarks>
+        private void PushNavigation()
+        {
+            if (!UI.Navigation.IsEnabled) return;
+
+            // ContainmentRoot is the authority — it is what EnforceContainment reads every frame, and
+            // a caller can set it without going through a Screen (as UI.Modal does).
+            _prevConfineRoot = UI.Navigation.ContainmentRoot;
+            UI.OwnerScreenOf(this)?.ConfineNavigationTo(_popup.gameObject);
+            UI.Navigation.ContainmentRoot = _popup.gameObject;
+
+            var es = FindEventSystem();
+            if (es == null) return;
+            var pick = SelectedTab != null && SelectedTab.GameObject != null
+                ? SelectedTab.GameObject
+                : UI.Navigation.FirstFocusableUnder(_popup.gameObject);
+            if (pick != null) es.SetSelectedGameObject(pick);
+        }
+
+        private void PopNavigation()
+        {
+            if (!UI.Navigation.IsEnabled) return;
+
+            UI.OwnerScreenOf(this)?.ConfineNavigationTo(_prevConfineRoot);
+            UI.Navigation.ContainmentRoot = _prevConfineRoot;
+            _prevConfineRoot = null;
+
+            var es = FindEventSystem();
+            if (es != null && GameObject != null) es.SetSelectedGameObject(GameObject);
+        }
+
+        // EventSystem.current is null in EditMode; mirror Screen.FindEventSystem's fallback.
+        private static UnityEngine.EventSystems.EventSystem FindEventSystem()
+            => UnityEngine.EventSystems.EventSystem.current
+               ?? UnityEngine.Object.FindAnyObjectByType<UnityEngine.EventSystems.EventSystem>();
+
+        private void EnableEscapeListener(bool on)
+        {
+            if (!on)
+            {
+                if (_escapeListener != null) _escapeListener.enabled = false;
+                return;
+            }
+            if (_escapeListener == null)
+            {
+                _escapeListener = _popup.gameObject.AddComponent<PromptUGUI.Application.Modals.ModalEscapeListener>();
+                // Unlike a modal, a menu is dismissed with the gamepad's Cancel button too.
+                _escapeListener.AlsoCancelButton = true;
+                _escapeListener.OnEscape = () => { NoteEscapeConsumed(); Collapse(); };
+            }
+            _escapeListener.enabled = true;
+        }
+
+        private static void NoteEscapeConsumed() => s_escapeFrame = Time.frameCount;
+
+        /// <summary>
+        /// Closes the open menu, if any, and reports whether this Escape belongs to a menu.
+        /// Called first thing by <c>UI.Modal</c>'s Escape handler.
+        /// </summary>
+        internal static bool TryConsumeEscape()
+        {
+            if (s_expanded != null)
+            {
+                NoteEscapeConsumed();
+                s_expanded.Collapse();
+                return true;
+            }
+            // The menu's own listener already handled this very press — swallow it here too.
+            return s_escapeFrame == Time.frameCount;
+        }
+
+        internal void NotifyEscapeConsumedForTests()
+        {
+            NoteEscapeConsumed();
+            Collapse();
+        }
+
+        internal static void ForgetEscapeFrameForTests() => s_escapeFrame = int.MinValue;
+
+        /// <summary>
+        /// Clears the two process-wide bits between tests. Both would otherwise leak: a menu left
+        /// open by one test would be collapsed (on a destroyed object) by the next one's Expand, and
+        /// <c>Time.frameCount</c> barely advances between EditMode tests, so a spent Escape would
+        /// keep reading as spent.
+        /// </summary>
+        internal static void ResetForTestsInternal()
+        {
+            s_expanded = null;
+            s_escapeFrame = int.MinValue;
         }
 
         private Canvas RootCanvas()
@@ -762,6 +891,9 @@ namespace PromptUGUI.Controls
                 _blocker = null;
             }
             CancelMotions();
+            if (UI.Navigation.ContainmentRoot != null && _popup != null
+                && UI.Navigation.ContainmentRoot == _popup.gameObject)
+                UI.Navigation.ContainmentRoot = _prevConfineRoot;
             RepointCaptionSource(null);
             _selectionSub?.Dispose();
             _activationSubs?.Dispose();
@@ -774,7 +906,9 @@ namespace PromptUGUI.Controls
         private void OnSelectionSettled()
         {
             RefreshCaption();
-            Collapse();
+            // Not while opening: see _expanding. Picking a row — by click or from code — is what
+            // closes a menu, and reactivating the panel is neither.
+            if (!_expanding) Collapse();
         }
 
         // Picking a row closes the menu — including a re-pick of the row already selected, which
@@ -784,7 +918,7 @@ namespace PromptUGUI.Controls
             _activationSubs?.Dispose();
             _activationSubs = new CompositeDisposable();
             for (int i = 0; i < _core.Tabs.Count; i++)
-                _core.Tabs[i].OnActivated.Subscribe(_ => Collapse()).AddTo(_activationSubs);
+                _core.Tabs[i].OnActivated.Subscribe(_ => { if (!_expanding) Collapse(); }).AddTo(_activationSubs);
         }
     }
 }

--- a/Runtime/Controls/TabMenu.cs
+++ b/Runtime/Controls/TabMenu.cs
@@ -56,10 +56,13 @@ namespace PromptUGUI.Controls
         private Tab _captionSource;
         private Action _captionSourceHandler;
         private IDisposable _selectionSub;
+        private CompositeDisposable _activationSubs;
 
         private float _iconSize = 24f;
         private float _arrowSize = 16f;
         private float _gap = 6f;
+        private float _popupWidth;                 // 0 = auto (max of handle width and content)
+        private float _popupGap = 4f;
         private string _fontType = "default";
 
         public TabMenu()
@@ -274,6 +277,14 @@ namespace PromptUGUI.Controls
         [UIAttr, Preserve]
         public string ItemTemplate { set => _core.ItemTemplate = value; }
 
+        /// <summary>Panel width. Unset (or 0) sizes it to the wider of the handle and its content.</summary>
+        [UIAttr, Preserve]
+        public float PopupWidth { set { _popupWidth = value; PlacePopup(); } }
+
+        /// <summary>Space between handle and panel, on whichever side the panel drops.</summary>
+        [UIAttr, Preserve]
+        public float PopupGap { set { _popupGap = value; PlacePopup(); } }
+
         // ── Selection (delegated to TabGroupCore) ──────────────────────────────────────────
 
         public int Count => _core.Tabs.Count;
@@ -380,9 +391,32 @@ namespace PromptUGUI.Controls
 
         private void ApplyFont() => FontApplier.Apply(_label, _fontType);
 
-        // ── Expand / collapse (Task 5 wires the real behaviour) ────────────────────────────
+        // ── Expand / collapse ──────────────────────────────────────────────────────────────
+
+        /// <summary>Name of the full-screen click catcher, on the root canvas while a menu is open.</summary>
+        internal const string BlockerName = "__TabMenuBlocker";
+
+        /// <summary>
+        /// How far above the root canvas the panel sorts. The catcher sits one below it, so both
+        /// clear the page without reaching the modal band (<c>UI.Modal.SortingOrderBase</c> = 1000).
+        /// </summary>
+        internal static int PopupSortingOffset = 2;
+
+        // At most one menu is open anywhere: the catcher covers the screen, so a second one could
+        // not be reached, and Escape needs a single unambiguous target (TM-D9 / TM-D16).
+        private static TabMenu s_expanded;
+
+        internal static bool HasExpandedMenu => s_expanded != null;
+
+        private GameObject _blocker;
+        private readonly Subject<Unit> _expandedSubject = new();
+        private readonly Subject<Unit> _collapsedSubject = new();
 
         public bool IsExpanded { get; private set; }
+
+        public Observable<Unit> OnExpanded => _expandedSubject;
+
+        public Observable<Unit> OnCollapsed => _collapsedSubject;
 
         public void Toggle()
         {
@@ -391,10 +425,121 @@ namespace PromptUGUI.Controls
 
         public void Expand()
         {
+            if (IsExpanded || !Interactable) return;
+            if (GameObject == null || !GameObject.activeInHierarchy) return;
+
+            if (s_expanded != null && s_expanded != this) s_expanded.Collapse();
+            s_expanded = this;
+            IsExpanded = true;
+
+            _popup.gameObject.SetActive(true);
+
+            var rootCanvas = RootCanvas();
+            var baseOrder = rootCanvas != null ? rootCanvas.sortingOrder : 0;
+            _popupCanvas.overrideSorting = true;
+            _popupCanvas.sortingOrder = baseOrder + PopupSortingOffset;
+
+            EnsureBlocker(rootCanvas, baseOrder + PopupSortingOffset - 1);
+            PlacePopup();
+
+            _expandedSubject.OnNext(Unit.Default);
         }
 
         public void Collapse()
         {
+            if (!IsExpanded) return;
+            IsExpanded = false;
+            if (s_expanded == this) s_expanded = null;
+
+            if (_blocker != null) _blocker.SetActive(false);
+            if (_popup != null)
+            {
+                _popupCanvas.overrideSorting = false;
+                _popup.gameObject.SetActive(false);
+            }
+
+            _collapsedSubject.OnNext(Unit.Default);
+        }
+
+        private Canvas RootCanvas()
+        {
+            var canvas = GameObject.GetComponentInParent<Canvas>(true);
+            return canvas != null ? canvas.rootCanvas : null;
+        }
+
+        // The catcher hangs off the ROOT canvas, not the menu: it has to cover the whole screen, and
+        // a child of the handle could never do that without inheriting its clipping and position.
+        private void EnsureBlocker(Canvas rootCanvas, int sortingOrder)
+        {
+            if (_blocker == null)
+            {
+                var host = rootCanvas != null ? rootCanvas.transform : GameObject.transform.root;
+                _blocker = new GameObject(BlockerName, typeof(RectTransform)) { layer = GameObject.layer };
+                var rt = (RectTransform)_blocker.transform;
+                rt.SetParent(host, false);
+                rt.anchorMin = Vector2.zero;
+                rt.anchorMax = Vector2.one;
+                rt.offsetMin = Vector2.zero;
+                rt.offsetMax = Vector2.zero;
+
+                var img = _blocker.AddComponent<UnityImage>();
+                img.color = new Color(0f, 0f, 0f, 0f);
+                img.raycastTarget = true;
+
+                _blocker.AddComponent<Canvas>().overrideSorting = true;
+                _blocker.AddComponent<GraphicRaycaster>();
+
+                var btn = _blocker.AddComponent<Button>();
+                btn.transition = Selectable.Transition.None;
+                // Invisible and keyboard-unreachable: it exists for the pointer only, and letting
+                // directional navigation land on it would strand the focus on nothing.
+                btn.navigation = new Navigation { mode = Navigation.Mode.None };
+                btn.onClick.AddListener(Collapse);
+            }
+            _blocker.transform.SetAsLastSibling();
+            _blocker.GetComponent<Canvas>().sortingOrder = sortingOrder;
+            _blocker.SetActive(true);
+        }
+
+        /// <summary>
+        /// Sizes the panel and hangs it off the handle, flipping or clamping it back inside the
+        /// canvas when it would otherwise overflow. See <see cref="PopupPlacer"/> for the rules.
+        /// </summary>
+        private void PlacePopup()
+        {
+            if (_popup == null || !IsExpanded) return;
+
+            LayoutRebuilder.ForceRebuildLayoutImmediate(_content);
+            var width = _popupWidth > 0f
+                ? _popupWidth
+                : Mathf.Max(RectTransform.rect.width, LayoutUtility.GetPreferredWidth(_content));
+            var height = LayoutUtility.GetPreferredHeight(_content);
+            _popup.sizeDelta = new Vector2(width, height);
+
+            var rootCanvas = RootCanvas();
+            var placement = rootCanvas != null
+                ? PopupPlacer.Solve(RectInCanvas(RectTransform, rootCanvas),
+                                    new Vector2(width, height),
+                                    ((RectTransform)rootCanvas.transform).rect,
+                                    _popupGap)
+                // No canvas to measure against (a detached test rig): keep the default drop-down.
+                : new PopupPlacement(new Vector2(0f, 0f), new Vector2(0f, 1f),
+                                     new Vector2(0f, -_popupGap), false);
+
+            _popup.anchorMin = placement.Anchor;
+            _popup.anchorMax = placement.Anchor;
+            _popup.pivot = placement.Pivot;
+            _popup.anchoredPosition = placement.AnchoredPosition;
+        }
+
+        private static Rect RectInCanvas(RectTransform rt, Canvas canvas)
+        {
+            var canvasRt = (RectTransform)canvas.transform;
+            var corners = new Vector3[4];
+            rt.GetWorldCorners(corners);
+            var min = canvasRt.InverseTransformPoint(corners[0]);   // bottom-left
+            var max = canvasRt.InverseTransformPoint(corners[2]);   // top-right
+            return new Rect(min.x, min.y, max.x - min.x, max.y - min.y);
         }
 
         // ── Lifecycle ──────────────────────────────────────────────────────────────────────
@@ -406,8 +551,14 @@ namespace PromptUGUI.Controls
             _core.CollectStatic(Children);
             _core.SyncInitialSelection();
             _core.WireTabSubscriptions();
-            _selectionSub ??= _core.SelectionChanged.Subscribe(_ => RefreshCaption());
+            _selectionSub ??= _core.SelectionChanged.Subscribe(_ => OnSelectionSettled());
+            WireActivationSubscriptions();
             RefreshCaption();
+
+            // A variant / theme pass that hides or disables the menu must not leave an orphaned
+            // panel floating over the page.
+            if (IsExpanded && (!Interactable || !GameObject.activeInHierarchy)) Collapse();
+            else PlacePopup();
 
             // The popup must stay active through Open()'s measuring pass: a TMP added by
             // AddComponent on an inactive GameObject never runs Awake and mis-measures its
@@ -425,13 +576,58 @@ namespace PromptUGUI.Controls
             if (!IsExpanded && _popup != null) _popup.gameObject.SetActive(false);
         }
 
+        /// <summary>
+        /// Mirrors <see cref="Btn.Interactable"/>: driving it from code greys the handle through the
+        /// underlying Button as well as the base CanvasGroup — and shuts an open menu, which the
+        /// user can no longer dismiss by clicking a row.
+        /// </summary>
+        public override bool Interactable
+        {
+            get => base.Interactable;
+            set
+            {
+                base.Interactable = value;
+                if (_btn != null) _btn.interactable = value;
+                if (!value) Collapse();
+            }
+        }
+
         public override void Dispose()
         {
             UI.Locale.Changed -= ApplyFont;
+            if (s_expanded == this) s_expanded = null;
+            IsExpanded = false;
+            // The catcher is parented to the root canvas, outside this control's subtree, so the
+            // Screen teardown that destroys everything else would leave it behind.
+            if (_blocker != null)
+            {
+                if (UnityEngine.Application.isPlaying) UnityEngine.Object.Destroy(_blocker);
+                else UnityEngine.Object.DestroyImmediate(_blocker);
+                _blocker = null;
+            }
             RepointCaptionSource(null);
             _selectionSub?.Dispose();
+            _activationSubs?.Dispose();
+            _expandedSubject.Dispose();
+            _collapsedSubject.Dispose();
             _core.Dispose();
             base.Dispose();
+        }
+
+        private void OnSelectionSettled()
+        {
+            RefreshCaption();
+            Collapse();
+        }
+
+        // Picking a row closes the menu — including a re-pick of the row already selected, which
+        // never reaches SelectionChanged (uGUI swallows it, see PuiToggle.OnClicked).
+        private void WireActivationSubscriptions()
+        {
+            _activationSubs?.Dispose();
+            _activationSubs = new CompositeDisposable();
+            for (int i = 0; i < _core.Tabs.Count; i++)
+                _core.Tabs[i].OnActivated.Subscribe(_ => Collapse()).AddTo(_activationSubs);
         }
     }
 }

--- a/Runtime/Controls/TabMenu.cs
+++ b/Runtime/Controls/TabMenu.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using LitMotion;
+using LitMotion.Extensions;
 using PromptUGUI.Application;
 using PromptUGUI.Controls.Internal;
 using PromptUGUI.Registry;
@@ -63,6 +65,10 @@ namespace PromptUGUI.Controls
         private float _gap = 6f;
         private float _popupWidth;                 // 0 = auto (max of handle width and content)
         private float _popupGap = 4f;
+        private float _transition = DefaultTransition;
+        private MotionHandle _fadeMotion;
+        private MotionHandle _slideMotion;
+        private MotionHandle _arrowMotion;
         private string _fontType = "default";
 
         public TabMenu()
@@ -285,6 +291,38 @@ namespace PromptUGUI.Controls
         [UIAttr, Preserve]
         public float PopupGap { set { _popupGap = value; PlacePopup(); } }
 
+        /// <summary>Default open / close duration when the author writes none.</summary>
+        internal const float DefaultTransition = 0.15f;
+
+        /// <summary>The resolved open / close duration, in seconds. 0 = no animation.</summary>
+        internal float TransitionSeconds => _transition;
+
+        /// <summary>
+        /// Open / close duration: <c>"0.15s"</c> / <c>"150ms"</c> / a bare number of seconds;
+        /// <c>0</c> snaps. The panel is an internal node, so an author cannot wrap it in an
+        /// <c>&lt;Animation&gt;</c> — this is the hook for its own entrance (TM-D13). For animating
+        /// the rows, use <c>&lt;Animation on="expand"&gt;</c> around each <c>&lt;Tab&gt;</c>.
+        /// </summary>
+        [UIAttr, Preserve]
+        public string Transition
+        {
+            set
+            {
+                if (string.IsNullOrEmpty(value)) { _transition = DefaultTransition; return; }
+                try
+                {
+                    _transition = Mathf.Max(0f, AnimationSpec.ParseSeconds(value));
+                }
+                catch (FormatException)
+                {
+                    Debug.LogWarning(
+                        $"<TabMenu id='{Id}'> transition='{value}' is not a duration " +
+                        $"('0.15s' / '150ms' / '0.15'); using {DefaultTransition}s.");
+                    _transition = DefaultTransition;
+                }
+            }
+        }
+
         // ── Selection (delegated to TabGroupCore) ──────────────────────────────────────────
 
         public int Count => _core.Tabs.Count;
@@ -441,6 +479,7 @@ namespace PromptUGUI.Controls
 
             EnsureBlocker(rootCanvas, baseOrder + PopupSortingOffset - 1);
             PlacePopup();
+            PlayTransition(expanding: true);
 
             _expandedSubject.OnNext(Unit.Default);
         }
@@ -452,13 +491,102 @@ namespace PromptUGUI.Controls
             if (s_expanded == this) s_expanded = null;
 
             if (_blocker != null) _blocker.SetActive(false);
-            if (_popup != null)
-            {
-                _popupCanvas.overrideSorting = false;
-                _popup.gameObject.SetActive(false);
-            }
+            PlayTransition(expanding: false);
 
             _collapsedSubject.OnNext(Unit.Default);
+        }
+
+        /// <summary>
+        /// Fades and slides the panel in or out and spins the caret, then — on the way out —
+        /// deactivates the panel once the motion lands.
+        /// </summary>
+        /// <remarks>
+        /// Outside play mode the motions are skipped and the end state written directly: LitMotion
+        /// ticks on the player loop, so an EditMode caller would otherwise be left with a panel
+        /// stuck at alpha 0 that never deactivates.
+        /// </remarks>
+        private void PlayTransition(bool expanding)
+        {
+            CancelMotions();
+
+            var slideFrom = SlideOffset();
+            var restPosition = _popup.anchoredPosition;
+
+            if (_transition <= 0f || !UnityEngine.Application.isPlaying)
+            {
+                _popupCg.alpha = expanding ? 1f : 0f;
+                _popup.anchoredPosition = restPosition;
+                SetArrowAngle(expanding ? 180f : 0f);
+                if (!expanding) DeactivatePopup();
+                return;
+            }
+
+            var fromAlpha = expanding ? 0f : _popupCg.alpha;
+            var toAlpha = expanding ? 1f : 0f;
+            _popupCg.alpha = fromAlpha;
+
+            _fadeMotion = LMotion.Create(fromAlpha, toAlpha, _transition)
+                .WithEase(Ease.OutCubic)
+                .Bind(_popupCg, static (v, cg) => { if (cg) cg.alpha = v; })
+                .AddTo(_popup.gameObject);
+
+            var from = expanding ? restPosition + slideFrom : restPosition;
+            var to = expanding ? restPosition : restPosition + slideFrom;
+            _popup.anchoredPosition = from;
+            _slideMotion = LMotion.Create(from, to, _transition)
+                .WithEase(Ease.OutCubic)
+                .Bind(_popup, static (v, rt) => { if (rt) rt.anchoredPosition = v; })
+                .AddTo(_popup.gameObject);
+
+            var fromAngle = CurrentArrowAngle();
+            var toAngle = expanding ? 180f : 0f;
+            _arrowMotion = LMotion.Create(fromAngle, toAngle, _transition)
+                .WithEase(Ease.OutCubic)
+                .Bind(this, static (v, self) => self.SetArrowAngle(v))
+                .AddTo(_popup.gameObject);
+
+            if (!expanding)
+            {
+                // Only the collapse owns the deactivation, and only if it actually finishes: a
+                // re-expand cancels this handle first, so a cancelled close cannot switch off a
+                // panel the user just re-opened.
+                var captured = _fadeMotion;
+                _fadeMotion.GetAwaiter().OnCompleted(() =>
+                {
+                    if (!IsExpanded && captured.Equals(_fadeMotion)) DeactivatePopup();
+                });
+            }
+        }
+
+        // Enters from the side it is anchored to, so the panel appears to unfold out of the handle.
+        private Vector2 SlideOffset()
+        {
+            const float Distance = 8f;
+            return _popup.pivot.y > 0.5f ? new Vector2(0f, Distance) : new Vector2(0f, -Distance);
+        }
+
+        private float CurrentArrowAngle()
+            => _arrow != null ? Mathf.Repeat(_arrow.rectTransform.localEulerAngles.z, 360f) : 0f;
+
+        private void SetArrowAngle(float degrees)
+        {
+            if (_arrow == null) return;
+            var e = _arrow.rectTransform.localEulerAngles;
+            _arrow.rectTransform.localEulerAngles = new Vector3(e.x, e.y, degrees);
+        }
+
+        private void CancelMotions()
+        {
+            if (_fadeMotion.IsActive()) _fadeMotion.TryCancel();
+            if (_slideMotion.IsActive()) _slideMotion.TryCancel();
+            if (_arrowMotion.IsActive()) _arrowMotion.TryCancel();
+        }
+
+        private void DeactivatePopup()
+        {
+            if (_popup == null) return;
+            _popupCanvas.overrideSorting = false;
+            _popup.gameObject.SetActive(false);
         }
 
         private Canvas RootCanvas()
@@ -605,6 +733,7 @@ namespace PromptUGUI.Controls
                 else UnityEngine.Object.DestroyImmediate(_blocker);
                 _blocker = null;
             }
+            CancelMotions();
             RepointCaptionSource(null);
             _selectionSub?.Dispose();
             _activationSubs?.Dispose();

--- a/Runtime/Controls/TabMenu.cs
+++ b/Runtime/Controls/TabMenu.cs
@@ -599,7 +599,7 @@ namespace PromptUGUI.Controls
             {
                 _popupCg.alpha = expanding ? 1f : 0f;
                 _popup.anchoredPosition = restPosition;
-                SetArrowAngle(expanding ? 180f : 0f);
+                SetArrowFlip(expanding ? 1f : 0f);
                 if (!expanding) DeactivatePopup();
                 return;
             }
@@ -621,11 +621,11 @@ namespace PromptUGUI.Controls
                 .Bind(_popup, static (v, rt) => { if (rt) rt.anchoredPosition = v; })
                 .AddTo(_popup.gameObject);
 
-            var fromAngle = CurrentArrowAngle();
-            var toAngle = expanding ? 180f : 0f;
-            _arrowMotion = LMotion.Create(fromAngle, toAngle, _transition)
+            var fromFlip = CurrentArrowFlip();
+            var toFlip = expanding ? 1f : 0f;
+            _arrowMotion = LMotion.Create(fromFlip, toFlip, _transition)
                 .WithEase(Ease.OutCubic)
-                .Bind(this, static (v, self) => self.SetArrowAngle(v))
+                .Bind(this, static (v, self) => self.SetArrowFlip(v))
                 .AddTo(_popup.gameObject);
 
             if (!expanding)
@@ -648,14 +648,26 @@ namespace PromptUGUI.Controls
             return _popup.pivot.y > 0.5f ? new Vector2(0f, Distance) : new Vector2(0f, -Distance);
         }
 
-        private float CurrentArrowAngle()
-            => _arrow != null ? Mathf.Repeat(_arrow.rectTransform.localEulerAngles.z, 360f) : 0f;
+        /// <summary>How far through the flip the caret is: 0 = pointing down, 1 = pointing up.</summary>
+        private float CurrentArrowFlip()
+            => _arrow != null ? (1f - _arrow.rectTransform.localScale.y) * 0.5f : 0f;
 
-        private void SetArrowAngle(float degrees)
+        /// <summary>
+        /// Mirrors the caret about its horizontal centre line — a vertical flip, not a rotation.
+        /// </summary>
+        /// <remarks>
+        /// A 180° <c>localEulerAngles.z</c> turn would look the same on a symmetric chevron but is
+        /// wrong here: rotation happens about the pivot, and the caret's pivot is its LEFT edge
+        /// (that is what lets <see cref="LayoutCaption"/> place it by its left side). Turning it
+        /// therefore swings the whole glyph to the left of where it was placed, so the caret visibly
+        /// jumps sideways every time the menu opens. Scaling y about a pivot whose y is already
+        /// centred leaves x untouched.
+        /// </remarks>
+        private void SetArrowFlip(float t)
         {
             if (_arrow == null) return;
-            var e = _arrow.rectTransform.localEulerAngles;
-            _arrow.rectTransform.localEulerAngles = new Vector3(e.x, e.y, degrees);
+            var scale = _arrow.rectTransform.localScale;
+            _arrow.rectTransform.localScale = new Vector3(scale.x, 1f - 2f * t, scale.z);
         }
 
         private void CancelMotions()

--- a/Runtime/Controls/TabMenu.cs
+++ b/Runtime/Controls/TabMenu.cs
@@ -434,13 +434,12 @@ namespace PromptUGUI.Controls
             }
         }
 
-        // Unconstrained natural width — NOT preferredWidth, which TMP measures at the live rect and
+        // Unconstrained natural size — NOT preferredWidth, which TMP measures at the live rect and
         // would feed the previous solve's value back on a ReSolve. Mirrors Btn / Tab / Text.
-        private float LabelWidth()
-            => string.IsNullOrEmpty(_label.text) ? 0f : _label.GetPreferredValues(_label.text).x;
+        private Vector2 MeasureText(string text)
+            => string.IsNullOrEmpty(text) ? Vector2.zero : _label.GetPreferredValues(text);
 
-        private float LabelHeight()
-            => string.IsNullOrEmpty(_label.text) ? 0f : _label.GetPreferredValues(_label.text).y;
+        private float LabelWidth() => MeasureText(_label.text).x;
 
         /// <summary>
         /// The collapsed handle hugs its caption — deliberately the opposite of
@@ -449,10 +448,37 @@ namespace PromptUGUI.Controls
         /// </summary>
         public override Vector2? GetNativeSize()
         {
-            var w = PadX * 2f + LabelWidth();
-            if (_icon != null && _icon.enabled) w += _iconSize + _gap;
+            // The caption is filled in OnAfterApply, which runs AFTER ApplyCommon measures us — so on
+            // the very first pass the label is still empty and measuring it would hand the layout a
+            // handle just wide enough for the caret. Peek at the tabs instead: they are children, so
+            // the DFS post-order apply has already given them their text and isOn.
+            var (text, hasIcon) = _label != null && !string.IsNullOrEmpty(_label.text)
+                ? (_label.text, _icon != null && _icon.enabled)
+                : PeekSelectedContent();
+
+            var size = MeasureText(text);
+            var w = PadX * 2f + size.x;
+            if (hasIcon) w += _iconSize + _gap;
             if (_arrow != null && _arrow.enabled) w += _gap + _arrowSize;
-            return new Vector2(w, Mathf.Max(MinTapHeight, LabelHeight() + PadY * 2f));
+            return new Vector2(w, Mathf.Max(MinTapHeight, size.y + PadY * 2f));
+        }
+
+        /// <summary>
+        /// What the caption is about to show, read straight off the tabs. Mirrors the group's
+        /// auto-select rule (first tab when none is <c>isOn</c>) so the measurement matches whatever
+        /// <see cref="RefreshCaption"/> lands on moments later.
+        /// </summary>
+        private (string Text, bool HasIcon) PeekSelectedContent()
+        {
+            Tab first = null;
+            foreach (var child in Children)
+            {
+                var tab = child as Tab ?? TabGroupCore.FindTabIn(child);
+                if (tab == null) continue;
+                first ??= tab;
+                if (tab.IsOn) return (tab.CaptionText, tab.CaptionIcon != null);
+            }
+            return first != null ? (first.CaptionText, first.CaptionIcon != null) : (null, false);
         }
 
         private void ApplyFont() => FontApplier.Apply(_label, _fontType);

--- a/Runtime/Controls/TabMenu.cs
+++ b/Runtime/Controls/TabMenu.cs
@@ -1,0 +1,437 @@
+using System;
+using System.Collections.Generic;
+using PromptUGUI.Application;
+using PromptUGUI.Controls.Internal;
+using PromptUGUI.Registry;
+using R3;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityImage = UnityEngine.UI.Image;
+
+namespace PromptUGUI.Controls
+{
+    /// <summary>
+    /// A tab group folded into a popup: collapsed it shows the selected tab's icon + text plus a
+    /// caret; expanded it drops a panel of <c>&lt;Tab&gt;</c> rows.
+    ///
+    /// <para>Its children <em>are</em> tabs, so everything <see cref="Tab"/> already does —
+    /// <c>bind=</c>, <c>isOn</c>, per-state colours, <c>selectedSprite</c>, procedural surfaces,
+    /// <c>&lt;Show on="state-*"&gt;</c>, <c>BindItems</c> — works unchanged here. The selection
+    /// semantics themselves are <see cref="TabGroupCore"/>, shared verbatim with
+    /// <see cref="TabBar"/>; this control owns only the presentation.</para>
+    ///
+    /// <para><b>The procedural surface is the popup panel, not the handle</b> (spec TM-D3):
+    /// <c>radius</c> / <c>glass</c> / <c>color</c> / <c>&lt;Decor&gt;</c> all describe the menu that
+    /// drops down, and the collapsed handle is transparent by design. Wrap it in a
+    /// <c>&lt;Frame&gt;</c> to give the handle a background — the same way <c>&lt;TabBar&gt;</c>
+    /// gets a bar background.</para>
+    /// </summary>
+    public sealed class TabMenu : ProceduralControl
+    {
+        // Caption metrics. Fixed like Btn's/Tab's padding constants: the tunable part of the
+        // caption is what the author writes (fontSize / iconSize / gap), not its inset.
+        private const float PadX = 4f;
+        private const float PadY = 6f;
+        private const float MinTapHeight = 44f;
+        private const float DefaultFontSize = 24f;
+
+        private UnityImage _hit;          // transparent, raycastTarget=true: the handle's click area
+        private UnityImage _icon;
+        private UnityImage _arrow;
+        private TMP_Text _label;
+        private RectTransform _popup;
+        private RectTransform _content;
+        private UnityImage _popupBg;
+        private CanvasGroup _popupCg;
+        private Canvas _popupCanvas;
+        private VerticalLayoutGroup _layout;
+        private PuiButton _btn;
+        private ToggleGroup _group;
+
+        private readonly TabGroupCore _core;
+
+        // The tab whose ContentChanged we currently mirror. Re-pointed on every selection change so
+        // a caption tracks renames of the selected tab only.
+        private Tab _captionSource;
+        private Action _captionSourceHandler;
+        private IDisposable _selectionSub;
+
+        private float _iconSize = 24f;
+        private float _arrowSize = 16f;
+        private float _gap = 6f;
+        private string _fontType = "default";
+
+        public TabMenu()
+        {
+            _core = new TabGroupCore(this, () => _content);
+        }
+
+        // The panel is what draws; the handle deliberately has no surface of its own (TM-D3).
+        private protected override GameObject SurfaceHost => _popup.gameObject;
+
+        // No Selectable: the panel is not the thing that hovers or presses. Handle state colours are
+        // out of scope for v1 (TM-D18), so nothing needs its targetGraphic followed.
+        private protected override Selectable SurfaceSelectable => null;
+
+        // Authored children — tabs, their Template/Animation wrappers, <Decor> — belong to the menu.
+        protected internal override Transform ChildHostTransform => _content;
+
+        public override void OnAttached()
+        {
+            var marker = GameObject.AddComponent<TabMenuMarker>();
+            marker.Owner = this;
+
+            _hit = GameObject.GetComponent<UnityImage>() ?? GameObject.AddComponent<UnityImage>();
+            _hit.color = new Color(0f, 0f, 0f, 0f);
+            _hit.raycastTarget = true;
+
+            _group = GameObject.AddComponent<ToggleGroup>();
+            _group.allowSwitchOff = false;
+
+            BuildCaption();
+            BuildPopup();
+
+            _btn = GameObject.GetComponent<PuiButton>() ?? GameObject.AddComponent<PuiButton>();
+            _btn.targetGraphic = _label;
+            _btn.onClick.AddListener(Toggle);
+
+            UI.Locale.Changed += ApplyFont;
+        }
+
+        private void BuildCaption()
+        {
+            _icon = ProceduralBuilders.AddImage(RectTransform, "Icon", raycast: false);
+            _icon.enabled = false;
+            var irt = _icon.rectTransform;
+            irt.anchorMin = new Vector2(0f, 0.5f);
+            irt.anchorMax = new Vector2(0f, 0.5f);
+            irt.pivot = new Vector2(0f, 0.5f);
+
+            _label = ProceduralBuilders.AddText(RectTransform, "Label");
+            _label.alignment = TextAlignmentOptions.Left;
+            _label.raycastTarget = false;
+            _label.fontSize = DefaultFontSize;
+            _label.text = "";
+            var lrt = _label.rectTransform;
+            lrt.anchorMin = new Vector2(0f, 0.5f);
+            lrt.anchorMax = new Vector2(0f, 0.5f);
+            lrt.pivot = new Vector2(0f, 0.5f);
+
+            _arrow = ProceduralBuilders.AddImage(RectTransform, "Arrow", raycast: false);
+            _arrow.color = ProceduralBuilders.DefaultGlyphColor;
+            ProceduralBuilders.ApplyDefaultSimpleSprite(_arrow, ProceduralBuilders.SpriteCaret);
+            var art = _arrow.rectTransform;
+            art.anchorMin = new Vector2(0f, 0.5f);
+            art.anchorMax = new Vector2(0f, 0.5f);
+            art.pivot = new Vector2(0f, 0.5f);
+
+            ApplyFont();
+        }
+
+        private void BuildPopup()
+        {
+            // Anchored to the handle's bottom-left corner, growing down. PlacePopup re-derives this
+            // (and may flip it upward) once there is a laid-out canvas to measure against.
+            _popup = ProceduralBuilders.AddChild(RectTransform, "Popup");
+            _popup.anchorMin = new Vector2(0f, 0f);
+            _popup.anchorMax = new Vector2(0f, 0f);
+            _popup.pivot = new Vector2(0f, 1f);
+
+            _popupBg = _popup.gameObject.AddComponent<UnityImage>();
+            _popupBg.color = ProceduralBuilders.DefaultPopupBgColor;
+            ProceduralBuilders.ApplyDefaultSlicedSprite(_popupBg);
+
+            _popupCg = _popup.gameObject.AddComponent<CanvasGroup>();
+
+            // Added now, disabled: a Canvas + Raycaster appearing on expand would force a rebuild in
+            // the frame the menu opens. overrideSorting is what lifts the panel above the page AND
+            // what breaks it out of an ancestor mask (MaskUtilities stops at an overriding Canvas),
+            // so a TabMenu inside a <ScrollList> still drops a full, unclipped menu.
+            _popupCanvas = _popup.gameObject.AddComponent<Canvas>();
+            _popupCanvas.overrideSorting = false;
+            _popup.gameObject.AddComponent<GraphicRaycaster>();
+
+            _content = ProceduralBuilders.AddChild(_popup, "Content");
+            _content.anchorMin = Vector2.zero;
+            _content.anchorMax = Vector2.one;
+            _content.offsetMin = Vector2.zero;
+            _content.offsetMax = Vector2.zero;
+
+            _layout = _content.gameObject.AddComponent<VerticalLayoutGroup>();
+            // Mirrors TabBar's sizing contract, with one deliberate difference: menu rows span the
+            // panel (childForceExpandWidth), because a column of ragged-width rows is not a menu.
+            _layout.childControlWidth = true;
+            _layout.childControlHeight = true;
+            _layout.childForceExpandWidth = true;
+            _layout.childForceExpandHeight = false;
+        }
+
+        // ── Attributes ─────────────────────────────────────────────────────────────────────
+
+        [UIAttr("fontSize"), Preserve]
+        public float FontSize
+        {
+            set { _label.fontSize = value; LayoutCaption(); }
+        }
+
+        /// <summary>Caption text colour; distinct from <c>color</c>, which fills the popup panel.</summary>
+        [UIAttr(IsColor = true), Preserve]
+        public string TextColor
+        {
+            set => LabelColorApplier.Apply(_label, value);
+        }
+
+        [UIAttr, Preserve]
+        public string Font
+        {
+            set
+            {
+                _fontType = string.IsNullOrEmpty(value) ? "default" : value;
+                ApplyFont();
+            }
+        }
+
+        /// <summary>Caption icon edge length. The slot takes no space when the selected tab has no icon.</summary>
+        [UIAttr, Preserve]
+        public float IconSize { set { _iconSize = value; LayoutCaption(); } }
+
+        /// <summary>Gap between caption icon, label and caret.</summary>
+        [UIAttr, Preserve]
+        public float Gap { set { _gap = value; LayoutCaption(); } }
+
+        /// <summary>Caret edge length.</summary>
+        [UIAttr, Preserve]
+        public float ArrowSize { set { _arrowSize = value; LayoutCaption(); } }
+
+        /// <summary>The caret. <c>""</c> hides it — a sprite-less Image renders a solid block.</summary>
+        [UIAttr(IsSprite = true), Preserve]
+        public string Arrow
+        {
+            set
+            {
+                var sprite = UI.ResolveSprite(value);
+                _arrow.sprite = sprite;
+                _arrow.enabled = sprite != null;
+                LayoutCaption();
+            }
+        }
+
+        [UIAttr(IsColor = true), Preserve]
+        public string ArrowColor
+        {
+            set => ColorApplier.Apply(_arrow, UI.Theme.ResolveSpec(value));
+        }
+
+        /// <summary>The popup panel's fill — <em>not</em> the collapsed handle's (TM-D3).</summary>
+        [UIAttr(IsColor = true), Preserve]
+        public string Color
+        {
+            set
+            {
+                var spec = UI.Theme.ResolveSpec(value);
+                ColorApplier.Apply(_popupBg, spec);
+                Surface.SetFill(spec.Top, spec.Bottom);
+            }
+        }
+
+        /// <summary>The popup panel's background sprite. <c>""</c> / <c>none</c> = flat colour.</summary>
+        [UIAttr(IsSprite = true), Preserve]
+        public string Sprite
+        {
+            set
+            {
+                if (string.IsNullOrEmpty(value) || value == "none")
+                {
+                    _popupBg.sprite = null;
+                    _popupBg.type = UnityImage.Type.Simple;
+                    return;
+                }
+                var sprite = UI.ResolveSprite(value);
+                if (sprite == null) return;
+                _popupBg.sprite = sprite;
+                _popupBg.type = ProceduralBuilders.DeriveType(sprite);
+            }
+        }
+
+        [UIAttr, Preserve]
+        public string Tint
+        {
+            set => ImageTint.Apply(_popupBg, value);
+        }
+
+        /// <summary>Padding inside the popup panel (same shorthand as <c>&lt;TabBar padding&gt;</c>).</summary>
+        [UIAttr, Preserve]
+        public string Padding
+        {
+            set => _layout.padding = PaddingParser.Parse(value, _layout.padding);
+        }
+
+        /// <summary>Gap between menu rows.</summary>
+        [UIAttr, Preserve]
+        public float Spacing { set => _layout.spacing = value; }
+
+        [UIAttr, Preserve]
+        public string ItemTemplate { set => _core.ItemTemplate = value; }
+
+        // ── Selection (delegated to TabGroupCore) ──────────────────────────────────────────
+
+        public int Count => _core.Tabs.Count;
+
+        public int SelectedIndex => _core.SelectedIndex;
+
+        public Tab SelectedTab => _core.SelectedTab;
+
+        public Tab GetAt(int index) => _core.Tabs[index];
+
+        public Observable<Tab> OnSelectionChanged => _core.SelectionChanged;
+
+        public IDisposable BindItems<T>(
+            Observable<IReadOnlyList<T>> source,
+            Action<Tab, T> bind)
+            => BindItems<T, Tab>(source, bind);
+
+        public IDisposable BindItems<T, TSlot>(
+            Observable<IReadOnlyList<T>> source,
+            Action<TSlot, T> bind) where TSlot : class, IControl
+            => _core.BindItems(source, bind);
+
+        // ── Caption ────────────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Re-reads the selected tab's icon + text into the caption. Called on every selection
+        /// change, on a content change of the selected tab, and after each attribute pass — a
+        /// caller should not normally need it.
+        /// </summary>
+        public void RefreshCaption()
+        {
+            var tab = SelectedTab;
+            RepointCaptionSource(tab);
+
+            _label.text = tab != null ? tab.CaptionText ?? "" : "";
+            var sprite = tab != null ? tab.CaptionIcon : null;
+            _icon.sprite = sprite;
+            _icon.enabled = sprite != null;
+
+            LayoutCaption();
+        }
+
+        // Only the SELECTED tab's renames reach the caption, so exactly one subscription is live at
+        // a time and it moves with the selection.
+        private void RepointCaptionSource(Tab tab)
+        {
+            if (ReferenceEquals(_captionSource, tab)) return;
+            if (_captionSource != null && _captionSourceHandler != null)
+                _captionSource.ContentChanged -= _captionSourceHandler;
+            _captionSource = tab;
+            if (tab == null) return;
+            _captionSourceHandler ??= RefreshCaption;
+            tab.ContentChanged += _captionSourceHandler;
+        }
+
+        /// <summary>
+        /// Places icon / label / caret in a row, left to right, each slot collapsing to nothing when
+        /// it has no content. Hand-placed rather than run through a HorizontalLayoutGroup so
+        /// <see cref="GetNativeSize"/> can state the same geometry as a closed-form expression.
+        /// </summary>
+        private void LayoutCaption()
+        {
+            var x = PadX;
+            if (_icon != null && _icon.enabled)
+            {
+                _icon.rectTransform.sizeDelta = new Vector2(_iconSize, _iconSize);
+                _icon.rectTransform.anchoredPosition = new Vector2(x, 0f);
+                x += _iconSize + _gap;
+            }
+
+            var textWidth = LabelWidth();
+            _label.rectTransform.sizeDelta = new Vector2(textWidth, _label.rectTransform.sizeDelta.y);
+            _label.rectTransform.anchoredPosition = new Vector2(x, 0f);
+            x += textWidth;
+
+            if (_arrow != null && _arrow.enabled)
+            {
+                x += _gap;
+                _arrow.rectTransform.sizeDelta = new Vector2(_arrowSize, _arrowSize);
+                _arrow.rectTransform.anchoredPosition = new Vector2(x, 0f);
+            }
+        }
+
+        // Unconstrained natural width — NOT preferredWidth, which TMP measures at the live rect and
+        // would feed the previous solve's value back on a ReSolve. Mirrors Btn / Tab / Text.
+        private float LabelWidth()
+            => string.IsNullOrEmpty(_label.text) ? 0f : _label.GetPreferredValues(_label.text).x;
+
+        private float LabelHeight()
+            => string.IsNullOrEmpty(_label.text) ? 0f : _label.GetPreferredValues(_label.text).y;
+
+        /// <summary>
+        /// The collapsed handle hugs its caption — deliberately the opposite of
+        /// <c>&lt;Dropdown&gt;</c>, whose fixed width keeps a form field from twitching as options
+        /// change. A channel switcher wants the caret to sit right after the name.
+        /// </summary>
+        public override Vector2? GetNativeSize()
+        {
+            var w = PadX * 2f + LabelWidth();
+            if (_icon != null && _icon.enabled) w += _iconSize + _gap;
+            if (_arrow != null && _arrow.enabled) w += _gap + _arrowSize;
+            return new Vector2(w, Mathf.Max(MinTapHeight, LabelHeight() + PadY * 2f));
+        }
+
+        private void ApplyFont() => FontApplier.Apply(_label, _fontType);
+
+        // ── Expand / collapse (Task 5 wires the real behaviour) ────────────────────────────
+
+        public bool IsExpanded { get; private set; }
+
+        public void Toggle()
+        {
+            if (IsExpanded) Collapse(); else Expand();
+        }
+
+        public void Expand()
+        {
+        }
+
+        public void Collapse()
+        {
+        }
+
+        // ── Lifecycle ──────────────────────────────────────────────────────────────────────
+
+        internal override void OnAfterApply()
+        {
+            base.OnAfterApply();
+
+            _core.CollectStatic(Children);
+            _core.SyncInitialSelection();
+            _core.WireTabSubscriptions();
+            _selectionSub ??= _core.SelectionChanged.Subscribe(_ => RefreshCaption());
+            RefreshCaption();
+
+            // The popup must stay active through Open()'s measuring pass: a TMP added by
+            // AddComponent on an inactive GameObject never runs Awake and mis-measures its
+            // preferred size. Same deferral Tab.bind uses for an unselected page.
+            if (!IsExpanded)
+            {
+                var owner = UI.OwnerScreenOf(this);
+                if (owner != null) owner.DeferDuringOpen(HidePopupIfCollapsed);
+                else HidePopupIfCollapsed();
+            }
+        }
+
+        private void HidePopupIfCollapsed()
+        {
+            if (!IsExpanded && _popup != null) _popup.gameObject.SetActive(false);
+        }
+
+        public override void Dispose()
+        {
+            UI.Locale.Changed -= ApplyFont;
+            RepointCaptionSource(null);
+            _selectionSub?.Dispose();
+            _core.Dispose();
+            base.Dispose();
+        }
+    }
+}

--- a/Runtime/Controls/TabMenu.cs
+++ b/Runtime/Controls/TabMenu.cs
@@ -343,7 +343,35 @@ namespace PromptUGUI.Controls
         public IDisposable BindItems<T, TSlot>(
             Observable<IReadOnlyList<T>> source,
             Action<TSlot, T> bind) where TSlot : class, IControl
-            => _core.BindItems(source, bind);
+            => _core.BindItems(source, bind, BeforeRebuild, AfterRebuild);
+
+        // A row is built by AddComponent-ing a TMP onto a fresh GameObject. Do that under an
+        // inactive parent — which is exactly what a collapsed popup is — and the TMP never runs
+        // Awake, so it reports a preferred size of 0 for the rest of its life and the row collapses.
+        // Activating for the duration of the rebuild and switching back within the same frame costs
+        // nothing visually (nothing renders between the two) and gets every row measured.
+        private bool _tempActivatedForRebuild;
+
+        private void BeforeRebuild()
+        {
+            if (_popup == null || _popup.gameObject.activeSelf) return;
+            _popup.gameObject.SetActive(true);
+            _tempActivatedForRebuild = true;
+        }
+
+        private void AfterRebuild()
+        {
+            WireActivationSubscriptions();
+            RefreshCaption();
+
+            if (_tempActivatedForRebuild)
+            {
+                _tempActivatedForRebuild = false;
+                _popup.gameObject.SetActive(false);
+                return;
+            }
+            PlacePopup();
+        }
 
         // ── Caption ────────────────────────────────────────────────────────────────────────
 

--- a/Runtime/Controls/TabMenu.cs.meta
+++ b/Runtime/Controls/TabMenu.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 73560317340ebfee080b5d085342dece

--- a/Runtime/Controls/Trigger.cs
+++ b/Runtime/Controls/Trigger.cs
@@ -72,6 +72,10 @@ namespace PromptUGUI.Controls
                 case TriggerKind.StateDisabled:
                     SubscribeState(_spec.Kind);
                     break;
+                case TriggerKind.Expand:
+                case TriggerKind.Collapse:
+                    SubscribeMenu(_spec.Kind);
+                    break;
                 case TriggerKind.Manual:
                     // no auto-subscribe; awaiting Fire()
                     break;
@@ -102,6 +106,13 @@ namespace PromptUGUI.Controls
                 TriggerKind.Press => src.OnPointerDown,
                 _ => throw new InvalidOperationException("unreachable"),
             };
+            _sourceSub = stream.Subscribe(_ => Fire());
+        }
+
+        private void SubscribeMenu(TriggerKind kind)
+        {
+            var menu = Internal.TriggerSourceResolver.FindTabMenu(this, _spec.SourceId);
+            var stream = kind == TriggerKind.Expand ? menu.OnExpanded : menu.OnCollapsed;
             _sourceSub = stream.Subscribe(_ => Fire());
         }
 

--- a/Runtime/Core/Lint/BuiltinTags.cs
+++ b/Runtime/Core/Lint/BuiltinTags.cs
@@ -21,7 +21,7 @@ namespace PromptUGUI.Lint
         {
             "Frame", "SafeArea", "Trigger", "Show", "Animation", "Decor",
             "Image", "RawImage", "Icon", "Text", "VStack", "HStack", "Grid",
-            "Btn", "Toggle", "Tab", "TabBar", "Slider", "Progress",
+            "Btn", "Toggle", "Tab", "TabBar", "TabMenu", "Slider", "Progress",
             "Dropdown", "ScrollList", "InputField", "Carousel", "Markdown",
         };
 

--- a/Runtime/Core/Lint/IRWalker.cs
+++ b/Runtime/Core/Lint/IRWalker.cs
@@ -192,7 +192,7 @@ namespace PromptUGUI.Lint
                     yield return issue;
 
             var childHasStateSourceAncestor = hasStateSourceAncestor || StateTriggerRules.IsStateSourceTag(node.Tag);
-            var isLayoutGroup = node.Tag is "VStack" or "HStack" or "Grid" or "TabBar" or "Carousel";
+            var isLayoutGroup = node.Tag is "VStack" or "HStack" or "Grid" or "TabBar" or "TabMenu" or "Carousel";
             var isTabBar = node.Tag == "TabBar";
             foreach (var child in node.Children)
             {

--- a/Runtime/Core/Lint/IRWalker.cs
+++ b/Runtime/Core/Lint/IRWalker.cs
@@ -24,13 +24,13 @@ namespace PromptUGUI.Lint
                 // PUI-NAV-UNKNOWN-TARGET. Add-directive children are part of the same Screen scope.
                 var screenIds = CollectScreenIds(screen);
 
-                foreach (var issue in WalkNode(screen.Root, inTemplateBody: false, hasStateSourceAncestor: false, parentIsLayoutGroup: false, isTemplateBodyRoot: false, screenIds: screenIds, styles: styles))
+                foreach (var issue in WalkNode(screen.Root, inTemplateBody: false, hasStateSourceAncestor: false, hasMenuAncestor: false, parentIsLayoutGroup: false, isTemplateBodyRoot: false, screenIds: screenIds, styles: styles))
                     yield return issue;
 
                 foreach (var variant in screen.Variants)
                     foreach (var add in variant.Adds)
                         foreach (var addChild in add.Children)
-                            foreach (var issue in WalkNode(addChild, inTemplateBody: false, hasStateSourceAncestor: false, parentIsLayoutGroup: false, isTemplateBodyRoot: false, screenIds: screenIds, styles: styles))
+                            foreach (var issue in WalkNode(addChild, inTemplateBody: false, hasStateSourceAncestor: false, hasMenuAncestor: false, parentIsLayoutGroup: false, isTemplateBodyRoot: false, screenIds: screenIds, styles: styles))
                                 yield return issue;
             }
 
@@ -50,7 +50,7 @@ namespace PromptUGUI.Lint
                 // invocation may merge CommonAttrs onto it, which PUI-VARIANT-NO-BASE must account for.
                 // s_emptyIds: template bodies don't belong to a specific Screen — skip nav-target check.
                 if (template.Body != null)
-                    foreach (var issue in WalkNode(template.Body, inTemplateBody: true, hasStateSourceAncestor: false, parentIsLayoutGroup: false, isTemplateBodyRoot: true, screenIds: s_emptyIds, styles: styles))
+                    foreach (var issue in WalkNode(template.Body, inTemplateBody: true, hasStateSourceAncestor: false, hasMenuAncestor: false, parentIsLayoutGroup: false, isTemplateBodyRoot: true, screenIds: s_emptyIds, styles: styles))
                         yield return issue;
             }
         }
@@ -82,13 +82,13 @@ namespace PromptUGUI.Lint
         /// <para>Issues that already carry an origin come from the recursive call below — a child
         /// stamps itself, so this must not overwrite them.</para>
         /// </summary>
-        private static IEnumerable<LintIssue> WalkNode(ElementNode node, bool inTemplateBody, bool hasStateSourceAncestor, bool parentIsLayoutGroup, bool isTemplateBodyRoot, HashSet<string> screenIds, StyleAttributeView styles)
+        private static IEnumerable<LintIssue> WalkNode(ElementNode node, bool inTemplateBody, bool hasStateSourceAncestor, bool hasMenuAncestor, bool parentIsLayoutGroup, bool isTemplateBodyRoot, HashSet<string> screenIds, StyleAttributeView styles)
         {
-            foreach (var issue in WalkNodeCore(node, inTemplateBody, hasStateSourceAncestor, parentIsLayoutGroup, isTemplateBodyRoot, screenIds, styles))
+            foreach (var issue in WalkNodeCore(node, inTemplateBody, hasStateSourceAncestor, hasMenuAncestor, parentIsLayoutGroup, isTemplateBodyRoot, screenIds, styles))
                 yield return issue.Origin == null ? issue.WithSource(node.OriginSrc, node.Line, node.InvokedAt) : issue;
         }
 
-        private static IEnumerable<LintIssue> WalkNodeCore(ElementNode node, bool inTemplateBody, bool hasStateSourceAncestor, bool parentIsLayoutGroup, bool isTemplateBodyRoot, HashSet<string> screenIds, StyleAttributeView styles)
+        private static IEnumerable<LintIssue> WalkNodeCore(ElementNode node, bool inTemplateBody, bool hasStateSourceAncestor, bool hasMenuAncestor, bool parentIsLayoutGroup, bool isTemplateBodyRoot, HashSet<string> screenIds, StyleAttributeView styles)
         {
             // Per-tag self-checks (mirror of ScreenInstantiator dispatch; CLI errors).
             // Self-relative — about the node itself, unlike parent-relative LayoutGroupChildRules.
@@ -112,6 +112,9 @@ namespace PromptUGUI.Lint
                     yield return issue;
             else if (node.Tag == "TabBar")
                 foreach (var issue in TabRules.CheckTabBar(node))
+                    yield return issue;
+            else if (node.Tag == "TabMenu")
+                foreach (var issue in TabMenuRules.CheckTabMenu(node))
                     yield return issue;
             else if (node.Tag == "Carousel")
                 foreach (var issue in CarouselRules.CheckCarousel(node))
@@ -188,12 +191,18 @@ namespace PromptUGUI.Lint
             // surface it statically here. Exempt Template bodies + instance roots — the clickable
             // ancestor may be supplied only at invocation. @id forms defer to runtime ScopedIds resolution.
             if (!inTemplateBody && !node.IsTemplateInstanceRoot)
+            {
                 foreach (var issue in StateTriggerRules.CheckStateSource(node, hasStateSourceAncestor))
                     yield return issue;
+                // Same shape, same exemptions: expand / collapse resolve upward to a <TabMenu>.
+                foreach (var issue in StateTriggerRules.CheckMenuSource(node, hasMenuAncestor))
+                    yield return issue;
+            }
 
             var childHasStateSourceAncestor = hasStateSourceAncestor || StateTriggerRules.IsStateSourceTag(node.Tag);
+            var childHasMenuAncestor = hasMenuAncestor || StateTriggerRules.IsMenuSourceTag(node.Tag);
             var isLayoutGroup = node.Tag is "VStack" or "HStack" or "Grid" or "TabBar" or "TabMenu" or "Carousel";
-            var isTabBar = node.Tag == "TabBar";
+            var isTabGroup = node.Tag is "TabBar" or "TabMenu";
             foreach (var child in node.Children)
             {
                 if (isLayoutGroup)
@@ -218,15 +227,15 @@ namespace PromptUGUI.Lint
                 // Template (e.g. <Template name='FileTab'><Frame><Tab/>...) is
                 // intentional — TabBar.CollectStaticTabs walks wrappers via FindTabIn.
                 if (child.Tag == "Tab"
-                    && !isTabBar
+                    && !isTabGroup
                     && !node.IsTemplateInstanceRoot
                     && !inTemplateBody)
                     yield return new LintIssue(
                         TabRules.TabParentCode, child.Tag, child.Id,
-                        $"<Tab id='{child.Id}'>: must be a direct child of <TabBar>; current parent is <{node.Tag}>. " +
+                        $"<Tab id='{child.Id}'>: must be a direct child of <TabBar> or <TabMenu>; current parent is <{node.Tag}>. " +
                         "Mutual exclusion and shared visuals will not apply.",
                         child.OriginSrc, child.Line, child.InvokedAt);
-                foreach (var issue in WalkNode(child, inTemplateBody, childHasStateSourceAncestor, parentIsLayoutGroup: isLayoutGroup, isTemplateBodyRoot: false, screenIds: screenIds, styles: styles))
+                foreach (var issue in WalkNode(child, inTemplateBody, childHasStateSourceAncestor, childHasMenuAncestor, parentIsLayoutGroup: isLayoutGroup, isTemplateBodyRoot: false, screenIds: screenIds, styles: styles))
                     yield return issue;
             }
         }

--- a/Runtime/Core/Lint/NavTargetRules.cs
+++ b/Runtime/Core/Lint/NavTargetRules.cs
@@ -30,7 +30,7 @@ namespace PromptUGUI.Lint
         /// <summary>Tags that have a uGUI <c>Selectable</c> component and therefore accept nav* attrs.</summary>
         private static readonly HashSet<string> SelectableTags = new HashSet<string>
         {
-            "Btn", "Tab", "Toggle", "Slider", "Dropdown", "InputField", "ScrollList"
+            "Btn", "Tab", "TabMenu", "Toggle", "Slider", "Dropdown", "InputField", "ScrollList"
         };
 
         /// <summary>All attributes that must appear only on selectable tags.</summary>

--- a/Runtime/Core/Lint/ProceduralSurfaceRules.cs
+++ b/Runtime/Core/Lint/ProceduralSurfaceRules.cs
@@ -30,7 +30,7 @@ namespace PromptUGUI.Lint
         /// </summary>
         internal static readonly HashSet<string> SurfaceTags = new()
         {
-            "Btn", "Tab", "Toggle", "Slider", "Dropdown", "InputField", "ScrollList", "Progress",
+            "Btn", "Tab", "TabMenu", "Toggle", "Slider", "Dropdown", "InputField", "ScrollList", "Progress",
         };
 
         // Image.overrideSprite swaps. On an SDF face there is no sprite to override.

--- a/Runtime/Core/Lint/StateTriggerRules.cs
+++ b/Runtime/Core/Lint/StateTriggerRules.cs
@@ -25,6 +25,7 @@ namespace PromptUGUI.Lint
     public static class StateTriggerRules
     {
         public const string NoSourceCode = "PUI-STATE-NO-SOURCE";
+        public const string NoMenuCode = "PUI-EXPAND-NO-SOURCE";
 
         private static readonly HashSet<string> StateTriggerTags =
             new HashSet<string> { "Trigger", "Animation", "Show" };
@@ -36,6 +37,9 @@ namespace PromptUGUI.Lint
 
         private static readonly HashSet<string> StateSourceTags =
             new HashSet<string> { "Btn", "Tab", "Toggle" };
+
+        private static readonly HashSet<string> BareMenuValues =
+            new HashSet<string> { "expand", "collapse" };
 
         /// <summary>True if <paramref name="tag"/> instantiates an IStateSource-backed control
         /// (broadcasts InteractState). Extend this set when a new clickable opts in.</summary>
@@ -59,6 +63,28 @@ namespace PromptUGUI.Lint
                 NoSourceCode, n.Tag, n.Id,
                 $"<{n.Tag} on=\"{on}\">: no <Btn>/<Tab>/<Toggle> ancestor. state-* resolves upward to the " +
                 "nearest clickable — place it inside a <Btn>/<Tab>/<Toggle>, or use state-...@<id>.");
+        }
+
+        /// <summary>True if <paramref name="tag"/> instantiates a <c>&lt;TabMenu&gt;</c>, the source
+        /// a bare <c>expand</c> / <c>collapse</c> trigger resolves upward to.</summary>
+        public static bool IsMenuSourceTag(string tag) => tag == "TabMenu";
+
+        /// <summary>
+        /// Yields <see cref="NoMenuCode"/> when <paramref name="n"/> is a bare (no-<c>@id</c>)
+        /// <c>expand</c> / <c>collapse</c> trigger with no <c>&lt;TabMenu&gt;</c> ancestor — the
+        /// same upward-resolution rule <c>state-*</c> follows, and the same runtime hard error.
+        /// </summary>
+        public static IEnumerable<LintIssue> CheckMenuSource(ElementNode n, bool hasMenuAncestor)
+        {
+            if (hasMenuAncestor) yield break;
+            if (!StateTriggerTags.Contains(n.Tag)) yield break;
+            if (!n.Attributes.TryGetValue("on", out var on)) yield break;
+            if (!BareMenuValues.Contains(on)) yield break;
+
+            yield return new LintIssue(
+                NoMenuCode, n.Tag, n.Id,
+                $"<{n.Tag} on=\"{on}\">: no <TabMenu> ancestor. {on} resolves upward to the nearest " +
+                $"menu — place it inside a <TabMenu>, or use {on}@<id>.");
         }
     }
 }

--- a/Runtime/Core/Lint/TabMenuRules.cs
+++ b/Runtime/Core/Lint/TabMenuRules.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using PromptUGUI.IR;
+
+namespace PromptUGUI.Lint
+{
+    /// <summary>
+    /// Structural checks for <c>&lt;TabMenu&gt;</c> — the popup-shaped tab group. Its rows are
+    /// <c>&lt;Tab&gt;</c>s, exactly as in a <c>&lt;TabBar&gt;</c>, so <see cref="TabRules"/> covers
+    /// what they have in common; what differs is that the rows span the panel and cannot be sized
+    /// across.
+    /// </summary>
+    public static class TabMenuRules
+    {
+        public const string ChildCode = "PUI-TABMENU-CHILD";
+        public const string ItemWidthCode = "PUI-TABMENU-ITEM-WIDTH";
+
+        public const string Tag = "TabMenu";
+
+        public static IEnumerable<LintIssue> CheckTabMenu(ElementNode n)
+        {
+            foreach (var c in n.Children)
+            {
+                // <Decor> is a legitimate non-row child: it decorates the panel itself and is
+                // excluded from the layout, so it never becomes a menu row.
+                if (c.Tag == "Decor") continue;
+
+                if (!TabRules.SubtreeMayResolveToTab(c))
+                {
+                    yield return new LintIssue(
+                        ChildCode, n.Tag, n.Id,
+                        $"<TabMenu id='{n.Id}'>: expected <Tab> rows; found <{c.Tag}>. " +
+                        "It will still be laid out in the popup, but no tab semantics apply to it.");
+                    continue;
+                }
+
+                foreach (var issue in CheckRowWidth(n, c))
+                    yield return issue;
+            }
+        }
+
+        /// <summary>
+        /// A menu row always spans the panel (the popup's layout group force-expands its children
+        /// across), so a <c>width</c> anywhere on the row is silently overridden.
+        /// </summary>
+        private static IEnumerable<LintIssue> CheckRowWidth(ElementNode menu, ElementNode row)
+        {
+            var carrier = FindWidthCarrier(row);
+            if (carrier == null) yield break;
+
+            yield return new LintIssue(
+                ItemWidthCode, carrier.Tag, carrier.Id,
+                $"<{carrier.Tag} id='{carrier.Id}'> inside <TabMenu id='{menu.Id}'>: 'width' is ignored — " +
+                "menu rows always span the panel. Fix: set 'popupWidth' on the <TabMenu> to size the " +
+                "menu, and remove 'width' from the row.");
+        }
+
+        // The row root or, for a Template-style wrapper, the <Tab> inside it — whichever declares a
+        // width (including a variant-only one, which is just as ignored).
+        private static ElementNode FindWidthCarrier(ElementNode node)
+        {
+            if (DeclaresWidth(node)) return node;
+            foreach (var c in node.Children)
+            {
+                var found = FindWidthCarrier(c);
+                if (found != null) return found;
+            }
+            return null;
+        }
+
+        private static bool DeclaresWidth(ElementNode n)
+            => n.Attributes.ContainsKey("width") || n.VariantOverrides.ContainsKey("width");
+    }
+}

--- a/Runtime/Core/Lint/TabMenuRules.cs.meta
+++ b/Runtime/Core/Lint/TabMenuRules.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5b20369caad2a7dacad9c3ac2a1d1b44

--- a/Runtime/Core/Lint/TabRules.cs
+++ b/Runtime/Core/Lint/TabRules.cs
@@ -47,7 +47,7 @@ namespace PromptUGUI.Lint
         /// rather than false-positive. At runtime this runs POST-expansion, where every tag is a
         /// registered builtin, so the non-builtin branch never fires and behaviour is unchanged.
         /// </summary>
-        private static bool SubtreeMayResolveToTab(ElementNode node)
+        public static bool SubtreeMayResolveToTab(ElementNode node)
         {
             if (node.Tag == "Tab") return true;
             if (!BuiltinTags.IsBuiltin(node.Tag)) return true; // Template invocation — unknown expansion

--- a/Tests/EditMode/Controls/ProceduralSurfaceRolloutTests.cs
+++ b/Tests/EditMode/Controls/ProceduralSurfaceRolloutTests.cs
@@ -17,9 +17,10 @@ namespace PromptUGUI.Tests.EditMode.Controls
     /// which is what makes the linter stop reporting its shape attributes as ignored — without
     /// arriving here at the same time.
     ///
-    /// <para>Two of them differ on purpose and are called out where it matters:
-    /// <c>&lt;Slider&gt;</c> keeps <c>targetGraphic</c> on its handle (spec §13.1), and
-    /// <c>&lt;Progress&gt;</c> keeps its surface inside a Bg layer that ships switched off.</para>
+    /// <para>Three of them differ on purpose and are called out where it matters:
+    /// <c>&lt;Slider&gt;</c> keeps <c>targetGraphic</c> on its handle (spec §13.1),
+    /// <c>&lt;Progress&gt;</c> keeps its surface inside a Bg layer that ships switched off, and
+    /// <c>&lt;TabMenu&gt;</c>'s surface is its popup panel rather than the face of its handle.</para>
     /// </summary>
     public class ProceduralSurfaceRolloutTests
     {
@@ -140,10 +141,10 @@ namespace PromptUGUI.Tests.EditMode.Controls
         [Test]
         public void ControlsWithASelectable_MoveTargetGraphicToTheSurface()
         {
-            // …except Slider, below.
+            // …except Slider and TabMenu, below.
             foreach (var tag in Tags)
             {
-                if (tag == "Slider") continue;
+                if (tag == "Slider" || tag == "TabMenu") continue;
                 var c = Load(tag, "radius='8'");
                 var selectable = c.GameObject.GetComponent<Selectable>();
                 if (selectable == null) continue;   // ScrollList / Progress have none of their own
@@ -166,6 +167,24 @@ namespace PromptUGUI.Tests.EditMode.Controls
 
             Assert.IsNotNull(PanelIn(c), "guard: the track did go procedural");
             Assert.AreEqual("Handle", slider.targetGraphic.gameObject.name);
+        }
+
+        /// <summary>
+        /// The other controls here draw one face, and the surface replaces it — so the Selectable's
+        /// targetGraphic has to follow. A TabMenu draws two things in two places: a handle that
+        /// hovers and presses, and a menu panel that is what <c>radius</c> / <c>glass</c> describe
+        /// (spec TM-D3). Pointing targetGraphic at the panel would tint the dropped menu on hovering
+        /// the handle; the handle is deliberately transparent, so its caption carries the state.
+        /// </summary>
+        [Test]
+        public void TabMenu_KeepsTargetGraphicOnItsCaption()
+        {
+            var c = Load("TabMenu", "radius='8'");
+            var button = c.GameObject.GetComponent<UnityEngine.UI.Button>();
+
+            Assert.IsNotNull(PanelIn(c), "guard: the panel did go procedural");
+            Assert.AreEqual("Popup", PanelIn(c).transform.parent.name, "…on the popup, not the handle");
+            Assert.AreEqual("Label", button.targetGraphic.gameObject.name);
         }
 
         /// <summary>

--- a/Tests/EditMode/Controls/TabMenuBindItemsTests.cs
+++ b/Tests/EditMode/Controls/TabMenuBindItemsTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using R3;
+using TMPro;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    /// <summary>
+    /// Dynamic rows for <c>&lt;TabMenu&gt;</c> — the same <c>BindItems</c> / <c>itemTemplate</c>
+    /// contract <c>&lt;TabBar&gt;</c> has (they share <c>TabGroupCore</c>), plus the one thing that
+    /// is genuinely different: rows are built inside a popup that is switched off while collapsed.
+    /// </summary>
+    public class TabMenuBindItemsTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static PromptUGUI.Application.Screen Open(string innerXml)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{innerXml}</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S");
+        }
+
+        private static TabMenu OpenMenu(string innerXml) => Open(innerXml).Get<TabMenu>("m");
+
+        private static RectTransform Popup(TabMenu m) => (RectTransform)m.RectTransform.Find("Popup");
+
+        private static TMP_Text CaptionOf(TabMenu m)
+            => m.RectTransform.Find("Label").GetComponent<TMP_Text>();
+
+        private static TMP_Text LabelOf(Tab t)
+            => t.GameObject.transform.Find("Label").GetComponent<TMP_Text>();
+
+        private static IDisposable BindStrings(TabMenu m, params string[] items)
+            => m.BindItems(Observable.Return<IReadOnlyList<string>>(items),
+                           (Tab tab, string s) => tab.Text = s);
+
+        [Test]
+        public void Builds_rows_inside_the_popup()
+        {
+            var m = OpenMenu("<TabMenu id='m'/>");
+            using var sub = BindStrings(m, "A", "B", "C");
+
+            Assert.AreEqual(3, m.Count);
+            Assert.AreSame(Popup(m).Find("Content"), m.GetAt(0).RectTransform.parent,
+                           "dynamic rows land in the menu, not on the handle");
+        }
+
+        [Test]
+        public void Replaces_static_rows()
+        {
+            var m = OpenMenu("<TabMenu id='m'><Tab text='static'/></TabMenu>");
+            Assert.AreEqual(1, m.Count);
+
+            using var sub = BindStrings(m, "dyn1", "dyn2");
+            Assert.AreEqual(2, m.Count);
+        }
+
+        [Test]
+        public void Caption_shows_the_first_bound_row()
+        {
+            var m = OpenMenu("<TabMenu id='m'/>");
+            using var sub = BindStrings(m, "World", "Guild");
+
+            Assert.AreEqual(0, m.SelectedIndex, "auto-selects the first, as TabBar does");
+            Assert.AreEqual("World", CaptionOf(m).text);
+        }
+
+        // The regression this whole design danced around: a TMP added by AddComponent on an
+        // INACTIVE GameObject never runs Awake, and then reports a preferred width of 0 forever.
+        // Rows bound while the menu is collapsed are built inside exactly such a parent, so the
+        // rebuild has to activate the popup for the duration and switch it back afterwards.
+        [Test]
+        public void Rows_bound_while_collapsed_still_measure()
+        {
+            var m = OpenMenu("<TabMenu id='m'/>");
+            Assert.IsFalse(Popup(m).gameObject.activeSelf, "precondition: collapsed");
+
+            using var sub = BindStrings(m, "A wide enough channel name");
+
+            var label = LabelOf(m.GetAt(0));
+            Assert.Greater(label.GetPreferredValues(label.text).x, 0f,
+                           "a row built inside an inactive popup must still know how wide it is");
+            Assert.IsFalse(Popup(m).gameObject.activeSelf, "…and the menu is left closed");
+        }
+
+        [Test]
+        public void Binding_while_expanded_leaves_the_menu_open()
+        {
+            var m = OpenMenu("<TabMenu id='m' transition='0'/>");
+            m.Expand();
+
+            using var sub = BindStrings(m, "A", "B");
+
+            Assert.IsTrue(m.IsExpanded);
+            Assert.IsTrue(Popup(m).gameObject.activeSelf);
+            Assert.Greater(Popup(m).rect.height, 0f, "…and is resized for its new contents");
+        }
+
+        [Test]
+        public void An_empty_list_clears_the_caption()
+        {
+            var m = OpenMenu("<TabMenu id='m'><Tab text='static'/></TabMenu>");
+            Tab seen = null;
+            var fired = false;
+            using var selection = m.OnSelectionChanged.Subscribe(t => { seen = t; fired = true; });
+
+            using var sub = m.BindItems(
+                Observable.Return<IReadOnlyList<string>>(new string[0]),
+                (Tab tab, string s) => tab.Text = s);
+
+            Assert.AreEqual(0, m.Count);
+            Assert.AreEqual(-1, m.SelectedIndex);
+            Assert.IsNull(m.SelectedTab);
+            Assert.AreEqual("", CaptionOf(m).text, "nothing selected means nothing to mirror");
+            Assert.IsTrue(fired);
+            Assert.IsNull(seen, "…and subscribers are told so explicitly");
+        }
+
+        [Test]
+        public void Picking_a_bound_row_switches_the_caption_and_closes()
+        {
+            var m = OpenMenu("<TabMenu id='m' transition='0'/>");
+            using var sub = BindStrings(m, "World", "Guild");
+            m.Expand();
+
+            m.GetAt(1).IsOn = true;
+
+            Assert.AreEqual("Guild", CaptionOf(m).text);
+            Assert.IsFalse(m.IsExpanded);
+        }
+
+        [Test]
+        public void ItemTemplate_wrapping_a_Tab_is_found()
+        {
+            UI.LoadDocument("t", @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Row'><Frame height='40'><Tab id='tab' anchor='stretch'/></Frame></Template>
+  <Screen name='S'><TabMenu id='m' itemTemplate='Row'/></Screen>
+</PromptUGUI>");
+            var m = UI.Open("S").Get<TabMenu>("m");
+
+            using var sub = m.BindItems<string, IControl>(
+                Observable.Return<IReadOnlyList<string>>(new[] { "A", "B" }),
+                (slot, text) => slot.Get<Tab>("tab").Text = text);
+
+            Assert.AreEqual(2, m.Count, "the <Tab> nested inside the wrapper is what carries tab semantics");
+            Assert.AreEqual("A", CaptionOf(m).text);
+            Assert.AreSame(Popup(m).Find("Content"), ((Control)m.GetAt(0)).RectTransform.parent.parent,
+                           "the wrapper is the row; the Tab sits inside it");
+        }
+
+        [Test]
+        public void Rebinding_replaces_the_previous_rows()
+        {
+            var m = OpenMenu("<TabMenu id='m'/>");
+            var items = new ReactiveProperty<IReadOnlyList<string>>(new[] { "A", "B" });
+            using var sub = m.BindItems(items, (Tab tab, string s) => tab.Text = s);
+            Assert.AreEqual(2, m.Count);
+
+            items.Value = new[] { "X" };
+
+            Assert.AreEqual(1, m.Count);
+            Assert.AreEqual("X", CaptionOf(m).text);
+        }
+    }
+}

--- a/Tests/EditMode/Controls/TabMenuBindItemsTests.cs.meta
+++ b/Tests/EditMode/Controls/TabMenuBindItemsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f985fc6483d5b53079ffa574018801d5

--- a/Tests/EditMode/Controls/TabMenuPlacementTests.cs
+++ b/Tests/EditMode/Controls/TabMenuPlacementTests.cs
@@ -1,0 +1,146 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    /// <summary>
+    /// Where a <c>&lt;TabMenu&gt;</c>'s popup lands (spec §7.2). The rules themselves are a pure
+    /// function — <see cref="PopupPlacer"/> — because EditMode cannot give a ScreenSpaceOverlay
+    /// canvas a deterministic size; the integration tests below only check the wiring.
+    /// </summary>
+    public class TabMenuPlacementTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        // A 800x600 canvas centred on the origin, with a 120x44 handle near its top-left.
+        private static readonly Rect Canvas800 = new Rect(-400f, -300f, 800f, 600f);
+        private static Rect Handle(float x, float y) => new Rect(x, y, 120f, 44f);
+
+        // ── The placement rules ────────────────────────────────────────────────────────────
+
+        [Test]
+        public void Defaults_to_below_the_handle_left_aligned()
+        {
+            var p = PopupPlacer.Solve(Handle(-380f, 200f), new Vector2(200f, 150f), Canvas800, 4f);
+
+            Assert.IsFalse(p.FlippedUp);
+            Assert.AreEqual(new Vector2(0f, 0f), p.Anchor, "anchored to the handle's bottom-left");
+            Assert.AreEqual(new Vector2(0f, 1f), p.Pivot, "…and hangs down from its own top edge");
+            Assert.AreEqual(0f, p.AnchoredPosition.x, "left edges line up");
+            Assert.AreEqual(-4f, p.AnchoredPosition.y, "gap below the handle");
+        }
+
+        [Test]
+        public void Flips_up_when_the_panel_cannot_fit_below()
+        {
+            // Handle sits at the very bottom: 20px of room below, 200px panel.
+            var p = PopupPlacer.Solve(Handle(-380f, -280f), new Vector2(200f, 200f), Canvas800, 4f);
+
+            Assert.IsTrue(p.FlippedUp);
+            Assert.AreEqual(new Vector2(0f, 1f), p.Anchor, "anchored to the handle's top-left");
+            Assert.AreEqual(new Vector2(0f, 0f), p.Pivot, "…and grows upward from its own bottom edge");
+            Assert.AreEqual(4f, p.AnchoredPosition.y, "gap above the handle");
+        }
+
+        [Test]
+        public void Flips_only_when_the_other_side_is_actually_roomier()
+        {
+            // Taller than either side can hold. Handle low on the canvas: 100 below vs 456 above —
+            // flipping still buys room, so it flips.
+            var p = PopupPlacer.Solve(Handle(-380f, -200f), new Vector2(200f, 900f), Canvas800, 4f);
+            Assert.IsTrue(p.FlippedUp, "above genuinely has more room here, so flipping does help");
+
+            // Same panel, handle near the top: below is the roomier side, so it must not jump —
+            // "below" is the convention and flipping would only make the overflow worse.
+            var q = PopupPlacer.Solve(Handle(-380f, 200f), new Vector2(200f, 900f), Canvas800, 4f);
+            Assert.IsFalse(q.FlippedUp);
+        }
+
+        [Test]
+        public void Clamps_left_when_the_panel_would_spill_past_the_right_edge()
+        {
+            // Handle's left edge at x=300, 200-wide panel → right edge would be 500, canvas ends at 400.
+            var p = PopupPlacer.Solve(Handle(300f, 200f), new Vector2(200f, 150f), Canvas800, 4f);
+            Assert.AreEqual(-100f, p.AnchoredPosition.x, "pulled back exactly to the edge");
+        }
+
+        [Test]
+        public void Never_pushes_the_panel_past_the_left_edge()
+        {
+            // A panel wider than the canvas: clamping right would drag it off the left. Left wins.
+            var p = PopupPlacer.Solve(Handle(-380f, 200f), new Vector2(900f, 150f), Canvas800, 4f);
+            Assert.AreEqual(-20f, p.AnchoredPosition.x, "stops at the canvas's left edge");
+        }
+
+        [Test]
+        public void Does_not_move_a_panel_that_already_fits()
+        {
+            var p = PopupPlacer.Solve(Handle(0f, 0f), new Vector2(200f, 100f), Canvas800, 4f);
+            Assert.AreEqual(0f, p.AnchoredPosition.x);
+            Assert.IsFalse(p.FlippedUp);
+        }
+
+        // ── Wiring ────────────────────────────────────────────────────────────────────────
+
+        private static PromptUGUI.Application.Screen OpenScreen(
+            string attrs, string tabs = "<Tab id='a' text='World'/>")
+        {
+            UI.LoadDocument("t",
+                "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'><Screen name='S'>" +
+                $"<TabMenu id='m' {attrs}>{tabs}</TabMenu>" +
+                "</Screen></PromptUGUI>");
+            var s = UI.Open("S");
+            Canvas.ForceUpdateCanvases();
+            return s;
+        }
+
+        private static TabMenu OpenMenu(string attrs, string tabs = "<Tab id='a' text='World'/>")
+            => OpenScreen(attrs, tabs).Get<TabMenu>("m");
+
+        private static RectTransform Popup(TabMenu m) => (RectTransform)m.RectTransform.Find("Popup");
+
+        [Test]
+        public void Explicit_popupWidth_wins()
+        {
+            var m = OpenMenu("popupWidth='240' transition='0'");
+            m.Expand();
+            Assert.AreEqual(240f, Popup(m).rect.width, 0.01f);
+        }
+
+        [Test]
+        public void Popup_is_at_least_as_wide_as_the_handle()
+        {
+            var m = OpenMenu("width='300' transition='0'");
+            m.Expand();
+            Assert.GreaterOrEqual(Popup(m).rect.width, 300f - 0.01f,
+                "with no popupWidth the panel is never narrower than the handle it hangs from");
+        }
+
+        [Test]
+        public void Popup_height_follows_its_content()
+        {
+            var m = OpenMenu("popupWidth='240' padding='8' transition='0'",
+                             "<Tab id='a' text='A' height='40'/><Tab id='b' text='B' height='40'/>");
+            m.Expand();
+            Assert.AreEqual(96f, Popup(m).rect.height, 1f, "two 40px rows plus 8px padding top and bottom");
+        }
+
+        [Test]
+        public void Reposition_survives_a_resolve_while_expanded()
+        {
+            var screen = OpenScreen("popupWidth='240' transition='0'");
+            var m = screen.Get<TabMenu>("m");
+            m.Expand();
+            var before = Popup(m).anchoredPosition;
+
+            screen.ReSolve();
+            Assert.IsTrue(m.IsExpanded, "a resize must not close an open menu (TM-D11)");
+            Assert.AreEqual(before, Popup(m).anchoredPosition);
+        }
+    }
+}

--- a/Tests/EditMode/Controls/TabMenuPlacementTests.cs.meta
+++ b/Tests/EditMode/Controls/TabMenuPlacementTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3d21c7c3b7042a59394f8b853b98343c

--- a/Tests/EditMode/Controls/TabMenuTests.cs
+++ b/Tests/EditMode/Controls/TabMenuTests.cs
@@ -1,0 +1,238 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using R3;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using PuguiScreen = PromptUGUI.Application.Screen;
+using UnityImage = UnityEngine.UI.Image;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    /// <summary>
+    /// Structure, caption mirroring and lifecycle for <c>&lt;TabMenu&gt;</c> — the popup-shaped tab
+    /// group (spec <c>2026-08-29-tabmenu-design.md</c>). Placement lives in
+    /// <see cref="TabMenuPlacementTests"/>, dynamic items in <c>TabMenuBindItemsTests</c>.
+    /// </summary>
+    public class TabMenuTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        internal const string TwoTabs = @"
+  <TabMenu id='m' fontSize='22'>
+    <Tab id='a' text='World' bind='pw' isOn='true'/>
+    <Tab id='b' text='Guild' bind='pg'/>
+  </TabMenu>
+  <Frame id='pw'/>
+  <Frame id='pg'/>";
+
+        internal static PuguiScreen Open(string innerXml)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{innerXml}</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S");
+        }
+
+        internal static RectTransform Popup(TabMenu m) => (RectTransform)m.RectTransform.Find("Popup");
+        internal static RectTransform Content(TabMenu m) => (RectTransform)Popup(m).Find("Content");
+        private static TMP_Text Label(TabMenu m) => m.RectTransform.Find("Label").GetComponent<TMP_Text>();
+        private static UnityImage Arrow(TabMenu m) => m.RectTransform.Find("Arrow").GetComponent<UnityImage>();
+        private static UnityImage IconOf(TabMenu m) => m.RectTransform.Find("Icon").GetComponent<UnityImage>();
+
+        // ── Registration & structure ───────────────────────────────────────────────────────
+
+        [Test]
+        public void Registered_as_builtin()
+        {
+            UI.ResetForTests();
+            Assert.IsTrue(UI.Registry.Has("TabMenu"));
+        }
+
+        [Test]
+        public void Tabs_land_in_popup_content_not_on_self()
+        {
+            var s = Open(TwoTabs);
+            var m = s.Get<TabMenu>("m");
+            var tab = s.Get<Tab>("a");
+
+            Assert.AreSame(Content(m), tab.RectTransform.parent, "children host is Popup/Content");
+            Assert.AreSame(Popup(m), Content(m).parent);
+            Assert.AreSame(m.RectTransform, Popup(m).parent, "popup stays inside the TabMenu subtree");
+        }
+
+        [Test]
+        public void Self_carries_toggle_group_and_button()
+        {
+            var m = Open(TwoTabs).Get<TabMenu>("m");
+            var group = m.GameObject.GetComponent<ToggleGroup>();
+            Assert.IsNotNull(group, "mutual exclusion lives on the TabMenu, like TabBar");
+            Assert.IsFalse(group.allowSwitchOff);
+            Assert.IsNotNull(m.GameObject.GetComponent<Button>(), "the caption is the click target");
+        }
+
+        [Test]
+        public void Trigger_area_is_transparent_but_clickable()
+        {
+            var m = Open(TwoTabs).Get<TabMenu>("m");
+            var img = m.GameObject.GetComponent<UnityImage>();
+            Assert.AreEqual(0f, img.color.a, "TM-D3: no chrome of its own — wrap it in a Frame for that");
+            Assert.IsTrue(img.raycastTarget, "…but still the click target for expanding");
+        }
+
+        [Test]
+        public void Popup_content_is_a_vertical_layout_that_fills_item_width()
+        {
+            var m = Open(TwoTabs).Get<TabMenu>("m");
+            var vlg = Content(m).GetComponent<VerticalLayoutGroup>();
+            Assert.IsNotNull(vlg);
+            Assert.IsTrue(vlg.childControlWidth);
+            Assert.IsTrue(vlg.childControlHeight);
+            Assert.IsTrue(vlg.childForceExpandWidth, "TM-D7: menu rows span the panel");
+            Assert.IsFalse(vlg.childForceExpandHeight, "…but keep their own height");
+        }
+
+        [Test]
+        public void Popup_is_inactive_after_open()
+        {
+            var m = Open(TwoTabs).Get<TabMenu>("m");
+            Assert.IsFalse(Popup(m).gameObject.activeSelf, "collapsed is the only initial state (TM-D11)");
+        }
+
+        // ── Caption mirroring (TM-D5) ──────────────────────────────────────────────────────
+
+        [Test]
+        public void Caption_mirrors_selected_tab_text()
+        {
+            var s = Open(TwoTabs);
+            var m = s.Get<TabMenu>("m");
+            Assert.AreEqual("World", Label(m).text);
+
+            s.Get<Tab>("b").IsOn = true;
+            Assert.AreEqual("Guild", Label(m).text);
+        }
+
+        [Test]
+        public void Caption_follows_a_runtime_text_change_on_the_selected_tab()
+        {
+            var s = Open(TwoTabs);
+            s.Get<Tab>("a").Text = "Renamed";
+            Assert.AreEqual("Renamed", Label(s.Get<TabMenu>("m")).text);
+        }
+
+        [Test]
+        public void Caption_ignores_text_changes_on_unselected_tabs()
+        {
+            var s = Open(TwoTabs);
+            s.Get<Tab>("b").Text = "Elsewhere";
+            Assert.AreEqual("World", Label(s.Get<TabMenu>("m")).text);
+        }
+
+        [Test]
+        public void Caption_icon_hidden_when_selected_tab_has_none()
+        {
+            var m = Open(TwoTabs).Get<TabMenu>("m");
+            Assert.IsFalse(IconOf(m).enabled, "no icon= on the tab means no caption icon slot");
+        }
+
+        [Test]
+        public void FontSize_applies_to_caption()
+        {
+            var m = Open(TwoTabs).Get<TabMenu>("m");
+            Assert.AreEqual(22f, Label(m).fontSize);
+        }
+
+        [Test]
+        public void Arrow_uses_the_default_caret()
+        {
+            var m = Open(TwoTabs).Get<TabMenu>("m");
+            Assert.IsTrue(Arrow(m).enabled);
+            Assert.IsNotNull(Arrow(m).sprite);
+        }
+
+        [Test]
+        public void Arrow_empty_hides_the_caret()
+        {
+            var m = Open(@"<TabMenu id='m' arrow=''><Tab id='a' text='X'/></TabMenu>").Get<TabMenu>("m");
+            Assert.IsFalse(Arrow(m).enabled, "arrow='' hides it — a sprite-less Image would draw a block");
+        }
+
+        // ── Selection semantics reused from TabBar ─────────────────────────────────────────
+
+        [Test]
+        public void Bind_shows_only_the_selected_page()
+        {
+            var s = Open(TwoTabs);
+            Assert.IsTrue(s.Get<Frame>("pw").GameObject.activeSelf);
+            Assert.IsFalse(s.Get<Frame>("pg").GameObject.activeSelf);
+
+            s.Get<Tab>("b").IsOn = true;
+            Assert.IsFalse(s.Get<Frame>("pw").GameObject.activeSelf);
+            Assert.IsTrue(s.Get<Frame>("pg").GameObject.activeSelf);
+        }
+
+        // Regression: the rows sit inside a collapsed (inactive) popup, where uGUI's ToggleGroup
+        // does nothing — Toggle.Set gates NotifyToggleOn on IsActive(), and a disabled toggle has
+        // already unregistered itself. Without TabGroupCore enforcing it, both tabs stay on.
+        [Test]
+        public void Selection_is_exclusive_even_while_collapsed()
+        {
+            var s = Open(TwoTabs);
+            Assert.IsFalse(Popup(s.Get<TabMenu>("m")).gameObject.activeSelf, "precondition: collapsed");
+
+            s.Get<Tab>("b").IsOn = true;
+            Assert.IsFalse(s.Get<Tab>("a").IsOn, "the previously selected tab must switch off");
+            Assert.AreEqual(1, s.Get<TabMenu>("m").SelectedIndex);
+        }
+
+        [Test]
+        public void Auto_selects_first_tab_when_none_declared()
+        {
+            var s = Open(@"<TabMenu id='m'><Tab id='a' text='A'/><Tab id='b' text='B'/></TabMenu>");
+            Assert.AreEqual(0, s.Get<TabMenu>("m").SelectedIndex);
+            Assert.AreEqual("A", Label(s.Get<TabMenu>("m")).text);
+        }
+
+        [Test]
+        public void Count_and_GetAt_see_static_tabs()
+        {
+            var m = Open(TwoTabs).Get<TabMenu>("m");
+            Assert.AreEqual(2, m.Count);
+            Assert.AreEqual("Guild", m.GetAt(1).CaptionText);
+        }
+
+        [Test]
+        public void OnSelectionChanged_fires_on_switch()
+        {
+            var s = Open(TwoTabs);
+            Tab seen = null;
+            using var sub = s.Get<TabMenu>("m").OnSelectionChanged.Subscribe(t => seen = t);
+            s.Get<Tab>("b").IsOn = true;
+            Assert.AreSame(s.Get<Tab>("b"), seen);
+        }
+
+        // ── Native size ────────────────────────────────────────────────────────────────────
+
+        [Test]
+        public void Native_size_hugs_the_caption()
+        {
+            var m = Open(TwoTabs).Get<TabMenu>("m");
+            var n = m.GetNativeSize();
+            Assert.IsTrue(n.HasValue);
+            Assert.Greater(n.Value.x, 0f, "width follows the caption text (TM-D6, unlike <Dropdown>)");
+            Assert.GreaterOrEqual(n.Value.y, 44f, "min tap target");
+        }
+
+        [Test]
+        public void Native_width_grows_with_a_longer_caption()
+        {
+            var s = Open(TwoTabs);
+            var m = s.Get<TabMenu>("m");
+            var before = m.GetNativeSize().Value.x;
+            s.Get<Tab>("a").Text = "A much, much longer channel name";
+            Assert.Greater(m.GetNativeSize().Value.x, before);
+        }
+    }
+}

--- a/Tests/EditMode/Controls/TabMenuTests.cs
+++ b/Tests/EditMode/Controls/TabMenuTests.cs
@@ -1,6 +1,11 @@
+using System.Linq;
 using NUnit.Framework;
 using PromptUGUI.Application;
 using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using PromptUGUI.IR;
+using PromptUGUI.Lint;
+using PromptUGUI.Parser;
 using R3;
 using TMPro;
 using UnityEngine;
@@ -38,9 +43,16 @@ namespace PromptUGUI.Tests.EditMode.Controls
 
         internal static RectTransform Popup(TabMenu m) => (RectTransform)m.RectTransform.Find("Popup");
         internal static RectTransform Content(TabMenu m) => (RectTransform)Popup(m).Find("Content");
-        private static TMP_Text Label(TabMenu m) => m.RectTransform.Find("Label").GetComponent<TMP_Text>();
+        private static TMP_Text LabelOf(TabMenu m) => m.RectTransform.Find("Label").GetComponent<TMP_Text>();
         private static UnityImage Arrow(TabMenu m) => m.RectTransform.Find("Arrow").GetComponent<UnityImage>();
         private static UnityImage IconOf(TabMenu m) => m.RectTransform.Find("Icon").GetComponent<UnityImage>();
+
+        private static System.Collections.Generic.List<LintIssue> Walk(string body)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{body}</Screen></PromptUGUI>";
+            return IRWalker.Walk(UIDocumentParser.Parse(xml)).ToList();
+        }
 
         // ── Registration & structure ───────────────────────────────────────────────────────
 
@@ -108,10 +120,10 @@ namespace PromptUGUI.Tests.EditMode.Controls
         {
             var s = Open(TwoTabs);
             var m = s.Get<TabMenu>("m");
-            Assert.AreEqual("World", Label(m).text);
+            Assert.AreEqual("World", LabelOf(m).text);
 
             s.Get<Tab>("b").IsOn = true;
-            Assert.AreEqual("Guild", Label(m).text);
+            Assert.AreEqual("Guild", LabelOf(m).text);
         }
 
         [Test]
@@ -119,7 +131,7 @@ namespace PromptUGUI.Tests.EditMode.Controls
         {
             var s = Open(TwoTabs);
             s.Get<Tab>("a").Text = "Renamed";
-            Assert.AreEqual("Renamed", Label(s.Get<TabMenu>("m")).text);
+            Assert.AreEqual("Renamed", LabelOf(s.Get<TabMenu>("m")).text);
         }
 
         [Test]
@@ -127,7 +139,7 @@ namespace PromptUGUI.Tests.EditMode.Controls
         {
             var s = Open(TwoTabs);
             s.Get<Tab>("b").Text = "Elsewhere";
-            Assert.AreEqual("World", Label(s.Get<TabMenu>("m")).text);
+            Assert.AreEqual("World", LabelOf(s.Get<TabMenu>("m")).text);
         }
 
         [Test]
@@ -141,7 +153,7 @@ namespace PromptUGUI.Tests.EditMode.Controls
         public void FontSize_applies_to_caption()
         {
             var m = Open(TwoTabs).Get<TabMenu>("m");
-            Assert.AreEqual(22f, Label(m).fontSize);
+            Assert.AreEqual(22f, LabelOf(m).fontSize);
         }
 
         [Test]
@@ -192,7 +204,7 @@ namespace PromptUGUI.Tests.EditMode.Controls
         {
             var s = Open(@"<TabMenu id='m'><Tab id='a' text='A'/><Tab id='b' text='B'/></TabMenu>");
             Assert.AreEqual(0, s.Get<TabMenu>("m").SelectedIndex);
-            Assert.AreEqual("A", Label(s.Get<TabMenu>("m")).text);
+            Assert.AreEqual("A", LabelOf(s.Get<TabMenu>("m")).text);
         }
 
         [Test]
@@ -214,6 +226,261 @@ namespace PromptUGUI.Tests.EditMode.Controls
         }
 
         // ── Native size ────────────────────────────────────────────────────────────────────
+
+        // ── Expand / collapse ─────────────────────────────────────────────────────────────
+
+        private static GameObject Blocker(PuguiScreen s)
+        {
+            var t = s.RootGameObject.transform.Find(TabMenu.BlockerName);
+            return t != null ? t.gameObject : null;
+        }
+
+        [Test]
+        public void Expand_activates_the_popup_and_lifts_it_above_the_page()
+        {
+            var s = Open(TwoTabs);
+            var m = s.Get<TabMenu>("m");
+            var rootOrder = s.RootGameObject.GetComponent<Canvas>().sortingOrder;
+
+            m.Expand();
+
+            Assert.IsTrue(m.IsExpanded);
+            Assert.IsTrue(Popup(m).gameObject.activeSelf);
+            var canvas = Popup(m).GetComponent<Canvas>();
+            Assert.IsTrue(canvas.overrideSorting, "also what frees the panel from an ancestor mask");
+            Assert.AreEqual(rootOrder + TabMenu.PopupSortingOffset, canvas.sortingOrder);
+        }
+
+        [Test]
+        public void Expand_puts_a_click_catcher_under_the_root_canvas()
+        {
+            var s = Open(TwoTabs);
+            var m = s.Get<TabMenu>("m");
+            var rootOrder = s.RootGameObject.GetComponent<Canvas>().sortingOrder;
+
+            m.Expand();
+
+            var blocker = Blocker(s);
+            Assert.IsNotNull(blocker, "the catcher lives on the root canvas, not inside the menu");
+            Assert.IsTrue(blocker.activeSelf);
+            Assert.AreEqual(rootOrder + TabMenu.PopupSortingOffset - 1,
+                            blocker.GetComponent<Canvas>().sortingOrder, "just below the panel");
+            Assert.AreEqual(0f, blocker.GetComponent<UnityImage>().color.a, "invisible…");
+            Assert.IsTrue(blocker.GetComponent<UnityImage>().raycastTarget, "…but catches the click");
+            Assert.AreEqual(UnityEngine.UI.Navigation.Mode.None,
+                            blocker.GetComponent<Button>().navigation.mode,
+                            "never a directional-navigation neighbour");
+        }
+
+        [Test]
+        public void Clicking_the_catcher_collapses()
+        {
+            var s = Open(TwoTabs);
+            var m = s.Get<TabMenu>("m");
+            m.Expand();
+
+            Blocker(s).GetComponent<Button>().onClick.Invoke();
+
+            Assert.IsFalse(m.IsExpanded);
+            Assert.IsFalse(Blocker(s).activeSelf);
+        }
+
+        [Test]
+        public void Collapse_hides_the_popup()
+        {
+            var m = Open(TwoTabs).Get<TabMenu>("m");
+            m.Expand();
+            m.Collapse();
+            Assert.IsFalse(m.IsExpanded);
+            Assert.IsFalse(Popup(m).gameObject.activeSelf);
+        }
+
+        [Test]
+        public void Toggle_flips_the_state()
+        {
+            var m = Open(TwoTabs).Get<TabMenu>("m");
+            m.Toggle();
+            Assert.IsTrue(m.IsExpanded);
+            m.Toggle();
+            Assert.IsFalse(m.IsExpanded);
+        }
+
+        [Test]
+        public void Clicking_the_handle_toggles()
+        {
+            var m = Open(TwoTabs).Get<TabMenu>("m");
+            m.GameObject.GetComponent<Button>().onClick.Invoke();
+            Assert.IsTrue(m.IsExpanded);
+        }
+
+        [Test]
+        public void Picking_a_tab_collapses()
+        {
+            var s = Open(TwoTabs);
+            var m = s.Get<TabMenu>("m");
+            m.Expand();
+
+            s.Get<Tab>("b").IsOn = true;
+
+            Assert.IsFalse(m.IsExpanded, "choosing is the whole point — the menu closes behind it");
+        }
+
+        [Test]
+        public void Re_picking_the_selected_tab_also_collapses()
+        {
+            var s = Open(TwoTabs);
+            var m = s.Get<TabMenu>("m");
+            m.Expand();
+
+            s.Get<Tab>("a").SimulateClickForTests();   // already isOn: no onValueChanged at all
+
+            Assert.IsFalse(m.IsExpanded);
+        }
+
+        [Test]
+        public void Only_one_menu_is_open_at_a_time()
+        {
+            var s = Open(@"
+              <TabMenu id='m1'><Tab id='a' text='A'/></TabMenu>
+              <TabMenu id='m2'><Tab id='b' text='B'/></TabMenu>");
+            var m1 = s.Get<TabMenu>("m1");
+            var m2 = s.Get<TabMenu>("m2");
+
+            m1.Expand();
+            m2.Expand();
+
+            Assert.IsFalse(m1.IsExpanded, "the blocker covers the screen — a second open menu is unreachable");
+            Assert.IsTrue(m2.IsExpanded);
+        }
+
+        [Test]
+        public void OnExpanded_and_OnCollapsed_fire()
+        {
+            var m = Open(TwoTabs).Get<TabMenu>("m");
+            int expanded = 0, collapsed = 0;
+            using var e = m.OnExpanded.Subscribe(_ => expanded++);
+            using var c = m.OnCollapsed.Subscribe(_ => collapsed++);
+
+            m.Expand();
+            m.Expand();       // already open: no second event
+            m.Collapse();
+            m.Collapse();     // already closed: no second event
+
+            Assert.AreEqual(1, expanded);
+            Assert.AreEqual(1, collapsed);
+        }
+
+        [Test]
+        public void A_disabled_menu_does_not_open()
+        {
+            var m = Open(@"<TabMenu id='m' interactable='false'><Tab id='a' text='A'/></TabMenu>")
+                .Get<TabMenu>("m");
+            m.Expand();
+            Assert.IsFalse(m.IsExpanded);
+        }
+
+        [Test]
+        public void Becoming_disabled_closes_an_open_menu()
+        {
+            var m = Open(TwoTabs).Get<TabMenu>("m");
+            m.Expand();
+            m.Interactable = false;
+            Assert.IsFalse(m.IsExpanded);
+        }
+
+        [Test]
+        public void Closing_the_screen_takes_the_catcher_with_it()
+        {
+            var s = Open(TwoTabs);
+            s.Get<TabMenu>("m").Expand();
+            Assert.IsNotNull(Blocker(s));
+
+            s.Close();
+            Assert.IsFalse(TabMenu.HasExpandedMenu, "no dangling global reference to a dead menu");
+        }
+
+        // ── Popup skin & procedural surface (TM-D3) ───────────────────────────────────────
+
+        [Test]
+        public void Color_fills_the_popup_panel_not_the_handle()
+        {
+            var m = Open(@"<TabMenu id='m' color='#FF0000'><Tab id='a' text='X'/></TabMenu>").Get<TabMenu>("m");
+            var panelBg = Popup(m).GetComponent<UnityImage>();
+            Assert.AreEqual(1f, panelBg.color.r);
+            Assert.AreEqual(0f, panelBg.color.g);
+            Assert.AreEqual(0f, m.GameObject.GetComponent<UnityImage>().color.a,
+                            "the handle stays transparent — color= describes the menu");
+        }
+
+        [Test]
+        public void Popup_has_a_default_rounded_skin()
+        {
+            var m = Open(TwoTabs).Get<TabMenu>("m");
+            Assert.AreEqual("pugui_9slice_round", Popup(m).GetComponent<UnityImage>().sprite.name);
+        }
+
+        [Test]
+        public void Sprite_empty_clears_the_popup_skin()
+        {
+            var m = Open(@"<TabMenu id='m' sprite=''><Tab id='a' text='X'/></TabMenu>").Get<TabMenu>("m");
+            var bg = Popup(m).GetComponent<UnityImage>();
+            Assert.IsNull(bg.sprite);
+            Assert.AreEqual(UnityImage.Type.Simple, bg.type);
+        }
+
+        [Test]
+        public void Radius_draws_a_procedural_surface_under_the_popup()
+        {
+            var m = Open(@"<TabMenu id='m' radius='12'><Tab id='a' text='X'/></TabMenu>").Get<TabMenu>("m");
+            Assert.IsNotNull(Popup(m).Find(ProceduralSurface.NodeName), "the panel is the surface host");
+            Assert.IsNull(m.RectTransform.Find(ProceduralSurface.NodeName), "…and the handle draws nothing");
+        }
+
+        [Test]
+        public void No_procedural_attributes_means_no_surface_node()
+        {
+            var m = Open(TwoTabs).Get<TabMenu>("m");
+            Assert.IsNull(Popup(m).Find(ProceduralSurface.NodeName));
+        }
+
+        [Test]
+        public void Padding_and_spacing_land_on_the_popup_layout()
+        {
+            var m = Open(@"<TabMenu id='m' padding='8,12' spacing='4'><Tab id='a' text='X'/></TabMenu>")
+                .Get<TabMenu>("m");
+            var vlg = Content(m).GetComponent<VerticalLayoutGroup>();
+            Assert.AreEqual(4f, vlg.spacing);
+            Assert.AreEqual(8, vlg.padding.top);
+            Assert.AreEqual(8, vlg.padding.bottom);
+            Assert.AreEqual(12, vlg.padding.left);
+            Assert.AreEqual(12, vlg.padding.right);
+        }
+
+        [Test]
+        public void TextColor_paints_the_caption_not_the_panel()
+        {
+            var m = Open(@"<TabMenu id='m' textColor='#00FF00' color='#FF0000'><Tab id='a' text='X'/></TabMenu>")
+                .Get<TabMenu>("m");
+            Assert.AreEqual(1f, LabelOf(m).color.g);
+            Assert.AreEqual(0f, LabelOf(m).color.r);
+        }
+
+        [Test]
+        public void Lint_accepts_procedural_attributes_on_TabMenu()
+        {
+            var issues = Walk("<TabMenu id='m' radius='12' glass='true'><Tab id='a' text='X'/></TabMenu>");
+            Assert.IsFalse(issues.Any(i => i.Code == PureContainerVisualAttrRules.VisualAttrCode),
+                           "TabMenu is a drawing tag: its surface is the popup panel");
+        }
+
+        [Test]
+        public void Lint_accepts_nav_attributes_on_TabMenu()
+        {
+            var issues = Walk(@"<TabMenu id='m' focus='true' navUp='other'><Tab id='a' text='X'/></TabMenu>
+                                <Btn id='other'>x</Btn>");
+            Assert.IsFalse(issues.Any(i => i.Code == NavTargetRules.NonSelectableCode),
+                           "the collapsed handle is a Button — it belongs in the navigation graph");
+        }
 
         [Test]
         public void Native_size_hugs_the_caption()

--- a/Tests/EditMode/Controls/TabMenuTests.cs
+++ b/Tests/EditMode/Controls/TabMenuTests.cs
@@ -413,7 +413,7 @@ namespace PromptUGUI.Tests.EditMode.Controls
             m.Expand();
 
             Assert.AreEqual(1f, Popup(m).GetComponent<CanvasGroup>().alpha);
-            Assert.AreEqual(180f, ArrowAngle(m), 0.01f, "the caret points up while open");
+            Assert.AreEqual(-1f, ArrowFlip(m), 0.01f, "the caret points up while open");
         }
 
         [Test]
@@ -422,7 +422,35 @@ namespace PromptUGUI.Tests.EditMode.Controls
             var m = Open(@"<TabMenu id='m' transition='0'><Tab id='a' text='A'/></TabMenu>").Get<TabMenu>("m");
             m.Expand();
             m.Collapse();
-            Assert.AreEqual(0f, ArrowAngle(m), 0.01f);
+            Assert.AreEqual(1f, ArrowFlip(m), 0.01f);
+        }
+
+        // Regression: the caret used to turn 180° about localEulerAngles.z. Its pivot is its LEFT
+        // edge (that is what places it by its left side after the label), so turning it swung the
+        // whole glyph to the left of where it was placed — the caret jumped sideways on every open.
+        [Test]
+        public void Flipping_the_caret_leaves_it_exactly_where_it_was()
+        {
+            var m = Open(@"<TabMenu id='m' transition='0'><Tab id='a' text='World'/></TabMenu>")
+                .Get<TabMenu>("m");
+            var arrow = (RectTransform)m.RectTransform.Find("Arrow");
+            var before = arrow.anchoredPosition;
+            var leftEdgeBefore = LeftEdgeOf(arrow);
+
+            m.Expand();
+
+            Assert.AreEqual(before, arrow.anchoredPosition);
+            Assert.AreEqual(leftEdgeBefore, LeftEdgeOf(arrow), 0.01f,
+                            "a vertical flip mirrors about the middle — it must not move in x");
+            Assert.AreEqual(0f, arrow.localEulerAngles.z, 0.01f, "…and it is a flip, not a turn");
+        }
+
+        // World-space left edge, so a pivot-relative move would show up even if anchoredPosition did not.
+        private static float LeftEdgeOf(RectTransform rt)
+        {
+            var corners = new Vector3[4];
+            rt.GetWorldCorners(corners);
+            return Mathf.Min(corners[0].x, corners[2].x);
         }
 
         [Test]
@@ -444,11 +472,8 @@ namespace PromptUGUI.Tests.EditMode.Controls
                 .Get<TabMenu>("m").TransitionSeconds, 0.0001f);
         }
 
-        private static float ArrowAngle(TabMenu m)
-        {
-            var z = m.RectTransform.Find("Arrow").localEulerAngles.z;
-            return Mathf.Repeat(z, 360f);
-        }
+        // -1 = flipped (menu open), 1 = at rest.
+        private static float ArrowFlip(TabMenu m) => m.RectTransform.Find("Arrow").localScale.y;
 
         // ── Popup skin & procedural surface (TM-D3) ───────────────────────────────────────
 

--- a/Tests/EditMode/Controls/TabMenuTests.cs
+++ b/Tests/EditMode/Controls/TabMenuTests.cs
@@ -9,6 +9,7 @@ using PromptUGUI.Parser;
 using R3;
 using TMPro;
 using UnityEngine;
+using UnityEngine.TestTools;
 using UnityEngine.UI;
 using PuguiScreen = PromptUGUI.Application.Screen;
 using UnityImage = UnityEngine.UI.Image;
@@ -397,6 +398,56 @@ namespace PromptUGUI.Tests.EditMode.Controls
 
             s.Close();
             Assert.IsFalse(TabMenu.HasExpandedMenu, "no dangling global reference to a dead menu");
+        }
+
+        // ── Transition (TM-D13) ───────────────────────────────────────────────────────────
+        //
+        // EditMode has no player loop, so LitMotion never ticks here — the control writes the end
+        // state directly outside play mode. What these pin down is that state; the interpolation
+        // itself is covered in TabMenuPlayTests.
+
+        [Test]
+        public void Transition_zero_lands_on_the_end_state_immediately()
+        {
+            var m = Open(@"<TabMenu id='m' transition='0'><Tab id='a' text='A'/></TabMenu>").Get<TabMenu>("m");
+            m.Expand();
+
+            Assert.AreEqual(1f, Popup(m).GetComponent<CanvasGroup>().alpha);
+            Assert.AreEqual(180f, ArrowAngle(m), 0.01f, "the caret points up while open");
+        }
+
+        [Test]
+        public void Collapse_restores_the_caret()
+        {
+            var m = Open(@"<TabMenu id='m' transition='0'><Tab id='a' text='A'/></TabMenu>").Get<TabMenu>("m");
+            m.Expand();
+            m.Collapse();
+            Assert.AreEqual(0f, ArrowAngle(m), 0.01f);
+        }
+
+        [Test]
+        public void An_unparseable_transition_falls_back_to_the_default()
+        {
+            LogAssert.Expect(LogType.Warning, new System.Text.RegularExpressions.Regex("transition"));
+            var m = Open(@"<TabMenu id='m' transition='soon'><Tab id='a' text='A'/></TabMenu>")
+                .Get<TabMenu>("m");
+            Assert.AreEqual(TabMenu.DefaultTransition, m.TransitionSeconds, 0.0001f);
+        }
+
+        [Test]
+        public void Transition_accepts_ms_and_bare_seconds()
+        {
+            Assert.AreEqual(0.25f, Open(@"<TabMenu id='m' transition='250ms'><Tab id='a' text='A'/></TabMenu>")
+                .Get<TabMenu>("m").TransitionSeconds, 0.0001f);
+            UI.ResetForTests();
+            Assert.AreEqual(0.4f, Open(@"<TabMenu id='m' transition='0.4'><Tab id='a' text='A'/></TabMenu>")
+                .Get<TabMenu>("m").TransitionSeconds, 0.0001f);
+        }
+
+        private static float ArrowAngle(TabMenu m)
+        {
+            var z = m.RectTransform.Find("Arrow").localEulerAngles.z;
+            return Mathf.Repeat(z, 360f);
         }
 
         // ── Popup skin & procedural surface (TM-D3) ───────────────────────────────────────

--- a/Tests/EditMode/Controls/TabMenuTests.cs
+++ b/Tests/EditMode/Controls/TabMenuTests.cs
@@ -543,6 +543,46 @@ namespace PromptUGUI.Tests.EditMode.Controls
             Assert.GreaterOrEqual(n.Value.y, 44f, "min tap target");
         }
 
+        // Regression: ApplyCommon measures a control BEFORE OnAfterApply fills the caption from the
+        // selected tab, so measuring the (still empty) label handed the layout a handle just wide
+        // enough for the caret — 30px, whatever the channel was called.
+        [Test]
+        public void Handle_is_laid_out_wide_enough_for_its_caption_on_the_first_pass()
+        {
+            var s = Open(@"<HStack anchor='top-stretch' height='64'>
+                             <TabMenu id='m' fontSize='22'>
+                               <Tab id='a' text='A reasonably long channel' isOn='true'/>
+                             </TabMenu>
+                             <Frame width='stretch'/>
+                           </HStack>");
+            Canvas.ForceUpdateCanvases();
+            var m = s.Get<TabMenu>("m");
+
+            Assert.AreEqual(m.GetNativeSize().Value.x, m.RectTransform.rect.width, 1f,
+                "the laid-out handle matches what it asks for — no measuring of an empty caption");
+        }
+
+        [Test]
+        public void Native_size_sees_the_selected_tab_before_the_caption_is_filled()
+        {
+            // Same thing one level down: the measurement peeks at the tabs, and picks the isOn one
+            // rather than blindly the first.
+            var s = Open(@"<TabMenu id='m'>
+                             <Tab id='a' text='x'/>
+                             <Tab id='b' text='A much, much longer name' isOn='true'/>
+                           </TabMenu>");
+            var wide = s.Get<TabMenu>("m").GetNativeSize().Value.x;
+
+            UI.ResetForTests();
+            var s2 = Open(@"<TabMenu id='m'>
+                             <Tab id='a' text='x' isOn='true'/>
+                             <Tab id='b' text='A much, much longer name'/>
+                           </TabMenu>");
+            var narrow = s2.Get<TabMenu>("m").GetNativeSize().Value.x;
+
+            Assert.Greater(wide, narrow, "the selected tab is what the handle has to fit");
+        }
+
         [Test]
         public void Native_width_grows_with_a_longer_caption()
         {

--- a/Tests/EditMode/Controls/TabMenuTests.cs.meta
+++ b/Tests/EditMode/Controls/TabMenuTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 24df60e193ffecf20bf16b20f9f5ff78

--- a/Tests/EditMode/Controls/TabMenuTriggerTests.cs
+++ b/Tests/EditMode/Controls/TabMenuTriggerTests.cs
@@ -1,0 +1,160 @@
+using System;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using R3;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    /// <summary>
+    /// <c>on="expand"</c> / <c>on="collapse"</c> — the hook for animating a menu's rows in, since
+    /// the panel itself is an internal node an author cannot wrap (spec §7.10).
+    ///
+    /// <para>They are not called <c>open</c> / <c>close</c> because <c>on="open"</c> already means
+    /// "the Screen opened".</para>
+    /// </summary>
+    public class TabMenuTriggerTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static PromptUGUI.Application.Screen Open(string innerXml)
+        {
+            UI.LoadDocument("t",
+                "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>" +
+                $"<Screen name='S'>{innerXml}</Screen></PromptUGUI>");
+            return UI.Open("S");
+        }
+
+        // ── Parsing ───────────────────────────────────────────────────────────────────────
+
+        [Test]
+        public void Parses_bare_and_targeted_forms()
+        {
+            Assert.AreEqual(TriggerKind.Expand, TriggerSpec.Parse("expand").Kind);
+            Assert.AreEqual(TriggerKind.Collapse, TriggerSpec.Parse("collapse").Kind);
+
+            var targeted = TriggerSpec.Parse("expand@channel");
+            Assert.AreEqual(TriggerKind.Expand, targeted.Kind);
+            Assert.AreEqual("channel", targeted.SourceId);
+
+            Assert.AreEqual("channel", TriggerSpec.Parse("collapse@channel").SourceId);
+        }
+
+        [Test]
+        public void An_empty_id_is_rejected_like_every_other_targeted_form()
+        {
+            Assert.Throws<ArgumentException>(() => TriggerSpec.Parse("expand@"));
+        }
+
+        // ── Firing ────────────────────────────────────────────────────────────────────────
+
+        [Test]
+        public void Expand_fires_on_open_only()
+        {
+            var s = Open(@"
+              <TabMenu id='m' transition='0'>
+                <Trigger id='t' on='expand'><Tab id='a' text='A'/></Trigger>
+              </TabMenu>");
+            var m = s.Get<TabMenu>("m");
+
+            int fired = 0;
+            using var sub = s.Get<Trigger>("t").OnFire.Subscribe(_ => fired++);
+
+            m.Expand();
+            Assert.AreEqual(1, fired);
+
+            m.Collapse();
+            Assert.AreEqual(1, fired, "collapsing is a different event");
+        }
+
+        [Test]
+        public void Collapse_fires_on_close_only()
+        {
+            var s = Open(@"
+              <TabMenu id='m' transition='0'>
+                <Trigger id='t' on='collapse'><Tab id='a' text='A'/></Trigger>
+              </TabMenu>");
+            var m = s.Get<TabMenu>("m");
+
+            int fired = 0;
+            using var sub = s.Get<Trigger>("t").OnFire.Subscribe(_ => fired++);
+
+            m.Expand();
+            Assert.AreEqual(0, fired);
+
+            m.Collapse();
+            Assert.AreEqual(1, fired);
+        }
+
+        [Test]
+        public void A_bare_trigger_resolves_upward_through_the_collapsed_popup()
+        {
+            // The trigger lives inside a popup that is switched off at this point — the ancestor
+            // walk has to include inactive objects or it finds nothing.
+            var s = Open(@"
+              <TabMenu id='m' transition='0'>
+                <Trigger id='t' on='expand'><Tab id='a' text='A'/></Trigger>
+              </TabMenu>");
+
+            int fired = 0;
+            using var sub = s.Get<Trigger>("t").OnFire.Subscribe(_ => fired++);
+            s.Get<TabMenu>("m").Expand();
+
+            Assert.AreEqual(1, fired);
+        }
+
+        // Same scope rule as state-*@<id>: the target is looked up in the trigger's own subtree,
+        // so a targeted form wraps the menu rather than sitting beside it.
+        [Test]
+        public void A_targeted_trigger_names_a_menu_in_its_subtree()
+        {
+            var s = Open(@"
+              <Trigger id='t' on='expand@m'>
+                <TabMenu id='m' transition='0'><Tab id='a' text='A'/></TabMenu>
+              </Trigger>");
+
+            int fired = 0;
+            using var sub = s.Get<Trigger>("t").OnFire.Subscribe(_ => fired++);
+            s.Get<TabMenu>("m").Expand();
+
+            Assert.AreEqual(1, fired);
+        }
+
+        // ── Misuse ────────────────────────────────────────────────────────────────────────
+
+        // The apply pass wraps whatever a setter throws in a ParseException, exactly as it does for
+        // a bad state-* source; what matters is that the message names the fix.
+        private static string MessageFromOpening(string innerXml)
+        {
+            var ex = Assert.Throws<PromptUGUI.Parser.ParseException>(() => Open(innerXml));
+            return ex.Message;
+        }
+
+        [Test]
+        public void A_bare_trigger_with_no_menu_ancestor_throws()
+        {
+            var message = MessageFromOpening("<Frame><Trigger id='t' on='expand'><Frame/></Trigger></Frame>");
+            StringAssert.Contains("no <TabMenu> ancestor found", message);
+            StringAssert.Contains("expand@<id>", message, "…and points at the way out");
+        }
+
+        [Test]
+        public void Targeting_something_that_is_not_a_menu_throws()
+        {
+            var message = MessageFromOpening(
+                "<Frame><Trigger id='t' on='expand@btn'><Btn id='btn'>x</Btn></Trigger></Frame>");
+            StringAssert.Contains("not a <TabMenu>", message);
+        }
+
+        [Test]
+        public void Show_still_refuses_anything_that_is_not_a_state()
+        {
+            var message = MessageFromOpening(
+                "<TabMenu id='m'><Show on='expand'><Tab id='a' text='A'/></Show></TabMenu>");
+            StringAssert.Contains("only accepts state-", message);
+            StringAssert.Contains("expand", message, "the message echoes what the author wrote");
+        }
+    }
+}

--- a/Tests/EditMode/Controls/TabMenuTriggerTests.cs.meta
+++ b/Tests/EditMode/Controls/TabMenuTriggerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a01b6bac6f10b6a7ab232d1cd34e2c2e

--- a/Tests/EditMode/Controls/TabTests.cs
+++ b/Tests/EditMode/Controls/TabTests.cs
@@ -399,5 +399,54 @@ namespace PromptUGUI.Tests.EditMode.Controls
             t.IsOn = false;
             Assert.AreEqual(UnityImage.Type.Tiled, bg.type, "deselection keeps the default skin Tiled");
         }
+
+        // ── Caption mirroring hooks for <TabMenu> (spec §5.2) ──────────────────────────────
+        // TabMenu shows the SELECTED tab's icon + text as its own caption, so it needs both a
+        // read-back of what a Tab currently displays and a signal for when that changes at
+        // runtime (a BindItems bind(), a code-side tab.Text = ...).
+
+        [Test]
+        public void CaptionText_reads_back_label_and_ContentChanged_fires()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
+            var t = OpenTab("<Tab id='t' text='A'/>");
+            Assert.AreEqual("A", t.CaptionText);
+
+            int fired = 0;
+            t.ContentChanged += () => fired++;
+            t.Text = "B";
+            Assert.AreEqual(1, fired, "Text setter must announce the change");
+            Assert.AreEqual("B", t.CaptionText);
+        }
+
+        [Test]
+        public void CaptionIcon_is_null_without_icon()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
+            var t = OpenTab("<Tab id='t' text='A'/>");
+            Assert.IsNull(t.CaptionIcon, "no icon= means no caption icon to mirror");
+        }
+
+        // A TabMenu collapses when the user picks an item — INCLUDING re-picking the one already
+        // selected. uGUI's ToggleGroup(allowSwitchOff=false) swallows that click (isOn is already
+        // true, so onValueChanged never fires), hence a separate activation channel.
+        [Test]
+        public void OnActivated_fires_on_click_even_when_already_on()
+        {
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Tab.*has no.*TabBar.*ancestor"));
+            var t = OpenTab("<Tab id='t' text='A' isOn='true'/>");
+
+            int valueChanges = 0, activations = 0;
+            using var vc = t.OnValueChanged.Subscribe(_ => valueChanges++);
+            using var ac = t.OnActivated.Subscribe(_ => activations++);
+
+            t.SimulateClickForTests();
+
+            Assert.AreEqual(1, activations, "clicking an already-selected Tab must still activate");
+            Assert.AreEqual(0, valueChanges, "isOn did not change, so OnValueChanged must stay silent");
+        }
     }
 }

--- a/Tests/EditMode/Editor/XsdGeneratorTests.cs
+++ b/Tests/EditMode/Editor/XsdGeneratorTests.cs
@@ -22,6 +22,17 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
+        public void Registered_TabMenu_reaches_the_schema_with_its_attributes()
+        {
+            // Reflected, unlike Frame's hand-written list — this guards the registration, so a
+            // <TabMenu> that authoring tools would flag as unknown fails here first.
+            var xsd = XsdGenerator.Generate(PromptUGUI.Application.UI.Registry);
+            StringAssert.Contains("name=\"TabMenu\"", xsd);
+            StringAssert.Contains("name=\"popupWidth\"", xsd);
+            StringAssert.Contains("name=\"transition\"", xsd);
+        }
+
+        [Test]
         public void Frame_lists_its_inner_glow_attributes()
         {
             // Frame's attribute list is hand-written rather than reflected, so every attribute

--- a/Tests/EditMode/Lint/TabMenuRulesTests.cs
+++ b/Tests/EditMode/Lint/TabMenuRulesTests.cs
@@ -1,0 +1,185 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using PromptUGUI.IR;
+using PromptUGUI.Lint;
+using PromptUGUI.Parser;
+
+namespace PromptUGUI.Tests.EditMode.Lint
+{
+    /// <summary>
+    /// <c>PUI-TABMENU-CHILD</c>, <c>PUI-TABMENU-ITEM-WIDTH</c> and <c>PUI-EXPAND-NO-SOURCE</c>, plus
+    /// the widening of <c>PUI-TAB-PARENT</c> to accept a <c>&lt;TabMenu&gt;</c> parent.
+    /// </summary>
+    public class TabMenuRulesTests
+    {
+        private static List<LintIssue> Walk(string body)
+        {
+            var xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>{body}</Screen></PromptUGUI>";
+            return IRWalker.Walk(UIDocumentParser.Parse(xml)).ToList();
+        }
+
+        private static bool Has(List<LintIssue> issues, string code) => issues.Any(i => i.Code == code);
+
+        // ── PUI-TAB-PARENT ────────────────────────────────────────────────────────────────
+
+        [Test]
+        public void A_Tab_inside_a_TabMenu_is_not_orphaned()
+        {
+            var issues = Walk("<TabMenu id='m'><Tab id='a' text='A'/></TabMenu>");
+            Assert.IsFalse(Has(issues, TabRules.TabParentCode),
+                           "<TabMenu> is a tab group too — its rows are exactly <Tab>s");
+        }
+
+        [Test]
+        public void A_Tab_under_a_plain_Frame_is_still_orphaned()
+        {
+            var issues = Walk("<Frame><Tab id='a' text='A'/></Frame>");
+            Assert.IsTrue(Has(issues, TabRules.TabParentCode));
+        }
+
+        // ── PUI-TABMENU-CHILD ─────────────────────────────────────────────────────────────
+
+        [Test]
+        public void A_non_row_child_is_reported()
+        {
+            var issues = Walk("<TabMenu id='m'><Tab id='a' text='A'/><Text id='t'>hi</Text></TabMenu>");
+            Assert.IsTrue(Has(issues, TabMenuRules.ChildCode));
+        }
+
+        [Test]
+        public void Decor_is_allowed_as_a_child()
+        {
+            var issues = Walk("<TabMenu id='m'><Tab id='a' text='A'/><Decor kind='bracket' at='top-left'/></TabMenu>");
+            Assert.IsFalse(Has(issues, TabMenuRules.ChildCode),
+                           "<Decor> decorates the panel and never becomes a row");
+        }
+
+        [Test]
+        public void A_wrapper_containing_a_Tab_is_allowed()
+        {
+            var issues = Walk("<TabMenu id='m'><Frame id='row'><Tab id='a' text='A'/></Frame></TabMenu>");
+            Assert.IsFalse(Has(issues, TabMenuRules.ChildCode));
+        }
+
+        [Test]
+        public void A_template_invocation_is_not_second_guessed()
+        {
+            // The CLI cannot expand it, so it may well contain a <Tab>.
+            var issues = Walk("<TabMenu id='m' itemTemplate='Row'><Row text='A'/></TabMenu>");
+            Assert.IsFalse(Has(issues, TabMenuRules.ChildCode));
+        }
+
+        // ── PUI-TABMENU-ITEM-WIDTH ────────────────────────────────────────────────────────
+
+        [Test]
+        public void A_width_on_a_row_is_reported()
+        {
+            var issues = Walk("<TabMenu id='m'><Tab id='a' text='A' width='120'/></TabMenu>");
+            Assert.IsTrue(Has(issues, TabMenuRules.ItemWidthCode));
+        }
+
+        [Test]
+        public void A_width_on_a_wrapper_row_is_reported()
+        {
+            var issues = Walk("<TabMenu id='m'><Frame id='row' width='120'><Tab id='a' text='A'/></Frame></TabMenu>");
+            Assert.IsTrue(Has(issues, TabMenuRules.ItemWidthCode));
+        }
+
+        [Test]
+        public void A_variant_only_width_is_reported_too()
+        {
+            var issues = Walk("<TabMenu id='m'><Tab id='a' text='A' width.mobile='120'/></TabMenu>");
+            Assert.IsTrue(Has(issues, TabMenuRules.ItemWidthCode),
+                          "a variant override is just as ignored as a base one");
+        }
+
+        [Test]
+        public void A_height_on_a_row_is_fine()
+        {
+            var issues = Walk("<TabMenu id='m'><Tab id='a' text='A' height='40'/></TabMenu>");
+            Assert.IsFalse(Has(issues, TabMenuRules.ItemWidthCode), "rows keep their own height");
+        }
+
+        [Test]
+        public void A_width_inside_a_TabBar_is_still_fine()
+        {
+            var issues = Walk("<TabBar id='b'><Tab id='a' text='A' width='120'/></TabBar>");
+            Assert.IsFalse(Has(issues, TabMenuRules.ItemWidthCode),
+                           "a bar honours per-tab widths; only a menu forces them to span");
+        }
+
+        // ── Layout-group child rules ──────────────────────────────────────────────────────
+
+        [Test]
+        public void A_row_may_not_anchor_itself()
+        {
+            var issues = Walk("<TabMenu id='m'><Tab id='a' text='A' anchor='top'/></TabMenu>");
+            Assert.IsTrue(Has(issues, LayoutGroupChildRules.AnchorCode),
+                          "<TabMenu> lays its rows out, exactly like <TabBar>");
+        }
+
+        // ── PUI-EXPAND-NO-SOURCE ──────────────────────────────────────────────────────────
+
+        [Test]
+        public void A_bare_expand_outside_a_menu_is_reported()
+        {
+            var issues = Walk("<Frame><Animation id='t' on='expand' type='fadein'><Frame/></Animation></Frame>");
+            Assert.IsTrue(Has(issues, StateTriggerRules.NoMenuCode));
+        }
+
+        [Test]
+        public void A_bare_collapse_outside_a_menu_is_reported()
+        {
+            var issues = Walk("<Frame><Trigger id='t' on='collapse'><Frame/></Trigger></Frame>");
+            Assert.IsTrue(Has(issues, StateTriggerRules.NoMenuCode));
+        }
+
+        [Test]
+        public void A_bare_expand_inside_a_menu_is_fine()
+        {
+            var issues = Walk(@"<TabMenu id='m'>
+                                  <Animation id='t' on='expand' type='fadein'><Tab id='a' text='A'/></Animation>
+                                </TabMenu>");
+            Assert.IsFalse(Has(issues, StateTriggerRules.NoMenuCode));
+        }
+
+        [Test]
+        public void A_targeted_expand_is_left_to_runtime()
+        {
+            var issues = Walk("<Frame><Trigger id='t' on='expand@m'><Frame/></Trigger></Frame>");
+            Assert.IsFalse(Has(issues, StateTriggerRules.NoMenuCode),
+                           "@id resolves against ScopedIds at runtime — not statically checkable");
+        }
+
+        [Test]
+        public void A_template_body_is_exempt()
+        {
+            var xml = @"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'>
+  <Template name='Row'><Trigger id='t' on='expand'><Tab id='a'/></Trigger></Template>
+  <Screen name='S'><TabMenu id='m' itemTemplate='Row'/></Screen>
+</PromptUGUI>";
+            var issues = IRWalker.Walk(UIDocumentParser.Parse(xml)).ToList();
+            Assert.IsFalse(Has(issues, StateTriggerRules.NoMenuCode),
+                           "the menu ancestor is supplied at invocation, not in the body");
+        }
+
+        // ── A clean document stays clean ──────────────────────────────────────────────────
+
+        [Test]
+        public void A_well_formed_menu_reports_nothing()
+        {
+            var issues = Walk(@"
+              <TabMenu id='m' popupWidth='240' padding='8' spacing='4' radius='12'>
+                <Tab id='a' text='World' bind='pw' isOn='true' height='44'/>
+                <Tab id='b' text='Guild' bind='pg' height='44'/>
+                <Decor kind='bracket' at='top-left'/>
+              </TabMenu>
+              <Frame id='pw'/>
+              <Frame id='pg'/>");
+            Assert.IsEmpty(issues, "issues: " + string.Join(", ", issues.Select(i => i.Code + " " + i.Message)));
+        }
+    }
+}

--- a/Tests/EditMode/Lint/TabMenuRulesTests.cs.meta
+++ b/Tests/EditMode/Lint/TabMenuRulesTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b2506159e5d7d79e0ac4287c3b9a47d0

--- a/Tests/EditMode/Navigation/TabMenuTrapTests.cs
+++ b/Tests/EditMode/Navigation/TabMenuTrapTests.cs
@@ -1,0 +1,175 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace PromptUGUI.Tests.EditMode.Navigation
+{
+    /// <summary>
+    /// Directional focus around an open <c>&lt;TabMenu&gt;</c>, and who gets to consume Escape when
+    /// a menu and a modal are both listening (spec §7.8 / §7.9).
+    /// </summary>
+    public class TabMenuTrapTests
+    {
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        // EventSystem.current is null in EditMode; mirror the ModalTrapTests pattern.
+        private static EventSystem GetEventSystem() =>
+            EventSystem.current ?? Object.FindAnyObjectByType<EventSystem>();
+
+        private static PromptUGUI.Application.Screen Open(string innerXml)
+        {
+            UI.LoadDocument("t",
+                "<?xml version='1.0' encoding='utf-8'?><PromptUGUI version='1'>" +
+                $"<Screen name='S'>{innerXml}</Screen></PromptUGUI>");
+            return UI.Open("S");
+        }
+
+        private const string PageWithMenu = @"
+          <Btn id='elsewhere'>O</Btn>
+          <TabMenu id='m' transition='0'>
+            <Tab id='a' text='World' isOn='true'/>
+            <Tab id='b' text='Guild'/>
+          </TabMenu>";
+
+        private static GameObject Popup(TabMenu m) => m.RectTransform.Find("Popup").gameObject;
+
+        // ── Focus containment ─────────────────────────────────────────────────────────────
+
+        [Test]
+        public void Expanding_cages_the_focus_inside_the_popup()
+        {
+            UI.UseGamepadNavigation();
+            var s = Open(PageWithMenu);
+            var m = s.Get<TabMenu>("m");
+
+            m.Expand();
+
+            Assert.AreSame(Popup(m), UI.Navigation.ContainmentRoot,
+                           "an open menu owns the focus while it is up");
+        }
+
+        [Test]
+        public void Expanding_puts_the_focus_on_the_selected_row()
+        {
+            UI.UseGamepadNavigation();
+            var s = Open(PageWithMenu);
+            var m = s.Get<TabMenu>("m");
+
+            m.Expand();
+
+            Assert.AreSame(s.Get<Tab>("a").GameObject, GetEventSystem().currentSelectedGameObject,
+                           "opening a menu lands on what is currently chosen, not on row 0 blindly");
+        }
+
+        [Test]
+        public void Focus_cannot_escape_to_the_page_behind()
+        {
+            UI.UseGamepadNavigation();
+            var s = Open(PageWithMenu);
+            var m = s.Get<TabMenu>("m");
+            m.Expand();
+
+            GetEventSystem().SetSelectedGameObject(s.Get<Btn>("elsewhere").GameObject);
+            UI.Navigation.EnforceContainmentForTests();
+
+            Assert.IsTrue(GetEventSystem().currentSelectedGameObject.transform.IsChildOf(Popup(m).transform));
+        }
+
+        [Test]
+        public void Collapsing_releases_the_cage_and_returns_focus_to_the_handle()
+        {
+            UI.UseGamepadNavigation();
+            var s = Open(PageWithMenu);
+            var m = s.Get<TabMenu>("m");
+            m.Expand();
+
+            m.Collapse();
+
+            Assert.IsNull(UI.Navigation.ContainmentRoot, "the page was not caged before, so it is not now");
+            Assert.AreSame(m.GameObject, GetEventSystem().currentSelectedGameObject,
+                           "the user is put back where they opened the menu from");
+        }
+
+        [Test]
+        public void Collapsing_inside_a_modal_restores_the_modal_cage()
+        {
+            UI.UseGamepadNavigation();
+            var s = Open(PageWithMenu);
+            var m = s.Get<TabMenu>("m");
+
+            // Stand in for an enclosing modal: something already owned the focus.
+            var modalRoot = s.RootGameObject;
+            UI.Navigation.ContainmentRoot = modalRoot;
+
+            m.Expand();
+            Assert.AreSame(Popup(m), UI.Navigation.ContainmentRoot);
+
+            m.Collapse();
+            Assert.AreSame(modalRoot, UI.Navigation.ContainmentRoot,
+                           "a menu restores whatever owned the focus before it, not null");
+        }
+
+        [Test]
+        public void Nothing_happens_to_focus_when_navigation_is_off()
+        {
+            var s = Open(PageWithMenu);          // no UseGamepadNavigation
+            var m = s.Get<TabMenu>("m");
+
+            m.Expand();
+            Assert.IsNull(UI.Navigation.ContainmentRoot);
+
+            m.Collapse();
+            Assert.IsNull(UI.Navigation.ContainmentRoot);
+        }
+
+        // ── Escape ────────────────────────────────────────────────────────────────────────
+
+        [Test]
+        public void Escape_is_not_consumed_when_no_menu_is_open()
+        {
+            Open(PageWithMenu);
+            Assert.IsFalse(TabMenu.TryConsumeEscape(), "a modal behind it must still close");
+        }
+
+        [Test]
+        public void Escape_closes_an_open_menu_and_is_consumed()
+        {
+            var m = Open(PageWithMenu).Get<TabMenu>("m");
+            m.Expand();
+
+            Assert.IsTrue(TabMenu.TryConsumeEscape(), "…so the modal underneath survives this press");
+            Assert.IsFalse(m.IsExpanded);
+        }
+
+        // Both listeners answer the same key press and the order between them is not defined. If the
+        // menu's own listener wins the race, the modal's handler must still see the press as spent,
+        // or one Escape would close the menu AND the modal behind it.
+        [Test]
+        public void Escape_is_still_consumed_when_the_menu_closed_itself_first()
+        {
+            var m = Open(PageWithMenu).Get<TabMenu>("m");
+            m.Expand();
+
+            m.NotifyEscapeConsumedForTests();      // the menu's own listener got there first
+            Assert.IsFalse(m.IsExpanded);
+
+            Assert.IsTrue(TabMenu.TryConsumeEscape(),
+                          "the modal's handler, running later in the same frame, must not act on it");
+        }
+
+        [Test]
+        public void A_stale_escape_from_an_earlier_frame_is_not_consumed()
+        {
+            var m = Open(PageWithMenu).Get<TabMenu>("m");
+            m.Expand();
+            m.NotifyEscapeConsumedForTests();
+            Assert.IsTrue(TabMenu.TryConsumeEscape());
+
+            TabMenu.ForgetEscapeFrameForTests();   // stand in for "a later frame"
+            Assert.IsFalse(TabMenu.TryConsumeEscape(), "only the frame it happened in is swallowed");
+        }
+    }
+}

--- a/Tests/EditMode/Navigation/TabMenuTrapTests.cs.meta
+++ b/Tests/EditMode/Navigation/TabMenuTrapTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c5bf9ddd857b0ed0585aa92d38a4ef41

--- a/Tests/PlayMode/Controls/TabMenuPlayTests.cs
+++ b/Tests/PlayMode/Controls/TabMenuPlayTests.cs
@@ -1,0 +1,111 @@
+using System.Collections;
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+
+namespace PromptUGUI.Tests.PlayMode.Controls
+{
+    /// <summary>
+    /// The parts of <c>&lt;TabMenu&gt;</c> that need a running player loop: the LitMotion transition
+    /// (EditMode never ticks it) and the real canvas sorting the panel relies on.
+    /// </summary>
+    public class TabMenuPlayTests
+    {
+        private const string Header = "<?xml version='1.0' encoding='utf-8'?>" +
+            "<PromptUGUI version='1'><Screen name='S'>";
+        private const string Footer = "</Screen></PromptUGUI>";
+
+        [SetUp] public void SetUp() => UI.ResetForTests();
+        [TearDown] public void TearDown() => UI.ResetForTests();
+
+        private static PromptUGUI.Application.Screen OpenMenu(string attrs)
+        {
+            UI.LoadDocument("t", Header +
+                $"<TabMenu id='m' {attrs}><Tab id='a' text='World'/><Tab id='b' text='Guild'/></TabMenu>" +
+                Footer);
+            return UI.Open("S");
+        }
+
+        private static RectTransform Popup(TabMenu m) => (RectTransform)m.RectTransform.Find("Popup");
+
+        [UnityTest]
+        public IEnumerator Expand_fades_the_panel_in()
+        {
+            var m = OpenMenu("transition='0.1s'").Get<TabMenu>("m");
+            m.Expand();
+
+            var cg = Popup(m).GetComponent<CanvasGroup>();
+            Assert.Less(cg.alpha, 1f, "the panel starts transparent and fades in");
+
+            yield return new WaitForSeconds(0.25f);
+            Assert.AreEqual(1f, cg.alpha, 0.01f);
+        }
+
+        [UnityTest]
+        public IEnumerator Collapse_hides_the_panel_only_after_the_transition()
+        {
+            var m = OpenMenu("transition='0.1s'").Get<TabMenu>("m");
+            m.Expand();
+            yield return new WaitForSeconds(0.25f);
+
+            m.Collapse();
+            Assert.IsFalse(m.IsExpanded, "the state flips immediately — only the visuals lag");
+            Assert.IsTrue(Popup(m).gameObject.activeSelf, "…and the panel stays up to be animated out");
+
+            yield return new WaitForSeconds(0.25f);
+            Assert.IsFalse(Popup(m).gameObject.activeSelf);
+        }
+
+        [UnityTest]
+        public IEnumerator Re_expanding_mid_collapse_keeps_the_panel_up()
+        {
+            var m = OpenMenu("transition='0.3s'").Get<TabMenu>("m");
+            m.Expand();
+            yield return new WaitForSeconds(0.4f);
+
+            m.Collapse();
+            yield return null;              // collapse is now animating out
+            m.Expand();                     // …and the user changes their mind
+
+            yield return new WaitForSeconds(0.5f);
+            Assert.IsTrue(m.IsExpanded);
+            Assert.IsTrue(Popup(m).gameObject.activeSelf,
+                          "the cancelled collapse must not deactivate a re-opened panel");
+            Assert.AreEqual(1f, Popup(m).GetComponent<CanvasGroup>().alpha, 0.01f);
+        }
+
+        [UnityTest]
+        public IEnumerator Panel_and_blocker_sort_above_the_page()
+        {
+            var s = OpenMenu("transition='0'");
+            var m = s.Get<TabMenu>("m");
+            var rootOrder = s.RootGameObject.GetComponent<Canvas>().sortingOrder;
+
+            m.Expand();
+            yield return null;
+
+            var panel = Popup(m).GetComponent<Canvas>();
+            var blocker = s.RootGameObject.transform.Find(TabMenu.BlockerName).GetComponent<Canvas>();
+
+            Assert.Greater(panel.sortingOrder, blocker.sortingOrder, "the panel sits above its catcher");
+            Assert.Greater(blocker.sortingOrder, rootOrder, "…and the catcher above the page");
+        }
+
+        [UnityTest]
+        public IEnumerator Closing_the_screen_destroys_the_blocker()
+        {
+            var s = OpenMenu("transition='0'");
+            s.Get<TabMenu>("m").Expand();
+            yield return null;
+
+            var blocker = s.RootGameObject.transform.Find(TabMenu.BlockerName).gameObject;
+            s.Close();
+            yield return null;
+
+            Assert.IsTrue(blocker == null, "the catcher lives outside the screen subtree — dispose owns it");
+        }
+    }
+}

--- a/Tests/PlayMode/Controls/TabMenuPlayTests.cs.meta
+++ b/Tests/PlayMode/Controls/TabMenuPlayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fbaf00a22aa8319e399688ae9371d315

--- a/docs~/superpowers/plans/2026-08-29-tabmenu.md
+++ b/docs~/superpowers/plans/2026-08-29-tabmenu.md
@@ -1,0 +1,556 @@
+# `<TabMenu>` 弹出式 Tab 组 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增 `<TabMenu>` —— 收起时是「选中项 icon + 文字 + 箭头」的把手、点开是一列 `<Tab>` 的弹窗菜单。子节点就是 `<Tab>`，因此 `bind=` / `isOn` / 状态色 / `selectedSprite` / 程序化表面 / `<Show on="state-*">` / `BindItems` 全部零成本复用；控件自身的程序化表面 = 弹窗面板。
+
+**Architecture:** 三层。(1) 从 `TabBar` 抽出 `internal TabGroupCore` —— 静态收集 / `BindItems` / `itemTemplate` / 初始选中 / 订阅，TabBar 与 TabMenu 共用一份「Tab 组语义」。(2) `TabMenu : ProceduralControl`，`SurfaceHost` = 内部 `Popup` 节点、`ChildHostTransform` = `Popup/Content`；弹窗不 reparent，靠嵌套 `Canvas(overrideSorting)` 置顶并逃出祖先 mask，blocker 挂 Screen 根 Canvas。(3) 外围接线：`Trigger` 新增 `expand` / `collapse` 事件、`Screen` 的导航圈闭泛化、`UI.Modal` 的 Esc 让位。
+
+**Tech Stack:** Unity 6 / C# (LangVersion 9.0)、R3 (`Observable` / `Subject`)、uGUI（`ToggleGroup` / `VerticalLayoutGroup` / 嵌套 `Canvas`）、LitMotion（展开过渡）、TMP。无新增包。
+
+设计依据：`docs~/superpowers/specs/2026-08-29-tabmenu-design.md`（下文 §N 均指该 spec 的节号）。
+
+## Global Constraints
+
+- **分支**：全部工作在 `feat/tabmenu`（Task 0 建）。**绝不提交到 main。**
+- **LangVersion 9.0**：不得用 C# 10+ 特性（无 primary constructor、无 collection expression `[]`、无 `[field: SerializeField]`）。switch 表达式 / target-typed `new()` / `??=` 可用。
+- **不用 System.Threading / Task**（WebGL）：本特性无异步。过渡走 LitMotion，**不要**用 `await`。
+- **float 解析**：`float.Parse(s, NumberStyles.Float, CultureInfo.InvariantCulture)`（**禁用** `AsSpan` 重载 —— lint CA1846 → Mono CS1503）。
+- **Core 纯 C# 子集**：`Runtime/Core/Lint/` 里的新规则**不得** `using UnityEngine`（TabMenuRules 只吃 `ElementNode`）。
+- **lint**：每个 Task 收尾从仓库根跑 `cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx`。**不要** `dotnet format analyzers --severity info`。
+- **同 PR 必改 SKILL**（英文）：见 Task 11。
+- **测试只由 controller 经 Unity MCP 跑**（子 agent 到不了 Unity MCP；子 agent 只写代码）。
+- **禁止** `execute_menu_item("Assets/Reimport All")`（弹模态卡死 MCP）。用 `refresh_unity(mode="force", scope="all")`。
+- **InternalsVisibleTo** 已对 `PromptUGUI.Tests.EditMode` / `PromptUGUI.Tests.PlayMode` 开放，测试可见所有 `internal` 类型。
+- **Red first**：每个 Task 先写失败测试、跑一次看它**因正确的原因**失败，再写实现。
+
+**RUN(ClassName) = controller 跑 EditMode 测试的标准流程：**
+1. `mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)`
+2. `mcp__UnityMCP__read_console(action="get", types=["error"])` —— 编译错误必须为空才继续
+3. `mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"], group_names=["ClassName"])` → 轮询 `mcp__UnityMCP__get_test_job(job_id=...)` 直到完成，读 pass/fail
+
+**RUNPLAY(ClassName)** 同上，`mode="PlayMode"` + `assembly_names=["PromptUGUI.Tests.PlayMode"]`。
+
+---
+
+## File Structure
+
+| 文件 | 责任 | 动作 |
+|---|---|---|
+| `Runtime/Controls/Internal/TabGroupCore.cs` | Tab 组语义单一实现（收集 / BindItems / 初始选中 / 订阅） | Create |
+| `Runtime/Controls/Internal/PaddingParser.cs` | `"t,r,b,l"` / `"v,h"` / `"all"` → `RectOffset` | Create |
+| `Runtime/Controls/TabBar.cs` | 改为委托 `TabGroupCore`；公开面不变 | Modify |
+| `Runtime/Controls/TabMenu.cs` | 新控件本体 | Create |
+| `Runtime/Controls/Internal/TabMenuMarker.cs` | 空 MonoBehaviour，供 `on="expand"` 向上查找 | Create |
+| `Runtime/Controls/Tab.cs` | `CaptionText` / `CaptionIcon` / `ContentChanged` / `OnActivated` | Modify |
+| `Runtime/Controls/Internal/PuiToggle.cs` | `OnClicked`（含点已选中项） | Modify |
+| `Runtime/Controls/Internal/TriggerSpec.cs` | `Expand` / `Collapse` 两种 kind | Modify |
+| `Runtime/Controls/Internal/TriggerSourceResolver.cs` | `FindTabMenu` | Modify |
+| `Runtime/Controls/Trigger.cs` | `SubscribeExpand` 分支 | Modify |
+| `Runtime/Application/Screen.cs` | `ConfineNavigationTo` / `RestoreNavigationConfine` | Modify |
+| `Runtime/Application/UI.Modal.cs` | Esc 先让 TabMenu 消费 | Modify |
+| `Runtime/Application/Modals/ModalEscapeListener.cs` | `AlsoCancelButton`（手柄 B） | Modify |
+| `Runtime/Application/BuiltinPrimitives.cs` | 注册 `TabMenu` | Modify |
+| `Runtime/Application/ScreenInstantiator.cs` | layout-group 名单 + lint 分发 | Modify |
+| `Runtime/Core/Lint/TabMenuRules.cs` | `PUI-TABMENU-CHILD` / `PUI-TABMENU-ITEM-WIDTH` | Create |
+| `Runtime/Core/Lint/TabRules.cs` | `PUI-TAB-PARENT` 接受 TabMenu 父 | Modify |
+| `Runtime/Core/Lint/StateTriggerRules.cs` | `PUI-EXPAND-NO-SOURCE` | Modify |
+| `Runtime/Core/Lint/IRWalker.cs` | 名单 + 分发 + `hasTabMenuAncestor` | Modify |
+| `Runtime/Core/Lint/BuiltinTags.cs` | `"TabMenu"` | Modify |
+| `Runtime/Core/Lint/ProceduralSurfaceRules.cs` | `SurfaceTags` += `TabMenu` | Modify |
+| `Runtime/Core/Lint/NavTargetRules.cs` | `SelectableTags` += `TabMenu` | Modify |
+| `Editor/XsdGenerator.cs` | 若有手列属性表则补 `TabMenu` | Modify |
+| `Tests/EditMode/Controls/TabMenuTests.cs` | 结构 / caption / 展开收起 / 皮肤 / ReSolve | Create |
+| `Tests/EditMode/Controls/TabMenuPlacementTests.cs` | 定位 / 尺寸 / 翻转 / 夹边 | Create |
+| `Tests/EditMode/Controls/TabMenuBindItemsTests.cs` | 动态项 / 同帧临时激活 / 空列表 | Create |
+| `Tests/EditMode/Controls/TabMenuTriggerTests.cs` | `expand` / `collapse` / `@id` | Create |
+| `Tests/EditMode/Navigation/TabMenuTrapTests.cs` | 圈闭 / 焦点 / Esc 让位 | Create |
+| `Tests/EditMode/Lint/TabMenuRulesTests.cs` | §9 规则 | Create |
+| `Tests/PlayMode/Controls/TabMenuPlayTests.cs` | 真实 Canvas 排序 / blocker / 过渡收尾 | Create |
+| `.claude/skills/authoring-promptugui-xml/SKILL.md` | catalog / 程序化表面 / native / selectable / tint 名单 | Modify |
+| `.claude/skills/authoring-promptugui-xml/reference/controls-tabs.md` | `## <TabMenu>` 节 | Modify |
+| `.claude/skills/authoring-promptugui-xml/reference/animations.md` | `expand` / `collapse` 行 | Modify |
+| `.claude/skills/authoring-promptugui-xml/reference/navigation.md` | Popup focus trap | Modify |
+| `.claude/skills/scripting-promptugui-csharp/SKILL.md` | C# API + 速查表 | Modify |
+| `docs~/superpowers/specs/2026-05-07-...-design.md` | §5 控件表加一行 | Modify |
+
+---
+
+## Task 0: 建分支 + 落 plan
+
+- [ ] `git checkout -b feat/tabmenu`
+- [ ] `git add docs~/superpowers/specs/2026-08-29-tabmenu-design.md docs~/superpowers/plans/2026-08-29-tabmenu.md && git commit -m "docs: TabMenu spec + plan"`
+- [ ] 确认 Unity MCP 可达：`mcp__UnityMCP__refresh_unity(compile="request", mode="force", scope="all", wait_for_ready=true)` + `read_console(action="get", types=["error"])` 干净
+
+---
+
+## Task 1: `PaddingParser` + `TabGroupCore` 抽取（纯重构，TabBar 行为不变）
+
+**Files:**
+- Create: `Runtime/Controls/Internal/PaddingParser.cs`、`Runtime/Controls/Internal/TabGroupCore.cs`
+- Modify: `Runtime/Controls/TabBar.cs`
+- Test: 既有 `TabBarTests` / `TabBarBindItemsTests` / `TabBarChildSizingTests`（**不改一行**，就是本 Task 的验收）
+
+**Interfaces:**
+- `internal static class PaddingParser { public static RectOffset Parse(string value, RectOffset fallback = null); }` —— 1 / 2 / 4 段，解析失败退回 `fallback ?? new RectOffset()`。
+- `internal sealed class TabGroupCore : IDisposable`，构造 `TabGroupCore(Control owner, Func<RectTransform> itemHost)`；成员见 spec §5.3。
+
+- [ ] **Step 1: 抽取（无新测试）**
+
+从 `TabBar.cs` 原样搬：`_tabs` / `_factory` / `_itemTemplate` / `_itemsSub` / `_tabSubs` / `_bound` / `_selectionChanged`；`BindItems<T,TSlot>` / `Rebuild` / `ClearTabs` / `FindTabIn` / `ResolveFactory` / `WireTabSubscriptions` / `SyncInitialSelection` / `CollectStaticTabs`。
+
+改动仅三处：
+1. `ResolveFactory` 的异常信息用 owner 的类型名拼：`$"<{_owner.GetType().Name} itemTemplate='{tag}'>: tag is neither a registered Control nor a Template"`（TabBar 的既有测试若断言了原文，把断言里的 `<TabBar` 保留 —— `GetType().Name` 正好是 `TabBar`）。
+2. `Rebuild` 的项父级从 `RectTransform` 换成 `_itemHost()`。
+3. `Rebuild` 增加两个可选钩子：`_beforeRebuild?.Invoke()` 在 `ClearTabs` 前、`_afterRebuild?.Invoke()` 在 `WireTabSubscriptions` 后（由 `BindItems` 的可选参数存下）。
+
+`TabBar` 改为：
+
+```csharp
+private readonly TabGroupCore _core;
+public TabBar() { _core = new TabGroupCore(this, () => RectTransform); }
+
+[UIAttr, Preserve] public string ItemTemplate { set => _core.ItemTemplate = value; }
+public int Count => _core.Tabs.Count;
+public int SelectedIndex => _core.SelectedIndex;
+public Tab SelectedTab => _core.SelectedTab;
+public Tab GetAt(int index) => _core.Tabs[index];
+public Observable<Tab> OnSelectionChanged => _core.SelectionChanged;
+public IDisposable BindItems<T>(Observable<IReadOnlyList<T>> s, Action<Tab, T> b) => _core.BindItems<T, Tab>(s, b);
+public IDisposable BindItems<T, TSlot>(Observable<IReadOnlyList<T>> s, Action<TSlot, T> b) where TSlot : class, IControl
+    => _core.BindItems(s, b);
+
+internal override void OnAfterApply()
+{
+    _core.CollectStatic(Children);
+    _core.SyncInitialSelection();
+    _core.WireTabSubscriptions();
+}
+public override void Dispose() { _core.Dispose(); base.Dispose(); }
+```
+
+`ApplyDirection` / `ApplySpacingPadding` / `ApplyChildSizing` 留在 TabBar；`ApplySpacingPadding` 里的 padding 手工解析换成 `PaddingParser.Parse(_padding, _layout.padding)`。
+
+> ⚠️ `TabBar` 是 `sealed`，`new()` 约束要求无参构造 —— `ControlRegistry.Register<T>` 有 `where T : Control, new()`，所以**必须**保留无参构造（上面的写法就是）。
+
+- [ ] **Step 2: RUN(TabBarTests) / RUN(TabBarBindItemsTests) / RUN(TabBarChildSizingTests)** —— 全绿即抽取成功。任一失败先修抽取，不要往下走。
+- [ ] **Step 3: lint**
+
+---
+
+## Task 2: `Tab` / `PuiToggle` 暴露 caption 与激活通道
+
+**Files:**
+- Modify: `Runtime/Controls/Tab.cs`、`Runtime/Controls/Internal/PuiToggle.cs`
+- Test: `Tests/EditMode/Controls/TabTests.cs`（追加两个用例）
+
+**Interfaces:**
+- `Tab`：`internal string CaptionText => _label != null ? _label.text : null;`、`internal Sprite CaptionIcon => _icon != null ? _icon.sprite : null;`、`internal event Action ContentChanged;`、`internal Observable<Unit> OnActivated`。
+- `PuiToggle`：`internal Observable<Unit> OnClicked`（`Subject<Unit>`，`OnPointerClick` / `OnSubmit` 走完 base 后 fire；`OnDestroy` 里 Dispose）。
+
+- [ ] **Step 1: 写失败测试**（追加到 `TabTests.cs`）
+
+```csharp
+[Test]
+public void ContentChanged_fires_when_text_or_icon_set()
+{
+    var screen = OpenScreen("<Screen><TabBar><Tab id='t' text='A'/></TabBar></Screen>");
+    var tab = screen.Get<Tab>("t");
+    int fired = 0;
+    tab.ContentChanged += () => fired++;
+    tab.Text = "B";
+    Assert.AreEqual(1, fired);
+    Assert.AreEqual("B", tab.CaptionText);
+}
+
+[Test]
+public void OnActivated_fires_on_click_even_when_already_on()
+{
+    var screen = OpenScreen("<Screen><TabBar><Tab id='t' text='A' isOn='true'/></TabBar></Screen>");
+    var tab = screen.Get<Tab>("t");
+    int fired = 0;
+    using var sub = tab.OnActivated.Subscribe(_ => fired++);
+    tab.SimulateClickForTests();          // 见 Step 2
+    Assert.AreEqual(1, fired, "点已选中的 Tab 也要 fire —— ToggleGroup 不会产生 onValueChanged");
+}
+```
+
+- [ ] **Step 2: 实现**
+
+`PuiToggle` 加：
+
+```csharp
+private readonly Subject<Unit> _clicked = new();
+internal Observable<Unit> OnClicked => _clicked;
+
+public override void OnPointerClick(PointerEventData eventData)
+{
+    base.OnPointerClick(eventData);
+    _clicked.OnNext(Unit.Default);
+}
+
+public override void OnSubmit(BaseEventData eventData)
+{
+    if (UI.Navigation.TryWakeOnSubmit()) return;
+    base.OnSubmit(eventData);
+    _clicked.OnNext(Unit.Default);
+}
+
+protected override void OnDestroy() { _clicked.Dispose(); _broadcaster.Dispose(); base.OnDestroy(); }
+internal void SimulateClickForTests() => _clicked.OnNext(Unit.Default);
+```
+
+`Tab` 加 `internal Observable<Unit> OnActivated => _toggle.OnClicked;`、`internal void SimulateClickForTests() => _toggle.SimulateClickForTests();`，并在 `Text` / `Icon` setter 末尾 `ContentChanged?.Invoke();`。
+
+> ⚠️ `OnSubmit` 的 wake-gate 早退**之前**不 fire（那次 submit 只唤回光标）—— 保持 nav-hidden-submit-wake 的既有语义。
+
+- [ ] **Step 3: RUN(TabTests) 全绿** —— 既有用例一并跑（`ContentChanged` 不能打乱既有 Text/Icon 行为）
+- [ ] **Step 4: lint**
+
+---
+
+## Task 3: `TabMenu` 骨架 —— 结构 / 注册 / caption 镜像
+
+**Files:**
+- Create: `Runtime/Controls/TabMenu.cs`、`Runtime/Controls/Internal/TabMenuMarker.cs`
+- Modify: `Runtime/Application/BuiltinPrimitives.cs`、`Runtime/Application/ScreenInstantiator.cs`、`Runtime/Core/Lint/BuiltinTags.cs`、`Runtime/Core/Lint/IRWalker.cs`
+- Test: `Tests/EditMode/Controls/TabMenuTests.cs`（本 Task 只写结构 / caption 部分）
+
+**Interfaces:** spec §5.1 的公开面；本 Task 先到 `SelectedTab` / `Count` / `GetAt` / `OnSelectionChanged` / `RefreshCaption`，展开收起留 Task 5。
+
+- [ ] **Step 1: 写失败测试**（`TabMenuTests.cs`）
+
+```csharp
+public class TabMenuTests
+{
+    [SetUp] public void SetUp() => UI.ResetForTests();
+    [TearDown] public void TearDown() => UI.ResetForTests();
+
+    private const string Xml = @"<Screen name='s'>
+        <TabMenu id='m' fontSize='22'>
+          <Tab id='a' icon='' text='World' bind='pw' isOn='true'/>
+          <Tab id='b' text='Guild' bind='pg'/>
+        </TabMenu>
+        <Frame id='pw'/><Frame id='pg'/>
+      </Screen>";
+
+    [Test] public void Registered_as_builtin() => Assert.IsTrue(UI.Registry.Has("TabMenu"));
+
+    [Test]
+    public void Children_land_in_popup_content_not_on_self()
+    {
+        var s = Open(Xml);
+        var menu = s.Get<TabMenu>("m");
+        var tab = s.Get<Tab>("a");
+        Assert.AreEqual("Content", tab.RectTransform.parent.name);
+        Assert.AreEqual("Popup", tab.RectTransform.parent.parent.name);
+        Assert.AreSame(menu.RectTransform, tab.RectTransform.parent.parent.parent);
+    }
+
+    [Test]
+    public void Caption_mirrors_selected_tab_text()
+    {
+        var s = Open(Xml);
+        var label = s.Get<TabMenu>("m").RectTransform.Find("Label").GetComponent<TMP_Text>();
+        Assert.AreEqual("World", label.text);
+        s.Get<Tab>("b").IsOn = true;
+        Assert.AreEqual("Guild", label.text);
+    }
+
+    [Test]
+    public void Caption_font_size_from_attribute() { /* fontSize='22' → label.fontSize == 22 */ }
+
+    [Test]
+    public void Caption_follows_selected_tab_text_change()
+    {
+        var s = Open(Xml);
+        s.Get<Tab>("a").Text = "Renamed";
+        Assert.AreEqual("Renamed", Label(s).text);
+    }
+
+    [Test]
+    public void Popup_is_inactive_after_open()
+    {
+        var s = Open(Xml);
+        Assert.IsFalse(Popup(s).activeSelf);
+    }
+
+    [Test]
+    public void Native_size_hugs_caption()
+    {
+        var s = Open(Xml);
+        var n = s.Get<TabMenu>("m").GetNativeSize().Value;
+        Assert.Greater(n.x, 0f);
+        Assert.GreaterOrEqual(n.y, 44f);
+    }
+
+    [Test]
+    public void Bind_shows_selected_page_only()
+    {
+        var s = Open(Xml);
+        Assert.IsTrue(s.Get<Frame>("pw").GameObject.activeSelf);
+        Assert.IsFalse(s.Get<Frame>("pg").GameObject.activeSelf);
+    }
+
+    [Test]
+    public void Layout_group_child_rules_apply_to_tabs()  // TabMenu 在 selfIsLayoutGroup 名单里
+    { /* <Tab anchor='top'> → Debug.LogWarning PUI-LAYOUT-ANCHOR（LogAssert.Expect） */ }
+}
+```
+
+- [ ] **Step 2: 实现结构**（spec §6）
+
+```csharp
+public sealed class TabMenu : ProceduralControl
+{
+    private const float PadX = 4f, PadY = 6f, MinTapHeight = 44f;
+    private UnityImage _hit;          // 自身 Image：透明但 raycastTarget=true，让触发区可点
+    private UnityImage _icon, _arrow, _popupBg;
+    private TMP_Text _label;
+    private RectTransform _popup, _content;
+    private CanvasGroup _popupCg;
+    private Canvas _popupCanvas;
+    private VerticalLayoutGroup _layout;
+    private PuiButton _btn;
+    private ToggleGroup _group;
+    private readonly TabGroupCore _core;
+    private Tab _captionSource;                 // 当前被订阅 ContentChanged 的 Tab
+    private float _iconSize = 24f, _arrowSize = 16f, _gap = 6f;
+    private string _fontType = "default";
+
+    public TabMenu() { _core = new TabGroupCore(this, () => _content); }
+
+    private protected override GameObject SurfaceHost => _popup.gameObject;
+    private protected override Selectable SurfaceSelectable => null;   // 面板不是 Selectable
+    protected internal override Transform ChildHostTransform => _content;
+
+    public override void OnAttached()
+    {
+        GameObject.AddComponent<TabMenuMarker>();
+        _hit = GameObject.GetComponent<UnityImage>() ?? GameObject.AddComponent<UnityImage>();
+        _hit.color = new UnityEngine.Color(0f, 0f, 0f, 0f);   // 透明但可点（TM-D3：触发区默认无底）
+        _group = GameObject.AddComponent<ToggleGroup>();
+        _group.allowSwitchOff = false;
+
+        _icon  = ProceduralBuilders.AddImage(RectTransform, "Icon", raycast: false);
+        _icon.enabled = false;
+        _label = ProceduralBuilders.AddText(RectTransform, "Label");
+        _label.alignment = TextAlignmentOptions.Left; _label.raycastTarget = false; _label.fontSize = 24;
+        _arrow = ProceduralBuilders.AddImage(RectTransform, "Arrow", raycast: false);
+        _arrow.color = ProceduralBuilders.DefaultGlyphColor;
+        ProceduralBuilders.ApplyDefaultSimpleSprite(_arrow, ProceduralBuilders.SpriteCaret);
+
+        BuildPopup();                                  // Popup + CanvasGroup + Canvas + Raycaster + Content
+        _btn = GameObject.AddComponent<PuiButton>();
+        _btn.targetGraphic = (Graphic)_label;
+        _btn.onClick.AddListener(Toggle);
+        UI.Locale.Changed += ApplyFont;
+    }
+}
+```
+
+`BuildPopup`：`Popup` 满宽锚在自身底边（`anchorMin=anchorMax=(0,0)`、`pivot=(0,1)`），`Image` 走 `ApplyDefaultSlicedSprite` + `DefaultPopupBgColor`；`CanvasGroup`；`Canvas`（`overrideSorting` 暂 false）；`GraphicRaycaster`；`Content` stretch + `VerticalLayoutGroup { childControlWidth = true, childControlHeight = true, childForceExpandWidth = true, childForceExpandHeight = false }`。
+
+`OnAfterApply`：`base` → `_core.CollectStatic(Children)` → `SyncInitialSelection` → `WireTabSubscriptions` → 订阅 `SelectionChanged` 一次（`_wired` 守卫）→ `RefreshCaption()` → `LayoutCaption()` → `UI.OwnerScreenOf(this)?.DeferDuringOpen(() => { if (!IsExpanded) _popup.gameObject.SetActive(false); })`。
+
+`RefreshCaption` / `LayoutCaption` 见 spec §7.3 / §6：Icon 在左（`enabled = sprite != null`）、Label 居中偏左、Arrow 贴右，横向按 `PadX` / `gap` 顺序摆；`GetNativeSize` 用 spec §10.3 的公式。
+
+- [ ] **Step 3: 注册与名单**
+  - `BuiltinPrimitives`: `reg.Register<TabMenu>("TabMenu", null);`
+  - `ScreenInstantiator.cs:288`: `selfIsLayoutGroup = node.Tag is "VStack" or "HStack" or "Grid" or "TabBar" or "TabMenu" or "Carousel";`
+  - `IRWalker.cs:195`: 同名单；`isTabBar` → `isTabGroup = node.Tag is "TabBar" or "TabMenu"`
+  - `BuiltinTags.All` += `"TabMenu"`（`BuiltinTagsTests` 会守）
+- [ ] **Step 4: RUN(TabMenuTests) / RUN(BuiltinTagsTests) 绿**
+- [ ] **Step 5: lint**
+
+---
+
+## Task 4: 弹窗皮肤 + 程序化表面 + padding / spacing
+
+**Files:** Modify `Runtime/Controls/TabMenu.cs`、`Runtime/Core/Lint/ProceduralSurfaceRules.cs`、`Runtime/Core/Lint/NavTargetRules.cs`
+**Test:** 追加到 `TabMenuTests.cs`
+
+**Interfaces:** `[UIAttr]` — `fontSize` / `textColor` / `font` / `iconSize` / `arrow` / `arrowColor` / `arrowSize` / `gap` / `color` / `sprite` / `tint` / `padding` / `spacing` / `popupWidth` / `popupGap` / `transition` / `itemTemplate`（spec §4）。
+
+- [ ] **Step 1: 写失败测试**
+
+```csharp
+[Test] public void Color_and_sprite_apply_to_popup_bg_not_self();       // _hit 保持透明
+[Test] public void Radius_creates_surface_under_popup();                // Popup 下有 "__Surface"，自身没有
+[Test] public void Glass_applies_to_popup();                            // ProceduralPanel 在 Popup 子节点上
+[Test] public void Sprite_empty_clears_popup_sprite();
+[Test] public void Padding_and_spacing_land_on_content_layout();
+[Test] public void Arrow_empty_disables_arrow_image();
+[Test] public void Procedural_surface_rules_accept_TabMenu();           // Lint：radius 不再报「纯容器」
+```
+
+- [ ] **Step 2: 实现 setter**
+
+`Color` 走 `UI.Theme.ResolveSpec` → `ColorApplier.Apply(_popupBg, spec)` + `Surface.SetFill(spec.Top, spec.Bottom)`（同 Btn / Tab）。`Sprite` 空 / `none` → `_popupBg.sprite = null; _popupBg.type = Simple;`。`Padding` → `_layout.padding = PaddingParser.Parse(value, _layout.padding)`。`Transition` → `ParseSeconds`（把 `AnimationSpec.ParseSeconds` 提成 `internal static` 供复用，**不要**复制一份）。
+
+- [ ] **Step 3: 名单**
+  - `ProceduralSurfaceRules.SurfaceTags` += `"TabMenu"`
+  - `NavTargetRules.SelectableTags` += `"TabMenu"`
+- [ ] **Step 4: RUN(TabMenuTests) / RUN(ProceduralSurfaceContractTests) / RUN(PureContainerVisualAttrRulesTests) / RUN(NavTargetRulesTests) 绿**
+- [ ] **Step 5: lint**
+
+---
+
+## Task 5: 展开 / 收起 —— blocker、排序、定位、翻转
+
+**Files:** Modify `Runtime/Controls/TabMenu.cs`
+**Test:** `Tests/EditMode/Controls/TabMenuPlacementTests.cs` + 追加到 `TabMenuTests.cs`
+
+**Interfaces:** `IsExpanded` / `Expand()` / `Collapse()` / `Toggle()` / `OnExpanded` / `OnCollapsed`；`internal static int PopupSortingOffset = 2`。
+
+- [ ] **Step 1: 写失败测试**
+
+`TabMenuTests` 追加：展开激活面板 + 建 blocker（Screen 根 Canvas 的最后一个子节点、`Button.navigation.mode == None`）+ `Canvas.overrideSorting && sortingOrder == root + 2`；blocker `sortingOrder == root + 1`；`Collapse` 后 blocker inactive、`s_expanded` 空；点 blocker 的 `Button.onClick.Invoke()` 收起；选中任一 Tab（含点已选中的 `SimulateClickForTests`）收起；第二个 TabMenu `Expand` 时第一个收起；`interactable=false` 时 `Expand()` no-op 且展开中被收起；`Dispose` 销毁 blocker。
+
+`TabMenuPlacementTests`：
+
+```csharp
+[Test] public void Popup_defaults_to_below_left_aligned();              // anchor(0,0) pivot(0,1) y == -popupGap
+[Test] public void Popup_width_is_max_of_trigger_and_content();
+[Test] public void Explicit_popupWidth_wins();
+[Test] public void Flips_up_when_no_room_below();                       // 触发区放在 canvas 底部
+[Test] public void Clamps_left_when_overflowing_right_edge();
+[Test] public void Reposition_on_resolve_keeps_expanded_state();
+```
+
+> 测试要有真实 Canvas 尺寸：用 `Open(...)` 后手动设 `screen.RootGameObject.GetComponent<RectTransform>().sizeDelta` 并 `LayoutRebuilder.ForceRebuildLayoutImmediate`，参照 `TabBarChildSizingTests` 的既有做法。
+
+- [ ] **Step 2: 实现** —— spec §7.1 / §7.2 逐条。`EnsureBlocker()` 用 `GetComponentInParent<Canvas>().rootCanvas` 找宿主；blocker `GameObject` 名 `__TabMenuBlocker`，`Image.color = (0,0,0,0)`、`raycastTarget = true`、`Button.navigation = new Navigation { mode = Navigation.Mode.None }`。
+- [ ] **Step 3: RUN(TabMenuTests) / RUN(TabMenuPlacementTests) 绿**
+- [ ] **Step 4: lint**
+
+---
+
+## Task 6: 过渡动画（LitMotion）
+
+**Files:** Modify `Runtime/Controls/TabMenu.cs`
+**Test:** 追加到 `TabMenuTests.cs` + `Tests/PlayMode/Controls/TabMenuPlayTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+  - EditMode：`transition="0"` → `Expand()` 后 `_popupCg.alpha == 1f` 且面板已在终态位置；`Collapse()` 后立即 `activeSelf == false`。
+  - EditMode：`transition` 非 0 → `Expand()` 后面板 active、`alpha < 1`（动画刚起步）。
+  - PlayMode：`transition="0.05s"` → `Collapse()` 后 `yield return new WaitForSeconds(0.15f)` → 面板 `activeSelf == false`；箭头 `localEulerAngles.z` 回到 0。
+- [ ] **Step 2: 实现** —— spec §7.7。两条 handle 存字段，`PlayTransition` 前 `TryCancel`；`.AddTo(_popup.gameObject)` 绑生命周期（照 `AnimationDriver` 的注释理由）。收起的 `OnComplete` 里 `SetActive(false)`；若中途又 `Expand`，先 `TryCancel` 再正放，`SetActive(false)` 不会误触发（handle 已取消）。
+- [ ] **Step 3: RUN(TabMenuTests) + RUNPLAY(TabMenuPlayTests) 绿**
+- [ ] **Step 4: lint**
+
+---
+
+## Task 7: `BindItems` + `itemTemplate`（含同帧临时激活）
+
+**Files:** Modify `Runtime/Controls/TabMenu.cs`
+**Test:** `Tests/EditMode/Controls/TabMenuBindItemsTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+  - 绑定后替换静态 Tab；`Count` / `SelectedIndex` / caption 正确。
+  - **收起态**绑定后，某个新 Tab 的 label `GetPreferredValues(text).x > 0`（证明同帧临时激活生效）；绑定结束后 `Popup.activeSelf == false`。
+  - 空列表 → caption 清空、`SelectedTab == null`、`OnSelectionChanged` fire null。
+  - `itemTemplate` 指向包着 `<Tab>` 的 Template → 找得到 Tab。
+  - 展开态绑定 → 面板保持 active、尺寸重算。
+- [ ] **Step 2: 实现** —— `BindItems` 转发 `_core.BindItems(source, bind, beforeRebuild: ..., afterRebuild: ...)`，钩子内容见 spec §7.5。
+- [ ] **Step 3: RUN(TabMenuBindItemsTests) 绿**
+- [ ] **Step 4: lint**
+
+---
+
+## Task 8: `on="expand"` / `on="collapse"` Trigger 事件
+
+**Files:** Modify `Runtime/Controls/Internal/TriggerSpec.cs`、`TriggerSourceResolver.cs`、`Trigger.cs`
+**Test:** `Tests/EditMode/Controls/TabMenuTriggerTests.cs` + 追加 `TriggerSpecTests`
+
+- [ ] **Step 1: 写失败测试**
+  - `TriggerSpec.Parse("expand")` / `"collapse"` / `"expand@menu"` → kind + SourceId。
+  - `<TabMenu><Trigger id='t' on='expand'><Tab/></Trigger></TabMenu>` → `Expand()` 时 `OnFire` fire 一次；`Collapse()` 不 fire。
+  - `on="collapse"` 反之。
+  - `on='expand@m'` 从 TabMenu **外部**引用（`@id` 走 ScopedIds）。
+  - bare `on='expand'` 无 TabMenu 祖先 → `InvalidOperationException`。
+  - `<Show on='expand'>` → 仍是既有的「只接受 state-*」ParseException。
+- [ ] **Step 2: 实现** —— spec §7.10 / §10.5。`FindTabMenu` 的 bare 分支用 `GetComponentInParent<TabMenuMarker>(true)`（**includeInactive**：弹窗收起态 inactive），再经 `UI.OwnerScreenOf` / `_nodeMap` 反查回 `TabMenu` 控件；简单起见 `TabMenuMarker` 直接持有 `internal TabMenu Owner` 引用（`OnAttached` 时赋值）。
+- [ ] **Step 3: RUN(TabMenuTriggerTests) / RUN(TriggerSpecTests) / RUN(TriggerTests) / RUN(StateTriggerTests) 绿**
+- [ ] **Step 4: lint**
+
+---
+
+## Task 9: 导航圈闭 + Esc / 手柄 B
+
+**Files:** Modify `Runtime/Application/Screen.cs`、`UI.Modal.cs`、`Modals/ModalEscapeListener.cs`、`Runtime/Controls/TabMenu.cs`
+**Test:** `Tests/EditMode/Navigation/TabMenuTrapTests.cs`
+
+- [ ] **Step 1: 写失败测试**
+  - `UI.UseGamepadNavigation()` 后展开 → `UI.Navigation.ContainmentRoot == Popup`；`EnforceContainmentForTests()` 把选择拉进面板；焦点落在选中 Tab。
+  - 收起 → `ContainmentRoot` 回到展开前的值（null 或模态根）；焦点回触发区 GameObject。
+  - 模态内的 TabMenu：展开→收起后 `ContainmentRoot` 回到模态根（不是 null）。
+  - Esc 让位两种顺序：(a) 先调 `TabMenu` 的 listener `FireForTests()` 再调模态的 → 模态不关；(b) 先调模态的 → `TryConsumeEscape` 收起弹窗且模态不关。
+  - 未展开时 `TryConsumeEscape()` 返回 false（模态照常关）。
+- [ ] **Step 2: 实现** —— spec §7.8 / §7.9 / §10.6 / §10.7。`Screen.ConfineNavigationToSelf()` 保留为 `ConfineNavigationTo(RootGameObject)` 的薄封装（`UI.Modal` 不动）。
+- [ ] **Step 3: RUN(TabMenuTrapTests) / RUN(ModalTrapTests) / RUN(ExplicitNavTests) / RUN(InitialFocusTests) 绿**
+- [ ] **Step 4: lint**
+
+---
+
+## Task 10: Lint 规则
+
+**Files:** Create `Runtime/Core/Lint/TabMenuRules.cs`；Modify `TabRules.cs`、`StateTriggerRules.cs`、`IRWalker.cs`、`ScreenInstantiator.cs`
+**Test:** `Tests/EditMode/Lint/TabMenuRulesTests.cs`
+
+- [ ] **Step 1: 写失败测试** —— spec §9 每条一个用例 + 一个「合法文档零 issue」的负例；`PUI-TAB-PARENT` 在 `<TabMenu>` 父下**不再**报。
+- [ ] **Step 2: 实现**
+  - `TabMenuRules.CheckTabMenu(ElementNode)`：`PUI-TABMENU-CHILD`（复用 `TabRules.SubtreeMayResolveToTab` 的思路，另外放行 `Decor`）、`PUI-TABMENU-ITEM-WIDTH`（子节点或其内 `<Tab>` 写了 `width`，含 `VariantOverrides`）。
+  - `TabRules`：`PUI-TAB-PARENT` 的父标签判断加 `"TabMenu"`。
+  - `StateTriggerRules`：加 `hasTabMenuAncestor` 位与 `PUI-EXPAND-NO-SOURCE`（bare `expand` / `collapse`；`@id` 与 Template body / instance root 豁免）。
+  - `IRWalker` / `ScreenInstantiator` 分发 `TabMenuRules.CheckTabMenu`。
+  - **纯 C#**：不得引 `UnityEngine`。
+- [ ] **Step 3: RUN(TabMenuRulesTests) / RUN(TabRulesTests) / RUN(StateTriggerRulesTests 若有) 绿**
+- [ ] **Step 4: CLI 冒烟**：写一份含 TabMenu 的临时 `.ui.xml` 到 scratchpad，`dotnet run --project .lint/UIXmlLint -- <file>`，确认输出与 exit code 符合预期
+- [ ] **Step 5: lint**
+
+---
+
+## Task 11: SKILL / spec 文档（英文，同 PR）
+
+**Files:** 见 File Structure 末尾五行 + 主 spec
+
+- [ ] `authoring-promptugui-xml/SKILL.md`：catalog 行；程序化表面「Which tags draw procedurally」+「主表面」表（TabMenu → **弹窗面板**）；native-size 名单（两处：layout-group 内 / 自由定位）；`focus` / `nav*` 的 Selectable 名单；`tint` 名单；Re-skinning 段 `<TabMenu arrow= arrowColor=>`；Color-token 适用控件表
+- [ ] `reference/controls-tabs.md`：标题改 "Tabs (`<TabBar>` / `<TabMenu>` / `<Tab>`)"；新增 `## <TabMenu>` 节（spec §3 三例 + §4 属性表 + `<Tab>` 差异 + caption 镜像 + 交互 + 定位翻转 + `transition` + lint 表）
+- [ ] `reference/animations.md`：`on=` 表加四行；UPWARD 段落加 TabMenu；Patterns 加「菜单项入场」
+- [ ] `reference/navigation.md`：Selectable 名单 + "Popup focus trap" 段
+- [ ] `scripting-promptugui-csharp/SKILL.md`：`TabMenu` API、事件速查表、DATA PUSH 行
+- [ ] 主 spec `2026-05-07-...-design.md` §5 控件表加 `<TabMenu>` 行；§5.7 提一句 `expand` / `collapse`
+- [ ] 设计 spec 头部状态改为「已实现」并补一节实施记录
+
+---
+
+## Task 12: 全套件 + XSD + 视觉 QA
+
+- [ ] `Tools → PromptUGUI → Schema → Generate XSD`（或 Editor 菜单等价入口）重生成；`XsdGeneratorTests` 若有手列表则补 `TabMenu` 的 substring 断言 → RUN(XsdGeneratorTests)
+- [ ] RUN 全 EditMode：`mcp__UnityMCP__run_tests(mode="EditMode", assembly_names=["PromptUGUI.Tests.EditMode"])`
+- [ ] RUN `PromptUGUI.Tests.EditorOnly`
+- [ ] RUNPLAY 全 PlayMode
+- [ ] `read_console(action="get", types=["error"])` 干净
+- [ ] `cd .lint && dotnet format --verify-no-changes --severity warn PromptUGUI.Lint.slnx`
+- [ ] **视觉 QA（人工，在 host 工程里跑 §3.1 的频道切换器）**：
+  - 收起态箭头紧跟文字、切换频道后 caption 宽度跟着变
+  - 展开后面板浮在聊天内容之上、不被父 mask 裁
+  - 玻璃面板在 Overlay canvas 下的表现符合 glass.md 的 backdrop 规则
+  - 点面板外收起；Esc 收起；手柄 B 收起且焦点回把手
+  - 把 TabMenu 塞进 `<ScrollList>` 里滚动，确认面板跟随且不被裁
+- [ ] PR：`gh pr create`，正文引 spec 与本 plan，列 §12 Out of Scope
+
+---
+
+## Self-Review 注记（写计划时已核）
+
+- `ControlRegistry.Register<T>` 的 `new()` 约束 → `TabMenu` / `TabBar` 必须有无参构造；`TabGroupCore` 在构造里建（`this` 逃逸仅存引用，不调虚方法）。
+- `TabMenu` 是 `sealed`（同其它内置控件），`ProceduralControl` 的 15 个程序化属性靠反射继承自动拿到。
+- 触发区自身的 `Image` 必须存在且 `raycastTarget=true`，否则 `PuiButton` 收不到点击 —— 但颜色透明（TM-D3 的「默认无底」）。
+- `SurfaceSelectable` 传 `null`：面板不是 Selectable，`hoverColor` 之类本就不作用于它（TM-D18 已把触发区状态色划到 v2）。
+- `AnimationSpec.ParseSeconds` 目前是 `private static` —— Task 4 要提成 `internal static`，不要复制第二份实现。
+- `PuiToggle.OnPointerClick` / `OnSubmit` 都是 `public override`（uGUI `Toggle` 的签名），加 `_clicked` 时别改可见性。
+- lint 新规则在 `Runtime/Core/Lint/`，**纯 C#**；`TabMenuRules` 只吃 `ElementNode`，别 `using UnityEngine`。
+- `IRWalker` 里 `isTabBar` 变量当前只用于 TabBar 分支；改名为 `isTabGroup` 后要确认所有引用点都跟着改。
+- 既有 `TabBar*Tests` 是 Task 1 抽取的唯一护栏 —— 抽取后**先跑绿**再动 TabMenu，否则后面分不清是抽取坏了还是新控件坏了。

--- a/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
+++ b/docs~/superpowers/specs/2026-05-07-promptugui-description-language-design.md
@@ -160,13 +160,14 @@ Template 同名（含 commons 与各 Import 的任意组合）→ 报错；`as="
 | `<Dropdown>` | 下拉选择（OnSelected: int；BindOptions 推送选项） | TMP_Dropdown |
 | `<ScrollList>` | 滚动列表（BindItems 推送数据；itemTemplate 引用 Template/Control 类） | ScrollRect + Mask |
 | `<TabBar>` | Tab 容器；私有 ToggleGroup + Horizontal/VerticalLayoutGroup；纯布局,无自身视觉；支持 `itemTemplate` + `BindItems` 动态构建 | RectTransform + ToggleGroup + LayoutGroup（详见 [`2026-05-27-tabbar-design.md`](2026-05-27-tabbar-design.md)） |
-| `<Tab>` | `<TabBar>` 子节点；可点击容器（接子，Frame 式叠放）；uGUI Toggle + 懒建 label + 可选 icon；`color` / `sprite` / `selectedSprite` 自管视觉（共享样式用 Template）；`bind="frame_id"` 声明式切换 Frame 可见性 | RectTransform + UnityImage + UnityToggle |
+| `<TabMenu>` | 弹出式 Tab 组：收起=选中 Tab 的 icon+文字+箭头（hug 内容），展开=一列 `<Tab>` 的弹窗面板；**程序化表面 = 弹窗面板**（把手默认透明）；`OnSelectionChanged` / `OnExpanded` / `OnCollapsed`；`itemTemplate` + `BindItems`；与 `<TabBar>` 共用同一份 Tab 组语义 | RectTransform + PuiButton + ToggleGroup + 内部 Popup（Canvas overrideSorting，逃出祖先 mask）（详见 [`2026-08-29-tabmenu-design.md`](2026-08-29-tabmenu-design.md)） |
+| `<Tab>` | `<TabBar>` / `<TabMenu>` 子节点；可点击容器（接子，Frame 式叠放）；uGUI Toggle + 懒建 label + 可选 icon；`color` / `sprite` / `selectedSprite` 自管视觉（共享样式用 Template）；`bind="frame_id"` 声明式切换 Frame 可见性 | RectTransform + UnityImage + UnityToggle |
 | `<Carousel>` | 水平翻页轮播卡容器；自动播放 + 拖动 + 无限循环 + 状态化指示点；itemTemplate + BindItems 动态卡片；当前页是运行期独占状态（resize 不重置） | RectTransform + RectMask2D + 自管卡条（详见 [`2026-06-04-carousel-design.md`](2026-06-04-carousel-design.md)） |
 | `<Markdown>` | Markdown document → scrollable subtree of existing primitives; dynamic `text`, resize-safe; soft-depends Markdig (`PROMPTUGUI_HAS_MARKDIG`) | see [`2026-06-09-markdown-control-design.md`](2026-06-09-markdown-control-design.md) |
 
 `<Btn>` 提供"按钮"这一通用交互原语：可作为 Template 根，配合 `<Image>` / `<Text>` 子节点组合出 PrimaryButton / DangerButton / IconButton 等业务变体而无需额外 prefab。`Btn` 内部用 R3 `Subject<Unit>` 暴露 `OnClick`（与 §9.4 的"事件统一为 `Observable<T>`"约束一致）。
 
-`<Toggle>` / `<Slider>` / `<Dropdown>` / `<ScrollList>` / `<TabBar>` 默认开启的参考实现（详见 [`2026-05-09-m5-common-controls-design.md`](2026-05-09-m5-common-controls-design.md)）。视觉风格用 `sprite` / `color` 等属性表达；需要项目级强差异化样式（像素描边、按下震动等）时作者继承相应类重写 `OnAttached`。
+`<Toggle>` / `<Slider>` / `<Dropdown>` / `<ScrollList>` / `<TabBar>` / `<TabMenu>` 默认开启的参考实现（详见 [`2026-05-09-m5-common-controls-design.md`](2026-05-09-m5-common-controls-design.md)）。视觉风格用 `sprite` / `color` 等属性表达；需要项目级强差异化样式（像素描边、按下震动等）时作者继承相应类重写 `OnAttached`。
 
 ### 5.1 通用属性（任何标签可用）
 

--- a/docs~/superpowers/specs/2026-08-29-tabmenu-design.md
+++ b/docs~/superpowers/specs/2026-08-29-tabmenu-design.md
@@ -56,7 +56,7 @@
 | TM-D10 | 收起时机 | 选中任一 Tab（含点已选中的）→ 收起；点 blocker → 收起；Esc / 手柄 B → 收起 | 菜单的通用约定；`closeOnSelect="false"` 留 v2 |
 | TM-D11 | 展开态与 ReSolve | 展开/收起是**运行期状态**：resize / Variant / Theme 的 ReSolve 不改它，只重算面板位置尺寸；不提供 XML `expanded=` | 与 `isOn` / `value` 的「运行期改过就不打回」同款；初始态永远是收起 |
 | TM-D12 | 收起态下的测量 | Screen.Open 的 apply pass 期间弹窗保持 active，测量完成后经 `Screen.DeferDuringOpen` 停用；`BindItems` 重建期间**同帧**临时激活 | `Tab.bind` 的既有先例（`Tab.cs` ApplyBindFrame 注释）：inactive 上 `AddComponent` 的 TMP 不跑 Awake，`preferredWidth` 会算错 |
-| TM-D13 | 过渡动画 | 内置：`transition`（默认 `0.15s`，`0` = 即时）= 面板 `CanvasGroup.alpha 0→1` + 沿展开方向 8px 位移 + 箭头 180° 翻转；收起反放，放完再 `SetActive(false)` | 弹窗面板是内部节点，作者无法用 `<Animation>` 包住它；LitMotion 已是硬依赖。预设名 / 自定义曲线留 v2 |
+| TM-D13 | 过渡动画 | 内置：`transition`（默认 `0.15s`，`0` = 即时）= 面板 `CanvasGroup.alpha 0→1` + 沿展开方向 8px 位移 + 箭头垂直翻转；收起反放，放完再 `SetActive(false)` | 弹窗面板是内部节点，作者无法用 `<Animation>` 包住它；LitMotion 已是硬依赖。预设名 / 自定义曲线留 v2 |
 | TM-D14 | Trigger 事件 | 新 kind `expand` / `collapse`（+ `expand@id` / `collapse@id`），**向上**解析到最近 `<TabMenu>` 祖先，同 `state-*` | 用途是弹窗内**逐项**入场动画（`<Animation on="expand" type="slidein-left" delay="0.05s"><Tab/></Animation>`，即 animations.md 的 Menu entry stagger 模式）和 C# 钩子。不能叫 `open` / `close`：`on="open"` 已是「Screen 打开」 |
 | TM-D15 | 手柄 / 键盘导航 | 展开 → `UI.Navigation.ContainmentRoot` 切到弹窗面板、按 `confineRoot` 重算显式邻居、焦点落到当前选中 Tab；收起 → 恢复之前的 root（模态根或 null）、焦点回触发区 | 复用模态圈闭（`Screen.ConfineNavigationToSelf` → 泛化为 `ConfineNavigationTo(root)`）；blocker 的 Button `navigation = None`，不进导航图 |
 | TM-D16 | Esc 消费 | `UI.Modal.OnEscapePressed` 首行调 `TabMenu.TryConsumeEscape()`：有展开中的就收起并返回；同帧已由 TabMenu 自己的 listener 收起过也返回 | 两个 `ModalEscapeListener` 同帧都会响，顺序不定；不做同帧 guard 会一次 Esc 同时关弹窗和模态 |
@@ -356,7 +356,7 @@ if (overflowRight > 0)                                  → anchoredPosition.x -
 LitMotion，两条 `MotionHandle`（面板、箭头），存在 TabMenu 上，`Dispose` / 下一次过渡前 `TryCancel`：
 
 - 面板：`CanvasGroup.alpha` 0→1；`Popup.anchoredPosition.y` 从终态偏 8px（向下长时 +8、向上翻时 -8）→ 终态；easing `OutCubic`；时长 `transition`。
-- 箭头：`localEulerAngles.z` 0→180（收起 180→0）。
+- 箭头：`localScale.y` 1→-1（收起 -1→1）—— **镜像，不是旋转**，见 §14.7。
 - `transition="0"`：不建 motion，直接写终态。
 - 过渡期间 blocker 已生效、Tab 可点（不等动画）。
 
@@ -607,6 +607,12 @@ EditMode 无法给 ScreenSpaceOverlay canvas 一个确定的尺寸，所以 §7.
 直接走 `Children` 找 `isOn` 的 Tab（没有就取第一个，镜像自动选中规则）读它的 text / icon。
 子节点在 DFS post-order 里已经 apply 完，所以这份数据是准的。
 运行期改 caption 不重排（`LayoutElement` 停在打开时的快照）是 `<Btn>` 同款既有行为，已在 skill 里写明。
+
+**14.7 箭头必须是垂直镜像，不能是 180° 旋转（§7.7 修正，作者实测反馈）。**
+旋转绕 pivot 发生，而箭头的 pivot 是它的**左边缘**（`LayoutCaption` 靠这一点把它按左侧摆在 label 之后）——
+转 180° 会把整个字形甩到摆放点的左边，菜单每次打开箭头都横向跳一下。改成 `localScale.y` 1→-1：
+pivot 的 y 已经居中，纵向镜像不动 x。回归测试同时断言 `anchoredPosition`、世界空间左缘、
+以及 `localEulerAngles.z == 0`（确认是翻转不是旋转）。
 
 **其余按设计实现**：TM-D1…D21 全部照做；§12 的 Out of Scope 一项未做。
 测试：EditMode 2844、EditorOnly 310、PlayMode 176，全绿。

--- a/docs~/superpowers/specs/2026-08-29-tabmenu-design.md
+++ b/docs~/superpowers/specs/2026-08-29-tabmenu-design.md
@@ -601,5 +601,12 @@ Time.frameCount` → 也返回 true。两种顺序都只关菜单、不关模态
 EditMode 无法给 ScreenSpaceOverlay canvas 一个确定的尺寸，所以 §7.2 的规则落在
 `Internal/PopupPlacer.Solve(handle, panel, canvas, gap)` 里单测；控件侧只测接线。
 
+**14.6 `GetNativeSize` 必须自己去看 Tab，不能读 caption 标签（§6 补充）。**
+`ApplyCommon` 在 `OnAfterApply` 填 caption **之前**测量控件，所以读 `_label.text` 测到的是空串 ——
+把手在 HStack 里被排成 30px（只够内边距 + 箭头），不管频道叫什么。改为回退到 `PeekSelectedContent()`：
+直接走 `Children` 找 `isOn` 的 Tab（没有就取第一个，镜像自动选中规则）读它的 text / icon。
+子节点在 DFS post-order 里已经 apply 完，所以这份数据是准的。
+运行期改 caption 不重排（`LayoutElement` 停在打开时的快照）是 `<Btn>` 同款既有行为，已在 skill 里写明。
+
 **其余按设计实现**：TM-D1…D21 全部照做；§12 的 Out of Scope 一项未做。
-测试：EditMode 2842、PlayMode 176，全绿。
+测试：EditMode 2844、EditorOnly 310、PlayMode 176，全绿。

--- a/docs~/superpowers/specs/2026-08-29-tabmenu-design.md
+++ b/docs~/superpowers/specs/2026-08-29-tabmenu-design.md
@@ -1,0 +1,567 @@
+# `<TabMenu>` —— 弹出式 Tab 组（频道切换器 / 折叠导航）
+
+**日期**: 2026-08-29
+**状态**: 设计阶段（决策见 §2，2026-08-29 与作者对齐；待 review，未进入实施）
+**相关**: `2026-05-27-tabbar-design.md`（`<TabBar>` / `<Tab>` 的出处，本文复用它的全部选中语义并抽出共享核心）、
+`2026-05-09-m5-common-controls-design.md`（`<Dropdown>` 参考实现 —— 本文 §1 说明为何不在它上面扩）、
+`2026-08-26-procedural-surface-design.md`（`ProceduralControl` / `SurfaceHost`）、
+`2026-08-23-glass-fill-design.md`（弹窗面板走同一套 backdrop 规则）、
+`2026-06-29-gamepad-keyboard-navigation-design.md`（`ContainmentRoot` / 模态焦点圈闭，本文 §7.8 复用）、
+`2026-08-27-decor-primitives-design.md`（`<Decor>` 作为弹窗面板的子节点）。
+
+**作用域**:
+1. 新增 `Runtime/Controls/TabMenu.cs`（触发区 + 弹窗面板 + 弹窗 Content；`ProceduralControl`，表面宿主 = 弹窗面板）
+2. 新增 `Runtime/Controls/Internal/TabGroupCore.cs`（从 `TabBar` 抽出的 Tab 组核心：静态收集 / `BindItems` / `itemTemplate` / 初始选中 / 订阅）；`TabBar.cs` 改为委托
+3. `Runtime/Controls/Tab.cs`：为 caption 镜像暴露 `internal` 读取器 + `ContentChanged`
+4. `Runtime/Controls/Internal/TriggerSpec.cs` / `TriggerSourceResolver.cs` / `Trigger.cs`：新增 `expand` / `collapse` 两种 TriggerKind（向上解析到最近 `<TabMenu>` 祖先）
+5. `Runtime/Application/Screen.cs`：`ConfineNavigationToSelf` 泛化为 `ConfineNavigationTo(root)` + `RestoreNavigationConfine(previous)`
+6. `Runtime/Application/UI.Modal.cs` + `Modals/ModalEscapeListener.cs`：Esc 先让展开中的 TabMenu 消费；listener 可选绑 `<Gamepad>/buttonEast`
+7. `Runtime/Application/BuiltinPrimitives.cs` 注册；`ScreenInstantiator.cs` 把 `"TabMenu"` 加进 `selfIsLayoutGroup` + lint 分发
+8. Lint：`TabRules.cs`（`PUI-TAB-PARENT` 接受 TabMenu 父）、新增 `TabMenuRules.cs`、`StateTriggerRules.cs`（`PUI-EXPAND-NO-SOURCE`）、`IRWalker.cs`、`BuiltinTags.cs`、`ProceduralSurfaceRules.SurfaceTags`、`NavTargetRules.SelectableTags`
+9. Skills：`authoring-promptugui-xml/SKILL.md`（catalog 行 + 程序化表面表 + native-size / selectable 名单）、`reference/controls-tabs.md`（新 `<TabMenu>` 节）、`reference/animations.md`（`expand` / `collapse` 行）、`reference/navigation.md`（弹窗圈闭）、`scripting-promptugui-csharp/SKILL.md`（C# API）；主 spec §5 控件表追加一行
+10. 测试：EditMode `TabMenuTests` / `TabMenuPlacementTests` / `TabMenuBindItemsTests` / `TabMenuTriggerTests` / `Navigation/TabMenuTrapTests` / `Lint/TabMenuRulesTests`；PlayMode `TabMenuPlayTests`；既有 `TabBar*Tests` 作为核心抽取的回归护栏
+
+**依赖**: 无新增。LitMotion（`Animation.cs` 已无条件 `using LitMotion`）用于弹窗过渡；`ProceduralSurface` / `ToggleGroup` / `ModalEscapeListener` / `ExplicitNavigationResolver` 全部复用。
+
+---
+
+## 1. 背景
+
+聊天面板顶栏要一个「频道切换器」：收起时是 `[🌐 星海频道 ▼]`，点开是一列频道，选一个就切到对应面板 —— 语义上就是 `<TabBar>`（互斥、每项 icon+文字、`bind=` 到一个 Frame），只是**呈现**收成了弹出式。
+
+作者最先想到的是 `<Dropdown>`，但它做不到，而且不是改几个数字的问题：
+
+- caption 内距 `(10,6)/(-25,-7)`、箭头贴右边 `-15` / 20×20、caption 与选项行字号 14、选项行高 20 全部写死（`Dropdown.cs:53-68, 106`；`ProceduralBuilders.AddText` 默认 14），没有 `fontSize` / `padding` 之类的口子。
+- **弹窗里的每一行是 TMP_Dropdown 克隆出来的裸 uGUI `Toggle`**（`Dropdown.cs:117-140`），不是 PromptUGUI Control：`<Show on="state-*">`、`hoverColor` / `selectedColor`、`radius` / `glass`、每行独立 icon 一样都用不上；`bind=` 只能做成 `bind="a,b,c"` 按下标映射，还得和 C# 里 `BindOptions` 推的列表手工对齐。
+- **弹窗宽度焊死等于触发按钮宽度**（Template 锚 0..1，`Dropdown.cs:72-77`），而设计图里触发区只有文字宽、菜单明显更宽。
+- Dropdown **刻意不按 caption 算尺寸**（DSS-D2，怕选项切换时宽度跳）。对表单里的「画质：高」是对的，对频道切换器恰恰相反 —— 要的就是箭头紧跟文字。
+
+把这三条都「完善」掉等于重写 Dropdown 的弹窗层，还背着 TMP_Dropdown 的包袱；而设计图需要的每一样 —— `icon` / `text` / `fontSize` / `bind` / 状态色 / `selectedSprite` / 程序化表面 / `<Show on="state-*">` / `isOn` / `BindItems` + `itemTemplate` —— `<Tab>` 全部已经有了。缺的只是一个「把一组 Tab 收进弹窗、用选中项当把手」的容器。
+
+**分层位置**：与 `<TabBar>` 平级的 Tab 容器。`<TabBar>` 是「铺开的 Tab 组」，`<TabMenu>` 是「折叠的 Tab 组」；两者共享同一份选中语义实现（§2 TM-D17），子节点都是 `<Tab>`。`<Dropdown>` 保持表单选择器定位不动。
+
+## 2. 决策一览
+
+| # | 决策 | 选择 | 理由 |
+|---|---|---|---|
+| TM-D1 | 新控件 vs 扩 Dropdown | 新控件 `<TabMenu>` | §1：Dropdown 的项是裸 Toggle、弹窗宽度焊死、caption 不 hug；三条都是结构问题 |
+| TM-D2 | 标签名 | `<TabMenu>` | 点出「Tab 语义 + 菜单式呈现」，与 `<TabBar>` / `<Tab>` 一眼是一家；`<TabDropdown>` 容易让人以为用法同 Dropdown（`BindOptions` / `value:int`） |
+| TM-D3 | 表面归属 | **控件的程序化表面 = 弹窗面板**；触发区只有 caption + 箭头、默认无底 | `color` / `sprite` / `radius` / `glass` / `<Decor>` 全落在弹窗上，零新皮肤属性、主题词汇一次全拿到。触发区要底就套 `<Frame>` / `<Image>` —— 与「TabBar 本身没视觉」同一先例。否决 Dropdown 式 `popup*` 前缀（弹窗拿不到 glass / Decor，除非再堆 `popupGlass…`）与「作者自带 `<Frame>` 面板」（嵌三层，面板 anchor/margin 还得由控件接管） |
+| TM-D4 | 子节点归属 | 子节点全部进弹窗（`ChildHostTransform` = 弹窗 Content）：`<Tab>`、包着 Tab 的 Template / `<Animation>` / `<Trigger>` 包装、`<Decor>` | 与 `<TabBar>`（子 = Tab）、`<Carousel>`（子进 Strip）同形；触发区不是作者可编辑的子树 |
+| TM-D5 | caption 内容 | 自动镜像**选中 Tab** 的 `icon` + `text` | 零额外标记。Template 包装的富 Tab 没写 `text=` / `icon=` 时 caption 为空 —— 在 Tab 上补 `text=` 即可。`text=` / `icon=` 覆盖、自定义 caption slot 留 v2 |
+| TM-D6 | 弹窗宽度 | `popupWidth=` 显式；缺省 = max(触发区宽, Content 首选宽) | 触发区 hug 文字、菜单按内容撑 —— 设计图的形态；Dropdown 式「等于触发区宽」作为下限保留 |
+| TM-D7 | 项的横向尺寸 | 项**填满**弹窗宽（`childForceExpandWidth = true`）；Tab 的 `width=` 无效 → lint `PUI-TABMENU-ITEM-WIDTH` | 菜单行天然通栏；TabBar 的「尊重 `width=`」在竖排菜单里只会造出参差的行 |
+| TM-D8 | 弹窗置顶 | 弹窗留在 TabMenu 子树里，**不 reparent**；展开时给面板加 `Canvas(overrideSorting)` + `GraphicRaycaster`；blocker 挂在 Screen 根 Canvas 下 | TMP_Dropdown 同款。Tab 的祖先链不变：`FindAncestorToggleGroup`、`OwnerScreenOf`、id scope、`bind=` 全部照旧；嵌套 Canvas + overrideSorting 同时逃出祖先 `RectMask2D` / stencil（`MaskUtilities` 在 overrideSorting 处截断）—— 放在 `<ScrollList>` 里的 TabMenu 弹窗不会被裁 |
+| TM-D9 | 同时展开数 | 全局至多一个（`static s_expanded`）；展开另一个先收起前一个 | blocker 盖住全屏，第二个本来就点不到；单例让 Esc 消费（TM-D16）有唯一目标 |
+| TM-D10 | 收起时机 | 选中任一 Tab（含点已选中的）→ 收起；点 blocker → 收起；Esc / 手柄 B → 收起 | 菜单的通用约定；`closeOnSelect="false"` 留 v2 |
+| TM-D11 | 展开态与 ReSolve | 展开/收起是**运行期状态**：resize / Variant / Theme 的 ReSolve 不改它，只重算面板位置尺寸；不提供 XML `expanded=` | 与 `isOn` / `value` 的「运行期改过就不打回」同款；初始态永远是收起 |
+| TM-D12 | 收起态下的测量 | Screen.Open 的 apply pass 期间弹窗保持 active，测量完成后经 `Screen.DeferDuringOpen` 停用；`BindItems` 重建期间**同帧**临时激活 | `Tab.bind` 的既有先例（`Tab.cs` ApplyBindFrame 注释）：inactive 上 `AddComponent` 的 TMP 不跑 Awake，`preferredWidth` 会算错 |
+| TM-D13 | 过渡动画 | 内置：`transition`（默认 `0.15s`，`0` = 即时）= 面板 `CanvasGroup.alpha 0→1` + 沿展开方向 8px 位移 + 箭头 180° 翻转；收起反放，放完再 `SetActive(false)` | 弹窗面板是内部节点，作者无法用 `<Animation>` 包住它；LitMotion 已是硬依赖。预设名 / 自定义曲线留 v2 |
+| TM-D14 | Trigger 事件 | 新 kind `expand` / `collapse`（+ `expand@id` / `collapse@id`），**向上**解析到最近 `<TabMenu>` 祖先，同 `state-*` | 用途是弹窗内**逐项**入场动画（`<Animation on="expand" type="slidein-left" delay="0.05s"><Tab/></Animation>`，即 animations.md 的 Menu entry stagger 模式）和 C# 钩子。不能叫 `open` / `close`：`on="open"` 已是「Screen 打开」 |
+| TM-D15 | 手柄 / 键盘导航 | 展开 → `UI.Navigation.ContainmentRoot` 切到弹窗面板、按 `confineRoot` 重算显式邻居、焦点落到当前选中 Tab；收起 → 恢复之前的 root（模态根或 null）、焦点回触发区 | 复用模态圈闭（`Screen.ConfineNavigationToSelf` → 泛化为 `ConfineNavigationTo(root)`）；blocker 的 Button `navigation = None`，不进导航图 |
+| TM-D16 | Esc 消费 | `UI.Modal.OnEscapePressed` 首行调 `TabMenu.TryConsumeEscape()`：有展开中的就收起并返回；同帧已由 TabMenu 自己的 listener 收起过也返回 | 两个 `ModalEscapeListener` 同帧都会响，顺序不定；不做同帧 guard 会一次 Esc 同时关弹窗和模态 |
+| TM-D17 | 与 TabBar 的关系 | 抽 `internal TabGroupCore`（静态收集 / `BindItems` / `ResolveFactory` / `FindTabIn` / `SyncInitialSelection` / 订阅）；TabBar、TabMenu 都委托 | 「Tab 组语义」保持单一实现；既有 `TabBar*Tests` 是抽取的回归护栏 |
+| TM-D18 | 触发区交互 | `PuiButton`，`targetGraphic` = caption label（uGUI 默认 ColorTint 给 hover / pressed）；触发区**不是** `IStateSource` | 子节点都在弹窗里，`<Show on="state-*">` 对触发区无处安放；caption 状态色留 v2 |
+| TM-D19 | 弹窗默认皮肤 | 与 Dropdown 弹窗同款：`pugui_9slice_round` + `DefaultPopupBgColor`；`sprite=""` 退化为纯色 | 不写任何皮肤也能用；主题一般会写 `class=` |
+| TM-D20 | 弹窗裁切 | v1 不做 `mask` | 行高亮溢出圆角只在 `padding="0"` 时可见；作者写 `padding` 或给 Tab `radius` 即可。`mask` 留 v2 |
+| TM-D21 | 弹窗定位 | 触发区**下方、左对齐**、间距 `popupGap`；右缘越出 Canvas → 整体左移贴边；下方放不下且上方更宽裕 → **向上翻**（pivot / anchor 对调） | TMP_Dropdown 的翻转行为；`popupAlign` 留 v2 |
+
+## 3. XML 形态
+
+### 3.1 频道切换器（本文动机）
+
+```xml
+<Style name="menu-item" sprite="" height="44" radius="8"
+       hoverColor="white/0.08" selectedColor="primary/0.35" fontSize="18"/>
+
+<HStack anchor="top-stretch" height="64" padding="0,16,0,16" spacing="8">
+  <TabMenu id="channel" fontSize="22" textColor="white" iconSize="24"
+           popupWidth="240" padding="8" spacing="4"
+           radius="12" glass="true" frost="0.5" color="primary-dark/0.6"
+           borderWidth="1" borderColor="primary-lighter/0.5">
+    <Tab class="menu-item" icon="ui:globe" text="星海频道" bind="ch_world" isOn="true"/>
+    <Tab class="menu-item" icon="ui:guild" text="公会频道" bind="ch_guild"/>
+    <Tab class="menu-item" icon="ui:team"  text="队伍频道" bind="ch_team"/>
+    <Decor kind="bracket" at="tl,br" extent="14"/>
+  </TabMenu>
+  <Frame width="stretch"/>
+  <Icon name="ui:members" size="20x20"/>
+  <Text fontSize="20">128</Text>
+</HStack>
+
+<Frame id="ch_world" anchor="stretch" margin="64,0,0,0">…</Frame>
+<Frame id="ch_guild" anchor="stretch" margin="64,0,0,0">…</Frame>
+<Frame id="ch_team"  anchor="stretch" margin="64,0,0,0">…</Frame>
+```
+
+- 触发区 = `🌐 星海频道 ▼`，hug 内容，透明；在 `<HStack>` 里是普通 layout child。
+- `radius` / `glass` / `color` / `borderWidth` / `<Decor>` 落在**弹窗面板**上；`padding` / `spacing` 是弹窗里 Tab 的竖排间距。
+- 选「公会频道」→ caption 变 `🏰 公会频道 ▼`，`ch_guild` 显示、其余隐藏，弹窗收起。
+
+### 3.2 触发区要底：套一层
+
+```xml
+<Frame radius="20" color="surface/0.6" borderWidth="1">
+  <TabMenu id="sort" anchor="stretch" margin="0,12,0,12" fontSize="16">
+    <Tab text="按时间" isOn="true"/>
+    <Tab text="按热度"/>
+  </TabMenu>
+</Frame>
+```
+
+同「给 TabBar 加背景条就套 `<Image>`」。
+
+### 3.3 弹窗内逐项入场动画 + 动态项
+
+```xml
+<Template name="ChannelTab">
+  <Param name="text"/>
+  <Param name="icon"/>
+  <Param name="bind"/>
+  <Animation on="expand" type="slidein-left" duration="0.12s">
+    <Tab id="tab" class="menu-item" icon="ui:{{icon}}" text="{{text}}" bind="{{bind}}"/>
+  </Animation>
+</Template>
+
+<TabMenu id="channel" itemTemplate="ChannelTab" popupWidth="240" padding="8"/>
+```
+
+```csharp
+screen.Get<TabMenu>("channel")
+      .BindItems(channels, (Tab tab, Channel c) => { tab.Text = c.Name; tab.Icon = c.IconKey; })
+      .AddTo(screen);
+```
+
+`on="expand"` 向上找到 `<TabMenu>`；`<Animation>` 包装 Tab 在 Content 的竖排里占一格（`Animation.GetNativeSize` 转发子节点尺寸，与 TabBar 的 Template 包装规则一致）。
+
+## 4. 属性表
+
+除下表外，`<TabMenu>` 接受全部通用属性（`anchor` / `size` / `margin` / `hidden` / `interactable` / `flow` / `class` / `if` / `focus` / `nav*`）与 `ProceduralControl` 的 15 个程序化属性（`radius` / `borderWidth` / `borderColor` / `glow` / `glowColor` / `innerGlow` / `innerGlowColor` / `glass` / `frost` / `depth` / `dispersion` / `lightAngle` / `lightIntensity` / `saturation` / `noise`），**全部作用于弹窗面板**。
+
+### 4.1 触发区（caption）
+
+| 属性 | 类型 / 取值 | 默认 | 说明 |
+|---|---|---|---|
+| `fontSize` | int | `24` | caption 字号（与 `<Tab>` label 默认一致） |
+| `textColor` | color | 默认 ink | caption 文字色；token / `/alpha` / 渐变 |
+| `font` | string | `default` | `FontApplier` 字体槽 |
+| `iconSize` | float | `24` | caption icon 边长；选中 Tab 没有 icon 时 icon 槽整个不占位 |
+| `arrow` · `arrowColor` | sprite key / color | `pugui_caret` / glyph 白 | 箭头。`arrow=""` 隐藏（无图 Image 会画成实心块，直接关组件）。展开时翻转 180°，随 `transition` 动画 |
+| `arrowSize` | float | `16` | 箭头边长 |
+| `gap` | float | `6` | icon–label–arrow 之间的间距 |
+
+触发区内边距固定：横 4、纵 6，最小高 44（tap target，同 Btn / Tab）。
+
+### 4.2 弹窗
+
+| 属性 | 类型 / 取值 | 默认 | 说明 |
+|---|---|---|---|
+| `popupWidth` | float | auto | 面板宽。缺省 = max(触发区宽, Content 首选宽)（TM-D6） |
+| `popupGap` | float | `4` | 触发区与面板的间距（向上翻时同样适用） |
+| `padding` | `t,r,b,l` / `v,h` / `all` | `0` | 面板内边距（Content 的 `VerticalLayoutGroup.padding`；语法同 `<TabBar padding>`） |
+| `spacing` | float | `0` | 项间距 |
+| `color` | color | `DefaultPopupBgColor` | 面板底色；程序化模式下即填充色（spec §7 同 Frame） |
+| `sprite` | sprite key | `pugui_9slice_round` | 面板底图（自动 9-slice）；`""` / `none` = 纯色 |
+| `tint` | `multiply` / `linear` | `multiply` | 面板底图混合模式 |
+| `transition` | duration | `0.15s` | 展开 / 收起过渡时长，`0.15s` / `150ms` / 裸秒数；`0` = 即时（TM-D13） |
+| `itemTemplate` | tag / Template 名 | `Tab` | `BindItems` 的项模板，同 `<TabBar>` |
+
+### 4.3 `<Tab>` 在 `<TabMenu>` 里
+
+与在 `<TabBar>` 里完全相同（`text` / `icon` / `bind` / `isOn` / 状态色 / `selectedSprite` / 程序化表面 / `<Show on="state-*">`），差别只有：
+
+- `width=` 无效（项填满面板宽，TM-D7）；`height=` 有效，缺省走 `Tab.GetNativeSize`（label + padding，最小 44）。
+- `anchor=` / `margin=` 非法（TabMenu 是 layout-group 型父，`PUI-LAYOUT-ANCHOR` / `PUI-LAYOUT-MARGIN`）。
+- Tab 的 `text` / `icon` 会被 caption 镜像。
+
+## 5. C# API
+
+### 5.1 `TabMenu`
+
+```csharp
+public sealed class TabMenu : ProceduralControl
+{
+    // 展开 / 收起
+    public bool IsExpanded { get; }
+    public void Expand();
+    public void Collapse();
+    public void Toggle();
+    public Observable<Unit> OnExpanded { get; }     // 过渡开始时
+    public Observable<Unit> OnCollapsed { get; }    // 过渡开始时（面板在过渡结束后 SetActive(false)）
+
+    // 选中语义 —— 与 TabBar 逐字相同
+    public Observable<Tab> OnSelectionChanged { get; }   // 选中变化；BindItems 清空时 fire null
+    public Tab SelectedTab { get; }
+    public int SelectedIndex { get; }                    // -1 = 无
+    public int Count { get; }
+    public Tab GetAt(int index);
+    public IDisposable BindItems<T>(Observable<IReadOnlyList<T>> source, Action<Tab, T> bind);
+    public IDisposable BindItems<T, TSlot>(Observable<IReadOnlyList<T>> source, Action<TSlot, T> bind)
+        where TSlot : class, IControl;
+
+    // caption
+    public void RefreshCaption();   // 一般不需要：选中变化 / Tab.Text / Tab.Icon 变化 / ReSolve 都会自动刷新
+
+    // 内部
+    internal static bool TryConsumeEscape();        // UI.Modal.OnEscapePressed 首行调用（TM-D16）
+    internal static int PopupSortingOffset = 2;     // 面板 = 根 Canvas order + 2，blocker = + 1
+}
+```
+
+用法：
+
+```csharp
+var menu = screen.Get<TabMenu>("channel");
+menu.OnSelectionChanged.Subscribe(tab => Chat.Switch(tab?.Id)).AddTo(screen);
+menu.OnExpanded.Subscribe(_ => Sfx.Play("ui_open")).AddTo(screen);
+// 键盘快捷键手动展开
+menu.Expand();
+```
+
+### 5.2 `Tab` 追加（internal）
+
+```csharp
+internal string CaptionText { get; }        // _label?.text
+internal Sprite CaptionIcon { get; }        // _icon?.sprite
+internal event Action ContentChanged;       // Text / Icon setter 末尾触发；TabMenu 只订阅当前选中项
+```
+
+### 5.3 `TabGroupCore`（internal，`Controls/Internal/`）
+
+```csharp
+internal sealed class TabGroupCore : IDisposable
+{
+    public TabGroupCore(Control owner, Func<RectTransform> itemHost);
+    public string ItemTemplate { set; }                 // 置空 factory，同 TabBar.ItemTemplate
+    public IReadOnlyList<Tab> Tabs { get; }
+    public int SelectedIndex { get; }
+    public Tab SelectedTab { get; }
+    public Observable<Tab> SelectionChanged { get; }
+
+    public void CollectStatic(IReadOnlyList<IControl> children);   // _bound 后 no-op
+    public IDisposable BindItems<T, TSlot>(Observable<IReadOnlyList<T>> source, Action<TSlot, T> bind,
+                                          Action beforeRebuild = null, Action afterRebuild = null)
+        where TSlot : class, IControl;                              // TabMenu 用两个钩子做同帧临时激活（TM-D12）
+    public void SyncInitialSelection();
+    public void WireTabSubscriptions();
+    public static Tab FindTabIn(IControl node);
+}
+```
+
+`TabBar` 保留全部公开成员（`Count` / `SelectedIndex` / `SelectedTab` / `GetAt` / `BindItems` / `OnSelectionChanged`），实现改为转发；`ApplyDirection` / `ApplySpacingPadding` / `ApplyChildSizing` 留在 TabBar（布局是 TabBar 自己的事）。`padding` 字符串解析抽成 `Internal.PaddingParser.Parse(string) → RectOffset`，两边共用。
+
+## 6. 程序化层级（固定）
+
+```
+TabMenu                      RectTransform + Image(sprite=null, color=(0,0,0,0), raycastTarget=true)
+                             + PuiButton(targetGraphic=Label, onClick→Toggle) + ToggleGroup(allowSwitchOff=false)
+├── Icon                     Image, raycast=false; anchor left-middle; iconSize²；无 icon 时 enabled=false
+├── Label                    TMP, raycast=false; anchor left-middle; fontSize 24; 宽 = preferred
+├── Arrow                    Image(pugui_caret), raycast=false; anchor left-middle; arrowSize²; 展开时 localRotation z=180
+└── Popup                    RectTransform + Image(bg, 9-slice round) + CanvasGroup + Canvas(overrideSorting) + GraphicRaycaster
+    │                        ← SurfaceHost；anchor 见 §7.2；收起态 inactive
+    ├── __Surface            ProceduralSurface 节点（懒建，sibling 0）
+    └── Content              RectTransform(stretch) + VerticalLayoutGroup   ← ChildHostTransform
+        │                    childControlWidth/Height=true, childForceExpandWidth=true, childForceExpandHeight=false
+        ├── <Tab> …          作者子节点 / BindItems 项
+        └── __Decor:*        <Decor> 实例（ParticipatesInLayout=false → ignoreLayout；stretch 到 Content = 面板矩形）
+
+Blocker (Screen 根 Canvas 直接子节点，展开时创建、收起时 SetActive(false)、Dispose 时销毁)
+                             RectTransform(stretch) + Image(color=(0,0,0,0)) + Canvas(overrideSorting, root+1)
+                             + GraphicRaycaster + Button(navigation=None, onClick→Collapse)
+```
+
+- `Popup` 的 `Canvas` / `GraphicRaycaster` 在 `OnAttached` 就加上（inactive 时无开销），避免展开时 `AddComponent` 触发一帧重建。
+- `__Surface` 挂在 `Popup` 而不是 `Content` 下，所以不会被 `VerticalLayoutGroup` 当成一行排版。
+- Icon / Label / Arrow 手工定位（不用 HorizontalLayoutGroup），`GetNativeSize` 与 Tab 一样走 `label.GetPreferredValues(text)` 的确定性公式。
+
+## 7. 行为细节
+
+### 7.1 展开 / 收起
+
+**Expand()**（已展开 / `!Interactable` / GameObject 非 active → no-op）：
+
+1. `s_expanded?.Collapse(immediate: true)`；`s_expanded = this`。
+2. 面板 `SetActive(true)`；Canvas `overrideSorting = true`，`sortingOrder = rootCanvas.sortingOrder + PopupSortingOffset`（rootCanvas = `GetComponentInParent<Canvas>().rootCanvas`）。
+3. `LayoutRebuilder.ForceRebuildLayoutImmediate(Content)` → §7.2 算宽高与位置。
+4. blocker：首次创建（挂 rootCanvas 下，最后一个 sibling），之后 `SetActive(true)`；`sortingOrder = root + PopupSortingOffset - 1`。
+5. 导航（§7.8）、Esc listener（§7.9）。
+6. 箭头翻转 + 面板过渡（§7.7）；`_expanded = true`；`OnExpanded.OnNext`。
+
+**Collapse(immediate = false)**（未展开 → no-op）：
+
+1. blocker `SetActive(false)`；导航 / Esc 复原；`s_expanded = null`；`_expanded = false`；`OnCollapsed.OnNext`。
+2. `immediate || transition == 0` → 面板立即 `SetActive(false)`；否则反放过渡，`OnComplete` 再 `SetActive(false)`。过渡中再次 `Expand()` → 取消反放、从当前 alpha 正放。
+
+**Toggle()** = `IsExpanded ? Collapse() : Expand()`；触发区 `PuiButton.onClick` 接它。
+
+### 7.2 面板定位与尺寸
+
+在 `Expand()` 第 3 步、`OnAfterApply`（展开态）与 `BindItems` 重建后执行：
+
+```
+contentW  = LayoutUtility.GetPreferredWidth(Content)      // VerticalLayoutGroup = 最宽子项 + padding
+contentH  = LayoutUtility.GetPreferredHeight(Content)
+popupW    = popupWidth ?? max(RectTransform.rect.width, contentW)
+Popup.sizeDelta = (popupW, contentH)
+
+// 默认：挂在触发区左下角，向下长
+Popup.anchorMin = anchorMax = (0, 0); pivot = (0, 1); anchoredPosition = (0, -popupGap)
+
+// 用根 Canvas 的矩形做越界判断（RectTransformUtility 换算到 rootCanvas 空间）
+overflowBelow = 面板底缘 < canvas 底缘
+roomAbove     = 触发区顶缘到 canvas 顶缘的距离
+if (overflowBelow && roomAbove > 面板可用的下方空间)   → 向上翻：anchor (0,1), pivot (0,0), y = +popupGap
+overflowRight = 面板右缘 - canvas 右缘
+if (overflowRight > 0)                                  → anchoredPosition.x -= overflowRight
+```
+
+位置只在展开 / ReSolve / 重建时算，不逐帧跟随（面板是触发区的子节点，随之移动）。
+
+### 7.3 选中 → 收起 + caption 镜像
+
+- `TabGroupCore.SelectionChanged` → `RefreshCaption()`；若 `IsExpanded` → `Collapse()`。
+- 点已选中的 Tab：`ToggleGroup(allowSwitchOff=false)` 不会产生 `onValueChanged`，因此 TabMenu 另外订阅每个 Tab 的 `PuiToggle.onClick`-等价事件（`Tab` 内部 `OnSubmitOrClick`，复用 `PuiToggle` 已有的 submit-wake 路径）→ 也收起。
+- `RefreshCaption()`：`Label.text = SelectedTab?.CaptionText ?? ""`；`Icon.sprite = SelectedTab?.CaptionIcon`，`Icon.enabled = sprite != null`；重排 Icon / Label / Arrow 的 x 偏移；若父是 layout group 则 `LayoutRebuilder.MarkLayoutForRebuild`（native size 变了）。同时把 `ContentChanged` 订阅切到新的选中 Tab。
+
+### 7.4 初始化序列
+
+1. `ScreenInstantiator` DFS 建树；`TabMenu.OnAttached` 建 §6 层级，`Popup` 此时 **active**。
+2. 子节点经 `ChildHostTransform` 进 `Content`；`Tab.OnAttached` 沿 transform 向上找到 TabMenu 的 `ToggleGroup`。
+3. `root.SetActive(true)` 整树激活 → 所有 TMP Awake。
+4. 属性 apply（DFS post-order）：Tab 的 `isOn` / `bind` 照 TabBar 走；`TabMenu.OnAfterApply`：`core.CollectStatic(Children)` → `SyncInitialSelection` → `WireTabSubscriptions` → `RefreshCaption` → `owner.DeferDuringOpen(() => Popup.SetActive(false))`。
+5. Open 收尾执行 deferred：面板停用。此时没有渲染过一帧，不闪。
+
+`Tab.bind` 自己的 deferred 初始隐藏与此并列，互不影响。
+
+### 7.5 BindItems 重建
+
+`core.BindItems(source, bind, beforeRebuild, afterRebuild)`：
+
+- `beforeRebuild`：若面板 inactive → `Popup.SetActive(true)`，记 `_tempActivated`。
+- 重建（`ClearTabs` → factory 建项 → `bind` → `SyncInitialSelection` → `Wire`）。
+- `afterRebuild`：`RefreshCaption()`；`IsExpanded` → §7.2 重算；`_tempActivated` → `Popup.SetActive(false)`。
+
+同帧激活→建→停用，不会渲染出来；新 Tab 的 TMP 在 `SetActive(true)` 时同步 Awake，`GetNativeSize` 测得准（TM-D12）。空列表：`SelectedTab = null`，caption 清空（只剩箭头），`OnSelectionChanged(null)`。
+
+### 7.6 ReSolve（resize / Variant / Theme）
+
+- `OnBeforeApply`：`base`（程序化表面 BeginPass）；`_transitionDeclared = false` 等每-pass 状态清零。
+- 各 setter 重写 caption 字号 / 颜色 / 箭头 / 弹窗皮肤 / padding / spacing。
+- `OnAfterApply`：`base`（Surface.Reconcile，面板 Image ↔ 程序化面板切换）；`core.CollectStatic`（`_bound` 后 no-op）；`SyncInitialSelection`（`isOn` 是运行期独占状态，用户选过的不打回）；`RefreshCaption`；`GameObject.activeInHierarchy == false && IsExpanded` → `Collapse(immediate: true)`（`hidden="true"` 的 Variant 把它藏了）；`IsExpanded` → §7.2 重算 + 取消进行中的过渡并 snap 到终态。
+- 展开态不变（TM-D11）。
+
+### 7.7 过渡动画
+
+LitMotion，两条 `MotionHandle`（面板、箭头），存在 TabMenu 上，`Dispose` / 下一次过渡前 `TryCancel`：
+
+- 面板：`CanvasGroup.alpha` 0→1；`Popup.anchoredPosition.y` 从终态偏 8px（向下长时 +8、向上翻时 -8）→ 终态；easing `OutCubic`；时长 `transition`。
+- 箭头：`localEulerAngles.z` 0→180（收起 180→0）。
+- `transition="0"`：不建 motion，直接写终态。
+- 过渡期间 blocker 已生效、Tab 可点（不等动画）。
+
+### 7.8 导航圈闭（`UI.Navigation.IsEnabled` 时）
+
+展开：
+
+```csharp
+_prevConfine = owner.NavConfineRoot;          // 模态根 / null
+owner.ConfineNavigationTo(Popup);             // NavConfineRoot = Popup；ExplicitNavigationResolver.Resolve(confineRoot: Popup)
+UI.Navigation.ContainmentRoot = Popup;        // 每帧 EnforceContainment 把选择关在面板里
+EventSystem.SetSelectedGameObject(SelectedTab?.GameObject ?? Navigation.FirstFocusableUnder(Popup));
+```
+
+收起：
+
+```csharp
+owner.RestoreNavigationConfine(_prevConfine); // NavConfineRoot = 之前；按之前的 confine 重算
+UI.Navigation.ContainmentRoot = _prevConfine;
+EventSystem.SetSelectedGameObject(GameObject); // 焦点回触发区
+```
+
+`Screen.ConfineNavigationToSelf()` 改为 `ConfineNavigationTo(RootGameObject)` 的调用；ReSolve 沿用 `NavConfineRoot` 重算，因此 resize 期间展开着的弹窗保持圈闭。触发区 `PuiButton` 本身进导航图（`nav*` / `focus` 可写，`NavTargetRules.SelectableTags` 加 `TabMenu`）；Submit（A / Enter）在触发区上 = `Toggle()`。
+
+### 7.9 Esc / 手柄 B
+
+展开时在 `Popup` 上启用一个 `ModalEscapeListener`（`AlsoCancelButton = true` → 额外绑 `<Gamepad>/buttonEast`；legacy Input 分支仍只有 Escape），回调 `Collapse(); s_escapeFrame = Time.frameCount;`。
+
+`UI.Modal.OnEscapePressed` 首行：
+
+```csharp
+if (Controls.TabMenu.TryConsumeEscape()) return;
+// TryConsumeEscape: s_expanded != null → Collapse 并返回 true；
+//                   否则 s_escapeFrame == Time.frameCount → true（TabMenu 的 listener 已先响过）；否则 false
+```
+
+两种同帧顺序都只关弹窗不关模态。`Tutorial.IsBlockingInput` 的判断保持在其后（引导期间 Esc 仍被吞）。
+
+### 7.10 `on="expand"` / `on="collapse"`
+
+- `TriggerSpec`：`TriggerKind.Expand` / `Collapse`；bare 形式与 `expand@<id>` / `collapse@<id>`。
+- `Trigger.InitTriggerSubscription`：`SubscribeExpand(kind)` → `TriggerSourceResolver.FindTabMenu(this, sourceId)`：bare → `GameObject.GetComponentInParent<TabMenuMarker>(true)`（TabMenu 在自身 GameObject 上挂一个空 `TabMenuMarker : MonoBehaviour`，与 `IStateSource` 的向上查找同法；`includeInactive` 因为弹窗收起态 inactive）→ 订阅 `OnExpanded` / `OnCollapsed`；`@id` → `ScopedIds` 查找 + 类型校验。
+- 找不到祖先 → `InvalidOperationException`（同 `state-*`）；lint `PUI-EXPAND-NO-SOURCE`。
+- `<Show>` 不接受这两个值（`Show` 只认 `state-*`，保持不变）。
+
+### 7.11 生命周期
+
+- `Dispose`：取消 motion；blocker `Destroy`（它不在 TabMenu 子树里）；`s_expanded == this` → 置空、导航 / Esc 复原；`core.Dispose()`；`Locale.Changed` 反订阅；`base.Dispose()`。
+- `Screen.Close` 展开中：Screen 根被销毁 → blocker（根 Canvas 子节点）随之销毁；`Dispose` 路径同上做兜底。
+- `interactable="false"`：`PuiButton.interactable = false` + `base`（CanvasGroup）；展开中 → `Collapse(immediate: true)`。
+
+## 8. 边界 / 错误处理
+
+| 场景 | 处理 |
+|---|---|
+| `<TabMenu>` 下没有任何 Tab | 合法；caption 只剩箭头；`Expand()` 弹出空面板（padding 高）；`SelectedTab = null` |
+| 子节点不是 Tab / 包装 / `<Decor>` | lint warning `PUI-TABMENU-CHILD`；运行时不阻拦（竖排照常，无 tab 语义） |
+| Tab 写 `width=` | lint warning `PUI-TABMENU-ITEM-WIDTH`；运行时被 `childForceExpandWidth` 覆盖 |
+| Tab 写 `anchor=` / `margin=` | `PUI-LAYOUT-ANCHOR` / `PUI-LAYOUT-MARGIN`（TabMenu 在 layout-group 名单里） |
+| `popupWidth` 小于触发区宽 | 尊重作者值（显式胜出），不夹 |
+| 面板比 Canvas 还高 | 不翻、不裁；`popupMaxHeight` + 滚动留 v2 |
+| 触发区在 `<ScrollList>` / masked `<Frame>` 里 | 面板经 overrideSorting Canvas 逃出裁切（TM-D8）；触发区自身仍被裁 |
+| 两个 TabMenu 先后展开 | 后者展开时前者 `Collapse(immediate: true)`（TM-D9） |
+| 展开中切 Variant 把 TabMenu `hidden` | `OnAfterApply` 检测 `!activeInHierarchy` → `Collapse(immediate: true)` |
+| 展开中 `BindItems` 重建 | 面板本就 active，不临时激活；重建后重算尺寸；焦点若在被销毁的 Tab 上 → `EnforceContainment` 下一帧落回面板首个可聚焦项 |
+| `bind="x"` 找不到 / 不是 Frame | 同 Tab 既有行为：首次切换 LogWarning 一次 |
+| `itemTemplate` 指向不存在的 tag / Template | `ParseException`（同 TabBar） |
+| `transition` 解析失败 | LogWarning，退回 0.15s |
+| `on="expand"` 无 TabMenu 祖先 | 运行时 `InvalidOperationException`；lint `PUI-EXPAND-NO-SOURCE`（Template body / instance root 豁免） |
+| Esc 时模态在上、弹窗在下层页面 | 弹窗属于下层页面时，上层模态自己的 listener 才是活的（`RefreshTopListener`）；`TryConsumeEscape` 仍会先收起弹窗、吞掉这次 Esc —— 可接受（弹窗被模态盖住本来就该关） |
+
+## 9. Lint 规则
+
+`Runtime/Core/Lint/TabMenuRules.cs`（新）；`IRWalker.WalkNode` 与 `ScreenInstantiator.InstantiateRecursive` 同源分发。
+
+| Code | 触发条件 | 级别 |
+|---|---|---|
+| `PUI-TAB-PARENT`（既有，放宽） | `<Tab>` 的直接父不是 `<TabBar>` **也不是** `<TabMenu>`（Template-instance root 内豁免） | warning |
+| `PUI-TABMENU-CHILD` | `<TabMenu>` 直接子的子树里既无字面 `<Tab>`、也不是 Template 调用、也不是 `<Decor>` | warning |
+| `PUI-TABMENU-ITEM-WIDTH` | `<TabMenu>` 直接子（或其 `<Tab>`）写了 `width=`（含 variant 覆盖） | warning |
+| `PUI-EXPAND-NO-SOURCE` | bare `on="expand"` / `on="collapse"` 的 `<Trigger>` / `<Animation>` 没有 `<TabMenu>` 祖先（`@id` 形式与 Template body 豁免）—— 并入 `StateTriggerRules.CheckStateSource` 的祖先扫描，加一个 `hasTabMenuAncestor` 位 | error |
+| `PUI-LAYOUT-ANCHOR` / `PUI-LAYOUT-MARGIN`（既有） | `<TabMenu>` 加入 `IRWalker` / `ScreenInstantiator` 的 layout-group 名单后自动覆盖其子节点 | error |
+
+名单同步：`BuiltinTags.All`（`BuiltinTagsTests` 守）、`ProceduralSurfaceRules.SurfaceTags`、`NavTargetRules.SelectableTags`、`StateTriggerRules` 的 expand 分支。
+
+## 10. 实现要点
+
+### 10.1 `Runtime/Controls/Internal/TabGroupCore.cs`（新）
+
+从 `TabBar.cs` 原样搬出：`_tabs` / `_factory` / `_itemTemplate` / `_itemsSub` / `_tabSubs` / `_bound` / `_selectionChanged`、`BindItems` / `Rebuild` / `ClearTabs` / `FindTabIn` / `ResolveFactory` / `WireTabSubscriptions` / `SyncInitialSelection` / `CollectStaticTabs`。`ResolveFactory` 的错误信息里的 `<TabBar itemTemplate=…>` 改成用 owner 的 tag 拼。`Rebuild` 加 `beforeRebuild` / `afterRebuild` 两个可选钩子。`owner` 用于 `UI.OwnerScreenOf(owner)`；`itemHost` 委托返回放项的 RectTransform（TabBar → 自身，TabMenu → Content）。
+
+### 10.2 `Runtime/Controls/TabBar.cs`
+
+保留公开面；字段换成 `private readonly TabGroupCore _core`；`OnAfterApply` → `_core.CollectStatic(Children); _core.SyncInitialSelection(); _core.WireTabSubscriptions();`。既有测试不改一行就应全绿。
+
+### 10.3 `Runtime/Controls/TabMenu.cs`（新）
+
+```csharp
+public sealed class TabMenu : ProceduralControl
+{
+    private protected override GameObject SurfaceHost => _popup.gameObject;
+    private protected override Selectable SurfaceSelectable => null;
+    protected internal override Transform ChildHostTransform => _content;
+
+    public override Vector2? GetNativeSize()
+    {
+        var pref = _label.GetPreferredValues(_label.text ?? "");
+        var w = PadX * 2 + (_icon.enabled ? _iconSize + _gap : 0) + pref.x + (_arrow.enabled ? _gap + _arrowSize : 0);
+        return new Vector2(w, Mathf.Max(MinTapHeight, pref.y + PadY * 2));
+    }
+    …
+}
+```
+
+关键私有方法：`BuildCaption()` / `BuildPopup()` / `LayoutCaption()` / `PlacePopup()` / `EnsureBlocker()` / `PlayTransition(bool expanding)` / `PushNav()` / `PopNav()`。注册：`reg.Register<TabMenu>("TabMenu", null)`（无 `defaultTextAttr`、无 `runtimeStateAttr` —— 展开态不是声明属性）。
+
+### 10.4 `Runtime/Controls/Tab.cs`
+
+`Text` / `Icon` setter 末尾 `ContentChanged?.Invoke()`；新增 `internal string CaptionText`、`internal Sprite CaptionIcon`；新增 `internal Observable<Unit> OnActivated`（isOn 变 true **或** 点击已选中项）供 §7.3 —— 由 `PuiToggle` 的 `onClick`-等价通道提供（`PuiToggle` 已有 `OnSubmit` wake 路径，加一个 `IPointerClickHandler` 转发即可）。
+
+### 10.5 Trigger 三件套
+
+`TriggerSpec`：enum 加 `Expand, Collapse`；`s_prefixedKinds` 加 `("expand@", …)`, `("collapse@", …)`；bare 表加 `"expand"` / `"collapse"`。`Trigger.InitTriggerSubscription` 加 `case Expand/Collapse: SubscribeExpand(kind)`。`TriggerSourceResolver.FindTabMenu(trigger, sourceId)` 仿 `FindStateSource`。
+
+### 10.6 `Runtime/Application/Screen.cs`
+
+```csharp
+internal void ConfineNavigationTo(GameObject root) { NavConfineRoot = root; Resolve(confineRoot: root); }
+internal void RestoreNavigationConfine(GameObject previous) { NavConfineRoot = previous; Resolve(confineRoot: previous); }
+internal void ConfineNavigationToSelf() => ConfineNavigationTo(RootGameObject);   // 保留给 UI.Modal
+```
+
+### 10.7 `UI.Modal.cs` / `ModalEscapeListener.cs`
+
+`OnEscapePressed` 首行 `if (Controls.TabMenu.TryConsumeEscape()) return;`。`ModalEscapeListener` 加 `internal bool AlsoCancelButton`，`OnEnable` 里按它决定是否 `AddBinding("<Gamepad>/buttonEast")`。
+
+### 10.8 `ScreenInstantiator.cs` / `IRWalker.cs`
+
+`selfIsLayoutGroup` / `isLayoutGroup` 两处名单加 `"TabMenu"`；`isTabBar` 改为 `isTabGroup = node.Tag is "TabBar" or "TabMenu"`；lint 分发加 `else if (node.Tag == "TabMenu") TabMenuRules.CheckTabMenu(node)`。
+
+### 10.9 测试（Red first）
+
+| 文件 | 覆盖 |
+|---|---|
+| `Tests/EditMode/Controls/TabMenuTests.cs` | 注册；子节点落在 Content；caption 镜像 text/icon 与选中变化；`GetNativeSize` hug；Open 后面板 inactive；`Expand` 激活面板 + 建 blocker + sorting；`Collapse` 反之；选中即收起；`bind` 显隐同 TabBar；展开态跨 ReSolve；第二个展开收起第一个；程序化属性落在 Popup（`__Surface` 是 Popup 子节点）；`color` / `sprite` 落在面板 Image；`transition="0"` 即时；`interactable=false` 收起 |
+| `Tests/EditMode/Controls/TabMenuPlacementTests.cs` | 默认左下；宽 = max(触发区, 内容)；`popupWidth` 显式；下方不够向上翻；右缘夹回 |
+| `Tests/EditMode/Controls/TabMenuBindItemsTests.cs` | 重建替换静态 Tab；收起态重建后 label preferred > 0（同帧临时激活）；空列表清 caption；包装 Template 找到 Tab |
+| `Tests/EditMode/Controls/TabMenuTriggerTests.cs` | `expand` / `collapse` / `@id` 解析；bare 向上解析；`OnFire` 时机；无祖先抛错 |
+| `Tests/EditMode/Navigation/TabMenuTrapTests.cs` | 展开 → `ContainmentRoot = Popup`、焦点在选中 Tab；收起恢复；Esc 收弹窗不关模态（两种顺序） |
+| `Tests/EditMode/Lint/TabMenuRulesTests.cs` + `BuiltinTagsTests` | §9 全部规则 |
+| `Tests/EditMode/Controls/TabBar*Tests.cs`（既有） | 核心抽取回归 |
+| `Tests/PlayMode/Controls/TabMenuPlayTests.cs` | 真实 Canvas 排序；blocker `onClick.Invoke` 收起；过渡结束后面板 inactive |
+
+## 11. 跟现有 spec / SKILL 的整合点
+
+### 11.1 主 spec `2026-05-07-promptugui-description-language-design.md`
+
+§5 控件表加一行：`<TabMenu>` — 弹出式 Tab 组；子 = `<Tab>`；表面 = 弹窗面板；caption 镜像选中项；`OnSelectionChanged` / `OnExpanded` / `OnCollapsed`；`itemTemplate` + `BindItems` — RectTransform + PuiButton + ToggleGroup + 内部 Popup(Canvas overrideSorting)（详见本文）。§5.7 提一句 `on="expand"` / `collapse`。
+
+### 11.2 `authoring-promptugui-xml/SKILL.md`
+
+- 内置 tag catalog 加 `<TabMenu>` 行，指向 `reference/controls-tabs.md#tabmenu`。
+- "Which tags draw procedurally" 名单与「程序化表面 → 主表面」表加 `<TabMenu>` → **弹窗面板**。
+- native-size 名单加 `<TabMenu>`（caption hug；最小高 44）；`focus` / `nav*` 的 Selectable 名单加 `<TabMenu>`；`tint` 名单加 `<TabMenu>`（面板底图）。
+- Re-skinning 段：`<TabMenu arrow= arrowColor=>`。
+
+### 11.3 `reference/controls-tabs.md`
+
+新 `## <TabMenu>` 节：§3 的三个例子、§4 属性表、`<Tab>` 在其中的差异（`width` 无效 / 项通栏）、caption 镜像规则、展开收起交互（blocker / Esc / B / 选中即收）、定位与翻转、`transition`、lint 表。标题改为 "Tabs (`<TabBar>` / `<TabMenu>` / `<Tab>`)"。
+
+### 11.4 `reference/animations.md`
+
+`on=` 表加 `expand` / `expand@<id>` / `collapse` / `collapse@<id>` 四行；"UPWARD" 段落把 TabMenu 祖先加进来；Patterns 加「菜单项入场」例子。
+
+### 11.5 `reference/navigation.md`
+
+Selectable 名单加 `<TabMenu>`；新段落「Popup focus trap」：展开时圈闭到面板、B / Esc 收起、焦点回触发区。
+
+### 11.6 `scripting-promptugui-csharp/SKILL.md`
+
+`TabMenu` API（§5.1）；事件速查表加 `TabMenu.OnSelectionChanged:Tab / OnExpanded / OnCollapsed`；DATA PUSH 加 `TabMenu.BindItems`。
+
+## 12. Out of Scope（v2 候选）
+
+- `popupAlign="left|center|right"`、`popupMaxHeight` + 内部滚动
+- `closeOnSelect="false"`（多选式菜单）、hover 展开、键盘首字母跳转
+- 弹窗 `mask`（TM-D20）
+- caption 覆盖（`text=` / `icon=` 固定 caption）与自定义 caption slot（TM-D5）
+- 过渡预设名 / 自定义曲线（`expandAnim="scalein"`）（TM-D13）
+- 触发区状态色（`hoverColor` 等作用于 caption）与 `IStateSource`（TM-D18）
+- `<Show on="expand">`
+- 弹窗里嵌套 TabMenu
+- `<Dropdown>` 的 `fontSize` / `itemFontSize` —— 独立小改，与本文无关
+
+## 13. 风险与回滚
+
+| 风险 | 缓解 |
+|---|---|
+| 面板 `sortingOrder = root + 2` 被同 sorting layer 里 order 更高的另一页面盖住 | `PopupSortingOffset` 是 internal static，可整体调；Router 分层页面若用了大间隔 order，在实施期确认一次并写进 skill |
+| 嵌套 Canvas 让面板逃出祖先 mask，同时也逃出祖先 `CanvasGroup` 的 `blocksRaycasts`？ | 不会：`CanvasGroup` 沿 transform 链生效，与 Canvas 无关；`interactable=false` 的父级仍能挡住面板 |
+| `Popup` 收起态 inactive 期间 ReSolve 重写 Tab 属性 | 与 `Tab.bind` 隐藏页同款路径（inactive 上 apply 是既有行为）；TMP 已 Awake 过，`GetPreferredValues` 可用 |
+| BindItems 同帧临时激活触发 `Toggle.OnEnable` → `ToggleGroup` 注册顺序导致多个 `isOn=true` 抖动 | `SyncInitialSelection` 在激活后执行，最终只有一个 on；与 TabBar 相同的兜底 |
+| 展开中 `ReSolve` 取消过渡 snap 到终态，视觉上跳一下 | 只发生在 resize / Variant / Theme 切换的那一帧，可接受 |
+| `TabGroupCore` 抽取改坏 TabBar | 既有 `TabBarTests` / `TabBarBindItemsTests` / `TabBarChildSizingTests` 覆盖全部公开行为；抽取是纯搬运，先跑绿再动 TabMenu |
+| Esc 同帧双 listener 顺序 | `TryConsumeEscape` 的两段判断覆盖两种顺序（§7.9），`TabMenuTrapTests` 两种顺序都测 |
+| blocker `Button` 被 `ExplicitNavigationResolver` 当成邻居 | `navigation = Navigation.defaultNavigation` 改为 `None`；`FocusableUnder` 只在 `ContainmentRoot`（面板）下找 |
+| XSD 不自动更新 | 同所有新 `[UIAttr]`：`Tools → PromptUGUI → Schema → Generate XSD`；`XsdGeneratorTests` 加 `TabMenu` 的 substring 断言 |
+| 回滚 | 新文件独立；`TabBar` 委托 `TabGroupCore` 是等价重构，可单独保留 |

--- a/docs~/superpowers/specs/2026-08-29-tabmenu-design.md
+++ b/docs~/superpowers/specs/2026-08-29-tabmenu-design.md
@@ -1,7 +1,7 @@
 # `<TabMenu>` —— 弹出式 Tab 组（频道切换器 / 折叠导航）
 
 **日期**: 2026-08-29
-**状态**: 设计阶段（决策见 §2，2026-08-29 与作者对齐；待 review，未进入实施）
+**状态**: **已实现**（Task 1–12 一轮做完，见 §14）。决策见 §2，2026-08-29 与作者对齐。
 **相关**: `2026-05-27-tabbar-design.md`（`<TabBar>` / `<Tab>` 的出处，本文复用它的全部选中语义并抽出共享核心）、
 `2026-05-09-m5-common-controls-design.md`（`<Dropdown>` 参考实现 —— 本文 §1 说明为何不在它上面扩）、
 `2026-08-26-procedural-surface-design.md`（`ProceduralControl` / `SurfaceHost`）、
@@ -565,3 +565,41 @@ Selectable 名单加 `<TabMenu>`；新段落「Popup focus trap」：展开时�
 | blocker `Button` 被 `ExplicitNavigationResolver` 当成邻居 | `navigation = Navigation.defaultNavigation` 改为 `None`；`FocusableUnder` 只在 `ContainmentRoot`（面板）下找 |
 | XSD 不自动更新 | 同所有新 `[UIAttr]`：`Tools → PromptUGUI → Schema → Generate XSD`；`XsdGeneratorTests` 加 `TabMenu` 的 substring 断言 |
 | 回滚 | 新文件独立；`TabBar` 委托 `TabGroupCore` 是等价重构，可单独保留 |
+
+---
+
+## 14. 实施记录（与设计的差异）
+
+实施计划：[`../plans/2026-08-29-tabmenu.md`](../plans/2026-08-29-tabmenu.md)。设计整体照做，四处在写代码时被现实修正：
+
+**14.1 互斥不能靠 uGUI 的 ToggleGroup（改动 TM-D4 的隐含前提）。**
+收起态弹窗是 inactive，而 uGUI `Toggle.Set` 把 `NotifyToggleOn` 的调用挡在 `IsActive()` 后面，
+被禁用的 Toggle 也已经从 group 注销。结果：菜单关着时用代码写 `tab.IsOn = true` 会同时选中两项、
+两个 `bind` 页面一起显示。互斥改由 `TabGroupCore` 在发 `SelectionChanged` **之前**自己保证
+（`EnforceExclusive`）—— 对 `<TabBar>` 是幂等 no-op，因为 ToggleGroup 已经先做过。
+`ToggleGroup` 仍然挂着（键盘/手柄路径与既有 Tab 行为依赖它）。
+
+**14.2 「选中即收起」需要一个展开期的重入保护（§7.1 补充）。**
+`Expand()` 里 `SetActive(true)` 弹窗子树，会让 uGUI 在 `OnEnable` 重新校验 ToggleGroup 并**补发**
+一次「已选中」事件。而「选中即收起」把它当成用户选择 —— 菜单在打开它的同一次调用里自己关掉了
+（`execute_code` 实测：`Expand()` 返回后 `IsExpanded` 已是 `false`）。加 `_expanding` 标志，
+展开进行中忽略选中驱动的收起；用户点击与代码设选中两条路径都保留。
+
+**14.3 Esc 让位需要同帧 guard（§7.9 已预见，实测确认必要）。**
+`TabMenu` 自己的 listener 与 `UI.Modal.OnEscapePressed` 响应同一次按键、顺序不定。
+`TryConsumeEscape()` 因此有两段判断：有展开中的菜单 → 收起并返回 true；否则 `s_escapeFrame ==
+Time.frameCount` → 也返回 true。两种顺序都只关菜单、不关模态。
+`s_expanded` / `s_escapeFrame` 纳入 `UI.ResetForTests`（EditMode 里 `Time.frameCount` 几乎不推进，
+不清会让「已消费」永久为真）。
+
+**14.4 `<TabMenu>` 是 `ProceduralSurfaceRollout` 契约的第三个正当例外。**
+其它控件只画一张脸，表面替换它、`targetGraphic` 跟着走。TabMenu 画两处：会 hover/press 的把手，
+和 `radius` / `glass` 描述的弹窗面板。把 `targetGraphic` 指向面板会让「悬停把手」染色整个菜单，
+所以它留在 caption 上。已按 Slider / Progress 的既有写法加具名测试记录（`TabMenu_KeepsTargetGraphicOnItsCaption`）。
+
+**14.5 定位数学抽成纯函数。**
+EditMode 无法给 ScreenSpaceOverlay canvas 一个确定的尺寸，所以 §7.2 的规则落在
+`Internal/PopupPlacer.Solve(handle, panel, canvas, gap)` 里单测；控件侧只测接线。
+
+**其余按设计实现**：TM-D1…D21 全部照做；§12 的 Out of Scope 一项未做。
+测试：EditMode 2842、PlayMode 176，全绿。


### PR DESCRIPTION
设计：[`docs~/superpowers/specs/2026-08-29-tabmenu-design.md`](docs~/superpowers/specs/2026-08-29-tabmenu-design.md) ·
计划：[`docs~/superpowers/plans/2026-08-29-tabmenu.md`](docs~/superpowers/plans/2026-08-29-tabmenu.md)

## 为什么是新控件，不是完善 `<Dropdown>`

聊天面板要一个频道切换器：收起是 `[🌐 星海频道 ▼]`，点开是一列频道，选一个切到对应面板 ——
语义上就是 `<TabBar>`（互斥、每项 icon+文字、`bind=` 到 Frame），只是**呈现**收成了弹出式。

`<Dropdown>` 做不到，而且不是改几个数字的问题：

- 弹窗里每一行是 TMP_Dropdown 克隆出来的**裸 uGUI `Toggle`**（`Dropdown.cs:117-140`），不是 PromptUGUI Control
  —— `<Show on="state-*">` / `hoverColor` / `radius` / 每行独立 icon 一样都用不上；`bind=` 只能做成按下标映射，
  还得跟 C# 里 `BindOptions` 推的列表手工对齐。
- **弹窗宽度焊死等于触发按钮宽度**（Template 锚 0..1，`Dropdown.cs:72-77`），而设计图里触发区只有文字宽、菜单更宽。
- Dropdown **刻意不按 caption 算尺寸**（DSS-D2，怕选项切换时宽度跳）。对表单里的「画质：高」是对的，
  对频道切换器恰恰相反 —— 要的就是箭头紧跟文字。

而设计图需要的每一样 —— `icon` / `text` / `fontSize` / `bind` / 状态色 / `selectedSprite` / 程序化表面 /
`<Show on="state-*">` / `isOn` / `BindItems` —— `<Tab>` 全都已经有了。缺的只是「把一组 Tab 收进弹窗、
用选中项当把手」的容器。`<Dropdown>` 保持表单选择器定位不动。

## 长什么样

```xml
<HStack anchor="top-stretch" height="64" padding="0,16,0,16" spacing="8">
  <TabMenu id="channel" fontSize="22" textColor="white" iconSize="24"
           popupWidth="240" padding="8" spacing="4"
           radius="12" glass="true" frost="0.5" color="primary-dark/0.6" borderWidth="1">
    <Tab class="menu-item" icon="ui:globe" text="星海频道" bind="ch_world" isOn="true"/>
    <Tab class="menu-item" icon="ui:guild" text="公会频道" bind="ch_guild"/>
    <Decor kind="bracket" at="top-left"/>
  </TabMenu>
</HStack>
```

**表面 = 弹窗面板，不是把手**（TM-D3）：`radius` / `glass` / `color` / `<Decor>` 全部描述掉下来的菜单，
收起的把手默认透明并 hug 内容。要给把手加底就套一层 `<Frame>` —— 跟「给 TabBar 加背景条套 `<Image>`」同一招。

## 主要设计决策

| | |
|---|---|
| 选中语义 | 抽 `internal TabGroupCore`，`<TabBar>` / `<TabMenu>` 共用一份实现（TM-D17） |
| 子节点 | 全部进弹窗 Content：`<Tab>`、包装它的 Template / `<Animation>`、`<Decor>`（TM-D4） |
| caption | 自动镜像**选中** Tab 的 icon + text，零额外标记（TM-D5） |
| 弹窗置顶 | 不 reparent，嵌套 `Canvas(overrideSorting)` —— 同时逃出祖先 mask，塞进 `<ScrollList>` 也不被裁（TM-D8） |
| 收起时机 | 选中任一项（含点已选中项）/ 点 blocker / Esc / 手柄 B；全局至多一个展开（TM-D9、D10） |
| 过渡 | 内置 `transition="0.15s"`（面板是内部节点，作者包不住）；逐项入场用 `<Animation on="expand">`（TM-D13、D14） |
| 事件名 | `expand` / `collapse`，不叫 `open` / `close` —— `on="open"` 已是「Screen 打开」 |

## 实现中修正的四处（spec §14）

1. **互斥不能靠 uGUI 的 ToggleGroup。** 收起态弹窗 inactive，而 `Toggle.Set` 把 `NotifyToggleOn` 挡在
   `IsActive()` 后面、被禁用的 Toggle 也已从 group 注销 —— 代码里 `tab.IsOn = true` 会同时选中两项、
   两个 `bind` 页面一起显示。改由 `TabGroupCore` 在发 `SelectionChanged` **之前**自己保证（对 TabBar 是幂等 no-op）。
2. **菜单会在打开它的同一次调用里自己关掉。** `Expand()` 里 `SetActive(true)` 弹窗子树，让 uGUI 在 `OnEnable`
   重新校验 ToggleGroup 并**补发**一次「已选中」，而「选中即收起」把它当成用户选择。
   （实测 `Expand()` 返回后 `IsExpanded` 已是 `false`。）加 `_expanding` 重入保护。
3. **把手被排成 30px。** `ApplyCommon` 在 `OnAfterApply` 填 caption **之前**测量，读到空标签 —— 只够内边距+箭头。
   改为直接走 `Children` 找 `isOn` 的 Tab 读 text / icon；同一场景现在排出 88.6px，与 native 一致。
4. **`<TabMenu>` 是 `ProceduralSurfaceRollout` 契约的第三个正当例外**（Slider / Progress 之后）：它画两处东西，
   `targetGraphic` 留在 caption 上，否则悬停把手会染色整个菜单。已按既有写法加具名测试记录。

## Lint

`PUI-TABMENU-CHILD`（非 Tab 子节点，`<Decor>` 放行）、`PUI-TABMENU-ITEM-WIDTH`（行上的 `width` 无效 ——
菜单行永远铺满面板，含 variant 覆盖）、`PUI-EXPAND-NO-SOURCE`（bare `expand`/`collapse` 无 `<TabMenu>` 祖先）；
`PUI-TAB-PARENT` 放宽到接受 `<TabMenu>` 父。规则纯 C#，运行时与 CLI 共用同一份实现。

## 文档（同 PR）

`authoring-promptugui-xml`：catalog 行、程序化表面与「主表面」表、native-size / selectable / tint 名单；
`reference/controls-tabs.md` 新增 `<TabMenu>` 一节（标题改为 Tabs (`<TabBar>` / `<TabMenu>` / `<Tab>`)）；
`reference/animations.md` 加 `expand` / `collapse` 与菜单行入场用例；`reference/navigation.md` 加 Popup focus trap；
`scripting-promptugui-csharp` 加 API 与速查表行；主 spec §5 控件表加一行。

## 测试

EditMode **2844/2844** · EditorOnly **310/310** · PlayMode **176/176** · `dotnet format --verify-no-changes` 干净 ·
UIXmlLint CLI 三条新规则实测命中、行号归属正确。

> ⚠️ **人工视觉 QA 尚未做**（plan Task 12 最后一项）：玻璃面板在 Overlay canvas 下的实际观感、
> 塞进 `<ScrollList>` 滚动时弹窗跟随且不被裁、手柄 B 的手感 —— 需要在 host 工程里跑一次确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfFCb9D4m1WL7Ji2JUpUy9
