### PR TITLE
fix: HDR 显示输出下 UI 的离屏合成 —— 六个 UI shader 改用分离 alpha 混合因子

### DIFF
--- a/Runtime/Resources/PromptUGUI/Material/UI-Decor.shader
+++ b/Runtime/Resources/PromptUGUI/Material/UI-Decor.shader
@@ -61,7 +61,9 @@ Shader "UI/Decor"
         Lighting Off
         ZWrite Off
         ZTest [unity_GUIZTestMode]
-        Blend SrcAlpha OneMinusSrcAlpha
+        // alpha 通道走 One OneMinusSrcAlpha：HDR 显示输出下的离屏 UI 合成要求正确的直 alpha，
+        // 理由见 UI-ProceduralPanel.shader 同一行的注释。
+        Blend SrcAlpha OneMinusSrcAlpha, One OneMinusSrcAlpha
         ColorMask [_ColorMask]
 
         Pass

--- a/Runtime/Resources/PromptUGUI/Material/UI-GlassGroup.shader
+++ b/Runtime/Resources/PromptUGUI/Material/UI-GlassGroup.shader
@@ -58,7 +58,9 @@ Shader "UI/GlassGroup"
         Lighting Off
         ZWrite Off
         ZTest [unity_GUIZTestMode]
-        Blend SrcAlpha OneMinusSrcAlpha
+        // alpha 通道走 One OneMinusSrcAlpha：HDR 显示输出下的离屏 UI 合成要求正确的直 alpha，
+        // 理由见 UI-ProceduralPanel.shader 同一行的注释。
+        Blend SrcAlpha OneMinusSrcAlpha, One OneMinusSrcAlpha
         ColorMask [_ColorMask]
 
         Pass

--- a/Runtime/Resources/PromptUGUI/Material/UI-GlassPanel.shader
+++ b/Runtime/Resources/PromptUGUI/Material/UI-GlassPanel.shader
@@ -75,7 +75,9 @@ Shader "UI/GlassPanel"
         Lighting Off
         ZWrite Off
         ZTest [unity_GUIZTestMode]
-        Blend SrcAlpha OneMinusSrcAlpha
+        // alpha 通道走 One OneMinusSrcAlpha：HDR 显示输出下的离屏 UI 合成要求正确的直 alpha，
+        // 理由见 UI-ProceduralPanel.shader 同一行的注释。
+        Blend SrcAlpha OneMinusSrcAlpha, One OneMinusSrcAlpha
         ColorMask [_ColorMask]
 
         Pass

--- a/Runtime/Resources/PromptUGUI/Material/UI-Grayscale.shader
+++ b/Runtime/Resources/PromptUGUI/Material/UI-Grayscale.shader
@@ -44,7 +44,9 @@ Shader "UI/Grayscale"
         Lighting Off
         ZWrite Off
         ZTest [unity_GUIZTestMode]
-        Blend SrcAlpha OneMinusSrcAlpha
+        // alpha 通道走 One OneMinusSrcAlpha：HDR 显示输出下的离屏 UI 合成要求正确的直 alpha，
+        // 理由见 UI-ProceduralPanel.shader 同一行的注释。
+        Blend SrcAlpha OneMinusSrcAlpha, One OneMinusSrcAlpha
         ColorMask [_ColorMask]
 
         Pass

--- a/Runtime/Resources/PromptUGUI/Material/UI-LinearLightTint.shader
+++ b/Runtime/Resources/PromptUGUI/Material/UI-LinearLightTint.shader
@@ -56,7 +56,9 @@ Shader "UI/LinearLightTint"
         Lighting Off
         ZWrite Off
         ZTest [unity_GUIZTestMode]
-        Blend SrcAlpha OneMinusSrcAlpha
+        // alpha 通道走 One OneMinusSrcAlpha：HDR 显示输出下的离屏 UI 合成要求正确的直 alpha，
+        // 理由见 UI-ProceduralPanel.shader 同一行的注释。
+        Blend SrcAlpha OneMinusSrcAlpha, One OneMinusSrcAlpha
         ColorMask [_ColorMask]
 
         Pass

--- a/Runtime/Resources/PromptUGUI/Material/UI-ProceduralPanel.shader
+++ b/Runtime/Resources/PromptUGUI/Material/UI-ProceduralPanel.shader
@@ -68,7 +68,17 @@ Shader "UI/ProceduralPanel"
         Lighting Off
         ZWrite Off
         ZTest [unity_GUIZTestMode]
