### PR TITLE
feat: 外部 .po 根目录 externalPoRoots —— 提取排除、打标与翻译包含

### DIFF
--- a/.claude/skills/scripting-promptugui-csharp/SKILL.md
+++ b/.claude/skills/scripting-promptugui-csharp/SKILL.md
@@ -569,6 +569,10 @@ dropdown.BindOptions(LocaleTicks.Select(_ => (IEnumerable<string>)
 
 **.po file location (Resources-backed)**: by default `.po` files live in `Assets/Resources/PromptUGUI/i18n/<locale>/` or `/PromptUGUI/i18n-custom/<locale>/`. Files anywhere under those paths are picked up by `Resources.LoadAll<TextAsset>`; subfolder names are ignored.
 
+**.po produced by external tools**: list their folders in `PromptUGUISettings.externalPoRoots` (project-relative, e.g. `Assets/_Project/i18n_server`). Use this for strings your project's extractor cannot see — typically a game server exporting player-visible text (faction names, generated place names) that reaches the client as `UI.Tr(someVariable)`. Semantics: **excluded from extraction, included everywhere else.** `Tools → PromptUGUI → I18n → 1. Extract Strings` neither writes into those folders, lets them win the output-folder election, nor reports their files as orphans; Addressables labelling, `2. AI Translate Locale...` and the runtime loader treat them exactly like your own `.po`. The layout rule is unchanged — files must still sit at `<root>/<locale>/*.po`, or they get no `Locale:` label. Default is an empty list, i.e. no behaviour change.
+
+> External tools must write their **own** files. Writing extra entries into a partition file that extraction owns (e.g. `_code.po`) still loses them on the next extract — `PoFileWriter.Merge` drops anything the current scan didn't produce.
+
 For Addressables-backed `.po` loading (`UI.Locale.UseAddressableResolver`, `Locale:<locale>` labels, `SetAsync`), see **using-promptugui-addressables**.
 
 ## Theme switching

--- a/.claude/skills/using-promptugui-addressables/SKILL.md
+++ b/.claude/skills/using-promptugui-addressables/SKILL.md
@@ -58,6 +58,8 @@ Run `Tools → PromptUGUI → I18n → Setup Addressables for Locale PO Files`. 
 
 Non-`Locale` labels you've set yourself (e.g. `UI`, `Stage:1-1`) are preserved.
 
+`.po` sitting under a `PromptUGUISettings.externalPoRoots` folder are labelled like any other — those roots only exclude folders from *extraction*. See **scripting-promptugui-csharp** -> ".po produced by external tools".
+
 ## Icon atlases via Addressables
 
 Tag your SpriteSet assets in Addressables with a label (default: `SpriteSets`). Addressables auto-pulls each referenced SpriteAtlas as a dependency.

--- a/Editor/I18n/AddressablePoLabelSyncer.cs
+++ b/Editor/I18n/AddressablePoLabelSyncer.cs
@@ -122,6 +122,50 @@ namespace PromptUGUI.Editor.I18n
         }
 
         /// <summary>
+        /// True if <paramref name="assetPath"/> sits under any of <paramref name="roots"/>
+        /// (a <c>PromptUGUISettings.externalPoRoots</c> entry). Comparison is Ordinal on
+        /// '/'-normalized paths and only matches on folder boundaries, so
+        /// <c>"Assets/i18n_server_old/x.po"</c> is NOT under root <c>"Assets/i18n_server"</c>.
+        /// Blank roots are ignored rather than matching everything.
+        /// </summary>
+        public static bool IsUnderAnyRoot(string assetPath, IEnumerable<string> roots)
+        {
+            if (string.IsNullOrEmpty(assetPath) || roots == null) return false;
+            var path = assetPath.Replace('\\', '/');
+            foreach (var raw in roots)
+            {
+                if (string.IsNullOrWhiteSpace(raw)) continue;
+                var root = raw.Replace('\\', '/').TrimEnd('/');
+                if (root.Length == 0) continue;
+                if (path.Length < root.Length) continue;
+                if (string.CompareOrdinal(path, 0, root, 0, root.Length) != 0) continue;
+                // Equal length = the root folder itself; otherwise demand a '/' so the
+                // match lands on a folder boundary.
+                if (path.Length == root.Length || path[root.Length] == '/') return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// The subset of <paramref name="assetPaths"/> that is NOT under any of
+        /// <paramref name="roots"/>, in input order. A null/empty root list passes
+        /// everything through — the default <c>externalPoRoots</c> is empty, so
+        /// extraction behaves exactly as it did before this option existed.
+        /// </summary>
+        public static IEnumerable<string> ExcludeExternalRoots(
+            IEnumerable<string> assetPaths, IEnumerable<string> roots)
+        {
+            if (assetPaths == null) yield break;
+            // Materialize once: callers may hand us a lazy sequence we'd otherwise
+            // re-enumerate per path.
+            var rootList = roots == null ? null : new List<string>(roots);
+            foreach (var path in assetPaths)
+            {
+                if (!IsUnderAnyRoot(path, rootList)) yield return path;
+            }
+        }
+
+        /// <summary>
         /// True when <paramref name="label"/> starts with <see cref="LabelPrefix"/>
         /// but doesn't match the <paramref name="currentLocale"/>'s expected label.
         /// Used to scrub stale <c>Locale:*</c> labels when a .po asset moves between

--- a/Editor/I18n/StringExtractor.cs
+++ b/Editor/I18n/StringExtractor.cs
@@ -14,7 +14,12 @@ namespace PromptUGUI.Editor.I18n
 {
     internal static class StringExtractor
     {
-        private const string DefaultOutputRoot = "Assets/Resources/PromptUGUI/i18n";
+        /// <summary>
+        /// Where extraction writes when nothing tells it otherwise. Shared with
+        /// <c>TranslateLocaleWindow</c> so "where the window looks" can never drift
+        /// from "where Extract writes".
+        /// </summary>
+        internal const string DefaultOutputRoot = "Assets/Resources/PromptUGUI/i18n";
 
         [MenuItem("Tools/PromptUGUI/I18n/1. Extract Strings")]
         public static void ExtractAll()
@@ -46,7 +51,10 @@ namespace PromptUGUI.Editor.I18n
             // to Resources/ when the runtime resolver is the Resources fallback —
             // that contract is the user's responsibility once they opt in to
             // UseAddressableResolver().
-            var labelledByLocale = CollectAddressablePoPathsByLocale();
+            // Folders owned by external tools (spec 2026-09-04 EPR): excluded from the
+            // output-folder election and from orphan reporting, included everywhere else.
+            var externalRoots = settings.externalPoRoots;
+            var labelledByLocale = CollectAddressablePoPathsByLocale(externalRoots);
 
             var activePartitions = new HashSet<string>(byPartition.Keys);
             var writtenPaths = new List<string>();
@@ -76,7 +84,7 @@ namespace PromptUGUI.Editor.I18n
                     File.WriteAllText(path, merged);
                     writtenPaths.Add(path);
                 }
-                orphanCount += ReportOrphanPoFiles(localeDir, activePartitions);
+                orphanCount += ReportOrphanPoFiles(localeDir, activePartitions, externalRoots);
             }
             // Targeted import instead of bulk AssetDatabase.Refresh(): unrelated
             // stale assets in the project can otherwise log "File couldn't be read"
@@ -97,13 +105,21 @@ namespace PromptUGUI.Editor.I18n
         // Pure helper: which .po files under <localeDir> no longer correspond to
         // a partition produced by the current scan. Paths are returned as given
         // (caller-supplied paths), only the relative-key lookup normalizes separators.
+        // <paramref name="externalRoots"/> (PromptUGUISettings.externalPoRoots) are
+        // skipped outright — those files come from tools outside this project and are
+        // never expected to match a partition. The check lives here rather than in the
+        // caller because ReportOrphanPoFiles scans <localeDir> recursively, so an
+        // external root nested inside it (e.g. <localeDir>/_server/) reaches this list.
         internal static IEnumerable<string> FindOrphanPoFiles(
-            IEnumerable<string> poFilePaths, string localeDir, ISet<string> activePartitions)
+            IEnumerable<string> poFilePaths, string localeDir, ISet<string> activePartitions,
+            IEnumerable<string> externalRoots = null)
         {
             var prefixLen = localeDir.Length + 1;
+            var roots = externalRoots == null ? null : new List<string>(externalRoots);
             foreach (var poPath in poFilePaths)
             {
                 var normalized = poPath.Replace('\\', '/');
+                if (AddressablePoLabelSyncer.IsUnderAnyRoot(normalized, roots)) continue;
                 if (normalized.Length <= prefixLen) continue;
                 var rel = normalized.Substring(prefixLen);
                 if (rel.EndsWith(".po")) rel = rel.Substring(0, rel.Length - 3);
@@ -111,12 +127,14 @@ namespace PromptUGUI.Editor.I18n
             }
         }
 
-        private static int ReportOrphanPoFiles(string localeDir, ISet<string> activePartitions)
+        private static int ReportOrphanPoFiles(
+            string localeDir, ISet<string> activePartitions, IEnumerable<string> externalRoots)
         {
             if (!Directory.Exists(localeDir)) return 0;
             var poFiles = Directory.GetFiles(localeDir, "*.po", SearchOption.AllDirectories);
             var count = 0;
-            foreach (var poPath in FindOrphanPoFiles(poFiles, localeDir, activePartitions))
+            foreach (var poPath in FindOrphanPoFiles(
+                         poFiles, localeDir, activePartitions, externalRoots))
             {
                 Debug.LogError(
                     $"[PromptUGUI] Orphan .po file: {poPath.Replace('\\', '/')} — " +
@@ -126,12 +144,20 @@ namespace PromptUGUI.Editor.I18n
             return count;
         }
 
-        private static Dictionary<string, List<string>> CollectAddressablePoPathsByLocale()
+        /// <summary>
+        /// Every Addressables-labelled <c>.po</c> path in the project, bucketed by the
+        /// locale its <c>Locale:&lt;locale&gt;</c> label names, minus anything under
+        /// <paramref name="externalRoots"/>. Shared with <c>TranslateLocaleWindow</c>
+        /// so both resolve the same locale folder. Empty when Addressables isn't installed.
+        /// </summary>
+        internal static Dictionary<string, List<string>> CollectAddressablePoPathsByLocale(
+            IEnumerable<string> externalRoots = null)
         {
             var result = new Dictionary<string, List<string>>();
 #if PROMPTUGUI_HAS_ADDRESSABLES
             var aa = AddressableAssetSettingsDefaultObject.Settings;
             if (aa == null) return result;
+            var roots = externalRoots == null ? null : new List<string>(externalRoots);
             foreach (var group in aa.groups)
             {
                 if (group == null) continue;
@@ -141,6 +167,9 @@ namespace PromptUGUI.Editor.I18n
                     var path = entry.AssetPath;
                     if (string.IsNullOrEmpty(path) ||
                         !path.EndsWith(".po", System.StringComparison.OrdinalIgnoreCase)) continue;
+                    // External .po must not join the output-folder election, or a root
+                    // whose name sorts earlier would silently redirect extraction output.
+                    if (AddressablePoLabelSyncer.IsUnderAnyRoot(path, roots)) continue;
                     foreach (var label in entry.labels)
                     {
                         if (string.IsNullOrEmpty(label) ||

--- a/Editor/I18n/TranslationMenu.cs
+++ b/Editor/I18n/TranslationMenu.cs
@@ -38,7 +38,6 @@ namespace PromptUGUI.Editor.I18n
 
     internal sealed class TranslateLocaleWindow : EditorWindow
     {
-        private const string I18nRoot = "Assets/Resources/PromptUGUI/i18n";
         private const int BatchSize = 50;
 
         private string[] _locales = Array.Empty<string>();
@@ -168,15 +167,15 @@ namespace PromptUGUI.Editor.I18n
                     "OK");
                 return;
             }
-            var localeDir = Path.Combine(I18nRoot, locale);
-            var poFiles = Directory.Exists(localeDir)
-                ? Directory.GetFiles(localeDir, "*.po", SearchOption.AllDirectories)
-                : Array.Empty<string>();
+            var searchDirs = ResolveSearchDirs(locale);
+            var poFiles = CollectPoFiles(searchDirs);
             if (poFiles.Length == 0)
             {
                 EditorUtility.DisplayDialog(
                     "PromptUGUI",
-                    $"No .po files for locale '{locale}' under '{localeDir}'. Run Extract Strings first.",
+                    $"No .po files for locale '{locale}' under: " +
+                    $"{string.Join(", ", searchDirs)}.\n\nRun Extract Strings first, or add the " +
+                    "folder holding them to PromptUGUISettings → External Po Roots.",
                     "OK");
                 return;
             }
@@ -315,6 +314,57 @@ namespace PromptUGUI.Editor.I18n
                         _statusLine = $"Done — {_entriesFilled} / {_entriesTotal} filled.";
                 }
             }
+        }
+
+        /// <summary>
+        /// Where this window looks for <paramref name="locale"/>'s .po files: the same
+        /// folder <c>StringExtractor</c> writes to (resolved from Addressables
+        /// <c>Locale:</c> labels, external roots excluded — so the election can't be
+        /// hijacked), plus every <c>externalPoRoots</c>/&lt;locale&gt; folder. Ordinal
+        /// distinct, '/'-normalized.
+        /// </summary>
+        internal static IReadOnlyList<string> ResolveSearchDirs(string locale)
+        {
+            var settings = PromptUGUISettings.Instance;
+            var externalRoots = settings != null ? settings.externalPoRoots : null;
+
+            var labelledByLocale =
+                StringExtractor.CollectAddressablePoPathsByLocale(externalRoots);
+            labelledByLocale.TryGetValue(locale, out var labelled);
+            var dirs = new List<string>
+            {
+                AddressablePoLabelSyncer.ResolveOutputDirForLocale(
+                    locale,
+                    labelled ?? (IEnumerable<string>)Array.Empty<string>(),
+                    StringExtractor.DefaultOutputRoot,
+                    out _),
+            };
+            if (externalRoots != null)
+            {
+                foreach (var root in externalRoots)
+                {
+                    if (string.IsNullOrWhiteSpace(root)) continue;
+                    dirs.Add(root.Replace('\\', '/').TrimEnd('/') + "/" + locale);
+                }
+            }
+            return dirs.Distinct(StringComparer.Ordinal).ToList();
+        }
+
+        private static string[] CollectPoFiles(IReadOnlyList<string> searchDirs)
+        {
+            // Distinct by full path: an external root nested inside the extraction
+            // folder would otherwise queue the same entry twice.
+            var found = new List<string>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var dir in searchDirs)
+            {
+                if (!Directory.Exists(dir)) continue;
+                foreach (var po in Directory.GetFiles(dir, "*.po", SearchOption.AllDirectories))
+                {
+                    if (seen.Add(Path.GetFullPath(po))) found.Add(po);
+                }
+            }
+            return found.ToArray();
         }
 
         private static List<(string poPath, PoEntry entry)> CollectQueue(string[] poFiles)

--- a/Editor/PromptUGUISettingsEditor.cs
+++ b/Editor/PromptUGUISettingsEditor.cs
@@ -15,6 +15,11 @@ namespace PromptUGUI.Editor
 
             EditorGUILayout.Space();
 
+            EditorGUILayout.PropertyField(
+                serializedObject.FindProperty("externalPoRoots"), true);
+
+            EditorGUILayout.Space();
+
             DrawLocales(serializedObject.FindProperty("locales"));
 
             serializedObject.ApplyModifiedProperties();

--- a/Runtime/Application/PromptUGUISettings.cs
+++ b/Runtime/Application/PromptUGUISettings.cs
@@ -26,6 +26,12 @@ namespace PromptUGUI.Application
         public List<string> fontTypes = new() { "default" };
         public List<LocaleConfig> locales = new();
 
+        [Tooltip("Project-relative folders holding .po files produced by external tools " +
+                 "(e.g. a game server exporting runtime-provided strings). Extraction never " +
+                 "writes to or reports on them; labelling and translation still include them. " +
+                 "Files must still sit under a '<locale>' folder: <root>/<locale>/*.po")]
+        public List<string> externalPoRoots = new();
+
         /// <summary>Resolved font + optional material preset for a (locale, type) pair.</summary>
         internal readonly struct FontResolution
         {

--- a/Tests/EditMode/Addressables/AddressablePoLabelSyncerIntegrationTests.cs
+++ b/Tests/EditMode/Addressables/AddressablePoLabelSyncerIntegrationTests.cs
@@ -162,6 +162,30 @@ namespace PromptUGUI.Tests.Addressables
                 "Repeated calls must converge to a single Locale: label.");
         }
 
+        [Test]
+        public void Make_labels_files_under_an_externalPoRoot_too()
+        {
+            // "Exclusion happens only during extraction" (spec 2026-09-04 EPR §3.3):
+            // labelling must stay blind to externalPoRoots, or server-produced .po
+            // would never ship.
+            var externalRoot = $"{FixturesRoot}/_server";
+            var poPath = WriteNestedPo("_server/zh-Hans", "systems.txt");
+            Assert.IsTrue(
+                AddressablePoLabelSyncer.IsUnderAnyRoot(poPath, new[] { externalRoot }),
+                "Pre-condition: the fixture really does sit under the external root, " +
+                "so this test would catch a leak of the extraction-side filter into " +
+                "MakeLocalePoFilesAddressable.");
+
+            AddressablePoLabelSyncer.MakeLocalePoFilesAddressable(
+                new[] { poPath }, Locales);
+
+            var settings = AddressableAssetSettingsDefaultObject.Settings;
+            var entry = settings.FindAssetEntry(AssetDatabase.AssetPathToGUID(poPath));
+            Assert.IsNotNull(entry, "External .po must still be made Addressable.");
+            Assert.IsTrue(entry.labels.Contains("Locale:zh-Hans"),
+                "External .po must still receive the Locale:<locale> label the runtime loads by.");
+        }
+
         private static string WritePo(string subfolder, string fileName)
         {
             // Use AssetDatabase.CreateFolder so Unity discovers the subdir without a
@@ -172,6 +196,25 @@ namespace PromptUGUI.Tests.Addressables
             if (!AssetDatabase.IsValidFolder(folder))
                 AssetDatabase.CreateFolder(FixturesRoot, subfolder);
 
+            var assetPath = $"{folder}/{fileName}";
+            File.WriteAllText(
+                Path.Combine(UnityEngine.Application.dataPath, "..", assetPath), "fixture\n");
+            AssetDatabase.ImportAsset(assetPath);
+            return assetPath;
+        }
+
+        /// <summary>Same as <see cref="WritePo"/> but creates a multi-segment
+        /// subfolder chain (e.g. "_server/zh-Hans") one level at a time.</summary>
+        private static string WriteNestedPo(string relFolder, string fileName)
+        {
+            var folder = FixturesRoot;
+            foreach (var segment in relFolder.Split('/'))
+            {
+                var next = $"{folder}/{segment}";
+                if (!AssetDatabase.IsValidFolder(next))
+                    AssetDatabase.CreateFolder(folder, segment);
+                folder = next;
+            }
             var assetPath = $"{folder}/{fileName}";
             File.WriteAllText(
                 Path.Combine(UnityEngine.Application.dataPath, "..", assetPath), "fixture\n");

--- a/Tests/EditMode/Editor/AddressablePoLabelSyncerTests.cs
+++ b/Tests/EditMode/Editor/AddressablePoLabelSyncerTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using NUnit.Framework;
 using PromptUGUI.Editor.I18n;
 
@@ -275,6 +276,147 @@ namespace PromptUGUI.Tests.Editor
                 out var detected);
             Assert.AreEqual("Assets/Resources/PromptUGUI/i18n/zh-Hans", dir);
             Assert.IsEmpty(detected);
+        }
+
+        // ---- externalPoRoots (spec 2026-09-04 EPR) ----
+
+        private static readonly string[] ServerRoot = { "Assets/_Project/i18n_server" };
+
+        [Test]
+        public void IsUnderAnyRoot_returns_true_for_file_directly_under_root()
+        {
+            Assert.IsTrue(AddressablePoLabelSyncer.IsUnderAnyRoot(
+                "Assets/_Project/i18n_server/en/systems.po", ServerRoot));
+        }
+
+        [Test]
+        public void IsUnderAnyRoot_returns_true_for_deeply_nested_file()
+        {
+            Assert.IsTrue(AddressablePoLabelSyncer.IsUnderAnyRoot(
+                "Assets/_Project/i18n_server/en/galaxy/names.po", ServerRoot));
+        }
+
+        [Test]
+        public void IsUnderAnyRoot_returns_true_when_path_equals_root()
+        {
+            Assert.IsTrue(AddressablePoLabelSyncer.IsUnderAnyRoot(
+                "Assets/_Project/i18n_server", ServerRoot),
+                "The root folder itself counts as under the root.");
+        }
+
+        [Test]
+        public void IsUnderAnyRoot_respects_folder_boundaries()
+        {
+            Assert.IsFalse(AddressablePoLabelSyncer.IsUnderAnyRoot(
+                "Assets/_Project/i18n_server_old/en/x.po", ServerRoot),
+                "A sibling folder sharing the root's name as a string prefix is NOT under it.");
+        }
+
+        [Test]
+        public void IsUnderAnyRoot_returns_false_for_unrelated_path()
+        {
+            Assert.IsFalse(AddressablePoLabelSyncer.IsUnderAnyRoot(
+                "Assets/_Project/i18n/en/_code.po", ServerRoot));
+        }
+
+        [Test]
+        public void IsUnderAnyRoot_normalizes_backslashes_on_both_sides()
+        {
+            Assert.IsTrue(AddressablePoLabelSyncer.IsUnderAnyRoot(
+                @"Assets\_Project\i18n_server\en\systems.po",
+                new[] { @"Assets\_Project\i18n_server" }));
+        }
+
+        [Test]
+        public void IsUnderAnyRoot_tolerates_trailing_slash_on_root()
+        {
+            Assert.IsTrue(AddressablePoLabelSyncer.IsUnderAnyRoot(
+                "Assets/_Project/i18n_server/en/systems.po",
+                new[] { "Assets/_Project/i18n_server/" }));
+        }
+
+        [Test]
+        public void IsUnderAnyRoot_returns_false_for_empty_or_null_root_list()
+        {
+            Assert.IsFalse(AddressablePoLabelSyncer.IsUnderAnyRoot(
+                "Assets/_Project/i18n_server/en/systems.po", new string[0]));
+            Assert.IsFalse(AddressablePoLabelSyncer.IsUnderAnyRoot(
+                "Assets/_Project/i18n_server/en/systems.po", null));
+        }
+
+        [Test]
+        public void IsUnderAnyRoot_ignores_null_and_empty_root_entries()
+        {
+            Assert.IsFalse(AddressablePoLabelSyncer.IsUnderAnyRoot(
+                "Assets/UI/en/x.po", new[] { null, "", "   " }),
+                "Blank roots must not degenerate into 'matches everything'.");
+        }
+
+        [Test]
+        public void IsUnderAnyRoot_returns_false_for_empty_path()
+        {
+            Assert.IsFalse(AddressablePoLabelSyncer.IsUnderAnyRoot(null, ServerRoot));
+            Assert.IsFalse(AddressablePoLabelSyncer.IsUnderAnyRoot("", ServerRoot));
+        }
+
+        [Test]
+        public void ExcludeExternalRoots_passes_everything_through_when_roots_empty()
+        {
+            var paths = new[] { "Assets/a/en/x.po", "Assets/b/en/y.po" };
+            CollectionAssert.AreEqual(
+                paths,
+                AddressablePoLabelSyncer.ExcludeExternalRoots(paths, null).ToList());
+        }
+
+        [Test]
+        public void ExcludeExternalRoots_drops_matches_and_preserves_order()
+        {
+            var paths = new[]
+            {
+                "Assets/_Project/i18n/en/_code.po",
+                "Assets/_Project/i18n_server/en/systems.po",
+                "Assets/_Project/i18n/en/screens/MainMenu.po",
+            };
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "Assets/_Project/i18n/en/_code.po",
+                    "Assets/_Project/i18n/en/screens/MainMenu.po",
+                },
+                AddressablePoLabelSyncer.ExcludeExternalRoots(paths, ServerRoot).ToList());
+        }
+
+        [Test]
+        public void ExcludeExternalRoots_returns_empty_for_null_paths()
+        {
+            CollectionAssert.IsEmpty(
+                AddressablePoLabelSyncer.ExcludeExternalRoots(null, ServerRoot).ToList());
+        }
+
+        [Test]
+        public void ExcludeExternalRoots_then_ResolveOutputDir_keeps_the_project_own_folder()
+        {
+            // Regression guard: Ordinal-wise "i18n-server/en" sorts BEFORE "i18n/en"
+            // ('-' 0x2D < '/' 0x2F), so an unfiltered external root would silently
+            // steal the extraction output directory.
+            var labelled = new[]
+            {
+                "Assets/_Project/i18n-server/en/systems.po",
+                "Assets/_Project/i18n/en/_code.po",
+            };
+            var roots = new[] { "Assets/_Project/i18n-server" };
+
+            var dir = AddressablePoLabelSyncer.ResolveOutputDirForLocale(
+                "en",
+                AddressablePoLabelSyncer.ExcludeExternalRoots(labelled, roots),
+                "Assets/Resources/PromptUGUI/i18n",
+                out var detected);
+
+            Assert.AreEqual("Assets/_Project/i18n/en", dir,
+                "External .po must not participate in the output-folder election.");
+            Assert.AreEqual(1, detected.Count,
+                "With the external folder filtered out only one candidate remains, " +
+                "so extraction must not log the 'Multiple <locale> folders' warning.");
         }
     }
 }

