### PR TITLE
fix: HDR 显示输出 + 后处理下 glass 不再发白 —— 降采样 blit 乘回显示色域/纸白的逆矩阵

### DIFF
--- a/.claude/skills/authoring-promptugui-xml/reference/glass.md
+++ b/.claude/skills/authoring-promptugui-xml/reference/glass.md
@@ -59,7 +59,10 @@ starts reading as a coloured panel with a blur behind it.
 
 The backdrop is **the capture camera's finished image**: the game world plus every Screen
 Space-Camera canvas on that camera. It is captured after post-processing, so glass shows the graded
-picture the player sees.
+picture the player sees. That holds on an HDR display too (URP HDR Output): URP hands the
+post-processed picture over already converted for the display — its gamut, its paper-white nits —
+and the capture converts it back into the space overlay UI is composited in, so the glass matches
+the scene behind it instead of turning into a white slab. Nothing to configure.
 
 **Overlay canvases are not in it.** uGUI has no grab pass, so a glass panel can never see its own
 siblings on the same Overlay canvas.

--- a/Runtime/Application/Glass/GlassBackdropDecode.cs
+++ b/Runtime/Application/Glass/GlassBackdropDecode.cs
@@ -1,0 +1,93 @@
+using UnityEngine;
+
+namespace PromptUGUI.Application.Glass
+{
+    /// <summary>
+    /// The colour transform the capture applies while downsampling, so that what a glass panel
+    /// samples sits in the space its own pixels are composited in.
+    ///
+    /// <para>On an SDR display that is the identity: the captured image is linear Rec709 and so is
+    /// the overlay UI. On an HDR display (URP's HDR Output) it is not. With post-processing on, URP
+    /// hands the capture over already prepared for the display — its colour-grading LUT rotates the
+    /// graded picture into the display's gamut and scales it to nits by the paper-white brightness
+    /// (<c>LutBuilderHdr.shader</c>: <c>RotateRec709ToOutputSpace × PaperWhite</c>; the PQ / scRGB
+    /// encoding itself waits for the final blit, which is why the capture can read the buffer at
+    /// all). The overlay UI, meanwhile, is drawn into an 8-bit off-screen target and composited
+    /// afterwards as SDR content: <c>SceneUIComposition</c> applies that same rotation and scale to
+    /// every UI pixel. A glass panel that samples the display-ready picture and outputs it as UI
+    /// therefore goes through the transform twice — a 1 % grey in the scene, 3 nits at a 300-nit
+    /// paper white, lands in the UI target as 3.0 and clips to white — and every panel turns into a
+    /// white slab with a faint tint wherever some channel stayed under 1/300. Undoing the transform
+    /// once here — inverse gamut rotation, then divide by paper white — puts the sample back where a
+    /// UI pixel is expected to be, and the composite then treats the glass exactly like the scene
+    /// behind it.</para>
+    ///
+    /// <para>Without post-processing there is nothing to undo: URP leaves the captured image as the
+    /// raw linear scene and converts scene and UI alike in the final blit
+    /// (<c>BlitHDROverlay.shader</c>).</para>
+    ///
+    /// <para>Pure C# on purpose — the URP half (<c>GlassBackdropSystem</c>) only supplies the four
+    /// inputs, so the matrix can be checked against URP's forward constants without an HDR
+    /// display.</para>
+    /// </summary>
+    internal static class GlassBackdropDecode
+    {
+        /// <summary>
+        /// Below this the paper white is not a brightness any more; URP's own output has already
+        /// gone to NaN by then, but the capture must not add to it.
+        /// </summary>
+        private const float MinPaperWhiteNits = 1e-3f;
+
+        // Inverses of the Rec709 → output-space rotations URP applies (core's HDROutput.hlsl and
+        // ColorSpaceUtils.cs; the P3 inverse is not spelled out there and was derived from its
+        // forward matrix). Row-major as written, like the HLSL.
+        private static readonly Matrix4x4 Rec2020ToRec709 = Rows(
+            1.660496f, -0.587656f, -0.072840f,
+            -0.124547f, 1.132895f, -0.008348f,
+            -0.018154f, -0.100597f, 1.118751f);
+
+        private static readonly Matrix4x4 P3D65ToRec709 = Rows(
+            1.224940f, -0.224940f, 0.000000f,
+            -0.042057f, 1.042057f, 0.000000f,
+            -0.019638f, -0.078635f, 1.098274f);
+
+        /// <summary>
+        /// The matrix to multiply every captured colour by. Identity unless
+        /// <paramref name="hdrOutputActive"/> and <paramref name="postProcessed"/> both hold for the
+        /// capture camera — the same two conditions under which URP's LUT pass converts for the
+        /// display.
+        /// </summary>
+        internal static Matrix4x4 For(bool hdrOutputActive, bool postProcessed,
+                                      ColorGamut displayGamut, float paperWhiteNits)
+        {
+            if (!hdrOutputActive || !postProcessed) return Matrix4x4.identity;
+
+            // A gamut URP cannot classify gets none of its conversions either
+            // (HDROutputUtils.GetColorSpaceForGamut bails out), so there is nothing to undo.
+            if (ColorGamutUtility.GetWhitePoint(displayGamut) != WhitePoint.D65) return Matrix4x4.identity;
+            Matrix4x4 rotate;
+            switch (ColorGamutUtility.GetColorPrimaries(displayGamut))
+            {
+                case ColorPrimaries.Rec709: rotate = Matrix4x4.identity; break;
+                case ColorPrimaries.Rec2020: rotate = Rec2020ToRec709; break;
+                case ColorPrimaries.P3: rotate = P3D65ToRec709; break;
+                default: return Matrix4x4.identity;
+            }
+
+            var scale = 1f / Mathf.Max(paperWhiteNits, MinPaperWhiteNits);
+            return Matrix4x4.Scale(new Vector3(scale, scale, scale)) * rotate;
+        }
+
+        private static Matrix4x4 Rows(
+            float m00, float m01, float m02,
+            float m10, float m11, float m12,
+            float m20, float m21, float m22)
+        {
+            var m = Matrix4x4.identity;
+            m.m00 = m00; m.m01 = m01; m.m02 = m02;
+            m.m10 = m10; m.m11 = m11; m.m12 = m12;
+            m.m20 = m20; m.m21 = m21; m.m22 = m22;
+            return m;
+        }
+    }
+}

