### PR TITLE
fix: 状态色扇出不再改写后代程序化面板的填充

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/reference/states.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/states.md
@@ -97,6 +97,7 @@ authored look in its **material** and treats `Graphic.color` as a **multiplier**
 - `*Color` (absolute) drives the panel's **fill**, and stays genuinely absolute. On glass this moves
   the pane's own tint, which is what "hover changes the colour" has to mean there.
 - `*Modulate` (relative) stays on `Graphic.color`, exactly as it does on an Image.
+- A **descendant** that is itself a procedural panel — an accent `<Frame color=>`, a hollow border-only `<Frame>` — keeps its own fill. The fan-out writes only the multiplier onto it; absolutes and the selected base never reach it (they are the control's own fill).
 
 One consequence worth knowing: **an absolute change snaps instead of fading** on a procedural
 surface. The fill is a material parameter, and tweening it per frame would mint a material per frame

--- a/Runtime/Controls/Internal/ColorApplier.cs
+++ b/Runtime/Controls/Internal/ColorApplier.cs
@@ -36,6 +36,10 @@ namespace PromptUGUI.Controls.Internal
         /// hint curve included) has to survive the round trip.</summary>
         public static ColorSpec Peek(Graphic g)
         {
+            // A procedural panel keeps its colour in the MATERIAL; Graphic.color is the multiplier
+            // (white at rest). Peeking that would hand a white base to a state reactor, which then
+            // paints it into the fill — see StateTintReactor.ApplyToPanel.
+            if (g is ProceduralPanel panel) return panel.Fill;
             var tint = g.GetComponent<GradientTint>();
             return tint != null && tint.enabled
                 ? tint.Spec

--- a/Runtime/Controls/Internal/ProceduralPanel.cs
+++ b/Runtime/Controls/Internal/ProceduralPanel.cs
@@ -35,6 +35,7 @@ namespace PromptUGUI.Controls.Internal
     [RequireComponent(typeof(CanvasRenderer))]
     internal sealed class ProceduralPanel : MaskableGraphic
     {
+        private ColorSpec _fill = ColorSpec.Solid(Color.clear);
         private Color _fillTop = Color.clear;
         private Color _fillBottom = Color.clear;
         private float _fillStopTop;
@@ -157,6 +158,7 @@ namespace PromptUGUI.Controls.Internal
 
         public void SetFill(in ColorSpec fill)
         {
+            _fill = fill;
             _fillTop = fill.Top;
             _fillBottom = fill.Bottom;
             _fillStopTop = fill.TopStop;
@@ -253,6 +255,14 @@ namespace PromptUGUI.Controls.Internal
         public void SetNoise(float v) { _noise = v; MarkDirty(); }
 
         internal bool IsGlass => _glass;
+
+        /// <summary>
+        /// The fill as last authored — what the Frame / surface painted. Read by
+        /// <see cref="ColorApplier.Peek"/>: on a panel the colour lives in the material and
+        /// <c>Graphic.color</c> is only the multiplier (white at rest), so a state reactor that
+        /// peeked <c>Graphic.color</c> for its fallback base would paint white into the fill.
+        /// </summary>
+        internal ColorSpec Fill => _fill;
 
         /// <summary>
         /// The glass values as written, regardless of whether glass mode is on. A weld container is

--- a/Runtime/Controls/Internal/StateTintInstaller.cs
+++ b/Runtime/Controls/Internal/StateTintInstaller.cs
@@ -68,7 +68,9 @@ namespace PromptUGUI.Controls.Internal
                 // The control's color= describes ITS bg. A descendant carries its own, which this
                 // code cannot see, so those keep the first-init Peek.
                 ColorSpec? authored = isTarget ? authoredBase : null;
-                var reactor = InstallReactor(g, abs, modulates, fade, selBase, selected, authored);
+                // Likewise the fill: a descendant panel's fill is that Frame's own color= (or none).
+                var reactor = InstallReactor(g, abs, modulates, fade, selBase, selected, authored,
+                    ownsFill: isTarget);
                 if (isTarget) targetReactor = reactor;
             }
             return targetReactor;
@@ -76,12 +78,12 @@ namespace PromptUGUI.Controls.Internal
 
         private static StateTintReactor InstallReactor(Graphic graphic, StateColorSet absolutes,
             StateColorSet modulates, float fade, ColorSpec? selectedBase, bool selected,
-            ColorSpec? authoredBase)
+            ColorSpec? authoredBase, bool ownsFill)
         {
             if (graphic == null) return null;
             var reactor = graphic.GetComponent<StateTintReactor>()
                           ?? graphic.gameObject.AddComponent<StateTintReactor>();
-            reactor.Configure(absolutes, modulates, fade, selectedBase, selected, authoredBase);
+            reactor.Configure(absolutes, modulates, fade, selectedBase, selected, authoredBase, ownsFill);
             return reactor;
         }
     }

--- a/Runtime/Controls/Internal/StateTintReactor.cs
+++ b/Runtime/Controls/Internal/StateTintReactor.cs
@@ -45,6 +45,7 @@ namespace PromptUGUI.Controls.Internal
         private ColorSpec _baseColor = ColorSpec.Solid(Color.white);
         private ColorSpec? _selectedBase;   // base while the source is selected (Tab/Toggle isOn); null ⇒ none
         private bool _selected;             // pushed by the owning control via SetSelected
+        private bool _ownsFill = true;      // false ⇒ fan-out reactor on a descendant: multiplier only
 
         private StateColorSet _absolutes;   // per-state ABSOLUTE base override (targetGraphic only)
         private StateColorSet _modulates;   // per-state relative MULTIPLIER (null entry = white identity)
@@ -89,9 +90,17 @@ namespace PromptUGUI.Controls.Internal
         /// current <c>color=</c> as <paramref name="authoredBase"/> and the base follows it; pass
         /// null and the first-init Peek stands.
         /// </summary>
+        /// <param name="ownsFill">
+        /// True for the control's <c>targetGraphic</c>, whose base / absolutes / selected base ARE its
+        /// fill. False for a fan-out reactor on a descendant: that graphic's fill (a child
+        /// <c>&lt;Frame color=&gt;</c>, or none at all for a hollow border Frame) belongs to its own
+        /// control and is never rewritten here — only the multiplier lands on it.
+        /// </param>
         public void Configure(StateColorSet absolutes, StateColorSet modulates, float fade,
-            ColorSpec? selectedBase = null, bool selected = false, ColorSpec? authoredBase = null)
+            ColorSpec? selectedBase = null, bool selected = false, ColorSpec? authoredBase = null,
+            bool ownsFill = true)
         {
+            _ownsFill = ownsFill;
             // The declaration wins over the pixels. Marking it captured also makes EnsureInit skip
             // its Peek on first init — the authored value is already the right answer there.
             if (authoredBase.HasValue)
@@ -228,6 +237,11 @@ namespace PromptUGUI.Controls.Internal
         /// a multiplier channel is not absolute at all — it darkens whatever is underneath, which on
         /// glass means tinting the blurred backdrop rather than the pane.</para>
         ///
+        /// <para>A fan-out reactor on a DESCENDANT panel (<c>_ownsFill</c> false) leaves the fill
+        /// alone entirely: the child's colour is the child's, and absolutes never fan out. Writing
+        /// the peeked base there painted every accent bar and hollow bracket Frame inside a
+        /// <c>&lt;Btn pressedModulate&gt;</c> opaque white.</para>
+        ///
         /// <para>So: absolutes drive the fill, modulates stay on the vertex colour. The one thing
         /// lost is the fade on an absolute change — the fill is a material parameter, and tweening it
         /// per frame would mint a material per frame through <c>ProceduralMaterialCache</c>. State
@@ -238,9 +252,11 @@ namespace PromptUGUI.Controls.Internal
         {
             if (_handle.IsActive()) _handle.TryCancel();
 
-            var basis = BaseFor(state);
-            _panel.SetFill(basis);
-            _panel.FlushParams();
+            if (_ownsFill)
+            {
+                _panel.SetFill(BaseFor(state));
+                _panel.FlushParams();
+            }
 
             var multiplier = MultiplierFor(state);
             var current = _graphic.color;

--- a/Tests/EditMode/Controls/StateFanOutPanelTests.cs
+++ b/Tests/EditMode/Controls/StateFanOutPanelTests.cs
@@ -1,0 +1,119 @@
+using NUnit.Framework;
+using PromptUGUI.Application;
+using PromptUGUI.Controls;
+using PromptUGUI.Controls.Internal;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Controls
+{
+    /// <summary>
+    /// <c>*Modulate</c> fan-out onto a PROCEDURAL descendant. The reactor installed on a child
+    /// <see cref="Frame"/>'s <see cref="ProceduralPanel"/> owns only the vertex multiplier
+    /// (<c>Graphic.color</c>); the panel's authored fill lives in its material and belongs to the
+    /// Frame. Regression: the descendant reactor wrote its fallback Peek (<c>Graphic.color</c> =
+    /// white) into the panel fill on install and on every state change, so a red accent bar and a
+    /// hollow border-only Frame inside a <c>&lt;Btn pressedModulate&gt;</c> both rendered as opaque
+    /// white slabs.
+    /// </summary>
+    public class StateFanOutPanelTests
+    {
+        private const int Normal = 0;
+        private const int Pressed = 2;
+
+        [SetUp] public void SetUp() { UI.ResetForTests(); StateTintReactor.TestForceInstant = true; }
+        [TearDown] public void TearDown() { UI.ResetForTests(); StateTintReactor.TestForceInstant = false; }
+
+        private static Btn Load(string btnAttrs, string body)
+        {
+            string xml = $@"<?xml version='1.0' encoding='utf-8'?>
+<PromptUGUI version='1'><Screen name='S'>
+  <Btn id='b' {btnAttrs}>{body}</Btn>
+</Screen></PromptUGUI>";
+            UI.LoadDocument("t", xml);
+            return UI.Open("S").Get<Btn>("b");
+        }
+
+        private static ProceduralPanel PanelOf(IControl c)
+            => ((Control)c).GameObject.GetComponent<ProceduralPanel>();
+
+        private static Color FillTop(ProceduralPanel panel)
+        {
+            panel.FlushParams();
+            return panel.materialForRendering.GetColor("_FillTop");
+        }
+
+        [Test]
+        public void DescendantFrameFill_SurvivesInstall()
+        {
+            var btn = Load("pressedModulate='#808080'", "<Frame id='f' color='#ff0000' radius='4'/>");
+            var fill = FillTop(PanelOf(btn.Get<Frame>("f")));
+            Assert.That(fill.r, Is.EqualTo(1f).Within(0.001f));
+            Assert.That(fill.g, Is.EqualTo(0f).Within(0.001f),
+                "the child's authored red was overwritten by the reactor's white fallback base");
+            Assert.That(fill.a, Is.EqualTo(1f).Within(0.001f));
+        }
+
+        [Test]
+        public void DescendantFrameFill_SurvivesStateChange_OnlyMultiplierMoves()
+        {
+            var btn = Load("pressedModulate='#808080'", "<Frame id='f' color='#ff0000' radius='4'/>");
+            var panel = PanelOf(btn.Get<Frame>("f"));
+            var pb = btn.GameObject.GetComponent<PuiButton>();
+
+            pb.SimulateState(Pressed);
+            Assert.That(FillTop(panel).g, Is.EqualTo(0f).Within(0.001f), "pressed: fill stays red");
+            Assert.That(panel.color.r, Is.EqualTo(0.5019608f).Within(0.001f),
+                "the modulate lands on the vertex colour, which the shader multiplies over the fill");
+
+            pb.SimulateState(Normal);
+            Assert.That(FillTop(panel).g, Is.EqualTo(0f).Within(0.001f), "normal: fill still red");
+            Assert.That(panel.color.r, Is.EqualTo(1f).Within(0.001f), "multiplier back to identity");
+        }
+
+        [Test]
+        public void HollowDescendantFrame_StaysHollow()
+        {
+            // A border-only Frame (no color=) is a hollow stroke: fill is Color.clear, and the
+            // fan-out reactor must not fill it white.
+            var btn = Load("pressedModulate='#808080'",
+                "<Frame id='f' radius='4' borderWidth='1' borderColor='#00ffff'/>");
+            Assert.That(FillTop(PanelOf(btn.Get<Frame>("f"))).a, Is.EqualTo(0f).Within(0.001f));
+        }
+
+        [Test]
+        public void DescendantFrame_ReSolvedColor_IsNotClobberedByStaleBase()
+        {
+            // The Frame's color= is re-applied on a ReSolve (Variant / theme); the descendant reactor
+            // must never write a base it captured earlier back over it.
+            var btn = Load("pressedModulate='#808080'",
+                "<Frame id='f' color='#ff0000' color.alt='#0000ff' radius='4'/>");
+            var panel = PanelOf(btn.Get<Frame>("f"));
+            UI.Variants.Set("alt", true);
+            var fill = FillTop(panel);
+            Assert.That(fill.b, Is.EqualTo(1f).Within(0.001f), "variant colour applied");
+            Assert.That(fill.r, Is.EqualTo(0f).Within(0.001f), "the pre-variant red must not come back");
+        }
+
+        [Test]
+        public void Peek_OnProceduralPanel_ReadsTheFill_NotGraphicColor()
+        {
+            // The reactor's fallback base for a graphic nobody authored a colour for is a Peek. On a
+            // panel Graphic.color is the multiplier (white at rest); the base has to be the FILL, or
+            // the target reactor paints white over whatever the surface painted.
+            var go = new GameObject("panel");
+            try
+            {
+                var panel = go.AddComponent<ProceduralPanel>();
+                panel.SetFill(ColorSpec.Solid(Color.red));
+                var peeked = ColorApplier.Peek(panel);
+                Assert.That(panel.color, Is.EqualTo(Color.white), "multiplier untouched");
+                Assert.That(peeked.Top.r, Is.EqualTo(1f).Within(0.001f));
+                Assert.That(peeked.Top.g, Is.EqualTo(0f).Within(0.001f), "peeked the fill, not Graphic.color");
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+    }
+}

--- a/Tests/EditMode/Controls/StateFanOutPanelTests.cs.meta
+++ b/Tests/EditMode/Controls/StateFanOutPanelTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bec618f4787b88945a21f74bb24d4e49


### PR DESCRIPTION
## 问题

`StateTintReactor.ApplyToPanel` 对**每个后代** `ProceduralPanel` 都 `SetFill(basis)`，而后代反应器的 basis 是 fallback `Peek(Graphic.color)` = 白。于是凡是带 `*Modulate` 扇出的 `<Btn>` / `<Tab>` / `<Toggle>` 里，子 `<Frame color="…">`（饰条）和无填充的描边 Frame（空心青边）全被刷成不透明白；主题重放后 `Frame.Color` 再落一次才暂时恢复，下一次 hover / press 又白回去。

在 ssw_re 的旗帜页签上撞到：选中卡整张发白、六张卡的彩色饰条全白。

## 修法

- `StateTintInstaller` 只给 `targetGraphic` 的反应器 `ownsFill: true`；后代反应器只落乘子到 `Graphic.color`，永不碰填充（absolute / selectedBase 本来就只属于控件自己的面，文档一直这么写）。
- `ColorApplier.Peek` 对 `ProceduralPanel` 读 `Fill` 而不是 `Graphic.color`——面板的颜色在材质里，`Graphic.color` 只是乘子（白）。`ProceduralPanel` 新增 `internal ColorSpec Fill`。
- `reference/states.md` 补一句：后代程序化面板保留自己的填充。

## 测试

先红后绿：新增 `Tests/EditMode/Controls/StateFanOutPanelTests.cs` 五条（安装后填充不变 / 状态切换只动乘子 / Variant 重放不被旧 base 覆盖 / 空心 Frame 保持空心 / Peek 读填充），修前 4 红。连带 StateAbsoluteColor / BtnState / ProceduralSurfaceContract / StateBaseColorReversibility / StateBornFrame / ColorApplier / CarouselDots / AttributeReversibility / FrameProceduralPanel / StyleIntegration 共 165 条回归全过；`dotnet format --verify-no-changes --severity warn` 干净。

https://claude.ai/code/session_01W1u5RGhadqdQ5Qpy1vaaw2