--- a/Tests/EditMode/Editor/StringExtractorTests.cs
+++ b/Tests/EditMode/Editor/StringExtractorTests.cs
@@ -47,5 +47,54 @@ namespace PromptUGUI.Tests.Editor
             CollectionAssert.IsEmpty(
                 StringExtractor.FindOrphanPoFiles(paths, localeDir, active).ToList());
         }
+
+        // ---- externalPoRoots (spec 2026-09-04 EPR) ----
+
+        [Test]
+        public void FindOrphanPoFiles_SkipsPathsUnderAnExternalRoot()
+        {
+            // ReportOrphanPoFiles scans <localeDir> recursively, so an external root
+            // that happens to sit inside it would otherwise be reported every extract.
+            var localeDir = "Assets/_Project/i18n/en";
+            var paths = new[]
+            {
+                $"{localeDir}/_code.po",
+                $"{localeDir}/_server/systems.po",
+                $"{localeDir}/screens/DeletedScreen.po",
+            };
+            var active = new HashSet<string> { "_code" };
+            var roots = new[] { $"{localeDir}/_server" };
+
+            var orphans = StringExtractor
+                .FindOrphanPoFiles(paths, localeDir, active, roots).ToList();
+
+            CollectionAssert.AreEqual(
+                new[] { $"{localeDir}/screens/DeletedScreen.po" },
+                orphans,
+                "External .po must not be reported as orphans, but genuine orphans still are.");
+        }
+
+        [Test]
+        public void FindOrphanPoFiles_SkipsExternalRootWithBackslashPaths()
+        {
+            var localeDir = "Assets/_Project/i18n/en";
+            var paths = new[] { $@"{localeDir}\_server\systems.po" };
+            var active = new HashSet<string> { "_code" };
+            var roots = new[] { $"{localeDir}/_server" };
+            CollectionAssert.IsEmpty(
+                StringExtractor.FindOrphanPoFiles(paths, localeDir, active, roots).ToList());
+        }
+
+        [Test]
+        public void FindOrphanPoFiles_EmptyExternalRoots_ReportsAsBefore()
+        {
+            var localeDir = "Assets/_Project/i18n/en";
+            var paths = new[] { $"{localeDir}/_server/systems.po" };
+            var active = new HashSet<string> { "_code" };
+            var orphans = StringExtractor
+                .FindOrphanPoFiles(paths, localeDir, active, new string[0]).ToList();
+            Assert.AreEqual(1, orphans.Count,
+                "Default (no roots configured) behaviour must be unchanged.");
+        }
     }
 }