--- a/Runtime/Application/Glass/GlassBackdropDecode.cs.meta
+++ b/Runtime/Application/Glass/GlassBackdropDecode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0eaad020f474b6d49ac72beb79255f26

--- a/Runtime/Application/Glass/GlassBackdropSystem.cs
+++ b/Runtime/Application/Glass/GlassBackdropSystem.cs
@@ -22,6 +22,13 @@ namespace PromptUGUI.Application.Glass
     ///
     /// <para><b>One capture serves every panel.</b> The cost is a fixed six blits at quarter
     /// resolution regardless of how many glass panels are on screen.</para>
+    ///
+    /// <para><b>HDR displays need one extra matrix.</b> Under URP's HDR Output the post-processed
+    /// picture is already rotated into the display's gamut and scaled to paper-white nits, and the
+    /// overlay UI is put through that same transform again at compositing. The downsample blit
+    /// multiplies by the inverse (<see cref="GlassBackdropDecode"/>) so a glass panel reads as the
+    /// scene behind it rather than as a white slab. On an SDR display the matrix is the
+    /// identity.</para>
     /// </summary>
     internal static class GlassBackdropSystem
     {
@@ -29,8 +36,17 @@ namespace PromptUGUI.Application.Glass
         private static readonly int BackdropAId = Shader.PropertyToID("_PUGUI_GlassBackdropA");
         private static readonly int BackdropBId = Shader.PropertyToID("_PUGUI_GlassBackdropB");
         private static readonly int BlurOffsetId = Shader.PropertyToID("_BlurOffset");
+        private static readonly int DecodeId = Shader.PropertyToID("_BackdropDecode");
 
         private const string BlurShaderPath = "PromptUGUI/Material/UI-GlassBlur";
+
+        // UI-GlassBlur.shader: pass 0 is the bare Kawase kernel, pass 1 the same kernel followed by
+        // the _BackdropDecode colour matrix. Only the downsample runs the matrix — it is the one
+        // blit that reads the camera's picture, and the matrix is what puts an HDR display's
+        // display-ready picture back into the space the overlay UI is composited in
+        // (GlassBackdropDecode has the whole story). On an SDR display it is the identity.
+        private const int BlurPass = 0;
+        private const int DownsampleDecodePass = 1;
 
         /// <summary>
         /// Capture resolution divisor. A quarter on each axis is 1/16th the fragments — this is
@@ -81,6 +97,10 @@ namespace PromptUGUI.Application.Glass
         private static Material _downsampleMat;
         private static Material[] _lightMats;
         private static Material[] _heavyMats;
+        // What _downsampleMat currently carries as _BackdropDecode; re-derived every frame so a
+        // display switching HDR on or off, or a Tonemapping override changing paper white, takes
+        // effect at once. Only pushed to the material when it actually changes.
+        private static Matrix4x4 _decode = Matrix4x4.identity;
 
         private static bool _warnedNoCamera;
         private static bool _warnedNotUniversal;
@@ -213,6 +233,9 @@ namespace PromptUGUI.Application.Glass
                 _downsampleMat = NewMaterial(shader);
                 _lightMats = NewMaterials(shader, LightBlurTaps.Length);
                 _heavyMats = NewMaterials(shader, HeavyBlurTaps.Length);
+                // A matrix uniform nobody has set is not the identity; start from one explicitly.
+                _decode = Matrix4x4.identity;
+                _downsampleMat.SetMatrix(DecodeId, _decode);
             }
 
             var width = Mathf.Max(1, camera.pixelWidth / Downsample);
