### PR TITLE
fix: 玻璃颗粒按 √亮度缩放 —— 消掉暗底上的纱窗噪点

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/reference/glass.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/glass.md
@@ -44,7 +44,7 @@ attribute. Writing any of them without `glass="true"` is a lint error
 | `lightAngle` | 度 | `0` | Light direction. `0` = straight up, growing clockwise. Any value, including negatives and >360 |
 | `lightIntensity` | `0`–`1` | `0.6` | Edge highlight strength. `0` turns the lighting layer off |
 | `saturation` | `≥0` | `1.15` | Backdrop vibrancy. `1` = untouched, `0` = greyscale. This is what makes glass look lit rather than washed out — reach for it before reaching for `dispersion` |
-| `noise` | `0`–`1` | `0.02` | Frosted grain. Doubles as dithering against banding on large blurred areas |
+| `noise` | `0`–`1` | `0.02` | Frosted grain, scaled by √luminance so it reads the same over dark and bright backdrops (a constant linear amplitude would be ~7× louder on a dark backdrop after the sRGB curve). Doubles as dithering against banding on large blurred areas |
 | `seam` | px, signed | `3` | **`weld` groups only** (`PUI-GLASS-SEAM-NO-WELD` elsewhere). How far the thickness step's glow reaches from the raised block's contour, and — by its **sign** — which side it falls on: `+` outside the block, `−` inside it. The bright line hugs the contour either way and takes roughly a third of the magnitude; the rest is the fade. `0` = as sharp as the screen can draw |
 
 Reused unchanged: `color` (tint painted over the glass — comma gradients, gradient **stop positions** and **hints** (`"A 70%,B"` / `"A, 70%, B"`, which glass draws per-pixel) and `/alpha` work exactly as

--- a/Runtime/Resources/PromptUGUI/Material/UI-GlassGroup.shader
+++ b/Runtime/Resources/PromptUGUI/Material/UI-GlassGroup.shader
@@ -352,7 +352,9 @@ Shader "UI/GlassGroup"
                     // 像同一块板，主次关系就丢了。
                     rgb *= 1.0 - crease * 0.45 * inside;
 
-                    rgb += (IGNoise(uv * _ScreenParams.xy) - 0.5) * noise;
+                    // 颗粒幅度按 sqrt(亮度) 缩放，理由见 UI-GlassPanel.shader 同一处的注释。
+                    float grainLuma = dot(rgb, float3(0.2126, 0.7152, 0.0722));
+                    rgb += (IGNoise(uv * _ScreenParams.xy) - 0.5) * noise * sqrt(max(grainLuma, 0.0));
 
                     base = float4(rgb, inside);
                 }

--- a/Runtime/Resources/PromptUGUI/Material/UI-GlassPanel.shader
+++ b/Runtime/Resources/PromptUGUI/Material/UI-GlassPanel.shader
@@ -233,8 +233,14 @@ Shader "UI/GlassPanel"
                     rgb += spec * bevel * intensity;
 
                     // 磨砂颗粒：兼作 dithering，挡住大面积模糊底上的色带。
-                    rgb += (IGNoise(IN.screenPos.xy / max(IN.screenPos.w, 1e-5) * _ScreenParams.xy)
-                            - 0.5) * noise;
+                    // 幅度按 sqrt(亮度) 缩放：这里是线性空间，而显示曲线（sRGB ≈ γ2.2）会把暗部的
+                    // 线性差值放大 —— 常数 ±0.01 落在 sRGB≈33 的暗底上是 ±14 级、±66% 的相对抖动，
+                    // 落在亮底上却只有 ±2 级，于是深色背景上的玻璃读成一层纱窗。感知幅度恒定的理想
+                    // 缩放是 L^0.545，√L 是它最便宜的近似（一次 dot + 一次 sqrt），全亮度范围都落在
+                    // ±1～2 级 —— 恰好是 dither 该有的量。亮度取叠过高光之后的 rgb，斜面亮边上的
+                    // 颗粒随之同步。
+                    float grainLuma = dot(rgb, float3(0.2126, 0.7152, 0.0722));
+                    rgb += (IGNoise(uv * _ScreenParams.xy) - 0.5) * noise * sqrt(max(grainLuma, 0.0));
 
                     base = float4(rgb, inside);
                 }


### PR DESCRIPTION
## 问题

玻璃面板在深色背景上有明显的规则噪点（屏幕亮度高时尤其显眼）。

## 原因

`noise` 是在**线性空间**加的常数幅度（默认 `0.02` → ±0.01）。项目是 Linear 色彩空间，显示曲线在暗部把线性差值放大：

| 背景 (sRGB) | 修改前 R 通道波动 | 修改后 |
|---|---|---|
| 33（深空） | **±14 级** | ±2 |
| 120 | ±3 | ±1 |
| 200 | ±2 | ±1 |

再加上 IGN 本身是规则晶格（横向近似逐像素交替、纵向 3.2 px 锯齿），幅度一大就读成纱窗而不是颗粒。截图实测 R 通道 15..46（σ≈7），与计算吻合。

## 修法

`rgb += (IGN − 0.5) × noise × √luma`（`UI-GlassPanel.shader` / `UI-GlassGroup.shader` 各一处）。sRGB ≈ γ2.2，感知幅度恒定的理想缩放是 L^0.545，√L 是它最便宜的近似——每片元多一次 `dot` + 一次 `sqrt`。luma 取叠过高光之后的 rgb，斜面亮边上的颗粒同步。

`noise` 的取值范围、默认值、C# 侧、lint 规则均不变；`glass.md` 的 `noise` 行补充了缩放说明。

## 验证

- 客户端 `Round.ui.xml` 实机离屏渲染：平坦玻璃区高频残差 σ **10.7 → 0.2～1.3**，2× 放大同框对比纱窗纹消失，8× 只剩 ±1 级细颗粒
- EditMode：`GlassRenderTests` / `CornerFilletGlassRenderTests` / `ProceduralSurfaceRenderTests` / `ProceduralMaskRenderTests` 21/21 通过
- 控制台无 shader 编译错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Emjk4XRm6hpJhozzj1b7B