--- a/docs~/superpowers/specs/2026-09-04-external-po-roots-design.md
+++ b/docs~/superpowers/specs/2026-09-04-external-po-roots-design.md
@@ -1,0 +1,176 @@
+# 外部 .po 根目录 —— `externalPoRoots`（EPR）
+
+> 状态：**已对齐，待实施**（2026-09-04）。决策编号 `EPR-Dn`（§7）。
+> 相关：`Editor/I18n/StringExtractor.cs`（提取与 orphan 报告）、
+> `Editor/I18n/AddressablePoLabelSyncer.cs`（目录竞选与打标）、
+> `Editor/I18n/PoFileWriter.cs`（合并语义）、
+> `docs~/superpowers/plans/2026-05-08-i18n-m5b-extraction.md`（提取管线的原始计划）。
+> 下游用例：ssw 游戏服务器把「服务器产的玩家可见文本」（星系名 / 势力名 / 对局展示名）导出成 .po
+> 写进 Unity 工程，见 `ssw_re_server/docs/superpowers/specs/2026-09-04-server-text-i18n-export-design.md`。
+
+## 0. 背景
+
+PromptUGUI 的 i18n 管线假设**所有 msgid 都来自本工程的 `.ui.xml` / C# 字面量**：Extract 扫源、
+按 partition 写 .po、msgstr 由翻译菜单或 CI 填。
+
+真实项目里有第三类来源：**工程外的工具生成的 .po**。ssw 的服务器把星系名、势力名等玩家可见文本
+导出成 .po 放进 Unity 工程——这些 msgid 客户端扫不到（它们在 C# 里长成 `UI.Tr(变量)`），却必须和
+扫出来的那批一起被打包、被翻译、被 `TranslationStore` 加载。
+
+运行时其实**已经支持**了：`UI.Locale.UseAddressableResolver()` 按 label `Locale:<locale>` 加载
+所有 .po，`TranslationStore` 按 `(locale, ctx, msgid)` 并表，来源是谁无所谓。出问题的只有 Editor 侧
+的三处「本工程假设」。
+
+## 1. 现状：外部 .po 放进工程会撞上什么
+
+| # | 机制 | 位置 | 撞法 |
+|---|---|---|---|
+| 1 | **条目级删除** | `PoFileWriter.Merge` | 「本轮提取里没有的条目丢弃」。外部串若写进客户端的 partition 文件（如 `_code.po`），下次 Extract 全部消失 |
+| 2 | **文件级 orphan 报告** | `StringExtractor.ReportOrphanPoFiles` | localeDir 下每个对不上 partition 的 .po 都 `Debug.LogError` 一条「Orphan .po file … delete manually」。文件不会被删，但每次提取刷红 |
+| 3 | **目录竞选** | `AddressablePoLabelSyncer.ResolveOutputDirForLocale` ← `CollectAddressablePoPathsByLocale` | 提取的输出目录 = 所有带 `Locale:` label 的 .po 的「最近的、名为 `<locale>` 的父目录」中 **Ordinal 第一个**。多于一个只 warning。外部 .po 一旦带 label 且落在名为 `<locale>` 的目录下，就参与竞选——**目录名排在前面时会把客户端自己的提取输出重定向过去**（`i18n-server/`、`ServerText/` 都排在 `i18n/` 前面） |
+
+第 3 条是真陷阱：它不报错，只是把 Extract 的结果写去了别处。
+
+## 2. 设计：一个「外部根」清单
+
+`PromptUGUISettings` 增加一个字段：
+
+```csharp
+[Tooltip("Project-relative folders holding .po files produced by external tools " +
+         "(e.g. a game server exporting runtime-provided strings). Extraction never " +
+         "writes to or reports on them; labelling and translation still include them.")]
+public List<string> externalPoRoots = new();   // e.g. "Assets/_Project/i18n_server"
+```
+
+语义一句话：**提取时排除，打标与翻译时包含。**
+
+- 排除（Extract 的两处）：不参与目录竞选、不进 orphan 报告。
+- 包含（其余全部）：Addressables 打标菜单照常给它们打 `Locale:<locale>`，翻译窗口/CI 照常填 msgstr，
+  运行时照常加载。
+
+外部根下的布局要求只有一条：`.po` 必须待在名为 `<locale>` 的目录下（`<root>/<locale>/xxx.po`），
+这样 `AddressablePoLabelSyncer.ComputeDesiredLocale` 才能给它算出 label。这与工程内的布局同规，
+不引入第二套约定。
+
+## 3. 改动点
+
+### 3.1 `PromptUGUISettings`
+
+加 `externalPoRoots` 字段 + 一个纯函数（放 `AddressablePoLabelSyncer`，便于单测，与既有纯函数同居）：
+
+```csharp
+/// <summary>True if <paramref name="assetPath"/> sits under any of <paramref name="roots"/>.
+/// Paths are compared with '/' separators, Ordinal, on folder boundaries — so
+/// "Assets/i18n_server_old/x.po" is NOT under root "Assets/i18n_server".</summary>
+public static bool IsUnderAnyRoot(string assetPath, IEnumerable<string> roots)
+```
+
+边界必须按 `/` 对齐（`root` 或 `root + "/"` 前缀），否则 `i18n_server` 会误吞 `i18n_server_old`。
+空 / null 根忽略；反斜杠统一成 `/`。
+
+配套第二个纯函数，给「提取排除」两处共用，同时把过滤逻辑从 `#if PROMPTUGUI_HAS_ADDRESSABLES`
+里拽到无条件编译区（否则 `PromptUGUI.Tests.EditorOnly` 那个 asmdef 测不到它，见 §5）：
+
+```csharp
+/// <summary>The subset of <paramref name="assetPaths"/> that is NOT under any of
+/// <paramref name="roots"/>. Null/empty roots ⇒ everything passes through.</summary>
+public static IEnumerable<string> ExcludeExternalRoots(
+    IEnumerable<string> assetPaths, IEnumerable<string> roots)
+```
+
+**Inspector 必须一并改。** `PromptUGUISettingsEditor` 是自定义 Inspector，只画 `fontTypes` +
+`locales` 两个属性——不加 `PropertyField(serializedObject.FindProperty("externalPoRoots"))`
+的话新字段在 Inspector 里根本不出现，作者只能改 YAML。放在 `fontTypes` 之后、`Locales` 之前。
+
+### 3.2 `StringExtractor.ExtractAll`
+
+两处过滤，都拿 `settings.externalPoRoots`：
+
+1. `CollectAddressablePoPathsByLocale()` —— 收集带 label 的 .po 时跳过外部根下的路径。
+   → 外部 .po 不参与目录竞选，"Multiple '<locale>' folders" 警告不再因外部根而出现。
+   过滤走 `ExcludeExternalRoots`，`#if` 块内只负责调用。
+2. `FindOrphanPoFiles(poFilePaths, localeDir, activePartitions, externalRoots)` —— 加一个
+   参数，逐文件跳过外部根下的路径。**过滤放进这个既有纯函数**（而不是 `ReportOrphanPoFiles`
+   这个读盘的调用方），否则 §5 的 orphan 测试打不到。
+   → 即便作者把外部根设在 localeDir **内部**（`Assets/_Project/i18n/en/_server/`），也不刷红；
+   `ReportOrphanPoFiles` 的 `Directory.GetFiles(..., AllDirectories)` 是递归的，这条路径真会发生。
+
+其余一律不动：写出路径、partition 分组、`PoFileWriter.Merge` 全部保持原状。
+
+顺带把 `CollectAddressablePoPathsByLocale` 从 `private` 提成 `internal`（§3.4 要复用），
+并把 `StringExtractor.DefaultOutputRoot` 与 `TranslateLocaleWindow.I18nRoot` 这两份同值字面量
+合成一处。
+
+### 3.3 `AddressablePoMenu` / 运行时
+
+**不改。** 打标菜单扫全工程 .po、按父目录名判 locale，外部根天然被包含；运行时只认 label。
+这正是「排除只发生在提取」的体现。
+
+### 3.4 `TranslateLocaleWindow`（顺带修，独立提交）
+
+`TranslateLocaleWindow.I18nRoot` 目前硬编码 `"Assets/Resources/PromptUGUI/i18n"`——工程一旦把 .po
+移到别处（ssw 就在 `Assets/_Project/i18n`），这个窗口就找不到任何文件、报 "Run Extract Strings first"。
+这个窗口对 Addressables **一无所知**：不看 label、不读 `PromptUGUISettings`（除了取 locale 列表）、
+也没有 fallback。
+
+改成与 Extract 同一套解析：
+
+1. `localeDir` = `ResolveOutputDirForLocale(locale, ExcludeExternalRoots(labelled), DefaultOutputRoot)`
+   —— 与 Extract 逐字同源，所以「窗口找的地方」永远等于「Extract 写的地方」。
+2. 再并上每个 `externalPoRoots/<locale>` 下的 `.po`。
+3. 两处结果按归一化路径去重后一起扫。
+
+副作用（可接受、且是 §2 语义的直接后果）：外部根下的服务器串会进 AI 翻译队列。ssw 用 CI 翻译，
+不受影响；窗口里会多出条目。
+
+另：`Path.Combine` 在 Windows 产出反斜杠，而 `FindLocaleFolder` / `FindOrphanPoFiles` 都按 `/`
+归一化——这里统一改成 `/` 拼接。
+
+这条与 EPR 无强依赖（ssw 用 CI 翻译），但既然动这块代码，顺手修掉；**单独一个提交**，便于回退。
+
+## 4. 不做什么
+
+- **不做「外部 msgid 参与 partition 分组」**：外部工具自己决定文件名与切分，PromptUGUI 不重排它们。
+- **不做外部 .po 的格式校验**：解析失败已经由运行时 `PoParser` 报错（`LoadPoFromAddressablesAsync`
+  里逐文件 try/catch 并 LogError），Editor 侧再来一遍没有增量价值。
+- **不做「反向保护」**：外部工具写进客户端 partition 文件仍然会被 Merge 清掉——那是外部工具的错，
+  文档里写清楚即可（EPR 的存在就是给它一个正确的落点）。
+- **不动运行时**：`TranslationStore` / resolver / label 契约零改动。
+
+## 5. 测试
+
+`Tests/EditMode/Editor/`（asmdef `PromptUGUI.Tests.EditorOnly`，**没有** `PROMPTUGUI_HAS_ADDRESSABLES`
+约束 —— 所以被测的必须是无条件编译的纯函数）：
+
+- `IsUnderAnyRoot`：命中、未命中、目录边界（`i18n_server` vs `i18n_server_old`）、反斜杠、空根列表、
+  根自身带尾斜杠、`null` 路径。
+- `ExcludeExternalRoots`：空根列表原样放行、命中的被剔除、保序。
+- `FindOrphanPoFiles` + 外部根：外部根下的 .po 不出现在 orphan 结果里；根设在 localeDir **内部**
+  （`<localeDir>/_server/`）时同样。
+- 目录竞选回归防线：`ExcludeExternalRoots` 过滤后喂给 `ResolveOutputDirForLocale`，即便外部根的
+  目录名 Ordinal 排在工程自己那个前面（`.../i18n-server/en` < `.../i18n/en`，因为 `-` < `/`），
+  输出目录仍是工程自己的那个，且 `detected.Count == 1` → 不 warning。
+
+`Tests/EditMode/Addressables/`：打标集成测试补一条——外部根下的 .po 仍被 `MakeLocalePoFilesAddressable`
+打上 `Locale:<locale>`（"排除只发生在提取" 的正面断言）。
+
+## 6. 兼容性
+
+`externalPoRoots` 默认空列表 = 现有行为逐字不变，无迁移动作。
+
+## 7. 决策
+
+- `EPR-D1`：外部 .po 用**设置里的根目录清单**标识，不用文件名约定、不用 label 区分。理由：根目录是
+  作者的一次性决策，且与「谁写这些文件」一一对应；label 区分会牵动运行时契约（多一个 label 就要多
+  一次 `LoadAssetsAsync`）。
+- `EPR-D2`：语义固定为**提取排除、打标/翻译包含**。外部 .po 与工程内 .po 在打包与运行时**完全等价**，
+  唯一区别是「谁生成它们」。
+- `EPR-D3`：外部根仍要求 `<root>/<locale>/*.po` 布局，复用既有 locale 目录约定，不引入第二套。
+- `EPR-D4`：`TranslateLocaleWindow` 的硬编码根一并修掉，但独立提交。
+- `EPR-D5`：过滤逻辑落在 `AddressablePoLabelSyncer` 的**无条件编译纯函数**里
+  （`IsUnderAnyRoot` / `ExcludeExternalRoots`），`#if PROMPTUGUI_HAS_ADDRESSABLES` 块内只调用不判断。
+  理由：与既有纯函数同居、可被无 Addressables 的测试 asmdef 覆盖；`FindOrphanPoFiles` 同理靠加参数
+  而非在读盘的调用方过滤。
+- `EPR-D6`：`externalPoRoots` 虽是 Editor 期语义，仍住在运行时的 `PromptUGUISettings`。理由：它已是
+  locale 配置的唯一落点（`locales[]` 就在那儿），另起一份 Editor-only 资产会让作者在两个地方配 i18n。
+  代价是 Player 里多一个不用的 `List<string>`，可忽略。