@@ -266,6 +289,47 @@ namespace PromptUGUI.Application.Glass
         private static void SetOffsets(Material[] mats, float[] taps, int sourceWidth, int sourceHeight)
         {
             for (var i = 0; i < mats.Length; i++) SetOffset(mats[i], taps[i], sourceWidth, sourceHeight);
+        }
+
+        /// <summary>
+        /// The colour matrix this frame's downsample has to apply. The two gates mirror the ones
+        /// URP's own LUT pass converts for the display under (<c>ColorGradingLutPass</c>:
+        /// <c>isHDROutputActive</c>, and post-processing on for this camera) — the capture reads
+        /// what that pass, through Uber, left in the colour buffer, so it must undo exactly what
+        /// was applied and nothing else. On an SDR display, or with post-processing off, that is
+        /// nothing.
+        /// </summary>
+        private static Matrix4x4 DecodeFor(UniversalCameraData cameraData)
+        {
+            var overrideForTests = GlassRuntime.BackdropDecodeOverrideForTests;
+            if (overrideForTests.HasValue) return overrideForTests.Value;
+
+            var hdrOutput = cameraData.isHDROutputActive;
+            var postProcessed = cameraData.postProcessEnabled;
+            if (!hdrOutput || !postProcessed) return Matrix4x4.identity;
+
+            return GlassBackdropDecode.For(hdrOutput, postProcessed,
+                                           cameraData.hdrDisplayColorGamut, PaperWhiteNits(cameraData));
+        }
+
+        /// <summary>
+        /// The paper white URP scales both the graded scene and the overlay UI by — mirrors its
+        /// internal <c>GetHDROutputLuminanceParameters</c>: the Tonemapping override's value
+        /// (300 nits by default) unless it asks for the display's own. Read from the volume stack
+        /// URP has already evaluated for this camera, the same one the post-processing pass reads.
+        /// </summary>
+        private static float PaperWhiteNits(UniversalCameraData cameraData)
+        {
+            var tonemapping = VolumeManager.instance.stack?.GetComponent<Tonemapping>();
+            if (tonemapping != null && !tonemapping.detectPaperWhite.value) return tonemapping.paperWhite.value;
+            return cameraData.hdrDisplayInformation.paperWhiteNits;
+        }
+
+        private static void ApplyDecode(Matrix4x4 decode)
+        {
+            if (decode == _decode) return;
+            _decode = decode;
+            _downsampleMat.SetMatrix(DecodeId, decode);
         }
 
         private static void ReleaseTargets()
@@ -345,6 +409,8 @@ namespace PromptUGUI.Application.Glass
                 var source = resources.activeColorTexture;
                 if (!source.IsValid()) return;
 
+                ApplyDecode(DecodeFor(frameData.Get<UniversalCameraData>()));
+
                 var light = renderGraph.ImportTexture(_light);
                 var heavy = renderGraph.ImportTexture(_heavy);
                 var scratch = renderGraph.ImportTexture(_scratch);
