### PR TITLE
fix: 程序化面让位的宿主 Image 不再被 *Modulate 扇出反应器重画

### DIFF
--- a/Runtime/Controls/Internal/StateTintInstaller.cs
+++ b/Runtime/Controls/Internal/StateTintInstaller.cs
@@ -41,11 +41,27 @@ namespace PromptUGUI.Controls.Internal
 
             var fade = StateTintReactor.DefaultFade;
             var target = selectable.targetGraphic;
+            // A procedural surface parents its panel under the host whose Image it retired
+            // (ProceduralSurface.EnsurePanel), so while the panel is the targetGraphic that host
+            // Image is the one standing down. Structural, not a flag: the surface is reconciled
+            // every pass and this has to follow it.
+            var retired = target is ProceduralPanel panel ? panel.transform.parent : null;
             StateTintReactor targetReactor = null;
             foreach (var g in root.GetComponentsInChildren<Graphic>(includeInactive: true))
             {
                 if (blocked.Contains(g.gameObject)) continue;
                 var isTarget = ReferenceEquals(g, target);
+                // The retired Image is nobody's target — not the control's (targetGraphic moved to
+                // the panel) and not a fan-out one either. Retirement zeroes Graphic.color's alpha
+                // but leaves the GradientTint a `color="A,B"` put on it intact, so a fan-out
+                // reactor's first-init Peek reads that gradient and re-applies it with
+                // Graphic.color = white: the sprite-less Image draws the tint as a hard rectangle
+                // behind the shaped surface. Same stand-down as the no-modulate branch below.
+                if (!isTarget && retired != null && g is UnityEngine.UI.Image && g.transform == retired)
+                {
+                    g.GetComponent<StateTintReactor>()?.Detach();
+                    continue;
+                }
                 // Descendants only matter for the fan-out multiplier: with no modulates, a descendant
                 // reactor would be a no-op (base × white). Skip them so we don't add idle MonoBehaviours
                 // + OnState subscriptions. The targetGraphic always installs (it carries the absolutes

--- a/Tests/EditMode/Controls/ProceduralSurfaceContractTests.cs
+++ b/Tests/EditMode/Controls/ProceduralSurfaceContractTests.cs
@@ -42,6 +42,7 @@ namespace PromptUGUI.Tests.EditMode.Controls
         // BtnStateTests.
         private const int NormalState = 0;
         private const int Highlighted = 1;
+        private const int Pressed = 2;
 
         [SetUp]
         public void SetUp()
@@ -526,6 +527,46 @@ namespace PromptUGUI.Tests.EditMode.Controls
                 + "skin's colour back as a hard rectangle behind the rounded surface");
         }
 
+        /// <summary>
+        /// The same stale-reactor shape reached WITHOUT a skin switch. A <c>*Modulate</c> makes the
+        /// installer fan a reactor out onto every descendant Graphic — and the retired Image is one.
+        /// Its first-init Peek reads the <c>GradientTint</c> that <c>color="A,B"</c> left on the Image
+        /// (retirement zeroes <c>Graphic.color</c>'s alpha, the tint's own alpha is intact), and
+        /// re-applying a gradient sets <c>Graphic.color = white</c>: the sprite-less Image draws the
+        /// tint as a hard rectangle behind the shaped surface. Straight from
+        /// <c>&lt;Tab radius=… color="A,B" pressedModulate=…&gt;</c>.
+        /// </summary>
+        [Test]
+        public void RetiredImage_IsNeverAFanOutTarget_GradientColour()
+        {
+            StateTintReactor.TestForceInstant = true;
+            var b = Load("radius='8' color='#102030,#000000' pressedModulate='#808080'");
+            var bg = b.GameObject.GetComponent<UnityImage>();
+            var btn = b.GameObject.GetComponent<PuiButton>();
+
+            Assert.AreEqual(0f, bg.color.a, 0.001f, "retired at open");
+            btn.SimulateState(Pressed);
+            Assert.AreEqual(0f, bg.color.a, 0.001f,
+                "the fan-out must not repaint the retired Image — it draws the gradient as a hard "
+                + "rectangle behind the shaped surface");
+            btn.SimulateState(NormalState);
+            Assert.AreEqual(0f, bg.color.a, 0.001f, "and not on the way back either");
+        }
+
+        /// <summary>Solid colour, same rule — the retired Image is nobody's fan-out target.</summary>
+        [Test]
+        public void RetiredImage_IsNeverAFanOutTarget_SolidColour()
+        {
+            StateTintReactor.TestForceInstant = true;
+            var b = Load("radius='8' color='#102030' pressedModulate='#808080'");
+            var bg = b.GameObject.GetComponent<UnityImage>();
+            var btn = b.GameObject.GetComponent<PuiButton>();
+
+            btn.SimulateState(Pressed);
+            Assert.AreEqual(0f, bg.color.a, 0.001f);
+            btn.SimulateState(NormalState);
+            Assert.AreEqual(0f, bg.color.a, 0.001f);
+        }
         /// <summary>…and it has to come back when the surface stands down again.</summary>
         [Test]
         public void WhenTheSurfaceStandsDown_TheImageIsDrivenAgain()


### PR DESCRIPTION
## 问题

`<Tab radius=… color="A,B" pressedModulate=…>`（ssw_re 的旗帜页签）四周露出一块**方形深色底**，把斜切 / 圆角面的轮廓框在一个矩形里。来源是 Tab 自带的那张 bg `Image`——它已经被程序化面让位（sprite 清空、alpha 归零），但仍在画。

链路：`ProceduralSurface.Retire` 只把宿主 Image 的 `Graphic.color` alpha 归零，`color="A,B"` 留在它身上的 `GradientTint` 原封不动（alpha 还在）；带 `*Modulate` 时 `StateTintInstaller` 把扇出反应器也装到这张已让位的 Image 上，它首次 `Peek` 读到的是 GradientTint 的渐变，`OnState` 再 `ColorApplier.Apply` 一次就把 `Graphic.color` 设回白（alpha 1）——无 sprite 的 Image 于是把深色渐变画成一块矩形。纯色 `color=` 不会触发（Peek 读到的是 alpha 0 的纯色），所以此前没被发现。

## 修法

`StateTintInstaller.Install`：当 `targetGraphic` 是 `ProceduralPanel` 时，它父节点上的 `Image` 就是正在让位的宿主（`ProceduralSurface.EnsurePanel` 把面板挂在宿主之下——结构约定，不是 flag），一律 `Detach` 并跳过，与现有的无 modulate stand-down 分支同一规则。

## 测试

先红后绿：`ProceduralSurfaceContractTests` 新增 `RetiredImage_IsNeverAFanOutTarget_GradientColour`（修前打开即 alpha 1.0）和 `_SolidColour`（守护），按下 / 松开前后 alpha 恒 0。连带 StateFanOutPanel / StateAbsoluteColor / BtnState / Tab / Toggle / Collapsible / Carousel / StyleIntegration 等 202 条回归全过；`dotnet format --verify-no-changes --severity warn` 干净。在 ssw_re_client 的 UIPreview 里实测六张 Tab 根 Image alpha 均为 0，方形底消失。

紧接 #122 之后的第二个扇出问题：#122 管的是后代**面板**的填充，这个管的是让位的**宿主 Image**。

https://claude.ai/code/session_01W1u5RGhadqdQ5Qpy1vaaw2