### PR DESCRIPTION
实现 `docs~/superpowers/specs/2026-09-04-external-po-roots-design.md`（EPR）。

## 问题

i18n 管线假设所有 msgid 都来自本工程的 `.ui.xml` / C# 字面量。真实项目有第三类来源：**工程外的工具生成的 .po** —— ssw 的服务器把星系名、势力名导出成 .po 放进 Unity 工程，这些 msgid 客户端扫不到（在 C# 里长成 `UI.Tr(变量)`），却必须和扫出来的那批一起被打包、被翻译、被 `TranslationStore` 加载。

运行时其实已经支持了（按 `Locale:<locale>` label 加载，来源是谁无所谓）。出问题的是 Editor 侧三处「本工程假设」：

| 机制 | 撞法 |
|---|---|
| `PoFileWriter.Merge` 条目级删除 | 外部串写进客户端 partition 文件，下次 Extract 全部消失 |
| `StringExtractor.ReportOrphanPoFiles` | localeDir 下每个对不上 partition 的 .po 都刷一条红 |
| `ResolveOutputDirForLocale` 目录竞选 | **真陷阱**：不报错，只是把 Extract 的结果静悄悄写去了别处 |

第三条值得展开：输出目录 = 所有带 label 的 .po 的最近 `<locale>` 父目录中 Ordinal 第一个。`.../i18n-server/en` 排在 `.../i18n/en` **前面**（`-` 0x2D < `/` 0x2F），所以外部根一旦带 label 就会夺走客户端自己的提取输出。