@@ -353,7 +419,8 @@ namespace PromptUGUI.Application.Glass
                 // between — so the downsample lands wherever leaves A's last pass writing A.
                 var afterDownsample = LightBlurTaps.Length % 2 == 0 ? light : scratch;
                 renderGraph.AddBlitPass(
-                    new RenderGraphUtils.BlitMaterialParameters(source, afterDownsample, _downsampleMat, 0),
+                    new RenderGraphUtils.BlitMaterialParameters(source, afterDownsample, _downsampleMat,
+                                                                DownsampleDecodePass),
                     "PromptUGUI Glass Downsample");
                 Chain(renderGraph, _lightMats, afterDownsample, light, scratch, "PromptUGUI Glass Blur A");
                 Chain(renderGraph, _heavyMats, light, heavy, scratch, "PromptUGUI Glass Blur B");
@@ -374,7 +441,7 @@ namespace PromptUGUI.Application.Glass
                 {
                     var dst = (mats.Length - 1 - i) % 2 == 0 ? final : spare;
                     renderGraph.AddBlitPass(
-                        new RenderGraphUtils.BlitMaterialParameters(src, dst, mats[i], 0), name);
+                        new RenderGraphUtils.BlitMaterialParameters(src, dst, mats[i], BlurPass), name);
                     src = dst;
                 }
             }

--- a/Runtime/Application/Glass/GlassRuntime.cs
+++ b/Runtime/Application/Glass/GlassRuntime.cs
@@ -65,6 +65,14 @@ namespace PromptUGUI.Application
         /// </summary>
         internal static bool RenderOutsidePlayModeForTests { get; set; }
 