-        Blend SrcAlpha OneMinusSrcAlpha
+        // 分离的 alpha 混合因子不是可选项：RGB 照常 source-over，**alpha 通道必须走 One
+        // OneMinusSrcAlpha**。开了 HDR 显示输出后，URP 不再把 overlay UI 直接画进 backbuffer，
+        // 而是画进一张清成透明黑的离屏 RGBA8，再由 SceneUIComposition 合成 —— 那段代码把这张图
+        // 当作「预乘 RGB + 直 alpha」：先 rgb/a 反预乘，再 rgb*a + scene*(1-a)。
+        // 若 alpha 通道也用 SrcAlpha 混，写进去的是 a*a：RGB 因为除回来而恰好抵消，但场景的透出量
+        // 变成 1-a²，于是每个 0<a<1 的像素都多漏进 a(1-a) 份背景（a=0.5 时高达 25%）。
+        // 实心填充与描边 (a=1) 毫发无损，**外发光那整条渐变**、玻璃、以及 1px AA 边却被背景冲淡，
+        // 只剩贴着形状边缘 a→1 的那一圈还是干净的 —— 正是「SDR 正常、HDR 上渐变没了只剩实色描边」。
+        // SDR 路径从不读 dst alpha，这个写法在那边逐位不变。TMP 用 `Blend One OneMinusSrcAlpha`
+        // （直接输出预乘色）绕开了同一个坑，所以文字一直是对的。
+        Blend SrcAlpha OneMinusSrcAlpha, One OneMinusSrcAlpha
         ColorMask [_ColorMask]
 
         Pass


### PR DESCRIPTION
## 症状

外发光在 SDR 显示器上正常；切到 HDR 显示器，**渐变整条消失，只剩紧贴形状边缘的一圈实色描边**。填充和描边不受影响。

## 成因

先排除一个方向：**发光本身不产生 HDR 颜色**。`_GlowColor` / `_InnerGlowColor` 都是普通 LDR `Color`（无 `[HDR]` 标记），`PuguiApplyOuterGlow` / `PuguiApplyInnerGlow` 只动 alpha（`color.a *= g*g*...`）后走直 alpha 的 source-over，输出恒在 `[0,1]`。

真正的问题在 alpha 通道。开了 HDR 显示输出后（`useHDRDisplay: 1`），URP 走的是另一条 UI 路径：overlay UI 不再直接画进 backbuffer，而是画进一张清成透明黑的离屏 `R8G8B8A8_SRGB`（`DrawScreenSpaceUIPass.ConfigureOffscreenUITextureDesc`），最后由 `HDROutput.hlsl` 的 `SceneUIComposition` 合成：

```hlsl
uiSample.rgb = uiSample.rgb / (uiSample.a == 0 ? 1 : uiSample.a);   // 反预乘
uiSample.rgb = RotateRec709ToOutputSpace(uiSample.rgb) * paperWhite;
return uiSample.rgb * uiSample.a + sceneColor * (1 - uiSample.a);
```

它要求那张图是**预乘 RGB + 正确的直 alpha**。而 `Blend SrcAlpha OneMinusSrcAlpha` 混出来的 RGB 确实是预乘的 ✅，alpha 通道却被混成了 `a*a` ❌（`a·a + 0·(1-a)`，因为目标清空为 0）。

代进去算：RGB 项因为「先除 a² 再乘 a²」恰好抵消、是对的；**错的是场景的透出量** —— 本该 `1-a`，实际成了 `1-a²`，每个半透明像素都多漏进 `a(1-a)` 份背景。

| 区域 | alpha | 多漏进的背景 |
|---|---|---|
| 填充 / 描边 | 1 | 0，毫发无损 |
| 外发光渐变 | 0→1 | 最高 25%（a=0.5 处） |
| glass、1px AA 边 | 0<a<1 | 同上 |

于是整条渐变被背景冲淡，只剩 a→1 的那一圈还干净 —— 正是「渐变没了，变成实色描边」。SDR 路径永远不读 dst alpha，所以同一份 shader 在那边完全正常。

## 改动

六个 UI shader 一律：

```hlsl
Blend SrcAlpha OneMinusSrcAlpha, One OneMinusSrcAlpha
```

`One` 让 alpha 通道累积回正确的 source-over（`a_s + a_d(1-a_s)`）。完整推导写在 `UI-ProceduralPanel.shader` 的 Blend 行上方，其余五个（Decor / GlassPanel / GlassGroup / Grayscale / LinearLightTint）指过去。

TMP 用 `Blend One OneMinusSrcAlpha`（直接输出预乘色）绕开的是同一个坑 —— 这也是为什么 HDR 下文字一直是对的。

## 风险

SDR 路径从不读 dst alpha，**逐位不变**。

## 测试

| 套件 | 结果 |
|---|---|
| `PromptUGUI.Tests.EditMode` | 3030 / 3030 ✅ |
| `PromptUGUI.Tests.EditorOnly` | 310 / 310 ✅ |
| `PromptUGUI.Tests.PlayMode` | 178 / 178 ✅ |

仓库里没有任何测试断言 shader 的 Blend 状态，全绿只说明没打破既有行为；HDR 那条路径由作者在 HDR 显示器上肉眼验过，外发光渐变恢复正常。

不涉及 XML 语义或公共 C# API，无需更新 SKILL。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Emjk4XRm6hpJhozzj1b7B