## 做法

`PromptUGUISettings.externalPoRoots`（`List<string>`，默认空 = 现有行为逐字不变）。语义一句话：**提取排除，打标与翻译包含。**外部 .po 与工程内 .po 在打包与运行时完全等价，唯一区别是「谁生成它们」。

三个提交：

1. **地基** —— 字段 + `IsUnderAnyRoot` / `ExcludeExternalRoots` 两个纯函数（边界按 `/` 对齐，`i18n_server` 不吞 `i18n_server_old`；空白根被忽略而不是退化成「匹配一切」）+ Inspector 补 PropertyField。
2. **提取排除** —— 目录竞选与 orphan 报告两处过滤。orphan 的过滤放进既有纯函数 `FindOrphanPoFiles` 而不是读盘的调用方，因为后者 `AllDirectories` 递归扫，外部根设在 localeDir 内部（`<localeDir>/_server/`）时文件真的会走到这里。`MakeLocalePoFilesAddressable` 一行不改。
3. **顺带修** —— `TranslateLocaleWindow` 的硬编码 `Assets/Resources/PromptUGUI/i18n`。

## 关于第 3 个提交

这条与 EPR 无强依赖（ssw 用 CI 翻译），独立提交便于回退。

窗口原先对 Addressables 一无所知：不看 label、不读 `PromptUGUISettings`（除了取 locale 列表）、也没有 fallback。工程一旦把 .po 移到别处（ssw 在 `Assets/_Project/i18n/`，靠 Addressables 标签定位、不放 Resources 好用 aa 包更新翻译），它就找不到任何文件、报 "Run Extract Strings first"。