+        /// <summary>
+        /// Replaces the colour transform the capture applies while downsampling (see
+        /// <c>GlassBackdropDecode</c>). Only the render tests set this: the real transform is
+        /// derived from the HDR display state, which no test can switch on, so they substitute a
+        /// matrix of their own to prove the capture actually applies one.
+        /// </summary>
+        internal static Matrix4x4? BackdropDecodeOverrideForTests { get; set; }
+
         internal static void PanelActivated()
         {
             _activePanels++;
@@ -168,6 +176,7 @@ namespace PromptUGUI.Application
             _enabled = true;
             Camera = null;
             RenderOutsidePlayModeForTests = false;
+            BackdropDecodeOverrideForTests = null;
             SyncCapture();
             _backdropAvailable = false;
             _lastPublishFrame = int.MinValue;

--- a/Runtime/Resources/PromptUGUI/Material/UI-GlassBlur.shader
+++ b/Runtime/Resources/PromptUGUI/Material/UI-GlassBlur.shader
@@ -4,6 +4,13 @@
 // 相邻 tap —— 降采样偏移 1 个源纹素恰好拼成 4×4 box，同分辨率的 pass 用半纹素偏移让每个
 // tap 落在纹素角上。偏移一大，四个 tap 就不再是模糊而是四份复制。
 //
+// 两个 pass 同一个核：pass 0 是纯模糊，同分辨率各档都用它；pass 1 只给降采样那一次 blit，
+// 在核之后多乘一个 3×3 颜色矩阵 _BackdropDecode。HDR 显示输出下 URP 的后处理交出来的是
+// 已按显示器色域旋转、按纸白亮度放大到 nit 的画面，而 overlay UI 合成时会对 UI 像素再做
+// 一遍同样的变换 —— 玻璃采样到的图必须先逆回去（矩阵由 GlassBackdropDecode 推导，SDR 下是
+// 单位阵）。矩阵与平均都是线性的，所以乘在四个 tap 平均之后：每个输出纹素一次 mul，
+// 四分之一分辨率，可以忽略。
+//
 // 刻意写成不含任何 URP / SRP 头文件的纯 CG：这个 shader 躺在 Runtime/Resources 里，会被
 // 每一个装了本包的工程导入。一旦 #include "Packages/com.unity.render-pipelines.core/..."，
 // 没装 URP 的工程一打开就是一条 shader 编译错误。全屏三角形的顶点数学在这里内联展开，
@@ -15,63 +22,93 @@ Shader "Hidden/PromptUGUI/GlassBlur"
         Tags { "RenderType"="Opaque" }
         Cull Off ZWrite Off ZTest Always Blend Off
 
+        CGINCLUDE
+        #include "UnityCG.cginc"
+
+        // RenderGraphUtils.AddBlitPass 用这两个名字绑定源纹理与缩放偏移（默认属性 ID）。
+        sampler2D _BlitTexture;
+        float4 _BlitScaleBias;
+
+        // 采样偏移，单位是「源纹理 UV」，由 C# 按两端分辨率算好 —— 依赖
+        // _BlitTexture_TexelSize 会踩自动填充的坑（RenderGraph 绑的纹理不保证填）。
+        float4 _BlurOffset;
+
+        // 降采样专用（pass 1）：采样结果左乘的颜色矩阵，只用左上 3×3。
+        float4x4 _BackdropDecode;
+
+        struct Attributes
+        {
+            uint vertexID : SV_VertexID;
+            UNITY_VERTEX_INPUT_INSTANCE_ID
+        };
+
+        struct Varyings
+        {
+            float4 positionCS : SV_POSITION;
+            float2 uv         : TEXCOORD0;
+            UNITY_VERTEX_OUTPUT_STEREO
+        };
+
+        Varyings Vert(Attributes input)
+        {
+            Varyings o;
+            UNITY_SETUP_INSTANCE_ID(input);
+            UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+            // 全屏三角形：顶点 0/1/2 → (0,0) (2,0) (0,2)，覆盖整个 NDC 且无对角线接缝。
+            float2 uv = float2((input.vertexID << 1) & 2, input.vertexID & 2);
+            o.positionCS = float4(uv * 2.0 - 1.0, UNITY_NEAR_CLIP_VALUE, 1.0);
+
+            #if UNITY_UV_STARTS_AT_TOP
+            uv.y = 1.0 - uv.y;
+            #endif
+            o.uv = uv * _BlitScaleBias.xy + _BlitScaleBias.zw;
+            return o;
+        }
+
+        half4 Kawase(float2 uv)
+        {
+            float2 o = _BlurOffset.xy;
+            half4 c  = tex2D(_BlitTexture, uv + float2(-o.x, -o.y));
+            c += tex2D(_BlitTexture, uv + float2(o.x, -o.y));
+            c += tex2D(_BlitTexture, uv + float2(-o.x, o.y));
+            c += tex2D(_BlitTexture, uv + float2(o.x, o.y));
+            return c * 0.25;
+        }
+
+        half4 FragBlur(Varyings i) : SV_Target
+        {
+            return Kawase(i.uv);
+        }
+
+        half4 FragDownsampleDecode(Varyings i) : SV_Target
+        {
+            half4 c = Kawase(i.uv);
+            // 色域逆旋转会把显示器色域里、Rec709 之外的颜色变成负分量。UI 目标是 UNORM，
+            // 到那里终归会被截成 0；在这里截掉，后面的模糊与玻璃的亮度/饱和度运算就不会
+            // 看到负值。>1 的高光保留 —— 模糊靠它们散开。
+            c.rgb = max(mul((float3x3)_BackdropDecode, c.rgb), 0.0);
+            return c;
+        }
+        ENDCG
+
         Pass
         {
             Name "KawaseBlur"
             CGPROGRAM
             #pragma vertex Vert
-            #pragma fragment Frag
+            #pragma fragment FragBlur
             #pragma target 3.0
+            ENDCG
+        }
 
-            #include "UnityCG.cginc"
-
-            // RenderGraphUtils.AddBlitPass 用这两个名字绑定源纹理与缩放偏移（默认属性 ID）。
-            sampler2D _BlitTexture;
-            float4 _BlitScaleBias;
-
-            // 采样偏移，单位是「源纹理 UV」，由 C# 按两端分辨率算好 —— 依赖
-            // _BlitTexture_TexelSize 会踩自动填充的坑（RenderGraph 绑的纹理不保证填）。
-            float4 _BlurOffset;
-
-            struct Attributes
-            {
-                uint vertexID : SV_VertexID;
-                UNITY_VERTEX_INPUT_INSTANCE_ID
-            };
-
-            struct Varyings
-            {
-                float4 positionCS : SV_POSITION;
-                float2 uv         : TEXCOORD0;
-                UNITY_VERTEX_OUTPUT_STEREO
-            };
-
-            Varyings Vert(Attributes input)
-            {
-                Varyings o;
-                UNITY_SETUP_INSTANCE_ID(input);
-                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-
-                // 全屏三角形：顶点 0/1/2 → (0,0) (2,0) (0,2)，覆盖整个 NDC 且无对角线接缝。
-                float2 uv = float2((input.vertexID << 1) & 2, input.vertexID & 2);
-                o.positionCS = float4(uv * 2.0 - 1.0, UNITY_NEAR_CLIP_VALUE, 1.0);
-
-                #if UNITY_UV_STARTS_AT_TOP
-                uv.y = 1.0 - uv.y;
-                #endif
-                o.uv = uv * _BlitScaleBias.xy + _BlitScaleBias.zw;
-                return o;
-            }
-
-            half4 Frag(Varyings i) : SV_Target
-            {
-                float2 o = _BlurOffset.xy;
-                half4 c  = tex2D(_BlitTexture, i.uv + float2(-o.x, -o.y));
-                c += tex2D(_BlitTexture, i.uv + float2(o.x, -o.y));
-                c += tex2D(_BlitTexture, i.uv + float2(-o.x, o.y));
-                c += tex2D(_BlitTexture, i.uv + float2(o.x, o.y));
-                return c * 0.25;
-            }
+        Pass
+        {
+            Name "KawaseDownsampleDecode"
+            CGPROGRAM
+            #pragma vertex Vert
+            #pragma fragment FragDownsampleDecode
+            #pragma target 3.0
             ENDCG
         }
     }

