### PR TITLE
fix: .po 提取器能看见插值洞里的 UI.Tr —— tokenizer 递归下钻 $"{...}"

### DIFF
--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -543,7 +543,12 @@ UI.Locale.SetToSystemDefault();
 
 // Strings extracted from code (these msgid land in the .po alongside XML strings)
 var text = string.Format(c, UI.Tr("Total: {0:C}"), price);
+
+// Inside an interpolation hole is fine — the extractor reads holes, so this msgid lands in the .po
+await MessageBox.Open($"{UI.Tr("Download failed:")}\n{e.Message}");
 ```
+
+**The extractor only sees `UI.Tr("...")` with a *literal* first argument.** `UI.Tr($"Hi {name}")` extracts nothing (there is no constant msgid to translate) — wrap the constant part instead: `string.Format(UI.Tr("Hi {0}"), name)`, or split the sentence across `$"{UI.Tr("...")}{value}"`. `ctx:` must be a literal too.
 
 Locale switching rides the Variant pipeline — already-open Screens auto-ReSolve. `UI.Locale.Set("zh-Hans")` internally registers `zh-Hans` as an active Variant; don't reuse that name for non-locale state.
 

--- a/Editor/I18n/CSharpStringScanner.cs
+++ b/Editor/I18n/CSharpStringScanner.cs
@@ -108,7 +108,18 @@ namespace PromptUGUI.Editor.I18n
         private static List<Tok> Tokenize(string src)
         {
             var toks = new List<Tok>();
-            var i = 0;
+            TokenizeInto(src, 0, toks, stopAtCloseBrace: false);
+            return toks;
+        }
+
+        // Appends tokens from `src` starting at `from`. With `stopAtCloseBrace`, returns
+        // at the first `}` that isn't opened inside this run — that's how an interpolation
+        // hole (`$"…{expr}…"`) delegates its expression back to the tokenizer, so `Tr(...)`
+        // calls inside a hole are ordinary tokens. Offsets stay absolute.
+        private static int TokenizeInto(string src, int from, List<Tok> toks, bool stopAtCloseBrace)
+        {
+            var i = from;
+            var braceDepth = 0;
             while (i < src.Length)
             {
                 var ch = src[i];
@@ -147,20 +158,7 @@ namespace PromptUGUI.Editor.I18n
                     if (i + 2 < src.Length && src[i + 1] == '"' && src[i + 2] == '"')
                     {
                         var start = i;
-                        var run = 0;
-                        while (i < src.Length && src[i] == '"') { run++; i++; }
-                        while (i < src.Length)
-                        {
-                            if (src[i] == '"')
-                            {
-                                var close = 0;
-                                var j = i;
-                                while (j < src.Length && src[j] == '"') { close++; j++; }
-                                if (close >= run) { i = j; break; }
-                                i = j;
-                            }
-                            else i++;
-                        }
+                        i = SkipRawString(src, i);
                         toks.Add(new Tok { Kind = TK.RawStr, Start = start });
                         continue;
                     }
@@ -260,23 +258,33 @@ namespace PromptUGUI.Editor.I18n
                         toks.Add(new Tok { Kind = TK.Other, Start = start });
                         continue;
                     }
+                    // `$"""raw"""` — skipped whole; holes there aren't scanned.
+                    if (i + 2 < src.Length && src[i + 1] == '"' && src[i + 2] == '"')
+                    {
+                        i = SkipRawString(src, i);
+                        toks.Add(new Tok { Kind = TK.RawStr, Start = start });
+                        continue;
+                    }
                     i++;
-                    var depth = 0;
+                    // The literal itself is never a msgid (holes make it non-constant),
+                    // but each hole's expression is tokenized inline right after it.
+                    toks.Add(new Tok { Kind = TK.InterpolatedStr, Start = start });
                     while (i < src.Length)
                     {
                         var c = src[i];
                         if (c == '{')
                         {
                             if (i + 1 < src.Length && src[i + 1] == '{') { i += 2; continue; }
-                            depth++; i++; continue;
+                            i = TokenizeInto(src, i + 1, toks, stopAtCloseBrace: true);
+                            if (i < src.Length && src[i] == '}') i++;
+                            continue;
                         }
                         if (c == '}')
                         {
                             if (i + 1 < src.Length && src[i + 1] == '}') { i += 2; continue; }
-                            if (depth > 0) { depth--; i++; continue; }
                             i++; continue;
                         }
-                        if (depth == 0 && c == '"')
+                        if (c == '"')
                         {
                             if (verbatim && i + 1 < src.Length && src[i + 1] == '"') { i += 2; continue; }
                             i++;
@@ -286,7 +294,6 @@ namespace PromptUGUI.Editor.I18n
                         if (!verbatim && (c == '\n' || c == '\r')) break;
                         i++;
                     }
-                    toks.Add(new Tok { Kind = TK.InterpolatedStr, Start = start });
                     continue;
                 }
 
@@ -335,8 +342,17 @@ namespace PromptUGUI.Editor.I18n
                 {
                     case '(': toks.Add(new Tok { Kind = TK.OpenParen, Start = i }); i++; break;
                     case ')': toks.Add(new Tok { Kind = TK.CloseParen, Start = i }); i++; break;
-                    case '{': toks.Add(new Tok { Kind = TK.OpenBrace, Start = i }); i++; break;
-                    case '}': toks.Add(new Tok { Kind = TK.CloseBrace, Start = i }); i++; break;
+                    case '{':
+                        braceDepth++;
+                        toks.Add(new Tok { Kind = TK.OpenBrace, Start = i });
+                        i++;
+                        break;
+                    case '}':
+                        if (stopAtCloseBrace && braceDepth == 0) return i;
+                        if (braceDepth > 0) braceDepth--;
+                        toks.Add(new Tok { Kind = TK.CloseBrace, Start = i });
+                        i++;
+                        break;
                     case '[': toks.Add(new Tok { Kind = TK.OpenBracket, Start = i }); i++; break;
                     case ']': toks.Add(new Tok { Kind = TK.CloseBracket, Start = i }); i++; break;
                     case ';': toks.Add(new Tok { Kind = TK.Semi, Start = i }); i++; break;
@@ -361,7 +377,28 @@ namespace PromptUGUI.Editor.I18n
                         break;
                 }
             }
-            return toks;
+            return i;
+        }
+
+        // `i` points at the first quote of a `"""…"""` run; returns the index just past
+        // the closing run (a run of at least as many quotes as the opener).
+        private static int SkipRawString(string src, int i)
+        {
+            var run = 0;
+            while (i < src.Length && src[i] == '"') { run++; i++; }
+            while (i < src.Length)
+            {
+                if (src[i] == '"')
+                {
+                    var close = 0;
+                    var j = i;
+                    while (j < src.Length && src[j] == '"') { close++; j++; }
+                    if (close >= run) return j;
+                    i = j;
+                }
+                else i++;
+            }
+            return i;
         }
 
         private static int NextSig(List<Tok> toks, int from)

--- a/Tests/EditMode/Editor/CSharpStringScannerTests.cs
+++ b/Tests/EditMode/Editor/CSharpStringScannerTests.cs
@@ -120,6 +120,72 @@ namespace PromptUGUI.Tests.Editor
         }
 
         [Test]
+        public void Scan_TrInsideInterpolationHole_Extracted()
+        {
+            var src = @"
+                class X {
+                    void R(System.Exception e) {
+                        var s = $""{UI.Tr(""下载星图失败:"")}\n{e.Message}"";
+                    }
+                }";
+            var es = CSharpStringScanner.Scan(src, "X.cs").Single();
+            Assert.AreEqual("下载星图失败:", es.Msgid);
+            Assert.IsTrue(es.ExtractedComments.Any(c => c.Contains("R")));
+        }
+
+        [Test]
+        public void Scan_TwoTrCallsInOneInterpolatedString_BothExtracted()
+        {
+            var src = "class X { void R(int n) { var s = $\"{UI.Tr(\"a\")} {n} {UI.Tr(\"b\", ctx: \"c\")}\"; } }";
+            var found = CSharpStringScanner.Scan(src, "X.cs").ToList();
+            CollectionAssert.AreEquivalent(new[] { "a", "b" }, found.Select(e => e.Msgid).ToList());
+            Assert.AreEqual("c", found.Single(e => e.Msgid == "b").Msgctxt);
+        }
+
+        [Test]
+        public void Scan_TrInHoleOfVerbatimInterpolatedString_Extracted()
+        {
+            var src = "class X { void R() { var s = $@\"[{UI.Tr(\"x\")}]\"; } }";
+            var es = CSharpStringScanner.Scan(src, "X.cs").Single();
+            Assert.AreEqual("x", es.Msgid);
+        }
+
+        [Test]
+        public void Scan_TrInNestedInterpolationHole_Extracted()
+        {
+            var src = "class X { void R(int n) { var s = $\"{(n > 0 ? $\"{UI.Tr(\"inner\")}\" : \"\")}\"; } }";
+            var found = CSharpStringScanner.Scan(src, "X.cs").ToList();
+            Assert.AreEqual(1, found.Count);
+            Assert.AreEqual("inner", found[0].Msgid);
+        }
+
+        [Test]
+        public void Scan_BraceInsideHoleStringLiteral_DoesNotEndHoleEarly()
+        {
+            var src = "class X { void R() { var s = $\"{UI.Tr(\"a}b\")}\"; var t = UI.Tr(\"after\"); } }";
+            var found = CSharpStringScanner.Scan(src, "X.cs").ToList();
+            CollectionAssert.AreEquivalent(new[] { "a}b", "after" }, found.Select(e => e.Msgid).ToList());
+        }
+
+        [Test]
+        public void Scan_EscapedBracesInInterpolatedString_NotTreatedAsHole()
+        {
+            var src = "class X { void R() { var s = $\"{{ not a hole }}\"; var t = UI.Tr(\"after\"); } }";
+            var found = CSharpStringScanner.Scan(src, "X.cs").ToList();
+            Assert.AreEqual(1, found.Count);
+            Assert.AreEqual("after", found[0].Msgid);
+        }
+
+        [Test]
+        public void Scan_FormatSpecifierInHole_NotExtracted()
+        {
+            var src = "class X { void R(float v) { var s = $\"{v:F2} {UI.Tr(\"unit\")}\"; } }";
+            var found = CSharpStringScanner.Scan(src, "X.cs").ToList();
+            Assert.AreEqual(1, found.Count);
+            Assert.AreEqual("unit", found[0].Msgid);
+        }
+
+        [Test]
         public void Scan_StringContainingDoubleSlash_NotTreatedAsComment()
         {
             var src = "class X { void R() { var fake = \"// not a comment\"; var s = UI.Tr(\"real\"); } }";


### PR DESCRIPTION
## 症状

```csharp
await MessageBox.Open($"{UI.Tr("下载星图失败:")}\n{e.Message}");
```

这条里的 `下载星图失败:` 提不进 `.po`。

## 根因

不在提取规则，在 tokenizer。`CSharpStringScanner` 把整个 `$"..."` 吞成一个不可穿透的 `TK.InterpolatedStr` token，插值洞 `{...}` 里的内容从来没进过扫描流 —— 洞里的 `UI.Tr(...)` 对提取器完全不可见。

## 改法

`Tokenize` 拆成可重入的 `TokenizeInto(src, from, toks, stopAtCloseBrace)`。遇到插值洞就递归回 tokenizer 自己，一路 token 化到那个**未配对的 `}`** 为止，产出的 token 直接拼进同一条流。洞里的 `UI.Tr("…")` 于是就是普通的 `Ident ( StringLit )` 序列 —— 匹配逻辑、`ctx:` 解析、`in Method()` 注释、前导 `//` 注释全部沿用原有实现，一字未改。