改成与 Extract 逐字同源的解析（含共用 `DefaultOutputRoot` 常量），所以「窗口找的地方」永远等于「Extract 写的地方」。副作用是外部根下的串会进 AI 翻译队列 —— 这是 EPR-D2 语义的直接后果。

## 三处 spec 之外的补充（调研时发现）

- **`PromptUGUISettingsEditor` 是自定义 Inspector**，只画 `fontTypes` + `locales`。不补一行 `PropertyField` 的话，新字段在 Inspector 里根本不出现，作者只能改 YAML。
- **过滤逻辑必须落在无条件编译区**（`EPR-D5`）。原本 `CollectAddressablePoPathsByLocale` 整个方法体在 `#if PROMPTUGUI_HAS_ADDRESSABLES` 内，而 `PromptUGUI.Tests.EditorOnly` 那个 asmdef 没有这个约束、进不去 —— 纯函数化之后目录竞选的回归防线才测得到。
- **`DefaultOutputRoot` 与 `I18nRoot` 是同一个字面量抄了两遍**，合并成一处。

spec 已按这三条更新（新增 `EPR-D5` / `EPR-D6`）。

## 不做什么

- 不做「外部 msgid 参与 partition 分组」：外部工具自己决定文件名与切分。
- 不做外部 .po 的格式校验：运行时 `PoParser` 已经逐文件 try/catch + LogError。
- 不做「反向保护」：外部工具写进客户端 partition 文件仍然会被 Merge 清掉 —— 那是外部工具的错，EPR 的存在就是给它一个正确的落点。SKILL 里写清楚了。
- 不动运行时：`TranslationStore` / resolver / label 契约零改动。

## 测试

`Tests/EditMode/Editor/` 新增 16 条（`IsUnderAnyRoot` 命中 / 边界 / 反斜杠 / 空根 / 尾斜杠、`ExcludeExternalRoots` 保序、orphan 跳过外部根含嵌套情形、以及目录竞选的回归防线）；`Tests/EditMode/Addressables/` 新增 1 条正面断言：外部根下的 .po 照样拿到 `Locale:<locale>`，否则服务器串永远发不出去。

`PromptUGUI.Tests.EditorOnly` + `PromptUGUI.Tests.EditMode.Addressables` 共 **367 / 367 通过**，`dotnet format --verify-no-changes --severity warn` 干净。

SKILL 已更新：`scripting-promptugui-csharp`（.po 位置一节新增 "外部工具产的 .po"）、`using-promptugui-addressables`（打标一节说明外部根照常打标）。

https://claude.ai/code/session_01HMNDizmHqq8bW1R6NXZngF