--- a/Tests/EditMode/Application/GlassBackdropDecodeTests.cs
+++ b/Tests/EditMode/Application/GlassBackdropDecodeTests.cs
@@ -1,0 +1,120 @@
+using NUnit.Framework;
+using PromptUGUI.Application.Glass;
+using UnityEngine;
+
+namespace PromptUGUI.Tests.EditMode.Application
+{
+    /// <summary>
+    /// On an HDR display URP's post-processing hands the glass capture over already prepared for
+    /// the display — rotated into its gamut and scaled to nits by the paper-white brightness —
+    /// while the overlay UI the glass panel draws into gets that same treatment later, during
+    /// compositing. Sampled as-is, the picture is transformed twice and every panel turns into a
+    /// white slab. The capture undoes the transform once with one matrix; this is the matrix.
+    ///
+    /// No test can turn an HDR display on, so the forward transform is reproduced here from URP's
+    /// own constants (HDROutput.hlsl / ColorSpaceUtils.cs) and the decode has to be its inverse.
+    /// </summary>
+    public class GlassBackdropDecodeTests
+    {
+        private static readonly Matrix4x4 Rec709ToRec2020 = Rows(
+            0.627402f, 0.329292f, 0.043306f,
+            0.069095f, 0.919544f, 0.011360f,
+            0.016394f, 0.088028f, 0.895578f);
+
+        private static readonly Matrix4x4 Rec709ToP3D65 = Rows(
+            0.822462f, 0.177538f, 0.000000f,
+            0.033194f, 0.966806f, 0.000000f,
+            0.017083f, 0.072397f, 0.910520f);
+
+        private static readonly Vector3[] Colors =
+        {
+            new(1f, 1f, 1f),
+            new(1f, 0f, 0f),
+            new(0f, 0f, 1f),
+            new(0.85f, 0.42f, 0.10f),
+            new(0.02f, 0.03f, 0.10f),
+        };
+
+        private static Matrix4x4 Rows(
+            float m00, float m01, float m02,
+            float m10, float m11, float m12,
+            float m20, float m21, float m22)
+        {
+            var m = Matrix4x4.identity;
+            m.m00 = m00; m.m01 = m01; m.m02 = m02;
+            m.m10 = m10; m.m11 = m11; m.m12 = m12;
+            m.m20 = m20; m.m21 = m21; m.m22 = m22;
+            return m;
+        }
+
+        /// <summary>What LutBuilderHdr / UberPost leave in the camera colour buffer on an HDR display.</summary>
+        private static Vector3 AsUrpLeavesIt(Vector3 rec709, Matrix4x4 toOutputSpace, float paperWhite)
+            => toOutputSpace.MultiplyVector(rec709) * paperWhite;
+
+        private static void AssertRoundTrips(Matrix4x4 decode, Matrix4x4 toOutputSpace, float paperWhite)
+        {
+            foreach (var c in Colors)
+            {
+                var back = decode.MultiplyVector(AsUrpLeavesIt(c, toOutputSpace, paperWhite));
+                Assert.AreEqual(c.x, back.x, 1e-3f, $"red of {c} came back as {back}");
+                Assert.AreEqual(c.y, back.y, 1e-3f, $"green of {c} came back as {back}");
+                Assert.AreEqual(c.z, back.z, 1e-3f, $"blue of {c} came back as {back}");
+            }
+        }
+
+        private static void AssertIdentity(Matrix4x4 m, string why)
+            => Assert.IsTrue(m == Matrix4x4.identity, $"{why}, got\n{m}");
+
+        [Test]
+        public void SdrDisplay_IsIdentity()
+        {
+            AssertIdentity(GlassBackdropDecode.For(hdrOutputActive: false, postProcessed: true,
+                                                   ColorGamut.HDR10, paperWhiteNits: 300f),
+                "on an SDR display the capture is already in the space the UI is drawn in");
+        }
+
+        [Test]
+        public void HdrDisplay_WithoutPostProcessing_IsIdentity()
+        {
+            // Without post-processing URP leaves the captured image untouched and converts scene
+            // and UI alike in the final blit — nothing to undo.
+            AssertIdentity(GlassBackdropDecode.For(hdrOutputActive: true, postProcessed: false,
+                                                   ColorGamut.HDR10, paperWhiteNits: 300f),
+                "without post-processing the capture is still the raw linear scene");
+        }
+
+        [Test]
+        public void HdrDisplay_Rec709_DividesByPaperWhite()
+        {
+            // scRGB (16-bit) output keeps Rec709 primaries: the only thing to undo is the scale.
+            var decode = GlassBackdropDecode.For(true, true, ColorGamut.Rec709, 200f);
+            AssertRoundTrips(decode, Matrix4x4.identity, 200f);
+        }
+
+        [Test]
+        public void HdrDisplay_Rec2020_RotatesBackAndDividesByPaperWhite()
+        {
+            // HDR10 (10-bit PQ) output: URP grades into Rec2020 and scales by paper white.
+            var decode = GlassBackdropDecode.For(true, true, ColorGamut.HDR10, 160f);
+            AssertRoundTrips(decode, Rec709ToRec2020, 160f);
+        }
+
+        [Test]
+        public void HdrDisplay_P3_RotatesBackAndDividesByPaperWhite()
+        {
+            var decode = GlassBackdropDecode.For(true, true, ColorGamut.DisplayP3, 300f);
+            AssertRoundTrips(decode, Rec709ToP3D65, 300f);
+        }
+
+        [Test]
+        public void ZeroPaperWhite_StaysFinite()
+        {
+            // The Tonemapping override's paper white can be dragged to 0. URP's own output is
+            // broken at that point; the capture must not add NaNs to it.
+            var decode = GlassBackdropDecode.For(true, true, ColorGamut.HDR10, 0f);
+            for (var i = 0; i < 16; i++)
+                Assert.IsFalse(float.IsNaN(decode[i]) || float.IsInfinity(decode[i]),
+                    $"element {i} is {decode[i]}");
+        }
+    }
+}