附带好处：

- **偏移保持绝对**，`.po` 的 `#: file:line` 引用行号照常。
- 洞的边界由 tokenizer 自己定，所以洞内的嵌套字符串、字符字面量、lambda 的 `{}`、注释、嵌套 `$"{...}"` 都不会把洞提前截断 —— `$"{UI.Tr("a}b")}"` 里那个 `}` 不再断句。
- `{{` / `}}` 转义、`$@""` 逐字插值、`{v:F2}` 格式说明符正确略过。
- 顺带修 `$"""raw"""`：以前会在第二个引号处被错误截断，导致其后源码整段错位解析；现在整体跳过（`SkipRawString` 提成共用 helper）。

## 仍旧不支持（也不该支持）

`UI.Tr($"Hi {name}")` —— 没有常量 msgid，gettext 无从对应，照旧跳过。该边界连同本次新支持的写法一起写进了 `scripting-promptugui-csharp` skill 的 i18n 段。

## 测试

新增 7 个用例：本 issue 原样写法、双洞带 `ctx:`、`$@""` 逐字插值、嵌套插值、洞内字符串含 `}`、`{{` 转义、格式说明符。旧用例（含 `Scan_InterpolatedString_Skipped`）全部保留不变。

- **EditorOnly 324/324 通过**
- 另在 Unity 外用独立 harness 单编译 `CSharpStringScanner` 跑了 20 个用例（含全部旧行为回归）全绿
- `dotnet format --verify-no-changes --severity warn` 干净

https://claude.ai/code/session_01PM96Cadc1beYCXr5B7Cb9q