--- a/Tests/EditMode/Application/GlassBackdropDecodeTests.cs.meta
+++ b/Tests/EditMode/Application/GlassBackdropDecodeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e443f1920d8510144a1c1e1cabe7e559

--- a/Tests/EditMode/Controls/GlassRenderTests.cs
+++ b/Tests/EditMode/Controls/GlassRenderTests.cs
@@ -650,5 +650,42 @@ namespace PromptUGUI.Tests.EditMode.Controls
                 Object.DestroyImmediate(square);
             }
         }
+
+        // ---- HDR display decode -----------------------------------------------------------------
+        //
+        // On an HDR display URP hands the capture over already prepared for the display — rotated
+        // into its gamut and scaled to paper-white nits — and the overlay UI the glass draws into
+        // gets that same treatment again at compositing. The capture undoes it once with a matrix
+        // on the downsample blit. GlassBackdropDecodeTests derive the matrix; this proves the blit
+        // applies whatever matrix it is given, which no HDR-less test rig can otherwise observe.
+
+        [Test]
+        public void BackdropDecode_IsAppliedToTheCapture()
+        {
+            // The capture camera moved back past its own far plane photographs nothing but its
+            // flat orange background — a picture whose every channel is known exactly.
+            _capture.transform.position = new Vector3(0f, 0f, -_capture.farClipPlane - 100f);
+            Open(string.Format(FlatGlass, "0"));
+
+            var plain = RenderAndSample().linear;
+            Assert.IsTrue(UI.Glass.IsActive, "the URP capture pass must have published a backdrop");
+            Assert.Greater(plain.r, plain.b, $"the orange world has red over blue, got {plain}");
+
+            // Swap red with blue and halve green: every channel has to move, each by its own rule.
+            var swapAndHalve = Matrix4x4.identity;
+            swapAndHalve.m00 = 0f; swapAndHalve.m02 = 1f;
+            swapAndHalve.m11 = 0.5f;
+            swapAndHalve.m20 = 1f; swapAndHalve.m22 = 0f;
+            GlassRuntime.BackdropDecodeOverrideForTests = swapAndHalve;
+
+            var decoded = RenderAndSample("promptugui-glass-decode.png").linear;
+
+            Assert.AreEqual(plain.r, decoded.b, 0.03f,
+                $"red should have moved into blue; plain {plain}, decoded {decoded}");
+            Assert.AreEqual(plain.b, decoded.r, 0.03f,
+                $"blue should have moved into red; plain {plain}, decoded {decoded}");
+            Assert.AreEqual(plain.g * 0.5f, decoded.g, 0.03f,
+                $"green should have halved; plain {plain}, decoded {decoded}");
+        }
     }
 }


### PR DESCRIPTION
## 问题

MainCamera 打开 Post Processing 后，在 HDR 显示器上 glass 面板整块发白、只剩一点杂色（见 issue 截图）；SDR 显示器正常，关掉后处理也正常。

## 根因

URP HDR Output + 后处理时，颜色分级 LUT 交出的画面**已经**旋进显示器色域并按 paper white 放大到 nit（`LutBuilderHdr.shader`：`RotateRec709ToOutputSpace × PaperWhite`；PQ/scRGB 编码留到最终 blit，所以 `AfterRenderingPostProcessing` 还读得到线性值）。而 overlay UI 走离屏 RGBA8 再由 `SceneUIComposition` 合成，合成时对每个 UI 像素**再做一遍**同样的旋转 + 纸白缩放。

玻璃采到的图因此被变换了两次：场景里 1% 的灰在 300 nit 纸白下是 3 nit，写进 8-bit UI 目标就是 3.0 → 截成白。整块面板成白板，只有某个通道还低于 1/300 的地方留下杂色 —— 正是截图里的样子。

没开后处理时 URP 在最终 blit（`BlitHDROverlay.shader`）里对场景与 UI 一视同仁地做转换，所以那条路一直是对的。

## 修法

降采样那一次 blit 乘上逆变换，把采样放回 UI 合成所期望的空间：

- **`GlassBackdropDecode`（纯 C#，新）**：按 `isHDROutputActive` / `postProcessEnabled` / 显示色域 / 纸白推出 3×3 矩阵 —— 色域逆旋转（Rec2020 / P3D65 → Rec709，常量取自 core 的 `HDROutput.hlsl` / `ColorSpaceUtils.cs`）再除以纸白。SDR、无后处理、或 URP 自己无法归类的色域都返回单位阵，两个门控与 URP `ColorGradingLutPass` 做显示转换的条件逐一对应。纸白镜像 URP 内部的 `GetHDROutputLuminanceParameters`：`Tonemapping` override 的值（默认 300），除非它勾了 detect 才用显示器的。
- **`UI-GlassBlur.shader`** 拆两个 pass：pass 0 纯 Kawase（同分辨率各档），pass 1 在核之后乘 `_BackdropDecode`（只给降采样）。矩阵与平均都线性，所以乘在四 tap 平均之后，每个 1/16 分辨率的纹素一次 mul。仍是不含 SRP 头文件的纯 CG。逆旋转产生的负分量在这里截 0，>1 高光保留给模糊散开。
- **`GlassBackdropSystem`** 每帧在 `RecordRenderGraph` 里从 `UniversalCameraData` 重算矩阵，变了才 `SetMatrix`；材质创建时显式置单位阵（未设置的矩阵 uniform 不是单位阵）。

## 测试

- `GlassBackdropDecodeTests`（6 条）：用 URP 的正向矩阵 × 纸白复现 LUT 的输出，断言解码后逐通道往返到 1e-3；覆盖 SDR、HDR 无后处理、Rec709(scRGB)、HDR10(Rec2020)、DisplayP3、纸白为 0 不产生 NaN。
- `GlassRenderTests.BackdropDecode_IsAppliedToTheCapture`：没有测试能打开 HDR 显示，所以通过 `GlassRuntime.BackdropDecodeOverrideForTests` 塞一个「R↔B 互换 + G 减半」矩阵，逐通道证明 blit 真的把矩阵乘上了。
- EditMode 全量 3498/3498 通过；`dotnet format --verify-no-changes` 通过。

## 文档

`reference/glass.md`「What the glass can see」补一句 HDR 显示下的行为（无需配置）。无 XML / 公共 API 变化。

https://claude.ai/code/session_01Kz3cVPUFq3q4mfEuXrNHqe
